### PR TITLE
feat: add autoware_geography_utils from autoware.universe with history

### DIFF
--- a/common/autoware_geography_utils/CHANGELOG.rst
+++ b/common/autoware_geography_utils/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package autoware_geography_utils
 0.38.0 (2024-11-08)
 -------------------
 * unify package.xml version to 0.37.0
-* refactor(geography_utils): prefix package and namespace with autoware (`#7790 <https://github.com/youtalk/autoware.universe/issues/7790>`_)
+* refactor(geography_utils): prefix package and namespace with autoware (`#7790 <https://github.com/autowarefoundation/autoware.universe/issues/7790>`_)
   * refactor(geography_utils): prefix package and namespace with autoware
   * move headers to include/autoware/
   ---------

--- a/common/autoware_geography_utils/CHANGELOG.rst
+++ b/common/autoware_geography_utils/CHANGELOG.rst
@@ -1,0 +1,15 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package autoware_geography_utils
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.38.0 (2024-11-08)
+-------------------
+* unify package.xml version to 0.37.0
+* refactor(geography_utils): prefix package and namespace with autoware (`#7790 <https://github.com/youtalk/autoware.universe/issues/7790>`_)
+  * refactor(geography_utils): prefix package and namespace with autoware
+  * move headers to include/autoware/
+  ---------
+* Contributors: Esteve Fernandez, Yutaka Kondo
+
+0.26.0 (2024-04-03)
+-------------------

