### PR TITLE
feat(autoware_planning_test_manager): porting autoware_planning_test_manager package from autoware.universe

### DIFF
--- a/testing/autoware_planning_test_manager/CMakeLists.txt
+++ b/testing/autoware_planning_test_manager/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_planning_test_manager)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+ament_auto_add_library(autoware_planning_test_manager SHARED
+  src/autoware_planning_test_manager.cpp
+)
+
+ament_auto_package()

--- a/testing/autoware_planning_test_manager/README.md
+++ b/testing/autoware_planning_test_manager/README.md
@@ -1,0 +1,92 @@
+# Autoware Planning Test Manager
+
+## Background
+
+In each node of the planning module, when exceptional input, such as unusual routes or significantly deviated ego-position, is given, the node may not be prepared for such input and could crash. As a result, debugging node crashes can be time-consuming. For example, if an empty trajectory is given as input and it was not anticipated during implementation, the node might crash due to the unaddressed exceptional input when changes are merged, during scenario testing or while the system is running on an actual vehicle.
+
+## Purpose
+
+The purpose is to provide a utility for implementing tests to ensure that node operates correctly when receiving exceptional input. By utilizing this utility and implementing tests for exceptional input, the purpose is to reduce bugs that are only discovered when actually running the system, by requiring measures for exceptional input before merging PRs.
+
+## Features
+
+### Confirmation of normal operation
+
+For the test target node, confirm that the node operates correctly and publishes the required messages for subsequent nodes. To do this, test_node publish the necessary messages and confirm that the node's output is being published.
+
+### Robustness confirmation for special inputs
+
+After confirming normal operation, ensure that the test target node does not crash when given exceptional input. To do this, provide exceptional input from the test_node and confirm that the node does not crash.
+
+(WIP)
+
+## Usage
+
+```cpp
+
+TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
+{
+  rclcpp::init(0, nullptr);
+
+  // instantiate test_manager with PlanningInterfaceTestManager type
+  auto test_manager = std::make_shared<autoware::planning_test_manager::PlanningInterfaceTestManager>();
+
+  // get package directories for necessary configuration files
+  const auto autoware_test_utils_dir =
+    ament_index_cpp::get_package_share_directory("autoware_test_utils");
+  const auto target_node_dir =
+    ament_index_cpp::get_package_share_directory("target_node");
+
+  // set arguments to get the config file
+  node_options.arguments(
+    {"--ros-args", "--params-file",
+     autoware_test_utils_dir + "/config/test_vehicle_info.param.yaml", "--params-file",
+     autoware_planning_validator_dir + "/config/planning_validator.param.yaml"});
+
+  // instantiate the TargetNode with node_options
+  auto test_target_node = std::make_shared<TargetNode>(node_options);
+
+  // publish the necessary topics from test_manager second argument is topic name
+  test_manager->publishOdometry(test_target_node, "/localization/kinematic_state");
+  test_manager->publishMaxVelocity(
+    test_target_node, "velocity_smoother/input/external_velocity_limit_mps");
+
+  // set scenario_selector's input topic name(this topic is changed to test node)
+  test_manager->setTrajectoryInputTopicName("input/parking/trajectory");
+
+  // test with normal trajectory
+  ASSERT_NO_THROW(test_manager->testWithNominalTrajectory(test_target_node));
+
+  // make sure target_node is running
+  EXPECT_GE(test_manager->getReceivedTopicNum(), 1);
+
+  // test with trajectory input with empty/one point/overlapping point
+  ASSERT_NO_THROW(test_manager->testWithAbnormalTrajectory(test_target_node));
+
+  // shutdown ROS context
+  rclcpp::shutdown();
+}
+```
+
+## Implemented tests
+
+| Node                        | Test name                                                                                 | exceptional input | output         | Exceptional input pattern                                                             |
+| --------------------------- | ----------------------------------------------------------------------------------------- | ----------------- | -------------- | ------------------------------------------------------------------------------------- |
+| autoware_planning_validator | NodeTestWithExceptionTrajectory                                                           | trajectory        | trajectory     | Empty, single point, path with duplicate points                                       |
+| velocity_smoother           | NodeTestWithExceptionTrajectory                                                           | trajectory        | trajectory     | Empty, single point, path with duplicate points                                       |
+| obstacle_cruise_planner     | NodeTestWithExceptionTrajectory                                                           | trajectory        | trajectory     | Empty, single point, path with duplicate points                                       |
+| obstacle_stop_planner       | NodeTestWithExceptionTrajectory                                                           | trajectory        | trajectory     | Empty, single point, path with duplicate points                                       |
+| obstacle_velocity_limiter   | NodeTestWithExceptionTrajectory                                                           | trajectory        | trajectory     | Empty, single point, path with duplicate points                                       |
+| path_optimizer              | NodeTestWithExceptionTrajectory                                                           | trajectory        | trajectory     | Empty, single point, path with duplicate points                                       |
+| scenario_selector           | NodeTestWithExceptionTrajectoryLaneDrivingMode NodeTestWithExceptionTrajectoryParkingMode | trajectory        | scenario       | Empty, single point, path with duplicate points for scenarios:LANEDRIVING and PARKING |
+| freespace_planner           | NodeTestWithExceptionRoute                                                                | route             | trajectory     | Empty route                                                                           |
+| behavior_path_planner       | NodeTestWithExceptionRoute NodeTestWithOffTrackEgoPose                                    | route             | route odometry | Empty route Off-lane ego-position                                                     |
+| behavior_velocity_planner   | NodeTestWithExceptionPathWithLaneID                                                       | path_with_lane_id | path           | Empty path                                                                            |
+
+## Important Notes
+
+During test execution, when launching a node, parameters are loaded from the parameter file within each package. Therefore, when adding parameters, it is necessary to add the required parameters to the parameter file in the target node package. This is to prevent the node from being unable to launch if there are missing parameters when retrieving them from the parameter file during node launch.
+
+## Future extensions / Unimplemented parts
+
+(WIP)

