### PR TITLE
ci: add "unusedFunction" to .cppcheck_supressions

### DIFF
--- a/.cppcheck_suppressions
+++ b/.cppcheck_suppressions
@@ -2,3 +2,4 @@
 
 missingIncludeSystem
 unmatchedSuppression
+unusedFunction


### PR DESCRIPTION
## Description

Some packages have functions that are only used in `autoware.universe`. They cause problems in the CI check. https://github.com/autowarefoundation/autoware.core/pull/150#issuecomment-2572425103

This pull request adds "unusedFunction" to .cppcheck_supressions, following veqcc-san's recommendation. https://github.com/autowarefoundation/autoware.core/pull/150#issuecomment-2574450600

## Related links

- [Link](https://github.com/autowarefoundation/autoware.core/pull/150)

## How was this PR tested?

None.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
