### PR TITLE
fix(autoware_trajectory): fix a bug of align_orientation_with_trajectory_direction

### DIFF
--- a/common/autoware_trajectory/src/pose.cpp
+++ b/common/autoware_trajectory/src/pose.cpp
@@ -112,46 +112,47 @@ void Trajectory<PointType>::align_orientation_with_trajectory_direction()
   for (const auto & s : bases_) {
     const double azimuth = this->azimuth(s);
     const double elevation = this->elevation(s);
+
     const geometry_msgs::msg::Quaternion current_orientation =
       orientation_interpolator_->compute(s);
+
     tf2::Quaternion current_orientation_tf2(
       current_orientation.x, current_orientation.y, current_orientation.z, current_orientation.w);
     current_orientation_tf2.normalize();
-    const tf2::Vector3 x_axis(1.0, 0.0, 0.0);
-    const tf2::Vector3 current_x_axis = tf2::quatRotate(current_orientation_tf2, x_axis);
 
+    // Calculate the current x-axis of the orientation (local x-axis)
+    const tf2::Vector3 current_x_axis =
+      tf2::quatRotate(current_orientation_tf2, tf2::Vector3(1, 0, 0));
+
+    // Calculate the desired x-axis direction based on the trajectory's azimuth and elevation
     const tf2::Vector3 desired_x_axis(
       std::cos(elevation) * std::cos(azimuth), std::cos(elevation) * std::sin(azimuth),
       std::sin(elevation));
+
+    // Compute the dot product and the angle between the current and desired x-axes
     const double dot_product = current_x_axis.dot(desired_x_axis);
     const double rotation_angle = std::acos(dot_product);
 
-    tf2::Quaternion delta_q;
-    // Compute cross product
-    tf2::Vector3 cross = current_x_axis.cross(desired_x_axis);
-    // Check if cross product is near zero vector
-    if (cross.length2() < 1e-6) {
-      // Vectors are parallel or anti-parallel
-      if (dot_product > 0.9999) {
-        // Vectors are nearly identical; no rotation needed
-        delta_q = tf2::Quaternion(0, 0, 0, 1);  // Identity quaternion
-      } else if (dot_product < -0.9999) {
-        // Vectors are opposite; choose an arbitrary axis perpendicular to current_x_axis
-        tf2::Vector3 arbitrary_axis(0.0, 1.0, 0.0);
-        if (std::abs(current_x_axis.dot(arbitrary_axis)) > 0.9999) {
-          arbitrary_axis = tf2::Vector3(0.0, 0.0, 1.0);
-        }
-        tf2::Vector3 rotation_axis = current_x_axis.cross(arbitrary_axis).normalized();
-        delta_q = tf2::Quaternion(rotation_axis, M_PI);
-      }
+    tf2::Vector3 rotation_axis;
+    // If the rotation angle is nearly 0 or 180 degrees, choose a default rotation axis
+    if (std::abs(rotation_angle) < 1e-6 || std::abs(rotation_angle - M_PI) < 1e-6) {
+      // Use the rotated z-axis as the fallback axis
+      rotation_axis = tf2::quatRotate(current_orientation_tf2, tf2::Vector3(0, 0, 1));
     } else {
-      tf2::Vector3 rotation_axis = cross.normalized();
-      delta_q = tf2::Quaternion(rotation_axis, rotation_angle);
+      // Otherwise, compute the rotation axis using the cross product of the current and desired
+      // x-axes
+      tf2::Vector3 cross = current_x_axis.cross(desired_x_axis);
+      rotation_axis = cross.normalized();
     }
 
+    // Create a quaternion representing the rotation required to align the x-axis
+    tf2::Quaternion delta_q = tf2::Quaternion(rotation_axis, rotation_angle);
+
+    // Apply the rotation delta to the current orientation and normalize the result
     const tf2::Quaternion aligned_orientation_tf2 =
       (delta_q * current_orientation_tf2).normalized();
 
+    // Convert the tf2 quaternion back to geometry_msgs quaternion format
     geometry_msgs::msg::Quaternion aligned_orientation;
     aligned_orientation.x = aligned_orientation_tf2.x();
     aligned_orientation.y = aligned_orientation_tf2.y();
@@ -163,7 +164,7 @@ void Trajectory<PointType>::align_orientation_with_trajectory_direction()
   const bool success = orientation_interpolator_->build(bases_, aligned_orientations);
   if (!success) {
     throw std::runtime_error(
-      "Failed to build orientation interpolator.");  // This Exception should not be thrown.
+      "Failed to build orientation interpolator.");  // This exception should not be thrown.
   }
 }
 