--- a/testing/autoware_planning_test_manager/include/autoware/planning_test_manager/autoware_planning_test_manager.hpp
+++ b/testing/autoware_planning_test_manager/include/autoware/planning_test_manager/autoware_planning_test_manager.hpp
@@ -30,8 +30,7 @@
            << std::endl;                                                                         \
   }
 
-#include <autoware/component_interface_specs_universe/planning.hpp>
-#include <autoware/component_interface_utils/rclcpp.hpp>
+#include <autoware/component_interface_specs/planning.hpp>
 #include <autoware_test_utils/autoware_test_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
 

--- a/testing/autoware_planning_test_manager/include/autoware/planning_test_manager/autoware_planning_test_manager.hpp
+++ b/testing/autoware_planning_test_manager/include/autoware/planning_test_manager/autoware_planning_test_manager.hpp
@@ -1,0 +1,122 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__PLANNING_TEST_MANAGER__AUTOWARE_PLANNING_TEST_MANAGER_HPP_
+#define AUTOWARE__PLANNING_TEST_MANAGER__AUTOWARE_PLANNING_TEST_MANAGER_HPP_
+
+// since ASSERT_NO_THROW in gtest masks the exception message, redefine it.
+#define ASSERT_NO_THROW_WITH_ERROR_MSG(statement)                                                \
+  try {                                                                                          \
+    statement;                                                                                   \
+    SUCCEED();                                                                                   \
+  } catch (const std::exception & e) {                                                           \
+    FAIL() << "Expected: " << #statement                                                         \
+           << " doesn't throw an exception.\nActual: it throws. Error message: " << e.what()     \
+           << std::endl;                                                                         \
+  } catch (...) {                                                                                \
+    FAIL() << "Expected: " << #statement                                                         \
+           << " doesn't throw an exception.\nActual: it throws. Error message is not available." \
+           << std::endl;                                                                         \
+  }
+
+#include <autoware/component_interface_specs_universe/planning.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
+#include <autoware_test_utils/autoware_test_utils.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_planning_msgs/msg/trajectory.hpp>
+
+#include <gtest/gtest.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+
+#include <ctime>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace autoware::planning_test_manager
+{
+class PlanningInterfaceTestManager
+{
+public:
+  PlanningInterfaceTestManager();
+
+  template <typename InputT>
+  void publishInput(
+    const rclcpp::Node::SharedPtr target_node, const std::string & topic_name, const InputT & input,
+    const int repeat_count = 3) const
+  {
+    autoware::test_utils::publishToTargetNode(
+      test_node_, target_node, topic_name, {}, input, repeat_count);
+  }
+
+  template <typename OutputT>
+  void subscribeOutput(const std::string & topic_name)
+  {
+    const auto qos = []() {
+      if constexpr (std::is_same_v<OutputT, autoware_planning_msgs::msg::Trajectory>) {
+        return rclcpp::QoS{1};
+      }
+      return rclcpp::QoS{10};
+    }();
+
+    test_output_subs_.push_back(test_node_->create_subscription<OutputT>(
+      topic_name, qos, [this](const typename OutputT::ConstSharedPtr) { received_topic_num_++; }));
+  }
+
+  void testWithNormalTrajectory(
+    rclcpp::Node::SharedPtr target_node, const std::string & topic_name);
+  void testWithAbnormalTrajectory(
+    rclcpp::Node::SharedPtr target_node, const std::string & topic_name);
+
+  void testWithNormalRoute(rclcpp::Node::SharedPtr target_node, const std::string & topic_name);
+  void testWithAbnormalRoute(rclcpp::Node::SharedPtr target_node, const std::string & topic_name);
+
+  void testWithBehaviorNormalRoute(
+    rclcpp::Node::SharedPtr target_node, const std::string & topic_name);
+
+  void testWithNormalPathWithLaneId(
+    rclcpp::Node::SharedPtr target_node, const std::string & topic_name);
+  void testWithAbnormalPathWithLaneId(
+    rclcpp::Node::SharedPtr target_node, const std::string & topic_name);
+
+  void testWithNormalPath(rclcpp::Node::SharedPtr target_node, const std::string & topic_name);
+  void testWithAbnormalPath(rclcpp::Node::SharedPtr target_node, const std::string & topic_name);
+
+  void testWithOffTrackInitialPoses(
+    rclcpp::Node::SharedPtr target_node, const std::string & topic_name);
+
+  void testWithOffTrackOdometry(
+    rclcpp::Node::SharedPtr target_node, const std::string & topic_name);
+
+  void resetReceivedTopicNum() { received_topic_num_ = 0; }
+
+  size_t getReceivedTopicNum() const { return received_topic_num_; }
+
+  rclcpp::Node::SharedPtr getTestNode() const { return test_node_; }
+
+private:
+  // Subscriber
+  std::vector<rclcpp::SubscriptionBase::SharedPtr> test_output_subs_;
+
+  // Node
+  rclcpp::Node::SharedPtr test_node_;
+
+  size_t received_topic_num_ = 0;
+};  // class PlanningInterfaceTestManager
+
+}  // namespace autoware::planning_test_manager
+
+#endif  // AUTOWARE__PLANNING_TEST_MANAGER__AUTOWARE_PLANNING_TEST_MANAGER_HPP_

