### PR TITLE
fix(autoware_test_utils): set timestamp in building trajectory msg

### DIFF
--- a/testing/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
+++ b/testing/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
@@ -374,6 +374,7 @@ T generateTrajectory(
   using Point = typename T::_points_type::value_type;
 
   T traj;
+  traj.header.stamp = rclcpp::Clock{RCL_ROS_TIME}.now();
   for (size_t i = 0; i < num_points; ++i) {
     const double theta = init_theta + static_cast<double>(i) * delta_theta;
     const double x = static_cast<double>(i) * point_interval * std::cos(theta);
@@ -399,6 +400,7 @@ inline PathWithLaneId generateTrajectory<PathWithLaneId>(
   const double init_theta, const double delta_theta, const size_t overlapping_point_index)
 {
   PathWithLaneId traj;
+  traj.header.stamp = rclcpp::Clock{RCL_ROS_TIME}.now();
 
   for (size_t i = 0; i < num_points; i++) {
     const double theta = init_theta + static_cast<double>(i) * delta_theta;


### PR DESCRIPTION
## Description

Set stamp so that we can test latency abnormality.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware.universe/pull/10241

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

PASS CI/CD

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
