### PR TITLE
ci(update-codeowners-from-packages): add build label

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -28,6 +28,7 @@
     - source: .github/workflows/sync-files.yaml
     - source: .github/workflows/update-codeowners-from-packages.yaml
       pre-commands: |
+        sd "            tag:update-codeowners-from-packages\n" "            tag:update-codeowners-from-packages\n            tag:run:build-and-test-differential\n" {source}
         sd "          auto-merge-method: squash\n" "          auto-merge-method: squash\n          global-codeowners: \"@autowarefoundation/autoware-core-global-codeowners\"\n" {source}
     - source: .clang-format
     - source: .clang-tidy

--- a/.github/workflows/update-codeowners-from-packages.yaml
+++ b/.github/workflows/update-codeowners-from-packages.yaml
@@ -34,6 +34,5 @@ jobs:
           pr-labels: |
             tag:bot
             tag:update-codeowners-from-packages
-            tag:run:build-and-test-differential
           auto-merge-method: squash
           global-codeowners: "@autowarefoundation/autoware-core-global-codeowners"

--- a/.github/workflows/update-codeowners-from-packages.yaml
+++ b/.github/workflows/update-codeowners-from-packages.yaml
@@ -34,5 +34,6 @@ jobs:
           pr-labels: |
             tag:bot
             tag:update-codeowners-from-packages
+            tag:run:build-and-test-differential
           auto-merge-method: squash
           global-codeowners: "@autowarefoundation/autoware-core-global-codeowners"


### PR DESCRIPTION
## Description

When this workflow tenerates a PR, we need to add the label manually to make it pass the CI.

This PR automates that.

## How was this PR tested?

I will test with manual dispatch on the sync-files change to see if `sd` command works as expected.

- ✅ https://github.com/autowarefoundation/autoware.core/pull/212#issuecomment-2674326969

## Notes for reviewers

None.

## Interface changes

None.


## Effects on system behavior

None.