--- a/testing/autoware_planning_test_manager/include/autoware/planning_test_manager/autoware_planning_test_manager_utils.hpp
+++ b/testing/autoware_planning_test_manager/include/autoware/planning_test_manager/autoware_planning_test_manager_utils.hpp
@@ -15,8 +15,8 @@
 #ifndef AUTOWARE__PLANNING_TEST_MANAGER__AUTOWARE_PLANNING_TEST_MANAGER_UTILS_HPP_
 #define AUTOWARE__PLANNING_TEST_MANAGER__AUTOWARE_PLANNING_TEST_MANAGER_UTILS_HPP_
 #include <autoware/route_handler/route_handler.hpp>
-#include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_test_utils/autoware_test_utils.hpp>
+#include <autoware_utils/geometry/geometry.hpp>
 
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <geometry_msgs/msg/pose.hpp>

--- a/testing/autoware_planning_test_manager/include/autoware/planning_test_manager/autoware_planning_test_manager_utils.hpp
+++ b/testing/autoware_planning_test_manager/include/autoware/planning_test_manager/autoware_planning_test_manager_utils.hpp
@@ -1,0 +1,132 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__PLANNING_TEST_MANAGER__AUTOWARE_PLANNING_TEST_MANAGER_UTILS_HPP_
+#define AUTOWARE__PLANNING_TEST_MANAGER__AUTOWARE_PLANNING_TEST_MANAGER_UTILS_HPP_
+#include <autoware/route_handler/route_handler.hpp>
+#include <autoware_utils/geometry/geometry.hpp>
+#include <autoware_test_utils/autoware_test_utils.hpp>
+
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace autoware_planning_test_manager::utils
+{
+using autoware::route_handler::RouteHandler;
+using autoware_planning_msgs::msg::LaneletRoute;
+using geometry_msgs::msg::Pose;
+using nav_msgs::msg::Odometry;
+using RouteSections = std::vector<autoware_planning_msgs::msg::LaneletSegment>;
+
+inline Pose createPoseFromLaneID(
+  const lanelet::Id & lane_id, const std::string & package_name = "autoware_test_utils",
+  const std::string & map_filename = "lanelet2_map.osm")
+{
+  auto map_bin_msg = autoware::test_utils::makeMapBinMsg(package_name, map_filename);
+  // create route_handler
+  auto route_handler = std::make_shared<RouteHandler>();
+  route_handler->setMap(map_bin_msg);
+
+  // get middle idx of the lanelet
+  const auto lanelet = route_handler->getLaneletsFromId(lane_id);
+  const auto center_line = lanelet.centerline();
+  const size_t middle_point_idx = std::floor(center_line.size() / 2.0);
+
+  // get middle position of the lanelet
+  geometry_msgs::msg::Point middle_pos;
+  middle_pos.x = center_line[middle_point_idx].x();
+  middle_pos.y = center_line[middle_point_idx].y();
+
+  // get next middle position of the lanelet
+  geometry_msgs::msg::Point next_middle_pos;
+  next_middle_pos.x = center_line[middle_point_idx + 1].x();
+  next_middle_pos.y = center_line[middle_point_idx + 1].y();
+
+  // calculate middle pose
+  geometry_msgs::msg::Pose middle_pose;
+  middle_pose.position = middle_pos;
+  const double yaw = autoware_utils::calc_azimuth_angle(middle_pos, next_middle_pos);
+  middle_pose.orientation = autoware_utils::create_quaternion_from_yaw(yaw);
+
+  return middle_pose;
+}
+
+// Function to create a route from given start and goal lanelet ids
+// start pose and goal pose are set to the middle of the lanelet
+inline LaneletRoute makeBehaviorRouteFromLaneId(
+  const int & start_lane_id, const int & goal_lane_id,
+  const std::string & package_name = "autoware_test_utils",
+  const std::string & map_filename = "lanelet2_map.osm")
+{
+  LaneletRoute route;
+  route.header.frame_id = "map";
+  auto start_pose = createPoseFromLaneID(start_lane_id, package_name, map_filename);
+  auto goal_pose = createPoseFromLaneID(goal_lane_id, package_name, map_filename);
+  route.start_pose = start_pose;
+  route.goal_pose = goal_pose;
+
+  auto map_bin_msg = autoware::test_utils::makeMapBinMsg(package_name, map_filename);
+  // create route_handler
+  auto route_handler = std::make_shared<RouteHandler>();
+  route_handler->setMap(map_bin_msg);
+
+  LaneletRoute route_msg;
+  RouteSections route_sections;
+  lanelet::ConstLanelets all_route_lanelets;
+
+  // Plan the path between checkpoints (start and goal poses)
+  lanelet::ConstLanelets path_lanelets;
+  if (!route_handler->planPathLaneletsBetweenCheckpoints(start_pose, goal_pose, &path_lanelets)) {
+    return route_msg;
+  }
+
+  // Add all path_lanelets to all_route_lanelets
+  for (const auto & lane : path_lanelets) {
+    all_route_lanelets.push_back(lane);
+  }
+  // create local route sections
+  route_handler->setRouteLanelets(path_lanelets);
+  const auto local_route_sections = route_handler->createMapSegments(path_lanelets);
+  route_sections =
+    autoware::test_utils::combineConsecutiveRouteSections(route_sections, local_route_sections);
+  for (const auto & route_section : route_sections) {
+    for (const auto & primitive : route_section.primitives) {
+      std::cerr << "primitive: " << primitive.id << std::endl;
+    }
+    std::cerr << "preferred_primitive id : " << route_section.preferred_primitive.id << std::endl;
+  }
+  route_handler->setRouteLanelets(all_route_lanelets);
+  route.segments = route_sections;
+
+  route.allow_modification = false;
+  return route;
+}
+
+inline Odometry makeInitialPoseFromLaneId(const lanelet::Id & lane_id)
+{
+  Odometry current_odometry;
+  current_odometry.pose.pose = createPoseFromLaneID(lane_id);
+  current_odometry.header.frame_id = "map";
+
+  return current_odometry;
+}
+
+}  // namespace autoware_planning_test_manager::utils
+#endif  // AUTOWARE__PLANNING_TEST_MANAGER__AUTOWARE_PLANNING_TEST_MANAGER_UTILS_HPP_

