### PR TITLE
ci(sync-files): escape double quotes to avoid pre-commit modifying the file

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -28,7 +28,7 @@
     - source: .github/workflows/sync-files.yaml
     - source: .github/workflows/update-codeowners-from-packages.yaml
       pre-commands: |
-        sd "          auto-merge-method: squash\n" "          auto-merge-method: squash\n          global-codeowners: \"@autowarefoundation/autoware-core-global-codeowners\"" {source}
+        sd "          auto-merge-method: squash\n" "          auto-merge-method: squash\n          global-codeowners: \"@autowarefoundation/autoware-core-global-codeowners\"\n" {source}
     - source: .clang-format
     - source: .clang-tidy
     - source: .markdown-link-check.json

--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -28,7 +28,7 @@
     - source: .github/workflows/sync-files.yaml
     - source: .github/workflows/update-codeowners-from-packages.yaml
       pre-commands: |
-        sd "          auto-merge-method: squash\n" "          auto-merge-method: squash\n          global-codeowners: '@autowarefoundation/autoware-core-global-codeowners'" {source}
+        sd "          auto-merge-method: squash\n" "          auto-merge-method: squash\n          global-codeowners: \"@autowarefoundation/autoware-core-global-codeowners\"" {source}
     - source: .clang-format
     - source: .clang-tidy
     - source: .markdown-link-check.json


### PR DESCRIPTION
## Description

Because it was adding it with single quotes, pre-commit replaces it with double quotes. And this way it creates a useless PR.

sync-files commit
![image](https://github.com/user-attachments/assets/9cafca6b-d189-415b-bd19-0beddb594e02)

pre-commit auto-fix commit
![image](https://github.com/user-attachments/assets/d74f23ff-838a-4f89-bf5e-ca454fa87d56)

end result:
![image](https://github.com/user-attachments/assets/feb788ef-6bc4-4ffb-b993-420c07f6cbf8)

## Related links

- https://github.com/autowarefoundation/autoware.core/pull/116

Follow up from:
- https://github.com/autowarefoundation/autoware.core/pull/114

## How was this PR tested?

- https://github.com/autowarefoundation/autoware.core/actions/runs/12257350792
- https://github.com/autowarefoundation/autoware.core/pull/116

The pr was self-closed by the sync-files action ✅

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
