### PR TITLE
refactor(autoware_geography_utils): apply modern C++17 style

### DIFF
--- a/common/autoware_geography_utils/include/autoware/geography_utils/height.hpp
+++ b/common/autoware_geography_utils/include/autoware/geography_utils/height.hpp
@@ -20,8 +20,8 @@
 namespace autoware::geography_utils
 {
 
-typedef double (*HeightConversionFunction)(
-  const double height, const double latitude, const double longitude);
+using HeightConversionFunction = double (*)(const double height, const double latitude, const double longitude);
+
 double convert_wgs84_to_egm2008(const double height, const double latitude, const double longitude);
 double convert_egm2008_to_wgs84(const double height, const double latitude, const double longitude);
 double convert_height(

--- a/common/autoware_geography_utils/include/autoware/geography_utils/height.hpp
+++ b/common/autoware_geography_utils/include/autoware/geography_utils/height.hpp
@@ -20,7 +20,8 @@
 namespace autoware::geography_utils
 {
 
-using HeightConversionFunction = double (*)(const double height, const double latitude, const double longitude);
+using HeightConversionFunction =
+  double (*)(const double height, const double latitude, const double longitude);
 
 double convert_wgs84_to_egm2008(const double height, const double latitude, const double longitude);
 double convert_egm2008_to_wgs84(const double height, const double latitude, const double longitude);

--- a/common/autoware_geography_utils/include/autoware/geography_utils/projection.hpp
+++ b/common/autoware_geography_utils/include/autoware/geography_utils/projection.hpp
@@ -25,8 +25,10 @@ using MapProjectorInfo = autoware_map_msgs::msg::MapProjectorInfo;
 using GeoPoint = geographic_msgs::msg::GeoPoint;
 using LocalPoint = geometry_msgs::msg::Point;
 
-LocalPoint project_forward(const GeoPoint & geo_point, const MapProjectorInfo & projector_info);
-GeoPoint project_reverse(const LocalPoint & local_point, const MapProjectorInfo & projector_info);
+[[nodiscard]] LocalPoint project_forward(
+  const GeoPoint & geo_point, const MapProjectorInfo & projector_info);
+[[nodiscard]] GeoPoint project_reverse(
+  const LocalPoint & local_point, const MapProjectorInfo & projector_info);
 
 }  // namespace autoware::geography_utils
 

--- a/common/autoware_geography_utils/src/height.cpp
+++ b/common/autoware_geography_utils/src/height.cpp
@@ -18,7 +18,6 @@
 #include <map>
 #include <stdexcept>
 #include <string>
-#include <string_view>
 #include <utility>
 
 namespace autoware::geography_utils
@@ -45,7 +44,7 @@ double convert_height(
   if (source_vertical_datum == target_vertical_datum) {
     return height;
   }
-  static const std::map<std::pair<std::string_view, std::string_view>, HeightConversionFunction>
+  static const std::map<std::pair<std::string, std::string>, HeightConversionFunction>
     conversion_map{
       {{"WGS84", "EGM2008"}, convert_wgs84_to_egm2008},
       {{"EGM2008", "WGS84"}, convert_egm2008_to_wgs84},

--- a/common/autoware_geography_utils/src/lanelet2_projector.cpp
+++ b/common/autoware_geography_utils/src/lanelet2_projector.cpp
@@ -28,30 +28,32 @@ namespace autoware::geography_utils
 std::unique_ptr<lanelet::Projector> get_lanelet2_projector(const MapProjectorInfo & projector_info)
 {
   if (projector_info.projector_type == MapProjectorInfo::LOCAL_CARTESIAN_UTM) {
-    lanelet::GPSPoint position{
+    const lanelet::GPSPoint position{
       projector_info.map_origin.latitude, projector_info.map_origin.longitude,
       projector_info.map_origin.altitude};
-    lanelet::Origin origin{position};
-    lanelet::projection::UtmProjector projector{origin};
+    const lanelet::Origin origin{position};
+    const lanelet::projection::UtmProjector projector{origin};
     return std::make_unique<lanelet::projection::UtmProjector>(projector);
+  }
 
-  } else if (projector_info.projector_type == MapProjectorInfo::MGRS) {
+  if (projector_info.projector_type == MapProjectorInfo::MGRS) {
     lanelet::projection::MGRSProjector projector{};
     projector.setMGRSCode(projector_info.mgrs_grid);
     return std::make_unique<lanelet::projection::MGRSProjector>(projector);
+  }
 
-  } else if (projector_info.projector_type == MapProjectorInfo::TRANSVERSE_MERCATOR) {
-    lanelet::GPSPoint position{
+  if (projector_info.projector_type == MapProjectorInfo::TRANSVERSE_MERCATOR) {
+    const lanelet::GPSPoint position{
       projector_info.map_origin.latitude, projector_info.map_origin.longitude,
       projector_info.map_origin.altitude};
-    lanelet::Origin origin{position};
-    lanelet::projection::TransverseMercatorProjector projector{origin};
+    const lanelet::Origin origin{position};
+    const lanelet::projection::TransverseMercatorProjector projector{origin};
     return std::make_unique<lanelet::projection::TransverseMercatorProjector>(projector);
   }
-  const std::string error_msg =
+
+  throw std::invalid_argument(
     "Invalid map projector type: " + projector_info.projector_type +
-    ". Currently supported types: MGRS, LocalCartesianUTM, and TransverseMercator";
-  throw std::invalid_argument(error_msg);
+    ". Currently supported types: MGRS, LocalCartesianUTM, and TransverseMercator");
 }
 
 }  // namespace autoware::geography_utils

--- a/common/autoware_geography_utils/src/projection.cpp
+++ b/common/autoware_geography_utils/src/projection.cpp
@@ -22,23 +22,19 @@
 namespace autoware::geography_utils
 {
 
-Eigen::Vector3d to_basic_point_3d_pt(const LocalPoint src)
+[[nodiscard]] Eigen::Vector3d to_basic_point_3d_pt(const LocalPoint src)
 {
-  Eigen::Vector3d dst;
-  dst.x() = src.x;
-  dst.y() = src.y;
-  dst.z() = src.z;
-  return dst;
+  return {src.x, src.y, src.z};
 }
 
 LocalPoint project_forward(const GeoPoint & geo_point, const MapProjectorInfo & projector_info)
 {
   std::unique_ptr<lanelet::Projector> projector = get_lanelet2_projector(projector_info);
-  lanelet::GPSPoint position{geo_point.latitude, geo_point.longitude, geo_point.altitude};
+  const lanelet::GPSPoint position{geo_point.latitude, geo_point.longitude, geo_point.altitude};
 
   lanelet::BasicPoint3d projected_local_point;
   if (projector_info.projector_type == MapProjectorInfo::MGRS) {
-    const int mgrs_precision = 9;  // set precision as 100 micro meter
+    constexpr int mgrs_precision = 9;  // set precision as 100 micro meter
     const auto mgrs_projector = dynamic_cast<lanelet::projection::MGRSProjector *>(projector.get());
 
     // project x and y using projector
@@ -70,7 +66,8 @@ GeoPoint project_reverse(const LocalPoint & local_point, const MapProjectorInfo 
 
   lanelet::GPSPoint projected_gps_point;
   if (projector_info.projector_type == MapProjectorInfo::MGRS) {
-    const auto mgrs_projector = dynamic_cast<lanelet::projection::MGRSProjector *>(projector.get());
+    const auto * mgrs_projector =
+      dynamic_cast<lanelet::projection::MGRSProjector *>(projector.get());
     // project latitude and longitude using projector
     // note that the z is ignored in MGRS projection conventionally
     projected_gps_point =

--- a/common/autoware_geography_utils/src/projection.cpp
+++ b/common/autoware_geography_utils/src/projection.cpp
@@ -24,7 +24,7 @@ namespace autoware::geography_utils
 
 [[nodiscard]] Eigen::Vector3d to_basic_point_3d_pt(const LocalPoint src)
 {
-  return {src.x, src.y, src.z};
+  return Eigen::Vector3d{src.x, src.y, src.z};
 }
 
 LocalPoint project_forward(const GeoPoint & geo_point, const MapProjectorInfo & projector_info)


### PR DESCRIPTION
## Description

This PR applies modern C++17 style to `autoware_geography_utils`.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