--- a/testing/autoware_planning_test_manager/include/autoware_planning_test_manager/autoware_planning_test_manager.hpp
+++ b/testing/autoware_planning_test_manager/include/autoware_planning_test_manager/autoware_planning_test_manager.hpp
@@ -1,0 +1,23 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is kept for backwards compatibility. Should be removed in the future.
+// Tracked by: https://github.com/autowarefoundation/autoware.core/issues/224
+
+#ifndef AUTOWARE_PLANNING_TEST_MANAGER__AUTOWARE_PLANNING_TEST_MANAGER_HPP_
+#define AUTOWARE_PLANNING_TEST_MANAGER__AUTOWARE_PLANNING_TEST_MANAGER_HPP_
+
+#include <autoware/planning_test_manager/autoware_planning_test_manager.hpp>
+
+#endif  // AUTOWARE_PLANNING_TEST_MANAGER__AUTOWARE_PLANNING_TEST_MANAGER_HPP_

--- a/testing/autoware_planning_test_manager/include/autoware_planning_test_manager/autoware_planning_test_manager_utils.hpp
+++ b/testing/autoware_planning_test_manager/include/autoware_planning_test_manager/autoware_planning_test_manager_utils.hpp
@@ -1,0 +1,23 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is kept for backwards compatibility. Should be removed in the future.
+// Tracked by: https://github.com/autowarefoundation/autoware.core/issues/224
+
+#ifndef AUTOWARE_PLANNING_TEST_MANAGER__AUTOWARE_PLANNING_TEST_MANAGER_UTILS_HPP_
+#define AUTOWARE_PLANNING_TEST_MANAGER__AUTOWARE_PLANNING_TEST_MANAGER_UTILS_HPP_
+
+#include <autoware/planning_test_manager/autoware_planning_test_manager_utils.hpp>
+
+#endif  // AUTOWARE_PLANNING_TEST_MANAGER__AUTOWARE_PLANNING_TEST_MANAGER_UTILS_HPP_

