### PR TITLE
feat(path_generator): add path cut feature

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -2,5 +2,6 @@
   "_comment": "configuration file for spell-check workflow",
   "ignorePaths": [],
   "ignoreRegExpList": [],
-  "words": []
+  // makeIndexedSegmenTree: temporary workaround until https://github.com/fzi-forschungszentrum-informatik/Lanelet2/pull/388 is merged
+  "words": ["makeIndexedSegmenTree"]
 }

--- a/.cspell.json
+++ b/.cspell.json
@@ -2,6 +2,5 @@
   "_comment": "configuration file for spell-check workflow",
   "ignorePaths": [],
   "ignoreRegExpList": [],
-  // makeIndexedSegmenTree: temporary workaround until https://github.com/fzi-forschungszentrum-informatik/Lanelet2/pull/388 is merged
   "words": ["makeIndexedSegmenTree"]
 }

--- a/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
+++ b/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
@@ -102,6 +102,30 @@ std::vector<std::pair<lanelet::ConstPoints3d, std::pair<double, double>>> get_wa
   const double group_separation_threshold, const double interval_margin_ratio);
 
 /**
+ * @brief get position of first self-intersection (point where return
+ * path intersects outward path) of lanelet sequence in arc length
+ * @param lanelet_sequence target lanelet sequence (both left and right bound are
+ * considered)
+ * @param s_start longitudinal distance of point to start searching for self-intersections
+ * @param s_end longitudinal distance of point to end search
+ * @return longitudinal distance of self-intersecting point (std::nullopt if no
+ * self-intersection)
+ */
+std::optional<double> get_first_self_intersection_arc_length(
+  const lanelet::LaneletSequence & lanelet_sequence, const double s_start, const double s_end);
+
+/**
+ * @brief get position of first self-intersection of line string in arc length
+ * @param line_string target line string
+ * @param s_start longitudinal distance of point to start searching for self-intersections
+ * @param s_end longitudinal distance of point to end search
+ * @return longitudinal distance of self-intersecting point (std::nullopt if no
+ * self-intersection)
+ */
+std::optional<double> get_first_self_intersection_arc_length(
+  const lanelet::BasicLineString2d & line_string, const double s_start, const double s_end);
+
+/**
  * @brief get bound of path cropped within specified range
  * @param lanelet_bound original bound of lanelet
  * @param lanelet_centerline centerline of lanelet

--- a/planning/autoware_path_generator/package.xml
+++ b/planning/autoware_path_generator/package.xml
@@ -7,11 +7,13 @@
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <maintainer email="takayuki.murooka@tier4.jp">Takayuki Murooka</maintainer>
   <maintainer email="mitsuhiro.sakamoto@tier4.jp">Mitsuhiro Sakamoto</maintainer>
+  <maintainer email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</maintainer>
   <license>Apache License 2.0</license>
 
   <author email="satoshi.ota@tier4.jp">Satoshi Ota</author>
   <author email="takayuki.murooka@tier4.jp">Takayuki Murooka</author>
   <author email="mitsuhiro.sakamoto@tier4.jp">Mitsuhiro Sakamoto</author>
+  <author email="kosuke.takeuchi@tier4.jp">Kosuke Takeuchi</author>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>

--- a/planning/autoware_path_generator/src/node.cpp
+++ b/planning/autoware_path_generator/src/node.cpp
@@ -245,6 +245,12 @@ std::optional<PathWithLaneId> PathGenerator::generate_path(
       s_end = std::min(s_end, goal_arc_coordinates.length);
     }
 
+    if (
+      const auto s_intersection =
+        utils::get_first_self_intersection_arc_length(lanelet_sequence, s_start, s_end)) {
+      s_end = std::clamp(s_end, 0.0, *s_intersection - vehicle_info_.max_longitudinal_offset_m);
+    }
+
     return s_end;
   }();
 


### PR DESCRIPTION
## Description

based on
https://github.com/mitukou1109/autoware.core/pull/2, fix for latest main branch ( thanks @mitukou1109 

This PR adds a feature to cut the path before the self-intersection to avoid incorrect neighbor search.

1 ) not cut if no self intersection

![image](https://github.com/user-attachments/assets/726452ac-149f-4c37-86ec-87ce4cb8824d)

2 ) 
cut if self intersection

![image](https://github.com/user-attachments/assets/53c579b5-b567-4830-b840-d82cef16f811)

not cut after passing self intersection point

![image](https://github.com/user-attachments/assets/18c82788-145c-45c1-b4b2-8eeafbc8a7c5)


## Related links


- https://tier4.atlassian.net/browse/RT1-9047 (tier4 internal)


**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Psim

[Screencast from 2025年02月07日 15時33分28秒.webm](https://github.com/user-attachments/assets/45dfbbc7-6d82-4589-be6e-a11bfa3739c0)




## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
