### PR TITLE
ci(pre-commit): update pre-commit-hooks-ros

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
       - id: yamllint
 
   - repo: https://github.com/tier4/pre-commit-hooks-ros
-    rev: v0.5.1
+    rev: v0.6.0
     hooks:
       - id: prettier-xacro
       - id: prettier-launch-xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,9 +82,10 @@ repos:
           ]
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v13.0.0
+    rev: v13.0.1
     hooks:
       - id: clang-format
+        types_or: [c++, c, cuda]
 
   - repo: https://github.com/cpplint/cpplint
     rev: 1.5.5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         args: [--line-length=100]


### PR DESCRIPTION
See https://github.com/tier4/pre-commit-hooks-ros/pull/50 and https://github.com/tier4/pre-commit-hooks-ros/releases/tag/v0.6.0.

Related: https://github.com/autowarefoundation/autoware/pull/143