--- a/testing/autoware_planning_test_manager/package.xml
+++ b/testing/autoware_planning_test_manager/package.xml
@@ -14,8 +14,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
-  <depend>autoware_component_interface_specs_universe</depend>
-  <depend>autoware_component_interface_utils</depend>
+  <depend>autoware_component_interface_specs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_test_utils</depend>

--- a/testing/autoware_planning_test_manager/package.xml
+++ b/testing/autoware_planning_test_manager/package.xml
@@ -24,6 +24,7 @@
   <depend>tf2_ros</depend>
   <depend>unique_identifier_msgs</depend>
   <depend>yaml_cpp_vendor</depend>
+  <!-- <depend>autoware_component_interface_utils</depend> -->
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/testing/autoware_planning_test_manager/package.xml
+++ b/testing/autoware_planning_test_manager/package.xml
@@ -16,22 +16,13 @@
 
   <depend>autoware_component_interface_specs_universe</depend>
   <depend>autoware_component_interface_utils</depend>
-  <depend>autoware_control_msgs</depend>
-  <depend>autoware_lanelet2_extension</depend>
-  <depend>autoware_map_msgs</depend>
   <depend>autoware_motion_utils</depend>
-  <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
-  <depend>autoware_route_handler</depend>
   <depend>autoware_test_utils</depend>
-  <depend>autoware_universe_utils</depend>
-  <depend>autoware_vehicle_msgs</depend>
-  <depend>lanelet2_io</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>tf2_msgs</depend>
   <depend>tf2_ros</depend>
-  <depend>tier4_planning_msgs</depend>
   <depend>unique_identifier_msgs</depend>
   <depend>yaml_cpp_vendor</depend>
 