--- a/common/autoware_trajectory/src/pose.cpp
+++ b/common/autoware_trajectory/src/pose.cpp
@@ -114,7 +114,6 @@ void Trajectory<PointType>::align_orientation_with_trajectory_direction()
     const double elevation = this->elevation(s);
     const geometry_msgs::msg::Quaternion current_orientation =
       orientation_interpolator_->compute(s);
-
     tf2::Quaternion current_orientation_tf2(
       current_orientation.x, current_orientation.y, current_orientation.z, current_orientation.w);
     current_orientation_tf2.normalize();
@@ -128,7 +127,6 @@ void Trajectory<PointType>::align_orientation_with_trajectory_direction()
       std::cos(elevation) * std::cos(azimuth), std::cos(elevation) * std::sin(azimuth),
       std::sin(elevation));
 
-    // Compute the dot product and the angle between the current and desired x-axes
     const double dot_product = current_x_axis.dot(desired_x_axis);
     const double rotation_angle = std::acos(dot_product);
 
@@ -151,7 +149,6 @@ void Trajectory<PointType>::align_orientation_with_trajectory_direction()
     const tf2::Quaternion aligned_orientation_tf2 =
       (delta_q * current_orientation_tf2).normalized();
 
-    // Convert the tf2 quaternion back to geometry_msgs quaternion format
     geometry_msgs::msg::Quaternion aligned_orientation;
     aligned_orientation.x = aligned_orientation_tf2.x();
     aligned_orientation.y = aligned_orientation_tf2.y();


### PR DESCRIPTION
## Description

Fix a bug of align_orientation_with_trajectory_direction.

Previously, we have used the following geometric relations to align the orientation.

![Untitled-2025-02-04-1150](https://github.com/user-attachments/assets/0d4b92dd-7a9a-4d48-8f81-c4238e17e37e)

However, if the rotation angle is 0 or M_PI, the rotation axis is not unique.
In this PR, I specify rotation axis as z-axis when rotation axis is 0 or M_PI.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

~~One of the reviewer @sasakisasaki is doing the tests now.~~ → **Now tested as follows**.
The PR author @yhisaki and @sasakisasaki are having the discussion in the same office.

### Tests Performed

**(Written by @sasakisasaki at 16:00 JST 4th Mar. 2025)** I checked as the following steps.
- Before applying the fix provided by this PR, I ran the scenario simulator tests on my local environment.
- I tried the case when the rotation angle is exactly zero and verified the normalized rotation axis became `nan` due to divided by zero-length: this finally generates invalid aligned orientation.
- I applied the change provided by this PR.
- Then re-run the same scenario simulator tests with the same condition.
- The divided-by-zero error disappears and the [failed scenario](https://evaluation.tier4.jp/evaluation/reports/ffc647ca-4989-5603-a8aa-b2ee9d52780f/tests/c1d426b0-0ec6-5ff1-a78d-7fe9d683e7c3/233d6876-2ce6-5016-aa4f-709863c42b9e/4f058399-7e1b-5bc2-ab3d-8f9d572435c9?project_id=prd_jt&state=failed) finally succeeded on my local machine.
  - Though only limited person can execute this command, let me share the command I used
```
$ webauto ci scenario run --project-id prd_jt --scenario-id 380415ee-f507-4676-8a15-e1eff8f7d4c7 --scenario-version-id 30 --scenario-parameters '__tier4_modifier_max_deceleration=1.0787315,__tier4_modifier_max_goal_lateral_deviation=0.15,__tier4_modifier_max_goal_longitudinal_deviation=0.1,__tier4_modifier_max_goal_yaw_deviation=0.0349066,__tier4_modifier_max_steer_angle=0.64' --simulation-name planning_sim_v2
```
- Thus, I declare that this PR solve the issue when the rotation angle is zero

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

(ADDED by reviewer @sasakisasaki) Bug fix for `void Trajectory<PointType>::align_orientation_with_trajectory_direction()` will be applied for all `autoware.core` users.