### PR TITLE
chore(autoware_motion_utils): add error handling, adapt to edge cases, and use an iterator-based algorithm

### DIFF
--- a/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp
+++ b/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp
@@ -29,6 +29,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <numeric>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -725,11 +726,19 @@ double calcSignedArcLength(const T & points, const size_t src_idx, const size_t 
     return -calcSignedArcLength(points, dst_idx, src_idx);
   }
 
-  double dist_sum = 0.0;
-  for (size_t i = src_idx; i < dst_idx; ++i) {
-    dist_sum += autoware_utils::calc_distance2d(points.at(i), points.at(i + 1));
+  if ((src_idx > points.size() - 1) || (dst_idx > points.size())) {
+    throw std::out_of_range(
+      "Out of bounds index received. point.size() = " + std::to_string(points.size()) +
+      ", src_idx = " + std::to_string(src_idx) + ", dst_idx = " + std::to_string(dst_idx));
   }
-  return dist_sum;
+  if (src_idx == points.size() - 1) {
+    return 0.0;
+  }
+  return std::accumulate(
+    std::next(points.begin(), src_idx), std::next(points.begin(), dst_idx), 0.0,
+    [](double sum, const auto & point) {
+      return sum + autoware_utils::calc_distance2d(point, *std::next(&point));
+    });
 }
 
 extern template double calcSignedArcLength<std::vector<autoware_planning_msgs::msg::PathPoint>>(


### PR DESCRIPTION
## Description

1. If given index of points are out of range, make it to throw out_of_range exception.
2. If src_idx is end, return 0.0 as a distance.
3. Use the range based accumulation algorithm.

## Related links

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Unit Test

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