--- a/testing/autoware_planning_test_manager/package.xml
+++ b/testing/autoware_planning_test_manager/package.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_planning_test_manager</name>
+  <version>0.0.0</version>
+  <description>ROS 2 node for testing interface of the nodes in planning module</description>
+  <maintainer email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</maintainer>
+  <maintainer email="takamasa.horibe@tier4.jp">Takamasa Horibe</maintainer>
+  <maintainer email="mamoru.sobue@tier4.jp">Mamoru Sobue</maintainer>
+  <license>Apache License 2.0</license>
+
+  <author email="kyoichi.sugahara@tier4.jp">Kyoichi Sugahara</author>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+
+  <depend>autoware_component_interface_specs_universe</depend>
+  <depend>autoware_component_interface_utils</depend>
+  <depend>autoware_control_msgs</depend>
+  <depend>autoware_lanelet2_extension</depend>
+  <depend>autoware_map_msgs</depend>
+  <depend>autoware_motion_utils</depend>
+  <depend>autoware_perception_msgs</depend>
+  <depend>autoware_planning_msgs</depend>
+  <depend>autoware_route_handler</depend>
+  <depend>autoware_test_utils</depend>
+  <depend>autoware_universe_utils</depend>
+  <depend>autoware_vehicle_msgs</depend>
+  <depend>lanelet2_io</depend>
+  <depend>nav_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>tf2_msgs</depend>
+  <depend>tf2_ros</depend>
+  <depend>tier4_planning_msgs</depend>
+  <depend>unique_identifier_msgs</depend>
+  <depend>yaml_cpp_vendor</depend>
+
+  <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/testing/autoware_planning_test_manager/src/autoware_planning_test_manager.cpp
+++ b/testing/autoware_planning_test_manager/src/autoware_planning_test_manager.cpp
@@ -1,0 +1,125 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware_planning_test_manager/autoware_planning_test_manager.hpp"
+
+#include <autoware/motion_utils/trajectory/conversion.hpp>
+
+#include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <autoware_planning_msgs/msg/path.hpp>
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+namespace autoware::planning_test_manager
+{
+using autoware_internal_planning_msgs::msg::PathWithLaneId;
+using autoware_planning_msgs::msg::LaneletRoute;
+using autoware_planning_msgs::msg::Path;
+using autoware_planning_msgs::msg::Trajectory;
+
+PlanningInterfaceTestManager::PlanningInterfaceTestManager()
+{
+  test_node_ = std::make_shared<rclcpp::Node>("planning_interface_test_node");
+}
+
+void PlanningInterfaceTestManager::testWithNormalTrajectory(
+  rclcpp::Node::SharedPtr target_node, const std::string & topic_name)
+{
+  publishInput(
+    target_node, topic_name, autoware::test_utils::generateTrajectory<Trajectory>(10, 1.0), 5);
+}
+
+void PlanningInterfaceTestManager::testWithAbnormalTrajectory(
+  rclcpp::Node::SharedPtr target_node, const std::string & topic_name)
+{
+  publishInput(target_node, topic_name, Trajectory{}, 5);
+  publishInput(
+    target_node, topic_name, autoware::test_utils::generateTrajectory<Trajectory>(1, 0.0), 5);
+  publishInput(
+    target_node, topic_name,
+    autoware::test_utils::generateTrajectory<Trajectory>(10, 0.0, 0.0, 0.0, 0.0, 1), 5);
+}
+
+void PlanningInterfaceTestManager::testWithNormalRoute(
+  rclcpp::Node::SharedPtr target_node, const std::string & topic_name)
+{
+  publishInput(target_node, topic_name, autoware::test_utils::makeNormalRoute(), 5);
+}
+
+void PlanningInterfaceTestManager::testWithAbnormalRoute(
+  rclcpp::Node::SharedPtr target_node, const std::string & topic_name)
+{
+  publishInput(target_node, topic_name, LaneletRoute{}, 5);
+}
+
+void PlanningInterfaceTestManager::testWithBehaviorNormalRoute(
+  rclcpp::Node::SharedPtr target_node, const std::string & topic_name)
+{
+  publishInput(target_node, topic_name, autoware::test_utils::makeBehaviorNormalRoute(), 5);
+}
+
+void PlanningInterfaceTestManager::testWithNormalPathWithLaneId(
+  rclcpp::Node::SharedPtr target_node, const std::string & topic_name)
+{
+  try {
+    const auto path = autoware::test_utils::loadPathWithLaneIdInYaml();
+    publishInput(target_node, topic_name, path, 5);
+  } catch (const std::exception & e) {
+    std::cerr << e.what() << '\n';
+  }
+}
+
+void PlanningInterfaceTestManager::testWithAbnormalPathWithLaneId(
+  rclcpp::Node::SharedPtr target_node, const std::string & topic_name)
+{
+  publishInput(target_node, topic_name, PathWithLaneId{}, 5);
+}
+
+void PlanningInterfaceTestManager::testWithNormalPath(
+  rclcpp::Node::SharedPtr target_node, const std::string & topic_name)
+{
+  try {
+    const auto path = autoware::test_utils::loadPathWithLaneIdInYaml();
+    publishInput(
+      target_node, topic_name, autoware::motion_utils::convertToPath<PathWithLaneId>(path), 5);
+  } catch (const std::exception & e) {
+    std::cerr << e.what() << '\n';
+  }
+}
+
+void PlanningInterfaceTestManager::testWithAbnormalPath(
+  rclcpp::Node::SharedPtr target_node, const std::string & topic_name)
+{
+  publishInput(target_node, topic_name, Path{}, 5);
+}
+
+void PlanningInterfaceTestManager::testWithOffTrackInitialPoses(
+  rclcpp::Node::SharedPtr target_node, const std::string & topic_name)
+{
+  for (const auto & deviation : {0.0, 1.0, 10.0, 100.0}) {
+    publishInput(target_node, topic_name, autoware::test_utils::makeInitialPose(deviation), 5);
+  }
+}
+
+void PlanningInterfaceTestManager::testWithOffTrackOdometry(
+  rclcpp::Node::SharedPtr target_node, const std::string & topic_name)
+{
+  for (const auto & deviation : {0.0, 1.0, 10.0, 100.0}) {
+    publishInput(target_node, topic_name, autoware::test_utils::makeOdometry(deviation), 5);
+  }
+}
+}  // namespace autoware::planning_test_manager


