### PR TITLE
fix(path_generator): set current pose appropriately in test

### DIFF
--- a/planning/autoware_path_generator/test/test_path_generator_node_interface.cpp
+++ b/planning/autoware_path_generator/test/test_path_generator_node_interface.cpp
@@ -50,7 +50,10 @@ TEST(PlanningModuleInterfaceTest, NodeTestWithExceptionTrajectory)
   test_manager->publishInput(
     test_target_node, "path_generator/input/vector_map", autoware::test_utils::makeMapBinMsg());
   test_manager->publishInput(
-    test_target_node, "path_generator/input/odometry", autoware::test_utils::makeOdometry());
+    test_target_node, "path_generator/input/odometry",
+    autoware::test_utils::makeOdometry().set__pose(
+      geometry_msgs::msg::PoseWithCovariance{}.set__pose(
+        autoware::test_utils::makeBehaviorNormalRoute().start_pose)));
 
   // create subscriber in test_manager
   test_manager->subscribeOutput<autoware_internal_planning_msgs::msg::PathWithLaneId>(


### PR DESCRIPTION
## Description

This PR fixes the node interface test. The ego's current pose was set to the origin, which meant that it was not on the route.

## Related links

internal: https://star4.slack.com/archives/C0575HP7NJG/p1741562457780569

## How was this PR tested?

```
colcon test --packages-select autoware_path_generator --event-handlers console_cohesion+
```
Result (the value display is for debugging and is not part of the PR):
```
1: [ RUN      ] PlanningModuleInterfaceTest.NodeTestWithExceptionTrajectory
1: [INFO] [1741576257.180988020] [path_generator]: length: 12.914741, start: 4.440289, end: 8.474452
1: [INFO] [1741576257.281931107] [path_generator]: length: 12.914741, start: 4.440289, end: 8.474452
1: [INFO] [1741576257.382559835] [path_generator]: length: 12.914741, start: 4.440289, end: 8.474452
1: [INFO] [1741576257.483280238] [path_generator]: length: 12.914741, start: 4.440289, end: 8.474452
1: [INFO] [1741576257.583995493] [path_generator]: length: 12.914741, start: 4.440289, end: 8.474452
1: [ERROR] [1741576257.685072796] [path_generator]: input route is empty, ignoring...
1: [INFO] [1741576257.685228361] [path_generator]: length: 12.914741, start: 4.440289, end: 8.474452
1: [INFO] [1741576257.785732903] [path_generator]: length: 12.914741, start: 4.440289, end: 8.474452
1: [INFO] [1741576257.886304584] [path_generator]: length: 12.914741, start: 4.440289, end: 8.474452
1: [INFO] [1741576257.986984006] [path_generator]: length: 12.914741, start: 4.440289, end: 8.474452
1: [INFO] [1741576258.087553122] [path_generator]: length: 12.914741, start: 4.440289, end: 8.474452
1: [       OK ] PlanningModuleInterfaceTest.NodeTestWithExceptionTrajectory (1675 ms)
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
