### PR TITLE
ci(sync-files): add global code owners

### DIFF
--- a/.github/CODEOWNERS-manual
+++ b/.github/CODEOWNERS-manual
@@ -1,1 +1,0 @@
-* mfc@autoware.org ryohsuke.mitsudome@tier4.jp yutaka.kondo@tier4.jp

--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -28,7 +28,7 @@
     - source: .github/workflows/sync-files.yaml
     - source: .github/workflows/update-codeowners-from-packages.yaml
       pre-commands: |
-        sd "          auto-merge-method: squash\n" "          auto-merge-method: squash\n          global-codeowners: @autowarefoundation/autoware-core-global-codeowners" {source}
+        sd "          auto-merge-method: squash\n" "          auto-merge-method: squash\n          global-codeowners: '@autowarefoundation/autoware-core-global-codeowners'" {source}
     - source: .clang-format
     - source: .clang-tidy
     - source: .markdown-link-check.json

--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -27,6 +27,8 @@
         sd "        with:\n" "        with:\n          local-cspell-json: .cspell.json\n" {source}
     - source: .github/workflows/sync-files.yaml
     - source: .github/workflows/update-codeowners-from-packages.yaml
+      pre-commands: |
+        sd "          auto-merge-method: squash\n" "          auto-merge-method: squash\n          global-codeowners: @autowarefoundation/autoware-core-global-codeowners" {source}
     - source: .clang-format
     - source: .clang-tidy
     - source: .markdown-link-check.json


### PR DESCRIPTION
## Description

This PR adds @autowarefoundation/autoware-core-global-codeowners  team to all packages.

And removes the manual code owners.

Detailed explanation of how the ordering in this file works: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file

### CODEOWNERS file _before_ this PR

https://github.com/autowarefoundation/autoware.core/blob/701e814822e67d119345a9e41ee702ecd06f772e/.github/CODEOWNERS

```
### Automatically generated from package.xml ###
common/autoware_geography_utils/** anh.nguyen.2@tier4.jp masahiro.sakamoto@tier4.jp ryu.yamamoto@tier4.jp shintaro.sakoda@tier4.jp taiki.yamada@tier4.jp yamato.ando@tier4.jp

### Copied from .github/CODEOWNERS-manual ###
* mfc@autoware.org ryohsuke.mitsudome@tier4.jp yutaka.kondo@tier4.jp
```

Any rule that comes later overrides the rules above.
This means, because the later coming `* name1 name2` rule is so broad and these will own all the files above. And any rules above won't have any meaning.

### CODEOWNERS file _after_ this PR

```
### Automatically generated from package.xml ###
common/autoware_geography_utils/** anh.nguyen.2@tier4.jp masahiro.sakamoto@tier4.jp ryu.yamamoto@tier4.jp shintaro.sakoda@tier4.jp taiki.yamada@tier4.jp yamato.ando@tier4.jp @autowarefoundation/autoware-core-global-codeowners

### Copied from .github/CODEOWNERS-manual ###
```

This way, the CI will add `@autowarefoundation/autoware-core-global-codeowners` automatically to the each package. And this team will be assigned as an additional code owner to all packages.

## Related links

**Similar to:**

- https://github.com/autowarefoundation/autoware.universe/pull/2315

**Follow up from:**

- https://github.com/autowarefoundation/autoware.core/pull/104
- https://github.com/autowarefoundation/autoware.core/pull/107#issuecomment-2521913266

## How was this PR tested?

- https://github.com/autowarefoundation/autoware.core/pull/115

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