### PR DESCRIPTION
## Description
We are porting autoware_planning_test_manager to autoware.core, and this PR adds the package to core.

Following modification were added:
- reset version in package.xml and remove CHANGELOG.rst
- modify include file directory structure to match with [Autoware Coding Guideline](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/directory-structure/#directory-structure)


## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware.core/issues/198

## How was this PR tested?

The whole project is built correctly locally. 
The github CICD errors are related to dependence to autoware.universe.
The launch failed locally and will be re-executed after the dependency resolved.

**Update:** Planning simulator works well in the following code version:
<details><summary>Version Information</summary>
<p>

- === ./core/autoware-github-actions (git) ===
  - main
  - commit a59cae0e24e46c8f04ddb0a1c5b9b9ddbb2fcd5b (HEAD -> main, origin/main, origin/HEAD)

- === ./core/autoware.core (git) ===
  - porting/autoware_planning_test_manager
  - commit 097421b7719023f31e5312f9621f56f5b15664a7 (HEAD -> porting/autoware_planning_test_manager, origin/porting/autoware_planning_test_manager)

- === ./core/autoware_adapi_msgs (git) ===
  - main
  - commit 7c2e79e3b50eeec857a4e5c9e6bfe343245de5b4 (HEAD -> main, tag: 1.7.0, origin/main, origin/HEAD)

- === ./core/autoware_cmake (git) ===
  - main
  - commit cff8b194d0c2d3b7a58a3cc405de254e49da1560 (HEAD -> main, origin/main, origin/HEAD)

- === ./core/autoware_internal_msgs (git) ===
  - main
  - commit 04484399dc98fb4b12f292128aea687a7b13d53e (HEAD -> main, tag: 1.6.0, origin/main, origin/HEAD)

- === ./core/autoware_lanelet2_extension (git) ===
  - main
  - commit c84775e2d13e559e12ca6998b8405a45bedb45dc (HEAD -> main, origin/main, origin/HEAD)

- === ./core/autoware_msgs (git) ===
  - main
  - commit 2a54c182c5a166eb8a55a2dfadc9c144232b1bf2 (HEAD -> main, tag: 1.4.0, origin/main, origin/HEAD)

- === ./core/autoware_utils (git) ===
  - main
  - commit 2a2ffa0f3aa554accf8d6e353063772d81ebde5a (HEAD -> main, tag: 1.2.0, origin/main, origin/HEAD)

- === ./core/external/autoware_auto_msgs (git) ===
  - tier4/main
  - commit 624aae9feb142eb2a4e16069ed06bf4050ccc3ea (HEAD -> tier4/main, origin/tier4/main, origin/HEAD)

- === ./launcher/autoware_launch (git) ===
  - main
  - commit 740164dec75097149cde7e9f4ceb3cef1766e447 (HEAD -> main, origin/main, origin/HEAD)

- === ./middleware/external/heaphook (git) ===
  - main
  - commit 856418ff7963d94972fe489da64fbbf36c54ac82 (HEAD -> main, origin/main, origin/HEAD)

- === ./param/autoware_individual_params (git) ===
  - main
  - commit 70000825155182d9261ce0980076b0e2c6dc3f51 (HEAD -> main, origin/main, origin/HEAD)

- === ./sensor_component/external/nebula (git) ===
  - （头指针在 v0.2.1 分离）
  - commit f43a28d1a8a51aca5efcae9186139767154bc44f (HEAD, tag: v0.2.1)

- === ./sensor_component/external/sensor_component_description (git) ===
  - main
  - commit 079820003a1c969df7fa02ca092e532c66ab809e (HEAD -> main, origin/main, origin/HEAD)

- === ./sensor_component/external/tamagawa_imu_driver (git) ===
  - ros2
  - commit de4bf6be79aa2968cf2f62e0ebe1ff8a5797e6ad (HEAD -> ros2, origin/ros2, origin/HEAD)

- === ./sensor_component/ros2_socketcan (git) ===
  - main
  - commit e39a814180b03f00a5692b6951a5d4e9f0463486 (HEAD -> main, origin/main, origin/HEAD)

- === ./sensor_component/transport_drivers (git) ===
  - main
  - commit 39ebd8afe1bb9760a6cd6272e428468480f6de90 (HEAD -> main, origin/main, origin/HEAD)

- === ./sensor_kit/awsim_labs_sensor_kit_launch (git) ===
  - main
  - commit 0408a820fc93bee269b16cdb7ee13e5d0b3e8625 (HEAD -> main, origin/main, origin/HEAD)

- === ./sensor_kit/external/awsim_sensor_kit_launch (git) ===
  - main
  - commit 9a2bec455ae3c4616b5e52bf7062ceeced82fbbf (HEAD -> main, origin/main, origin/HEAD)

- === ./sensor_kit/sample_sensor_kit_launch (git) ===
  - main
  - commit 561034ec56328329ade3a52e1ebbed5db70cdc06 (HEAD -> main, origin/main, origin/HEAD)

- === ./sensor_kit/single_lidar_sensor_kit_launch (git) ===
  - main
  - commit bfbf37b50481e9173c5888f9739f4eabaa45d10e (HEAD -> main, origin/main, origin/HEAD)

- === ./universe/autoware.universe (git) ===
  - porting/autoware_planning_test_manager
  - commit e306a315dafee7d4f5897f137a5abb513af3d20e (HEAD -> porting/autoware_planning_test_manager)

- === ./universe/external/eagleye (git) ===
  - autoware-main
  - commit c1919448336e86a8dd9c94a337032c05fcf6c381 (HEAD -> autoware-main, origin/autoware-main)

- === ./universe/external/glog (git) ===
  - v0.6.0_t4-ros
  - commit ea36766fdc2ac8e8c8e3ac988ae69acd6d09bb30 (HEAD -> v0.6.0_t4-ros, origin/v0.6.0_t4-ros)

- === ./universe/external/llh_converter (git) ===
  - ros2
  - commit 07ad112b4f6b83eccd3a5f777bbe40ff01c67382 (HEAD -> ros2, origin/ros2)

- === ./universe/external/morai_msgs (git) ===
  - （头指针在 e2e75fc 分离）
  - commit e2e75fc1603a9798773e467a679edf68b448e705 (HEAD)

- === ./universe/external/muSSP (git) ===
  - tier4/main
  - commit c79e98fd5e658f4f90c06d93472faa977bc873b9 (HEAD -> tier4/main, origin/tier4/main, origin/HEAD)

- === ./universe/external/pointcloud_to_laserscan (git) ===
  - tier4/main
  - commit d969ec699f84fad827fbadfa3001c9c657482fbe (HEAD -> tier4/main, origin/tier4/main, origin/HEAD)

- === ./universe/external/rtklib_ros_bridge (git) ===
  - ros2-v0.1.0
  - commit ef094407bba4f475a8032972e0c60cbb939b51b8 (HEAD -> ros2-v0.1.0, origin/ros2-v0.1.0)

- === ./universe/external/tier4_ad_api_adaptor (git) ===
  - tier4/universe
  - commit 278e32d1bc3f14cb79e27c6ef8131db82504769d (HEAD -> tier4/universe, tag: 0.41.0, origin/tier4/universe, origin/sync-micro-bus, origin/HEAD)

- === ./universe/external/tier4_autoware_msgs (git) ===
  - tier4/universe
  - commit e6d504b0bf4fc80d994a92fc7a783bdca11ac8d0 (HEAD -> tier4/universe, tag: v0.41.0, origin/tier4/universe, origin/HEAD)

- === ./universe/external/trt_batched_nms (git) ===
  - main
  - commit 1a9df130b4a5d96c25019b5793abbfde42d237ac (HEAD -> main, origin/main, origin/HEAD)

- === ./vehicle/awsim_labs_vehicle_launch (git) ===
  - main
  - commit be791b9b257ef6a440c635f95438310abf876d95 (HEAD -> main, origin/main, origin/HEAD)

- === ./vehicle/external/pacmod_interface (git) ===
  - main
  - commit 1c033a21ce0c41cd4fb878b95d3e1620de79e95a (HEAD -> main, origin/main, origin/HEAD)

- === ./vehicle/sample_vehicle_launch (git) ===
  - main
  - commit cd852aed85aaf033a0747050cf4300967e89c1ae (HEAD -> main, origin/main, origin/HEAD)

</p>
</details> 

## Notes for reviewers

This PR should be handled together with
- https://github.com/autowarefoundation/autoware.universe/pull/10164

This PR depends on
- https://github.com/autowarefoundation/autoware.core/pull/172

This PR depends on autoware_component_interface_utils(not ported from universe yet). **Update:** The header file referenced in this package is not used. So the reference of autoware_component_interface_utils is deleted.


## Interface changes

None.

## Effects on system behavior

None.
