### PR TITLE
ci: update minor CI settings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
 ### Copied from .github/CODEOWNERS-manual ###
-.github/* @autowarefoundation/autoware-maintainers
 
 ### Automatically generated from package.xml ###

--- a/.github/CODEOWNERS-manual
+++ b/.github/CODEOWNERS-manual
@@ -1,1 +1,0 @@
-.github/* @autowarefoundation/autoware-maintainers

--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -12,6 +12,7 @@
     - source: .github/PULL_REQUEST_TEMPLATE/standard-change.md
     - source: .github/dependabot.yaml
     - source: .github/stale.yml
+    - source: .github/workflows/cancel-previous-workflows.yaml
     - source: .github/workflows/github-release.yaml
     - source: .github/workflows/pre-commit.yaml
     - source: .github/workflows/pre-commit-optional.yaml
@@ -35,7 +36,6 @@
     - source: .github/workflows/build-and-test-differential.yaml
     - source: .github/workflows/build-and-test-differential-self-hosted.yaml
     - source: .github/workflows/build-and-test-self-hosted.yaml
-    - source: .github/workflows/cancel-previous-workflows.yaml
     - source: .github/workflows/check-build-depends.yaml
     - source: .github/workflows/clang-tidy-pr-comments.yaml
     - source: .github/workflows/update-codeowners-from-packages.yaml


### PR DESCRIPTION
Same as https://github.com/autowarefoundation/autoware.universe/pull/1765.
- Remove autoware-maintainers from `CODEOWNERS-manual`.
  - I've confirmed that `CODEOWNERS-manual` works.
  - It's noisy for other maintainers.
- Sync `cancel-previous-workflows.yaml` from autowarefoundation/autoware.
  - https://github.com/autowarefoundation/autoware/pull/2836