--- a/common/autoware_geography_utils/CMakeLists.txt
+++ b/common/autoware_geography_utils/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_geography_utils)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+# GeographicLib
+find_package(PkgConfig)
+find_path(GeographicLib_INCLUDE_DIR GeographicLib/Config.h
+  PATH_SUFFIXES GeographicLib
+)
+set(GeographicLib_INCLUDE_DIRS ${GeographicLib_INCLUDE_DIR})
+find_library(GeographicLib_LIBRARIES NAMES Geographic)
+
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/height.cpp
+  src/projection.cpp
+  src/lanelet2_projector.cpp
+)
+
+target_link_libraries(${PROJECT_NAME}
+  ${GeographicLib_LIBRARIES}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_ros REQUIRED)
+
+  file(GLOB_RECURSE test_files test/*.cpp)
+
+  ament_add_ros_isolated_gtest(test_${PROJECT_NAME} ${test_files})
+
+  target_link_libraries(test_${PROJECT_NAME}
+  ${PROJECT_NAME}
+  )
+endif()
+
+ament_auto_package()

--- a/common/autoware_geography_utils/README.md
+++ b/common/autoware_geography_utils/README.md
@@ -1,0 +1,5 @@
+# geography_utils
+
+## Purpose
+
+This package contains geography-related functions used by other packages, so please refer to them as needed.

--- a/common/autoware_geography_utils/include/autoware/geography_utils/height.hpp
+++ b/common/autoware_geography_utils/include/autoware/geography_utils/height.hpp
@@ -1,0 +1,33 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__GEOGRAPHY_UTILS__HEIGHT_HPP_
+#define AUTOWARE__GEOGRAPHY_UTILS__HEIGHT_HPP_
+
+#include <string>
+
+namespace autoware::geography_utils
+{
+
+typedef double (*HeightConversionFunction)(
+  const double height, const double latitude, const double longitude);
+double convert_wgs84_to_egm2008(const double height, const double latitude, const double longitude);
+double convert_egm2008_to_wgs84(const double height, const double latitude, const double longitude);
+double convert_height(
+  const double height, const double latitude, const double longitude,
+  const std::string & source_vertical_datum, const std::string & target_vertical_datum);
+
+}  // namespace autoware::geography_utils
+
+#endif  // AUTOWARE__GEOGRAPHY_UTILS__HEIGHT_HPP_

--- a/common/autoware_geography_utils/include/autoware/geography_utils/lanelet2_projector.hpp
+++ b/common/autoware_geography_utils/include/autoware/geography_utils/lanelet2_projector.hpp
@@ -1,0 +1,32 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__GEOGRAPHY_UTILS__LANELET2_PROJECTOR_HPP_
+#define AUTOWARE__GEOGRAPHY_UTILS__LANELET2_PROJECTOR_HPP_
+
+#include <tier4_map_msgs/msg/map_projector_info.hpp>
+
+#include <lanelet2_io/Projection.h>
+
+#include <memory>
+
+namespace autoware::geography_utils
+{
+using MapProjectorInfo = tier4_map_msgs::msg::MapProjectorInfo;
+
+std::unique_ptr<lanelet::Projector> get_lanelet2_projector(const MapProjectorInfo & projector_info);
+
+}  // namespace autoware::geography_utils
+
+#endif  // AUTOWARE__GEOGRAPHY_UTILS__LANELET2_PROJECTOR_HPP_

--- a/common/autoware_geography_utils/include/autoware/geography_utils/lanelet2_projector.hpp
+++ b/common/autoware_geography_utils/include/autoware/geography_utils/lanelet2_projector.hpp
@@ -15,7 +15,7 @@
 #ifndef AUTOWARE__GEOGRAPHY_UTILS__LANELET2_PROJECTOR_HPP_
 #define AUTOWARE__GEOGRAPHY_UTILS__LANELET2_PROJECTOR_HPP_
 
-#include <tier4_map_msgs/msg/map_projector_info.hpp>
+#include <autoware_map_msgs/msg/map_projector_info.hpp>
 
 #include <lanelet2_io/Projection.h>
 
@@ -23,7 +23,7 @@
 
 namespace autoware::geography_utils
 {
-using MapProjectorInfo = tier4_map_msgs::msg::MapProjectorInfo;
+using MapProjectorInfo = autoware_map_msgs::msg::MapProjectorInfo;
 
 std::unique_ptr<lanelet::Projector> get_lanelet2_projector(const MapProjectorInfo & projector_info);
 

--- a/common/autoware_geography_utils/include/autoware/geography_utils/projection.hpp
+++ b/common/autoware_geography_utils/include/autoware/geography_utils/projection.hpp
@@ -1,0 +1,33 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__GEOGRAPHY_UTILS__PROJECTION_HPP_
+#define AUTOWARE__GEOGRAPHY_UTILS__PROJECTION_HPP_
+
+#include <geographic_msgs/msg/geo_point.hpp>
+#include <geometry_msgs/msg/point.hpp>
+#include <tier4_map_msgs/msg/map_projector_info.hpp>
+
+namespace autoware::geography_utils
+{
+using MapProjectorInfo = tier4_map_msgs::msg::MapProjectorInfo;
+using GeoPoint = geographic_msgs::msg::GeoPoint;
+using LocalPoint = geometry_msgs::msg::Point;
+
+LocalPoint project_forward(const GeoPoint & geo_point, const MapProjectorInfo & projector_info);
+GeoPoint project_reverse(const LocalPoint & local_point, const MapProjectorInfo & projector_info);
+
+}  // namespace autoware::geography_utils
+
+#endif  // AUTOWARE__GEOGRAPHY_UTILS__PROJECTION_HPP_

--- a/common/autoware_geography_utils/include/autoware/geography_utils/projection.hpp
+++ b/common/autoware_geography_utils/include/autoware/geography_utils/projection.hpp
@@ -15,13 +15,13 @@
 #ifndef AUTOWARE__GEOGRAPHY_UTILS__PROJECTION_HPP_
 #define AUTOWARE__GEOGRAPHY_UTILS__PROJECTION_HPP_
 
+#include <autoware_map_msgs/msg/map_projector_info.hpp>
 #include <geographic_msgs/msg/geo_point.hpp>
 #include <geometry_msgs/msg/point.hpp>
-#include <tier4_map_msgs/msg/map_projector_info.hpp>
 
 namespace autoware::geography_utils
 {
-using MapProjectorInfo = tier4_map_msgs::msg::MapProjectorInfo;
+using MapProjectorInfo = autoware_map_msgs::msg::MapProjectorInfo;
 using GeoPoint = geographic_msgs::msg::GeoPoint;
 using LocalPoint = geometry_msgs::msg::Point;
 

--- a/common/autoware_geography_utils/package.xml
+++ b/common/autoware_geography_utils/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_geography_utils</name>
+  <version>0.1.0</version>
+  <description>The autoware_geography_utils package</description>
+  <maintainer email="koji.minoda@tier4.jp">Koji Minoda</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+
+  <depend>autoware_lanelet2_extension</depend>
+  <depend>geographic_msgs</depend>
+  <depend>geographiclib</depend>
+  <depend>geometry_msgs</depend>
+  <depend>lanelet2_io</depend>
+  <depend>tier4_map_msgs</depend>
+
+  <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/common/autoware_geography_utils/package.xml
+++ b/common/autoware_geography_utils/package.xml
@@ -17,11 +17,11 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_lanelet2_extension</depend>
+  <depend>autoware_map_msgs</depend>
   <depend>geographic_msgs</depend>
   <depend>geographiclib</depend>
   <depend>geometry_msgs</depend>
   <depend>lanelet2_io</depend>
-  <depend>tier4_map_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/common/autoware_geography_utils/package.xml
+++ b/common/autoware_geography_utils/package.xml
@@ -4,8 +4,14 @@
   <name>autoware_geography_utils</name>
   <version>0.1.0</version>
   <description>The autoware_geography_utils package</description>
-  <maintainer email="koji.minoda@tier4.jp">Koji Minoda</maintainer>
+  <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
+  <maintainer email="masahiro.sakamoto@tier4.jp">Masahiro Sakamoto</maintainer>
+  <maintainer email="anh.nguyen.2@tier4.jp">NGUYEN Viet Anh</maintainer>
+  <maintainer email="taiki.yamada@tier4.jp">Taiki Yamada</maintainer>
+  <maintainer email="shintaro.sakoda@tier4.jp">Shintaro Sakoda</maintainer>
+  <maintainer email="ryu.yamamoto@tier4.jp">Ryu Yamamoto</maintainer>
   <license>Apache License 2.0</license>
+  <author email="koji.minoda@tier4.jp">Koji Minoda</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>

--- a/common/autoware_geography_utils/package.xml
+++ b/common/autoware_geography_utils/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_geography_utils</name>
-  <version>0.1.0</version>
+  <version>0.38.0</version>
   <description>The autoware_geography_utils package</description>
   <maintainer email="yamato.ando@tier4.jp">Yamato Ando</maintainer>
   <maintainer email="masahiro.sakamoto@tier4.jp">Masahiro Sakamoto</maintainer>

--- a/common/autoware_geography_utils/src/height.cpp
+++ b/common/autoware_geography_utils/src/height.cpp
@@ -1,0 +1,63 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <GeographicLib/Geoid.hpp>
+#include <autoware/geography_utils/height.hpp>
+
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace autoware::geography_utils
+{
+
+double convert_wgs84_to_egm2008(const double height, const double latitude, const double longitude)
+{
+  GeographicLib::Geoid egm2008("egm2008-1");
+  // cSpell: ignore ELLIPSOIDTOGEOID
+  return egm2008.ConvertHeight(latitude, longitude, height, GeographicLib::Geoid::ELLIPSOIDTOGEOID);
+}
+
+double convert_egm2008_to_wgs84(const double height, const double latitude, const double longitude)
+{
+  GeographicLib::Geoid egm2008("egm2008-1");
+  // cSpell: ignore GEOIDTOELLIPSOID
+  return egm2008.ConvertHeight(latitude, longitude, height, GeographicLib::Geoid::GEOIDTOELLIPSOID);
+}
+
+double convert_height(
+  const double height, const double latitude, const double longitude,
+  const std::string & source_vertical_datum, const std::string & target_vertical_datum)
+{
+  if (source_vertical_datum == target_vertical_datum) {
+    return height;
+  }
+  std::map<std::pair<std::string, std::string>, HeightConversionFunction> conversion_map;
+  conversion_map[{"WGS84", "EGM2008"}] = convert_wgs84_to_egm2008;
+  conversion_map[{"EGM2008", "WGS84"}] = convert_egm2008_to_wgs84;
+
+  auto key = std::make_pair(source_vertical_datum, target_vertical_datum);
+  if (conversion_map.find(key) != conversion_map.end()) {
+    return conversion_map[key](height, latitude, longitude);
+  } else {
+    std::string error_message =
+      "Invalid conversion types: " + std::string(source_vertical_datum.c_str()) + " to " +
+      std::string(target_vertical_datum.c_str());
+
+    throw std::invalid_argument(error_message);
+  }
+}
+
+}  // namespace autoware::geography_utils

--- a/common/autoware_geography_utils/src/lanelet2_projector.cpp
+++ b/common/autoware_geography_utils/src/lanelet2_projector.cpp
@@ -1,0 +1,54 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <GeographicLib/Geoid.hpp>
+#include <autoware/geography_utils/lanelet2_projector.hpp>
+#include <autoware_lanelet2_extension/projection/mgrs_projector.hpp>
+#include <autoware_lanelet2_extension/projection/transverse_mercator_projector.hpp>
+
+#include <lanelet2_projection/UTM.h>
+
+namespace autoware::geography_utils
+{
+
+std::unique_ptr<lanelet::Projector> get_lanelet2_projector(const MapProjectorInfo & projector_info)
+{
+  if (projector_info.projector_type == MapProjectorInfo::LOCAL_CARTESIAN_UTM) {
+    lanelet::GPSPoint position{
+      projector_info.map_origin.latitude, projector_info.map_origin.longitude,
+      projector_info.map_origin.altitude};
+    lanelet::Origin origin{position};
+    lanelet::projection::UtmProjector projector{origin};
+    return std::make_unique<lanelet::projection::UtmProjector>(projector);
+
+  } else if (projector_info.projector_type == MapProjectorInfo::MGRS) {
+    lanelet::projection::MGRSProjector projector{};
+    projector.setMGRSCode(projector_info.mgrs_grid);
+    return std::make_unique<lanelet::projection::MGRSProjector>(projector);
+
+  } else if (projector_info.projector_type == MapProjectorInfo::TRANSVERSE_MERCATOR) {
+    lanelet::GPSPoint position{
+      projector_info.map_origin.latitude, projector_info.map_origin.longitude,
+      projector_info.map_origin.altitude};
+    lanelet::Origin origin{position};
+    lanelet::projection::TransverseMercatorProjector projector{origin};
+    return std::make_unique<lanelet::projection::TransverseMercatorProjector>(projector);
+  }
+  const std::string error_msg =
+    "Invalid map projector type: " + projector_info.projector_type +
+    ". Currently supported types: MGRS, LocalCartesianUTM, and TransverseMercator";
+  throw std::invalid_argument(error_msg);
+}
+
+}  // namespace autoware::geography_utils

--- a/common/autoware_geography_utils/src/projection.cpp
+++ b/common/autoware_geography_utils/src/projection.cpp
@@ -1,0 +1,95 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <GeographicLib/Geoid.hpp>
+#include <autoware/geography_utils/lanelet2_projector.hpp>
+#include <autoware/geography_utils/projection.hpp>
+#include <autoware_lanelet2_extension/projection/mgrs_projector.hpp>
+
+namespace autoware::geography_utils
+{
+
+Eigen::Vector3d to_basic_point_3d_pt(const LocalPoint src)
+{
+  Eigen::Vector3d dst;
+  dst.x() = src.x;
+  dst.y() = src.y;
+  dst.z() = src.z;
+  return dst;
+}
+
+LocalPoint project_forward(const GeoPoint & geo_point, const MapProjectorInfo & projector_info)
+{
+  std::unique_ptr<lanelet::Projector> projector = get_lanelet2_projector(projector_info);
+  lanelet::GPSPoint position{geo_point.latitude, geo_point.longitude, geo_point.altitude};
+
+  lanelet::BasicPoint3d projected_local_point;
+  if (projector_info.projector_type == MapProjectorInfo::MGRS) {
+    const int mgrs_precision = 9;  // set precision as 100 micro meter
+    const auto mgrs_projector = dynamic_cast<lanelet::projection::MGRSProjector *>(projector.get());
+
+    // project x and y using projector
+    // note that the altitude is ignored in MGRS projection conventionally
+    projected_local_point = mgrs_projector->forward(position, mgrs_precision);
+  } else {
+    // project x and y using projector
+    // note that the original projector such as UTM projector does not compensate for the altitude
+    // offset
+    projected_local_point = projector->forward(position);
+
+    // correct z based on the map origin
+    // note that the converted altitude in local point is in the same vertical datum as the geo
+    // point
+    projected_local_point.z() = geo_point.altitude - projector_info.map_origin.altitude;
+  }
+
+  LocalPoint local_point;
+  local_point.x = projected_local_point.x();
+  local_point.y = projected_local_point.y();
+  local_point.z = projected_local_point.z();
+
+  return local_point;
+}
+
+GeoPoint project_reverse(const LocalPoint & local_point, const MapProjectorInfo & projector_info)
+{
+  std::unique_ptr<lanelet::Projector> projector = get_lanelet2_projector(projector_info);
+
+  lanelet::GPSPoint projected_gps_point;
+  if (projector_info.projector_type == MapProjectorInfo::MGRS) {
+    const auto mgrs_projector = dynamic_cast<lanelet::projection::MGRSProjector *>(projector.get());
+    // project latitude and longitude using projector
+    // note that the z is ignored in MGRS projection conventionally
+    projected_gps_point =
+      mgrs_projector->reverse(to_basic_point_3d_pt(local_point), projector_info.mgrs_grid);
+  } else {
+    // project latitude and longitude using projector
+    // note that the original projector such as UTM projector does not compensate for the altitude
+    // offset
+    projected_gps_point = projector->reverse(to_basic_point_3d_pt(local_point));
+
+    // correct altitude based on the map origin
+    // note that the converted altitude in local point is in the same vertical datum as the geo
+    // point
+    projected_gps_point.ele = local_point.z + projector_info.map_origin.altitude;
+  }
+
+  GeoPoint geo_point;
+  geo_point.latitude = projected_gps_point.lat;
+  geo_point.longitude = projected_gps_point.lon;
+  geo_point.altitude = projected_gps_point.ele;
+  return geo_point;
+}
+
+}  // namespace autoware::geography_utils

--- a/common/autoware_geography_utils/test/test_geography_utils.cpp
+++ b/common/autoware_geography_utils/test/test_geography_utils.cpp
@@ -1,0 +1,26 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/geography_utils/height.hpp"
+#include "autoware/geography_utils/lanelet2_projector.hpp"
+#include "autoware/geography_utils/projection.hpp"
+
+#include <gtest/gtest.h>
+
+int main(int argc, char * argv[])
+{
+  testing::InitGoogleTest(&argc, argv);
+  bool result = RUN_ALL_TESTS();
+  return result;
+}

--- a/common/autoware_geography_utils/test/test_height.cpp
+++ b/common/autoware_geography_utils/test/test_height.cpp
@@ -1,0 +1,86 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <autoware/geography_utils/height.hpp>
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <string>
+
+// Test case to verify if same source and target datums return original height
+TEST(GeographyUtils, SameSourceTargetDatum)
+{
+  const double height = 10.0;
+  const double latitude = 35.0;
+  const double longitude = 139.0;
+  const std::string datum = "WGS84";
+
+  double converted_height =
+    autoware::geography_utils::convert_height(height, latitude, longitude, datum, datum);
+
+  EXPECT_DOUBLE_EQ(height, converted_height);
+}
+
+// Test case to verify valid source and target datums
+TEST(GeographyUtils, ValidSourceTargetDatum)
+{
+  // Calculated with
+  // https://www.unavco.org/software/geodetic-utilities/geoid-height-calculator/geoid-height-calculator.html
+  const double height = 10.0;
+  const double latitude = 35.0;
+  const double longitude = 139.0;
+  const double target_height = -30.18;
+
+  double converted_height =
+    autoware::geography_utils::convert_height(height, latitude, longitude, "WGS84", "EGM2008");
+
+  EXPECT_NEAR(target_height, converted_height, 0.1);
+}
+
+// Test case to verify invalid source and target datums
+TEST(GeographyUtils, InvalidSourceTargetDatum)
+{
+  const double height = 10.0;
+  const double latitude = 35.0;
+  const double longitude = 139.0;
+
+  EXPECT_THROW(
+    autoware::geography_utils::convert_height(height, latitude, longitude, "INVALID1", "INVALID2"),
+    std::invalid_argument);
+}
+
+// Test case to verify invalid source datums
+TEST(GeographyUtils, InvalidSourceDatum)
+{
+  const double height = 10.0;
+  const double latitude = 35.0;
+  const double longitude = 139.0;
+
+  EXPECT_THROW(
+    autoware::geography_utils::convert_height(height, latitude, longitude, "INVALID1", "WGS84"),
+    std::invalid_argument);
+}
+
+// Test case to verify invalid target datums
+TEST(GeographyUtils, InvalidTargetDatum)
+{
+  const double height = 10.0;
+  const double latitude = 35.0;
+  const double longitude = 139.0;
+
+  EXPECT_THROW(
+    autoware::geography_utils::convert_height(height, latitude, longitude, "WGS84", "INVALID2"),
+    std::invalid_argument);
+}

--- a/common/autoware_geography_utils/test/test_projection.cpp
+++ b/common/autoware_geography_utils/test/test_projection.cpp
@@ -1,0 +1,161 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <autoware/geography_utils/projection.hpp>
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <string>
+
+TEST(GeographyUtilsProjection, ProjectForwardToMGRS)
+{
+  // source point
+  geographic_msgs::msg::GeoPoint geo_point;
+  geo_point.latitude = 35.62426;
+  geo_point.longitude = 139.74252;
+  geo_point.altitude = 10.0;
+
+  // target point
+  geometry_msgs::msg::Point local_point;
+  local_point.x = 86128.0;
+  local_point.y = 43002.0;
+  local_point.z = 10.0;
+
+  // projector info
+  tier4_map_msgs::msg::MapProjectorInfo projector_info;
+  projector_info.projector_type = tier4_map_msgs::msg::MapProjectorInfo::MGRS;
+  projector_info.mgrs_grid = "54SUE";
+  projector_info.vertical_datum = tier4_map_msgs::msg::MapProjectorInfo::WGS84;
+
+  // conversion
+  const geometry_msgs::msg::Point converted_point =
+    autoware::geography_utils::project_forward(geo_point, projector_info);
+
+  EXPECT_NEAR(converted_point.x, local_point.x, 1.0);
+  EXPECT_NEAR(converted_point.y, local_point.y, 1.0);
+  EXPECT_NEAR(converted_point.z, local_point.z, 1.0);
+}
+
+TEST(GeographyUtilsProjection, ProjectReverseFromMGRS)
+{
+  // source point
+  geometry_msgs::msg::Point local_point;
+  local_point.x = 86128.0;
+  local_point.y = 43002.0;
+  local_point.z = 10.0;
+
+  // target point
+  geographic_msgs::msg::GeoPoint geo_point;
+  geo_point.latitude = 35.62426;
+  geo_point.longitude = 139.74252;
+  geo_point.altitude = 10.0;
+
+  // projector info
+  tier4_map_msgs::msg::MapProjectorInfo projector_info;
+  projector_info.projector_type = tier4_map_msgs::msg::MapProjectorInfo::MGRS;
+  projector_info.mgrs_grid = "54SUE";
+  projector_info.vertical_datum = tier4_map_msgs::msg::MapProjectorInfo::WGS84;
+
+  // conversion
+  const geographic_msgs::msg::GeoPoint converted_point =
+    autoware::geography_utils::project_reverse(local_point, projector_info);
+
+  EXPECT_NEAR(converted_point.latitude, geo_point.latitude, 0.0001);
+  EXPECT_NEAR(converted_point.longitude, geo_point.longitude, 0.0001);
+  EXPECT_NEAR(converted_point.altitude, geo_point.altitude, 0.0001);
+}
+
+TEST(GeographyUtilsProjection, ProjectForwardAndReverseMGRS)
+{
+  // source point
+  geographic_msgs::msg::GeoPoint geo_point;
+  geo_point.latitude = 35.62426;
+  geo_point.longitude = 139.74252;
+  geo_point.altitude = 10.0;
+
+  // projector info
+  tier4_map_msgs::msg::MapProjectorInfo projector_info;
+  projector_info.projector_type = tier4_map_msgs::msg::MapProjectorInfo::MGRS;
+  projector_info.mgrs_grid = "54SUE";
+  projector_info.vertical_datum = tier4_map_msgs::msg::MapProjectorInfo::WGS84;
+
+  // conversion
+  const geometry_msgs::msg::Point converted_local_point =
+    autoware::geography_utils::project_forward(geo_point, projector_info);
+  const geographic_msgs::msg::GeoPoint converted_geo_point =
+    autoware::geography_utils::project_reverse(converted_local_point, projector_info);
+
+  EXPECT_NEAR(converted_geo_point.latitude, geo_point.latitude, 0.0001);
+  EXPECT_NEAR(converted_geo_point.longitude, geo_point.longitude, 0.0001);
+  EXPECT_NEAR(converted_geo_point.altitude, geo_point.altitude, 0.0001);
+}
+
+TEST(GeographyUtilsProjection, ProjectForwardToLocalCartesianUTMOrigin)
+{
+  // source point
+  geographic_msgs::msg::GeoPoint geo_point;
+  geo_point.latitude = 35.62406;
+  geo_point.longitude = 139.74252;
+  geo_point.altitude = 10.0;
+
+  // target point
+  geometry_msgs::msg::Point local_point;
+  local_point.x = 0.0;
+  local_point.y = -22.18;
+  local_point.z = 20.0;
+
+  // projector info
+  tier4_map_msgs::msg::MapProjectorInfo projector_info;
+  projector_info.projector_type = tier4_map_msgs::msg::MapProjectorInfo::LOCAL_CARTESIAN_UTM;
+  projector_info.vertical_datum = tier4_map_msgs::msg::MapProjectorInfo::WGS84;
+  projector_info.map_origin.latitude = 35.62426;
+  projector_info.map_origin.longitude = 139.74252;
+  projector_info.map_origin.altitude = -10.0;
+
+  // conversion
+  const geometry_msgs::msg::Point converted_point =
+    autoware::geography_utils::project_forward(geo_point, projector_info);
+
+  EXPECT_NEAR(converted_point.x, local_point.x, 1.0);
+  EXPECT_NEAR(converted_point.y, local_point.y, 1.0);
+  EXPECT_NEAR(converted_point.z, local_point.z, 1.0);
+}
+
+TEST(GeographyUtilsProjection, ProjectForwardAndReverseLocalCartesianUTMOrigin)
+{
+  // source point
+  geographic_msgs::msg::GeoPoint geo_point;
+  geo_point.latitude = 35.62426;
+  geo_point.longitude = 139.74252;
+  geo_point.altitude = 10.0;
+
+  // projector info
+  tier4_map_msgs::msg::MapProjectorInfo projector_info;
+  projector_info.projector_type = tier4_map_msgs::msg::MapProjectorInfo::LOCAL_CARTESIAN_UTM;
+  projector_info.vertical_datum = tier4_map_msgs::msg::MapProjectorInfo::WGS84;
+  projector_info.map_origin.latitude = 35.0;
+  projector_info.map_origin.longitude = 139.0;
+  projector_info.map_origin.altitude = 0.0;
+
+  // conversion
+  const geometry_msgs::msg::Point converted_local_point =
+    autoware::geography_utils::project_forward(geo_point, projector_info);
+  const geographic_msgs::msg::GeoPoint converted_geo_point =
+    autoware::geography_utils::project_reverse(converted_local_point, projector_info);
+
+  EXPECT_NEAR(converted_geo_point.latitude, geo_point.latitude, 0.0001);
+  EXPECT_NEAR(converted_geo_point.longitude, geo_point.longitude, 0.0001);
+  EXPECT_NEAR(converted_geo_point.altitude, geo_point.altitude, 0.0001);
+}

--- a/common/autoware_geography_utils/test/test_projection.cpp
+++ b/common/autoware_geography_utils/test/test_projection.cpp
@@ -34,10 +34,10 @@ TEST(GeographyUtilsProjection, ProjectForwardToMGRS)
   local_point.z = 10.0;
 
   // projector info
-  tier4_map_msgs::msg::MapProjectorInfo projector_info;
-  projector_info.projector_type = tier4_map_msgs::msg::MapProjectorInfo::MGRS;
+  autoware_map_msgs::msg::MapProjectorInfo projector_info;
+  projector_info.projector_type = autoware_map_msgs::msg::MapProjectorInfo::MGRS;
   projector_info.mgrs_grid = "54SUE";
-  projector_info.vertical_datum = tier4_map_msgs::msg::MapProjectorInfo::WGS84;
+  projector_info.vertical_datum = autoware_map_msgs::msg::MapProjectorInfo::WGS84;
 
   // conversion
   const geometry_msgs::msg::Point converted_point =
@@ -63,10 +63,10 @@ TEST(GeographyUtilsProjection, ProjectReverseFromMGRS)
   geo_point.altitude = 10.0;
 
   // projector info
-  tier4_map_msgs::msg::MapProjectorInfo projector_info;
-  projector_info.projector_type = tier4_map_msgs::msg::MapProjectorInfo::MGRS;
+  autoware_map_msgs::msg::MapProjectorInfo projector_info;
+  projector_info.projector_type = autoware_map_msgs::msg::MapProjectorInfo::MGRS;
   projector_info.mgrs_grid = "54SUE";
-  projector_info.vertical_datum = tier4_map_msgs::msg::MapProjectorInfo::WGS84;
+  projector_info.vertical_datum = autoware_map_msgs::msg::MapProjectorInfo::WGS84;
 
   // conversion
   const geographic_msgs::msg::GeoPoint converted_point =
@@ -86,10 +86,10 @@ TEST(GeographyUtilsProjection, ProjectForwardAndReverseMGRS)
   geo_point.altitude = 10.0;
 
   // projector info
-  tier4_map_msgs::msg::MapProjectorInfo projector_info;
-  projector_info.projector_type = tier4_map_msgs::msg::MapProjectorInfo::MGRS;
+  autoware_map_msgs::msg::MapProjectorInfo projector_info;
+  projector_info.projector_type = autoware_map_msgs::msg::MapProjectorInfo::MGRS;
   projector_info.mgrs_grid = "54SUE";
-  projector_info.vertical_datum = tier4_map_msgs::msg::MapProjectorInfo::WGS84;
+  projector_info.vertical_datum = autoware_map_msgs::msg::MapProjectorInfo::WGS84;
 
   // conversion
   const geometry_msgs::msg::Point converted_local_point =
@@ -117,9 +117,9 @@ TEST(GeographyUtilsProjection, ProjectForwardToLocalCartesianUTMOrigin)
   local_point.z = 20.0;
 
   // projector info
-  tier4_map_msgs::msg::MapProjectorInfo projector_info;
-  projector_info.projector_type = tier4_map_msgs::msg::MapProjectorInfo::LOCAL_CARTESIAN_UTM;
-  projector_info.vertical_datum = tier4_map_msgs::msg::MapProjectorInfo::WGS84;
+  autoware_map_msgs::msg::MapProjectorInfo projector_info;
+  projector_info.projector_type = autoware_map_msgs::msg::MapProjectorInfo::LOCAL_CARTESIAN_UTM;
+  projector_info.vertical_datum = autoware_map_msgs::msg::MapProjectorInfo::WGS84;
   projector_info.map_origin.latitude = 35.62426;
   projector_info.map_origin.longitude = 139.74252;
   projector_info.map_origin.altitude = -10.0;
@@ -142,9 +142,9 @@ TEST(GeographyUtilsProjection, ProjectForwardAndReverseLocalCartesianUTMOrigin)
   geo_point.altitude = 10.0;
 
   // projector info
-  tier4_map_msgs::msg::MapProjectorInfo projector_info;
-  projector_info.projector_type = tier4_map_msgs::msg::MapProjectorInfo::LOCAL_CARTESIAN_UTM;
-  projector_info.vertical_datum = tier4_map_msgs::msg::MapProjectorInfo::WGS84;
+  autoware_map_msgs::msg::MapProjectorInfo projector_info;
+  projector_info.projector_type = autoware_map_msgs::msg::MapProjectorInfo::LOCAL_CARTESIAN_UTM;
+  projector_info.vertical_datum = autoware_map_msgs::msg::MapProjectorInfo::WGS84;
   projector_info.map_origin.latitude = 35.0;
   projector_info.map_origin.longitude = 139.0;
   projector_info.map_origin.altitude = 0.0;


### PR DESCRIPTION
## Description

This is a test PR.

- Reference: https://github.com/autowarefoundation/autoware.core/pull/100#pullrequestreview-2478404758

- Simple version: https://github.com/autowarefoundation/autoware.core/pull/100

I've ran these commands:

```bash
sudo apt update
sudo apt install git-filter-repo
```

a fresh clone
```console
a@b:~/projects$ git clone https://github.com/autowarefoundation/autoware.universe.git
a@b:~/projects$ cd autoware.universe
a@b:~/projects/autoware.universe$ git filter-repo --path common/autoware_geography_utils
a@b:~/projects/autoware.universe$ git checkout -b feat/add-autoware_geography_utils
a@b:~/projects/autoware.universe$ git remote add core https://github.com/autowarefoundation/autoware.core.git
a@b:~/projects/autoware.universe$ git rebase --root feat/add-autoware_geography_utils --onto core/main
```

and pushed.

This kept the commits that contributed to this package intact and rebased on top of the main.

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
