### PR TITLE
Chore/autoware trajectory move interpolated array

### DIFF
--- a/common/autoware_trajectory/include/autoware/trajectory/detail/interpolated_array.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/detail/interpolated_array.hpp
@@ -72,9 +72,10 @@ public:
     return interpolator_->build(bases_, values_);
   }
 
-  interpolator::InterpolationResult build(std::vector<double> && bases, std::vector<T> && values)
+  interpolator::InterpolationResult build(
+    const std::vector<double> & bases, std::vector<T> && values)
   {
-    bases_ = std::move(bases);
+    bases_ = bases;
     values_ = std::move(values);
     return interpolator_->build(bases_, values_);
   }

--- a/common/autoware_trajectory/include/autoware/trajectory/detail/interpolated_array.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/detail/interpolated_array.hpp
@@ -64,14 +64,15 @@ public:
 
   InterpolatedArray(InterpolatedArray && other) = default;
 
-  bool build(const std::vector<double> & bases, const std::vector<T> & values)
+  interpolator::InterpolationResult build(
+    const std::vector<double> & bases, const std::vector<T> & values)
   {
     bases_ = bases;
     values_ = values;
     return interpolator_->build(bases_, values_);
   }
 
-  bool build(std::vector<double> && bases, std::vector<T> && values)
+  interpolator::InterpolationResult build(std::vector<double> && bases, std::vector<T> && values)
   {
     bases_ = std::move(bases);
     values_ = std::move(values);
@@ -160,7 +161,7 @@ public:
       // Set the values in the specified range
       std::fill(values.begin() + start_index, values.begin() + end_index + 1, value);
 
-      bool success = parent_.interpolator_->build(bases, values);
+      const auto success = parent_.interpolator_->build(bases, values);
       if (!success) {
         throw std::runtime_error(
           "Failed to build interpolator.");  // This Exception should not be thrown.
@@ -194,7 +195,7 @@ public:
   InterpolatedArray & operator=(const T & value)
   {
     std::fill(values_.begin(), values_.end(), value);
-    bool success = interpolator_->build(bases_, values_);
+    const auto success = interpolator_->build(bases_, values_);
     if (!success) {
       throw std::runtime_error(
         "Failed to build interpolator.");  // This Exception should not be thrown.

--- a/common/autoware_trajectory/include/autoware/trajectory/detail/types.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/detail/types.hpp
@@ -17,8 +17,6 @@
 
 #include "lanelet2_core/primitives/Point.h"
 
-#include <Eigen/Core>
-
 #include <autoware_internal_planning_msgs/msg/path_point_with_lane_id.hpp>
 #include <autoware_planning_msgs/msg/detail/trajectory_point__struct.hpp>
 #include <autoware_planning_msgs/msg/path_point.hpp>

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolated_array.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolated_array.hpp
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__TRAJECTORY__DETAIL__INTERPOLATED_ARRAY_HPP_
-#define AUTOWARE__TRAJECTORY__DETAIL__INTERPOLATED_ARRAY_HPP_
+#ifndef AUTOWARE__TRAJECTORY__INTERPOLATED_ARRAY_HPP_
+#define AUTOWARE__TRAJECTORY__INTERPOLATED_ARRAY_HPP_
 
 #include "autoware/trajectory/detail/logging.hpp"
 #include "autoware/trajectory/interpolator/interpolator.hpp"
 
-#include <Eigen/Core>
 #include <rclcpp/logging.hpp>
 
 #include <algorithm>
@@ -220,4 +219,4 @@ public:
 
 }  // namespace autoware::trajectory::detail
 
-#endif  // AUTOWARE__TRAJECTORY__DETAIL__INTERPOLATED_ARRAY_HPP_
+#endif  // AUTOWARE__TRAJECTORY__INTERPOLATED_ARRAY_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/akima_spline.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/akima_spline.hpp
@@ -62,7 +62,7 @@ private:
    * @param values The values to interpolate.
    */
   [[nodiscard]] bool build_impl(
-    std::vector<double> && bases, std::vector<double> && values) override;
+    const std::vector<double> & bases, std::vector<double> && values) override;
 
   /**
    * @brief Compute the interpolated value at the given point.

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/cubic_spline.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/cubic_spline.hpp
@@ -65,7 +65,7 @@ private:
    * @return True if the interpolator was built successfully, false otherwise.
    */
   [[nodiscard]] bool build_impl(
-    std::vector<double> && bases, std::vector<double> && values) override;
+    const std::vector<double> & bases, std::vector<double> && values) override;
 
   /**
    * @brief Compute the interpolated value at the given point.

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/detail/interpolator_common_interface.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/detail/interpolator_common_interface.hpp
@@ -15,7 +15,8 @@
 #ifndef AUTOWARE__TRAJECTORY__INTERPOLATOR__DETAIL__INTERPOLATOR_COMMON_INTERFACE_HPP_
 #define AUTOWARE__TRAJECTORY__INTERPOLATOR__DETAIL__INTERPOLATOR_COMMON_INTERFACE_HPP_
 
-#include <Eigen/Dense>
+#include "autoware/trajectory/interpolator/result.hpp"
+
 #include <rclcpp/logging.hpp>
 
 #include <utility>
@@ -141,15 +142,23 @@ public:
     std::conjunction_v<
       std::is_same<std::decay_t<BaseVectorT>, std::vector<double>>,
       std::is_same<std::decay_t<ValueVectorT>, std::vector<T>>>,
-    bool>
+    InterpolationResult>
   {
     if (bases.size() != values.size()) {
-      return false;
+      return tl::unexpected(InterpolationFailure{
+        "base size " + std::to_string(bases.size()) + " and value size " +
+        std::to_string(values.size()) + " are different"});
     }
-    if (bases.size() < minimum_required_points()) {
-      return false;
+    if (const auto minimum_required = minimum_required_points(); bases.size() < minimum_required) {
+      return tl::unexpected(InterpolationFailure{
+        "base size " + std::to_string(bases.size()) + " is less than minimum required " +
+        std::to_string(minimum_required)});
     }
-    return build_impl(std::forward<BaseVectorT>(bases), std::forward<ValueVectorT>(values));
+    if (!build_impl(std::forward<BaseVectorT>(bases), std::forward<ValueVectorT>(values))) {
+      return tl::unexpected(
+        InterpolationFailure{"failed to interpolate from given base and values"});
+    }
+    return InterpolationSuccess{};
   }
 
   /**

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/detail/interpolator_common_interface.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/detail/interpolator_common_interface.hpp
@@ -77,7 +77,8 @@ protected:
    * @param bases The bases values.
    * @param values The values to interpolate.
    */
-  [[nodiscard]] virtual bool build_impl(std::vector<double> && bases, std::vector<T> && values) = 0;
+  [[nodiscard]] virtual bool build_impl(
+    const std::vector<double> & bases, std::vector<T> && values) = 0;
 
   /**
    * @brief Validate the input to the compute method.

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/detail/interpolator_mixin.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/detail/interpolator_mixin.hpp
@@ -81,13 +81,14 @@ struct InterpolatorMixin : public InterpolatorInterface<T>
     }
 
     template <typename... Args>
-    [[nodiscard]] std::optional<InterpolatorType> build(Args &&... args)
+    [[nodiscard]] tl::expected<InterpolatorType, interpolator::InterpolationFailure> build(
+      Args &&... args)
     {
       auto interpolator = InterpolatorType(std::forward<Args>(args)...);
       const interpolator::InterpolationResult success =
         interpolator.build(std::move(bases_), std::move(values_));
       if (!success) {
-        return std::nullopt;
+        return tl::unexpected(success.error());
       }
       return interpolator;
     }

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/detail/interpolator_mixin.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/detail/interpolator_mixin.hpp
@@ -84,7 +84,8 @@ struct InterpolatorMixin : public InterpolatorInterface<T>
     [[nodiscard]] std::optional<InterpolatorType> build(Args &&... args)
     {
       auto interpolator = InterpolatorType(std::forward<Args>(args)...);
-      const bool success = interpolator.build(std::move(bases_), std::move(values_));
+      const interpolator::InterpolationResult success =
+        interpolator.build(std::move(bases_), std::move(values_));
       if (!success) {
         return std::nullopt;
       }

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/detail/nearest_neighbor_common_impl.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/detail/nearest_neighbor_common_impl.hpp
@@ -76,9 +76,10 @@ protected:
    * @param values The values to interpolate.
    * @return True if the interpolator was built successfully, false otherwise.
    */
-  [[nodiscard]] bool build_impl(std::vector<double> && bases, std::vector<T> && values) override
+  [[nodiscard]] bool build_impl(
+    const std::vector<double> & bases, std::vector<T> && values) override
   {
-    this->bases_ = std::move(bases);
+    this->bases_ = bases;
     this->values_ = std::move(values);
     return true;
   }

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/detail/stairstep_common_impl.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/detail/stairstep_common_impl.hpp
@@ -73,9 +73,10 @@ protected:
    * @param bases The bases values.
    * @param values The values to interpolate.
    */
-  [[nodiscard]] bool build_impl(std::vector<double> && bases, std::vector<T> && values) override
+  [[nodiscard]] bool build_impl(
+    const std::vector<double> & bases, std::vector<T> && values) override
   {
-    this->bases_ = std::move(bases);
+    this->bases_ = bases;
     this->values_ = std::move(values);
     return true;
   }

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/linear.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/linear.hpp
@@ -52,7 +52,7 @@ private:
    * @return True if the interpolator was built successfully, false otherwise.
    */
   [[nodiscard]] bool build_impl(
-    std::vector<double> && bases, std::vector<double> && values) override;
+    const std::vector<double> & bases, std::vector<double> && values) override;
 
   /**
    * @brief Compute the interpolated value at the given point.

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/result.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/result.hpp
@@ -1,0 +1,42 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TRAJECTORY__INTERPOLATOR__RESULT_HPP_
+#define AUTOWARE__TRAJECTORY__INTERPOLATOR__RESULT_HPP_
+
+#include <tl_expected/expected.hpp>
+
+#include <string>
+
+namespace autoware::trajectory::interpolator
+{
+struct InterpolationSuccess
+{
+};
+
+struct InterpolationFailure
+{
+  const std::string what;
+};
+
+inline InterpolationFailure operator+(
+  const InterpolationFailure & primary, const InterpolationFailure & nested)
+{
+  return InterpolationFailure{primary.what + ". " + nested.what};
+}
+
+using InterpolationResult = tl::expected<InterpolationSuccess, InterpolationFailure>;
+
+}  // namespace autoware::trajectory::interpolator
+#endif  // AUTOWARE__TRAJECTORY__INTERPOLATOR__RESULT_HPP_

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/result.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/result.hpp
@@ -33,7 +33,7 @@ struct InterpolationFailure
 inline InterpolationFailure operator+(
   const InterpolationFailure & primary, const InterpolationFailure & nested)
 {
-  return InterpolationFailure{primary.what + ". " + nested.what};
+  return InterpolationFailure{primary.what + " ==> " + nested.what};
 }
 
 using InterpolationResult = tl::expected<InterpolationSuccess, InterpolationFailure>;

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/spherical_linear.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/spherical_linear.hpp
@@ -54,7 +54,7 @@ private:
    * @return True if the interpolator was built successfully, false otherwise.
    */
   [[nodiscard]] bool build_impl(
-    std::vector<double> && bases,
+    const std::vector<double> & bases,
     std::vector<geometry_msgs::msg::Quaternion> && quaternions) override;
 
   /**

--- a/common/autoware_trajectory/include/autoware/trajectory/path_point.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/path_point.hpp
@@ -15,7 +15,7 @@
 #ifndef AUTOWARE__TRAJECTORY__PATH_POINT_HPP_
 #define AUTOWARE__TRAJECTORY__PATH_POINT_HPP_
 
-#include "autoware/trajectory/detail/interpolated_array.hpp"
+#include "autoware/trajectory/interpolated_array.hpp"
 #include "autoware/trajectory/interpolator/result.hpp"
 #include "autoware/trajectory/pose.hpp"
 

--- a/common/autoware_trajectory/include/autoware/trajectory/path_point_with_lane_id.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/path_point_with_lane_id.hpp
@@ -52,7 +52,7 @@ public:
    * @param points Vector of points
    * @return True if the build is successful
    */
-  bool build(const std::vector<PointType> & points);
+  interpolator::InterpolationResult build(const std::vector<PointType> & points);
 
   std::vector<double> get_internal_bases() const override;
 
@@ -136,14 +136,16 @@ public:
       return *this;
     }
 
-    std::optional<Trajectory> build(const std::vector<PointType> & points)
+    tl::expected<Trajectory, interpolator::InterpolationFailure> build(
+      const std::vector<PointType> & points)
     {
-      if (trajectory_->build(points)) {
-        auto result = std::make_optional<Trajectory>(std::move(*trajectory_));
+      auto trajectory_result = trajectory_->build(points);
+      if (trajectory_result) {
+        auto result = Trajectory(std::move(*trajectory_));
         trajectory_.reset();
         return result;
       }
-      return std::nullopt;
+      return tl::unexpected(trajectory_result.error());
     }
   };
 };

--- a/common/autoware_trajectory/include/autoware/trajectory/point.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/point.hpp
@@ -90,7 +90,7 @@ public:
    * @param points Vector of points
    * @return True if the build is successful
    */
-  bool build(const std::vector<PointType> & points);
+  interpolator::InterpolationResult build(const std::vector<PointType> & points);
 
   /**
    * @brief Get the azimuth angle at a given s value
@@ -148,14 +148,16 @@ public:
       return *this;
     }
 
-    std::optional<Trajectory> build(const std::vector<PointType> & points)
+    tl::expected<Trajectory, interpolator::InterpolationFailure> build(
+      const std::vector<PointType> & points)
     {
-      if (trajectory_->build(points)) {
-        auto result = std::make_optional<Trajectory>(std::move(*trajectory_));
+      auto trajectory_result = trajectory_->build(points);
+      if (trajectory_result) {
+        auto result = Trajectory(std::move(*trajectory_));
         trajectory_.reset();
         return result;
       }
-      return std::nullopt;
+      return tl::unexpected(trajectory_result.error());
     }
   };
 };

--- a/common/autoware_trajectory/include/autoware/trajectory/point.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/point.hpp
@@ -18,13 +18,10 @@
 #include "autoware/trajectory/forward.hpp"
 #include "autoware/trajectory/interpolator/interpolator.hpp"
 
-#include <Eigen/Dense>
-
 #include <geometry_msgs/msg/point.hpp>
 
 #include <cstddef>
 #include <memory>
-#include <optional>
 #include <utility>
 #include <vector>
 

--- a/common/autoware_trajectory/include/autoware/trajectory/pose.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/pose.hpp
@@ -52,7 +52,7 @@ public:
   // enable making trajectory from point trajectory
   explicit Trajectory(const Trajectory<geometry_msgs::msg::Point> & point_trajectory);
 
-  bool build(const std::vector<PointType> & points);
+  interpolator::InterpolationResult build(const std::vector<PointType> & points);
 
   /**
    * @brief Get the internal bases(arc lengths) of the trajectory
@@ -112,14 +112,16 @@ public:
       return *this;
     }
 
-    std::optional<Trajectory> build(const std::vector<PointType> & points)
+    tl::expected<Trajectory, interpolator::InterpolationFailure> build(
+      const std::vector<PointType> & points)
     {
-      if (trajectory_->build(points)) {
-        auto result = std::make_optional<Trajectory>(std::move(*trajectory_));
+      auto trajectory_result = trajectory_->build(points);
+      if (trajectory_result) {
+        auto result = Trajectory(std::move(*trajectory_));
         trajectory_.reset();
         return result;
       }
-      return std::nullopt;
+      return tl::unexpected(trajectory_result.error());
     }
   };
 };

--- a/common/autoware_trajectory/include/autoware/trajectory/trajectory_point.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/trajectory_point.hpp
@@ -103,7 +103,7 @@ public:
    * @param points Vector of points
    * @return True if the build is successful
    */
-  bool build(const std::vector<PointType> & points);
+  interpolator::InterpolationResult build(const std::vector<PointType> & points);
 
   /**
    * @brief Compute the point on the trajectory at a given s value
@@ -201,14 +201,16 @@ public:
       return *this;
     }
 
-    std::optional<Trajectory> build(const std::vector<PointType> & points)
+    tl::expected<Trajectory, interpolator::InterpolationFailure> build(
+      const std::vector<PointType> & points)
     {
-      if (trajectory_->build(points)) {
-        auto result = std::make_optional<Trajectory>(std::move(*trajectory_));
+      auto trajectory_result = trajectory_->build(points);
+      if (trajectory_result) {
+        auto result = Trajectory(std::move(*trajectory_));
         trajectory_.reset();
         return result;
       }
-      return std::nullopt;
+      return tl::unexpected(trajectory_result.error());
     }
   };
 };

--- a/common/autoware_trajectory/include/autoware/trajectory/trajectory_point.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/trajectory_point.hpp
@@ -15,7 +15,7 @@
 #ifndef AUTOWARE__TRAJECTORY__TRAJECTORY_POINT_HPP_
 #define AUTOWARE__TRAJECTORY__TRAJECTORY_POINT_HPP_
 
-#include "autoware/trajectory/detail/interpolated_array.hpp"
+#include "autoware/trajectory/interpolated_array.hpp"
 #include "autoware/trajectory/pose.hpp"
 
 #include <autoware_planning_msgs/msg/trajectory.hpp>

--- a/common/autoware_trajectory/include/autoware/trajectory/utils/find_intervals.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/utils/find_intervals.hpp
@@ -18,8 +18,6 @@
 #include "autoware/trajectory/detail/types.hpp"
 #include "autoware/trajectory/forward.hpp"
 
-#include <Eigen/Core>
-
 #include <functional>
 #include <vector>
 namespace autoware::trajectory

--- a/common/autoware_trajectory/package.xml
+++ b/common/autoware_trajectory/package.xml
@@ -20,6 +20,7 @@
   <depend>lanelet2_core</depend>
   <depend>rclcpp</depend>
   <depend>tf2</depend>
+  <depend>tl_expected</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/common/autoware_trajectory/src/interpolator/akima_spline.cpp
+++ b/common/autoware_trajectory/src/interpolator/akima_spline.cpp
@@ -69,12 +69,11 @@ bool AkimaSpline::build_impl(const std::vector<double> & bases, const std::vecto
   return true;
 }
 
-bool AkimaSpline::build_impl(std::vector<double> && bases, std::vector<double> && values)
+bool AkimaSpline::build_impl(const std::vector<double> & bases, std::vector<double> && values)
 {
-  this->bases_ = std::move(bases);
+  this->bases_ = bases;
   compute_parameters(
-    Eigen::Map<const Eigen::VectorXd>(
-      this->bases_.data(), static_cast<Eigen::Index>(this->bases_.size())),
+    Eigen::Map<const Eigen::VectorXd>(bases.data(), static_cast<Eigen::Index>(bases.size())),
     Eigen::Map<const Eigen::VectorXd>(values.data(), static_cast<Eigen::Index>(values.size())));
   return true;
 }

--- a/common/autoware_trajectory/src/interpolator/akima_spline.cpp
+++ b/common/autoware_trajectory/src/interpolator/akima_spline.cpp
@@ -60,15 +60,6 @@ void AkimaSpline::compute_parameters(
   }
 }
 
-bool AkimaSpline::build_impl(const std::vector<double> & bases, const std::vector<double> & values)
-{
-  this->bases_ = bases;
-  compute_parameters(
-    Eigen::Map<const Eigen::VectorXd>(bases.data(), static_cast<Eigen::Index>(bases.size())),
-    Eigen::Map<const Eigen::VectorXd>(values.data(), static_cast<Eigen::Index>(values.size())));
-  return true;
-}
-
 bool AkimaSpline::build_impl(const std::vector<double> & bases, std::vector<double> && values)
 {
   this->bases_ = bases;

--- a/common/autoware_trajectory/src/interpolator/akima_spline.cpp
+++ b/common/autoware_trajectory/src/interpolator/akima_spline.cpp
@@ -60,6 +60,15 @@ void AkimaSpline::compute_parameters(
   }
 }
 
+bool AkimaSpline::build_impl(const std::vector<double> & bases, const std::vector<double> & values)
+{
+  this->bases_ = bases;
+  compute_parameters(
+    Eigen::Map<const Eigen::VectorXd>(bases.data(), static_cast<Eigen::Index>(bases.size())),
+    Eigen::Map<const Eigen::VectorXd>(values.data(), static_cast<Eigen::Index>(values.size())));
+  return true;
+}
+
 bool AkimaSpline::build_impl(const std::vector<double> & bases, std::vector<double> && values)
 {
   this->bases_ = bases;

--- a/common/autoware_trajectory/src/interpolator/cubic_spline.cpp
+++ b/common/autoware_trajectory/src/interpolator/cubic_spline.cpp
@@ -70,9 +70,9 @@ bool CubicSpline::build_impl(const std::vector<double> & bases, const std::vecto
   return true;
 }
 
-bool CubicSpline::build_impl(std::vector<double> && bases, std::vector<double> && values)
+bool CubicSpline::build_impl(const std::vector<double> & bases, std::vector<double> && values)
 {
-  this->bases_ = std::move(bases);
+  this->bases_ = bases;
   compute_parameters(
     Eigen::Map<const Eigen::VectorXd>(
       this->bases_.data(), static_cast<Eigen::Index>(this->bases_.size())),

--- a/common/autoware_trajectory/src/interpolator/linear.cpp
+++ b/common/autoware_trajectory/src/interpolator/linear.cpp
@@ -30,9 +30,9 @@ bool Linear::build_impl(const std::vector<double> & bases, const std::vector<dou
   return true;
 }
 
-bool Linear::build_impl(std::vector<double> && bases, std::vector<double> && values)
+bool Linear::build_impl(const std::vector<double> & bases, std::vector<double> && values)
 {
-  this->bases_ = std::move(bases);
+  this->bases_ = bases;
   this->values_ =
     Eigen::Map<const Eigen::VectorXd>(values.data(), static_cast<Eigen::Index>(values.size()));
   return true;

--- a/common/autoware_trajectory/src/interpolator/result.cpp
+++ b/common/autoware_trajectory/src/interpolator/result.cpp
@@ -12,28 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__TRAJECTORY__INTERPOLATOR__RESULT_HPP_
-#define AUTOWARE__TRAJECTORY__INTERPOLATOR__RESULT_HPP_
+#include "autoware/trajectory/interpolator/result.hpp"
 
-#include <tl_expected/expected.hpp>
-
-#include <string>
+#include <iostream>
+#include <sstream>
 
 namespace autoware::trajectory::interpolator
 {
-struct InterpolationSuccess
-{
-};
-
-struct InterpolationFailure
-{
-  const std::string what;
-};
 
 InterpolationFailure operator+(
-  const InterpolationFailure & primary, const InterpolationFailure & nested);
-
-using InterpolationResult = tl::expected<InterpolationSuccess, InterpolationFailure>;
+  const InterpolationFailure & primary, const InterpolationFailure & nested)
+{
+  std::stringstream ss;
+  ss << primary.what << "." << std::endl << "\tReason: " << nested.what << std::endl;
+  return InterpolationFailure{ss.str()};
+}
 
 }  // namespace autoware::trajectory::interpolator
-#endif  // AUTOWARE__TRAJECTORY__INTERPOLATOR__RESULT_HPP_

--- a/common/autoware_trajectory/src/interpolator/spherical_linear.cpp
+++ b/common/autoware_trajectory/src/interpolator/spherical_linear.cpp
@@ -32,9 +32,9 @@ bool SphericalLinear::build_impl(
 }
 
 bool SphericalLinear::build_impl(
-  std::vector<double> && bases, std::vector<geometry_msgs::msg::Quaternion> && quaternions)
+  const std::vector<double> & bases, std::vector<geometry_msgs::msg::Quaternion> && quaternions)
 {
-  this->bases_ = std::move(bases);
+  this->bases_ = bases;
   this->quaternions_ = std::move(quaternions);
   return true;
 }

--- a/common/autoware_trajectory/src/path_point.cpp
+++ b/common/autoware_trajectory/src/path_point.cpp
@@ -15,7 +15,6 @@
 #include "autoware/trajectory/path_point.hpp"
 
 #include "autoware/trajectory/detail/helpers.hpp"
-#include "autoware/trajectory/detail/interpolated_array.hpp"
 #include "autoware/trajectory/forward.hpp"
 #include "autoware/trajectory/interpolator/stairstep.hpp"
 #include "autoware/trajectory/pose.hpp"

--- a/common/autoware_trajectory/src/path_point.cpp
+++ b/common/autoware_trajectory/src/path_point.cpp
@@ -23,8 +23,8 @@
 #include <autoware_planning_msgs/msg/path_point.hpp>
 
 #include <memory>
+#include <utility>
 #include <vector>
-
 namespace autoware::trajectory
 {
 
@@ -80,18 +80,20 @@ interpolator::InterpolationResult Trajectory<PointType>::build(
     return tl::unexpected(
       interpolator::InterpolationFailure{"failed to interpolate PathPoint::pose"} + result.error());
   }
-  if (const auto result =
-        this->longitudinal_velocity_mps().build(bases_, longitudinal_velocity_mps_values);
+  if (const auto result = this->longitudinal_velocity_mps().build(
+        bases_, std::move(longitudinal_velocity_mps_values));
       !result) {
     return tl::unexpected(interpolator::InterpolationFailure{
       "failed to interpolate PathPoint::longitudinal_velocity_mps"});
   }
-  if (const auto result = this->lateral_velocity_mps().build(bases_, lateral_velocity_mps_values);
+  if (const auto result =
+        this->lateral_velocity_mps().build(bases_, std::move(lateral_velocity_mps_values));
       !result) {
     return tl::unexpected(
       interpolator::InterpolationFailure{"failed to interpolate PathPoint::lateral_velocity_mps"});
   }
-  if (const auto result = this->heading_rate_rps().build(bases_, heading_rate_rps_values);
+  if (const auto result =
+        this->heading_rate_rps().build(bases_, std::move(heading_rate_rps_values));
       !result) {
     return tl::unexpected(
       interpolator::InterpolationFailure{"failed to interpolate PathPoint::heading_rate_rps"});

--- a/common/autoware_trajectory/src/path_point.cpp
+++ b/common/autoware_trajectory/src/path_point.cpp
@@ -61,7 +61,8 @@ Trajectory<PointType> & Trajectory<PointType>::operator=(const Trajectory & rhs)
   return *this;
 }
 
-bool Trajectory<PointType>::build(const std::vector<PointType> & points)
+interpolator::InterpolationResult Trajectory<PointType>::build(
+  const std::vector<PointType> & points)
 {
   std::vector<geometry_msgs::msg::Pose> poses;
   std::vector<double> longitudinal_velocity_mps_values;
@@ -75,14 +76,28 @@ bool Trajectory<PointType>::build(const std::vector<PointType> & points)
     heading_rate_rps_values.emplace_back(point.heading_rate_rps);
   }
 
-  bool is_valid = true;
+  if (const auto result = Trajectory<geometry_msgs::msg::Pose>::build(poses); !result) {
+    return tl::unexpected(
+      interpolator::InterpolationFailure{"failed to interpolate PathPoint::pose"} + result.error());
+  }
+  if (const auto result =
+        this->longitudinal_velocity_mps().build(bases_, longitudinal_velocity_mps_values);
+      !result) {
+    return tl::unexpected(interpolator::InterpolationFailure{
+      "failed to interpolate PathPoint::longitudinal_velocity_mps"});
+  }
+  if (const auto result = this->lateral_velocity_mps().build(bases_, lateral_velocity_mps_values);
+      !result) {
+    return tl::unexpected(
+      interpolator::InterpolationFailure{"failed to interpolate PathPoint::lateral_velocity_mps"});
+  }
+  if (const auto result = this->heading_rate_rps().build(bases_, heading_rate_rps_values);
+      !result) {
+    return tl::unexpected(
+      interpolator::InterpolationFailure{"failed to interpolate PathPoint::heading_rate_rps"});
+  }
 
-  is_valid &= Trajectory<geometry_msgs::msg::Pose>::build(poses);
-  is_valid &= this->longitudinal_velocity_mps().build(bases_, longitudinal_velocity_mps_values);
-  is_valid &= this->lateral_velocity_mps().build(bases_, lateral_velocity_mps_values);
-  is_valid &= this->heading_rate_rps().build(bases_, heading_rate_rps_values);
-
-  return is_valid;
+  return interpolator::InterpolationSuccess{};
 }
 
 std::vector<double> Trajectory<PointType>::get_internal_bases() const

--- a/common/autoware_trajectory/src/path_point_with_lane_id.cpp
+++ b/common/autoware_trajectory/src/path_point_with_lane_id.cpp
@@ -40,7 +40,8 @@ Trajectory<PointType> & Trajectory<PointType>::operator=(const Trajectory & rhs)
   return *this;
 }
 
-bool Trajectory<PointType>::build(const std::vector<PointType> & points)
+interpolator::InterpolationResult Trajectory<PointType>::build(
+  const std::vector<PointType> & points)
 {
   std::vector<autoware_planning_msgs::msg::PathPoint> path_points;
   std::vector<std::vector<int64_t>> lane_ids_values;
@@ -49,10 +50,18 @@ bool Trajectory<PointType>::build(const std::vector<PointType> & points)
     path_points.emplace_back(point.point);
     lane_ids_values.emplace_back(point.lane_ids);
   }
-  bool is_valid = true;
-  is_valid &= BaseClass::build(path_points);
-  is_valid &= lane_ids().build(bases_, lane_ids_values);
-  return is_valid;
+
+  if (const auto result = BaseClass::build(path_points); !result) {
+    return tl::unexpected(
+      interpolator::InterpolationFailure{"failed to interpolate PathPointWithLaneId::point"} +
+      result.error());
+  }
+  if (const auto result = lane_ids().build(bases_, lane_ids_values); !result) {
+    return tl::unexpected(
+      interpolator::InterpolationFailure{"failed to interpolate PathPointWithLaneId::lane_id"});
+  }
+
+  return interpolator::InterpolationSuccess{};
 }
 
 std::vector<double> Trajectory<PointType>::get_internal_bases() const

--- a/common/autoware_trajectory/src/path_point_with_lane_id.cpp
+++ b/common/autoware_trajectory/src/path_point_with_lane_id.cpp
@@ -18,6 +18,7 @@
 #include "autoware/trajectory/interpolator/stairstep.hpp"
 
 #include <memory>
+#include <utility>
 #include <vector>
 
 namespace autoware::trajectory
@@ -56,7 +57,7 @@ interpolator::InterpolationResult Trajectory<PointType>::build(
       interpolator::InterpolationFailure{"failed to interpolate PathPointWithLaneId::point"} +
       result.error());
   }
-  if (const auto result = lane_ids().build(bases_, lane_ids_values); !result) {
+  if (const auto result = lane_ids().build(bases_, std::move(lane_ids_values)); !result) {
     return tl::unexpected(
       interpolator::InterpolationFailure{"failed to interpolate PathPointWithLaneId::lane_id"});
   }

--- a/common/autoware_trajectory/src/point.cpp
+++ b/common/autoware_trajectory/src/point.cpp
@@ -25,6 +25,7 @@
 #include <cmath>
 #include <cstddef>
 #include <memory>
+#include <utility>
 #include <vector>
 
 namespace autoware::trajectory
@@ -87,15 +88,15 @@ interpolator::InterpolationResult Trajectory<PointType>::build(
   start_ = bases_.front();
   end_ = bases_.back();
 
-  if (const auto result = x_interpolator_->build(bases_, xs); !result) {
+  if (const auto result = x_interpolator_->build(bases_, std::move(xs)); !result) {
     return tl::unexpected(
       interpolator::InterpolationFailure{"failed to interpolate Point::x"} + result.error());
   }
-  if (const auto result = y_interpolator_->build(bases_, ys); !result) {
+  if (const auto result = y_interpolator_->build(bases_, std::move(ys)); !result) {
     return tl::unexpected(
       interpolator::InterpolationFailure{"failed to interpolate Point::y"} + result.error());
   }
-  if (const auto result = z_interpolator_->build(bases_, zs); !result) {
+  if (const auto result = z_interpolator_->build(bases_, std::move(zs)); !result) {
     return tl::unexpected(
       interpolator::InterpolationFailure{"failed to interpolate Point::z"} + result.error());
   }

--- a/common/autoware_trajectory/src/point.cpp
+++ b/common/autoware_trajectory/src/point.cpp
@@ -18,7 +18,6 @@
 #include "autoware/trajectory/interpolator/cubic_spline.hpp"
 #include "autoware/trajectory/interpolator/linear.hpp"
 
-#include <Eigen/Core>
 #include <rclcpp/logging.hpp>
 
 #include <algorithm>
@@ -77,9 +76,8 @@ interpolator::InterpolationResult Trajectory<PointType>::build(
   zs.emplace_back(points[0].z);
 
   for (size_t i = 1; i < points.size(); ++i) {
-    const Eigen::Vector2d p0(points[i - 1].x, points[i - 1].y);
-    const Eigen::Vector2d p1(points[i].x, points[i].y);
-    bases_.emplace_back(bases_.back() + (p1 - p0).norm());
+    const auto dist = std::hypot(points[i].x - points[i - 1].x, points[i].y - points[i - 1].y);
+    bases_.emplace_back(bases_.back() + dist);
     xs.emplace_back(points[i].x);
     ys.emplace_back(points[i].y);
     zs.emplace_back(points[i].z);
@@ -105,7 +103,7 @@ interpolator::InterpolationResult Trajectory<PointType>::build(
 
 double Trajectory<PointType>::clamp(const double s, bool show_warning) const
 {
-  if ((s < 0 || s > length()) && show_warning) {
+  if (show_warning && (s < 0 || s > length())) {
     RCLCPP_WARN(
       rclcpp::get_logger("Trajectory"), "The arc length %f is out of the trajectory length %f", s,
       length());

--- a/common/autoware_trajectory/src/pose.cpp
+++ b/common/autoware_trajectory/src/pose.cpp
@@ -21,6 +21,7 @@
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/LinearMath/Vector3.h>
 
+#include <utility>
 #include <vector>
 
 namespace autoware::trajectory
@@ -61,7 +62,7 @@ Trajectory<PointType>::Trajectory(const Trajectory<geometry_msgs::msg::Point> & 
   for (size_t i = 0; i < bases_.size(); ++i) {
     orientations[i].w = 1.0;
   }
-  const auto success = orientation_interpolator_->build(bases_, orientations);
+  const auto success = orientation_interpolator_->build(bases_, std::move(orientations));
 
   if (!success) {
     throw std::runtime_error(
@@ -88,7 +89,8 @@ interpolator::InterpolationResult Trajectory<PointType>::build(
     return tl::unexpected(
       interpolator::InterpolationFailure{"failed to interpolate Pose::points"} + result.error());
   }
-  if (const auto result = orientation_interpolator_->build(bases_, orientations); !result) {
+  if (const auto result = orientation_interpolator_->build(bases_, std::move(orientations));
+      !result) {
     return tl::unexpected(
       interpolator::InterpolationFailure{"failed to interpolate Pose::orientation"} +
       result.error());
@@ -164,7 +166,7 @@ void Trajectory<PointType>::align_orientation_with_trajectory_direction()
 
     aligned_orientations.emplace_back(aligned_orientation);
   }
-  const auto success = orientation_interpolator_->build(bases_, aligned_orientations);
+  const auto success = orientation_interpolator_->build(bases_, std::move(aligned_orientations));
   if (!success) {
     throw std::runtime_error(
       "Failed to build orientation interpolator.");  // This exception should not be thrown.

--- a/common/autoware_trajectory/src/pose.cpp
+++ b/common/autoware_trajectory/src/pose.cpp
@@ -61,7 +61,7 @@ Trajectory<PointType>::Trajectory(const Trajectory<geometry_msgs::msg::Point> & 
   for (size_t i = 0; i < bases_.size(); ++i) {
     orientations[i].w = 1.0;
   }
-  bool success = orientation_interpolator_->build(bases_, orientations);
+  const auto success = orientation_interpolator_->build(bases_, orientations);
 
   if (!success) {
     throw std::runtime_error(
@@ -72,7 +72,8 @@ Trajectory<PointType>::Trajectory(const Trajectory<geometry_msgs::msg::Point> & 
   align_orientation_with_trajectory_direction();
 }
 
-bool Trajectory<PointType>::build(const std::vector<PointType> & points)
+interpolator::InterpolationResult Trajectory<PointType>::build(
+  const std::vector<PointType> & points)
 {
   std::vector<geometry_msgs::msg::Point> path_points;
   std::vector<geometry_msgs::msg::Quaternion> orientations;
@@ -83,10 +84,16 @@ bool Trajectory<PointType>::build(const std::vector<PointType> & points)
     orientations.emplace_back(point.orientation);
   }
 
-  bool is_valid = true;
-  is_valid &= BaseClass::build(path_points);
-  is_valid &= orientation_interpolator_->build(bases_, orientations);
-  return is_valid;
+  if (const auto result = BaseClass::build(path_points); !result) {
+    return tl::unexpected(
+      interpolator::InterpolationFailure{"failed to interpolate Pose::points"} + result.error());
+  }
+  if (const auto result = orientation_interpolator_->build(bases_, orientations); !result) {
+    return tl::unexpected(
+      interpolator::InterpolationFailure{"failed to interpolate Pose::orientation"} +
+      result.error());
+  }
+  return interpolator::InterpolationSuccess{};
 }
 
 std::vector<double> Trajectory<PointType>::get_internal_bases() const
@@ -157,7 +164,7 @@ void Trajectory<PointType>::align_orientation_with_trajectory_direction()
 
     aligned_orientations.emplace_back(aligned_orientation);
   }
-  const bool success = orientation_interpolator_->build(bases_, aligned_orientations);
+  const auto success = orientation_interpolator_->build(bases_, aligned_orientations);
   if (!success) {
     throw std::runtime_error(
       "Failed to build orientation interpolator.");  // This exception should not be thrown.

--- a/common/autoware_trajectory/src/trajectory_point.cpp
+++ b/common/autoware_trajectory/src/trajectory_point.cpp
@@ -15,7 +15,6 @@
 #include "autoware/trajectory/trajectory_point.hpp"
 
 #include "autoware/trajectory/detail/helpers.hpp"
-#include "autoware/trajectory/detail/interpolated_array.hpp"
 #include "autoware/trajectory/forward.hpp"
 #include "autoware/trajectory/interpolator/stairstep.hpp"
 #include "autoware/trajectory/pose.hpp"

--- a/common/autoware_trajectory/src/trajectory_point.cpp
+++ b/common/autoware_trajectory/src/trajectory_point.cpp
@@ -106,25 +106,25 @@ interpolator::InterpolationResult Trajectory<PointType>::build(
         bases_, std::move(longitudinal_velocity_mps_values));
       !result) {
     return tl::unexpected(interpolator::InterpolationFailure{
-      "failed to interpolate TrajectoryPoint::longitudinal_velocity_mps_values"});
+      "failed to interpolate TrajectoryPoint::longitudinal_velocity_mps"});
   }
   if (const auto result =
         this->lateral_velocity_mps().build(bases_, std::move(lateral_velocity_mps_values));
       !result) {
     return tl::unexpected(interpolator::InterpolationFailure{
-      "failed to interpolate TrajectoryPoint::lateral_velocity_mps_values"});
+      "failed to interpolate TrajectoryPoint::lateral_velocity_mps"});
   }
   if (const auto result =
         this->heading_rate_rps().build(bases_, std::move(heading_rate_rps_values));
       !result) {
     return tl::unexpected(interpolator::InterpolationFailure{
-      "failed to interpolate TrajectoryPoint::heading_rate_rps_values"});
+      "failed to interpolate TrajectoryPoint::heading_rate_rps"});
   }
   if (const auto result =
         this->acceleration_mps2().build(bases_, std::move(acceleration_mps2_values));
       !result) {
     return tl::unexpected(interpolator::InterpolationFailure{
-      "failed to interpolate TrajectoryPoint::acceleration_mps2_values"});
+      "failed to interpolate TrajectoryPoint::acceleration_mps2"});
   }
   if (const auto result =
         this->front_wheel_angle_rad().build(bases_, std::move(front_wheel_angle_rad_values));

--- a/common/autoware_trajectory/src/trajectory_point.cpp
+++ b/common/autoware_trajectory/src/trajectory_point.cpp
@@ -23,6 +23,7 @@
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 
 #include <memory>
+#include <utility>
 #include <vector>
 
 namespace autoware::trajectory
@@ -101,33 +102,38 @@ interpolator::InterpolationResult Trajectory<PointType>::build(
       interpolator::InterpolationFailure{"failed to interpolate TrajectoryPoint::pose"} +
       result.error());
   }
-  if (const auto result =
-        this->longitudinal_velocity_mps().build(bases_, longitudinal_velocity_mps_values);
+  if (const auto result = this->longitudinal_velocity_mps().build(
+        bases_, std::move(longitudinal_velocity_mps_values));
       !result) {
     return tl::unexpected(interpolator::InterpolationFailure{
       "failed to interpolate TrajectoryPoint::longitudinal_velocity_mps_values"});
   }
-  if (const auto result = this->lateral_velocity_mps().build(bases_, lateral_velocity_mps_values);
+  if (const auto result =
+        this->lateral_velocity_mps().build(bases_, std::move(lateral_velocity_mps_values));
       !result) {
     return tl::unexpected(interpolator::InterpolationFailure{
       "failed to interpolate TrajectoryPoint::lateral_velocity_mps_values"});
   }
-  if (const auto result = this->heading_rate_rps().build(bases_, heading_rate_rps_values);
+  if (const auto result =
+        this->heading_rate_rps().build(bases_, std::move(heading_rate_rps_values));
       !result) {
     return tl::unexpected(interpolator::InterpolationFailure{
       "failed to interpolate TrajectoryPoint::heading_rate_rps_values"});
   }
-  if (const auto result = this->acceleration_mps2().build(bases_, acceleration_mps2_values);
+  if (const auto result =
+        this->acceleration_mps2().build(bases_, std::move(acceleration_mps2_values));
       !result) {
     return tl::unexpected(interpolator::InterpolationFailure{
       "failed to interpolate TrajectoryPoint::acceleration_mps2_values"});
   }
-  if (const auto result = this->front_wheel_angle_rad().build(bases_, front_wheel_angle_rad_values);
+  if (const auto result =
+        this->front_wheel_angle_rad().build(bases_, std::move(front_wheel_angle_rad_values));
       !result) {
     return tl::unexpected(interpolator::InterpolationFailure{
       "failed to interpolate TrajectoryPoint::front_wheel_angle_rad"});
   }
-  if (const auto result = this->rear_wheel_angle_rad().build(bases_, rear_wheel_angle_rad_values);
+  if (const auto result =
+        this->rear_wheel_angle_rad().build(bases_, std::move(rear_wheel_angle_rad_values));
       !result) {
     return tl::unexpected(interpolator::InterpolationFailure{
       "failed to interpolate TrajectoryPoint::rear_wheel_angle_rad"});

--- a/common/autoware_trajectory/src/trajectory_point.cpp
+++ b/common/autoware_trajectory/src/trajectory_point.cpp
@@ -75,7 +75,8 @@ Trajectory<PointType> & Trajectory<PointType>::operator=(const Trajectory & rhs)
   return *this;
 }
 
-bool Trajectory<PointType>::build(const std::vector<PointType> & points)
+interpolator::InterpolationResult Trajectory<PointType>::build(
+  const std::vector<PointType> & points)
 {
   std::vector<geometry_msgs::msg::Pose> poses;
   std::vector<double> longitudinal_velocity_mps_values;
@@ -95,17 +96,44 @@ bool Trajectory<PointType>::build(const std::vector<PointType> & points)
     rear_wheel_angle_rad_values.emplace_back(point.rear_wheel_angle_rad);
   }
 
-  bool is_valid = true;
+  if (const auto result = Trajectory<geometry_msgs::msg::Pose>::build(poses); !result) {
+    return tl::unexpected(
+      interpolator::InterpolationFailure{"failed to interpolate TrajectoryPoint::pose"} +
+      result.error());
+  }
+  if (const auto result =
+        this->longitudinal_velocity_mps().build(bases_, longitudinal_velocity_mps_values);
+      !result) {
+    return tl::unexpected(interpolator::InterpolationFailure{
+      "failed to interpolate TrajectoryPoint::longitudinal_velocity_mps_values"});
+  }
+  if (const auto result = this->lateral_velocity_mps().build(bases_, lateral_velocity_mps_values);
+      !result) {
+    return tl::unexpected(interpolator::InterpolationFailure{
+      "failed to interpolate TrajectoryPoint::lateral_velocity_mps_values"});
+  }
+  if (const auto result = this->heading_rate_rps().build(bases_, heading_rate_rps_values);
+      !result) {
+    return tl::unexpected(interpolator::InterpolationFailure{
+      "failed to interpolate TrajectoryPoint::heading_rate_rps_values"});
+  }
+  if (const auto result = this->acceleration_mps2().build(bases_, acceleration_mps2_values);
+      !result) {
+    return tl::unexpected(interpolator::InterpolationFailure{
+      "failed to interpolate TrajectoryPoint::acceleration_mps2_values"});
+  }
+  if (const auto result = this->front_wheel_angle_rad().build(bases_, front_wheel_angle_rad_values);
+      !result) {
+    return tl::unexpected(interpolator::InterpolationFailure{
+      "failed to interpolate TrajectoryPoint::front_wheel_angle_rad"});
+  }
+  if (const auto result = this->rear_wheel_angle_rad().build(bases_, rear_wheel_angle_rad_values);
+      !result) {
+    return tl::unexpected(interpolator::InterpolationFailure{
+      "failed to interpolate TrajectoryPoint::rear_wheel_angle_rad"});
+  }
 
-  is_valid &= Trajectory<geometry_msgs::msg::Pose>::build(poses);
-  is_valid &= this->longitudinal_velocity_mps().build(bases_, longitudinal_velocity_mps_values);
-  is_valid &= this->lateral_velocity_mps().build(bases_, lateral_velocity_mps_values);
-  is_valid &= this->heading_rate_rps().build(bases_, heading_rate_rps_values);
-  is_valid &= this->acceleration_mps2().build(bases_, acceleration_mps2_values);
-  is_valid &= this->front_wheel_angle_rad().build(bases_, front_wheel_angle_rad_values);
-  is_valid &= this->rear_wheel_angle_rad().build(bases_, rear_wheel_angle_rad_values);
-
-  return is_valid;
+  return interpolator::InterpolationSuccess{};
 }
 
 std::vector<double> Trajectory<PointType>::get_internal_bases() const

--- a/common/autoware_trajectory/test/test_interpolator.cpp
+++ b/common/autoware_trajectory/test/test_interpolator.cpp
@@ -61,7 +61,7 @@ TYPED_TEST_SUITE(TestInterpolator, Interpolators, );
 TYPED_TEST(TestInterpolator, compute)
 {
   this->interpolator =
-    typename TypeParam::Builder().set_bases(this->bases).set_values(this->values).build();
+    typename TypeParam::Builder().set_bases(this->bases).set_values(this->values).build().value();
   for (size_t i = 0; i < this->bases.size(); ++i) {
     EXPECT_NEAR(this->values[i], this->interpolator->compute(this->bases[i]), 1e-6);
   }

--- a/common/autoware_trajectory/test/test_trajectory_container.cpp
+++ b/common/autoware_trajectory/test/test_trajectory_container.cpp
@@ -66,8 +66,9 @@ public:
       path_point_with_lane_id(8.11, 6.07, 1), path_point_with_lane_id(8.76, 7.23, 1),
       path_point_with_lane_id(9.36, 8.74, 1), path_point_with_lane_id(10.0, 10.0, 1)};
 
-    trajectory = Trajectory::Builder{}.build(points);
-    ASSERT_TRUE(trajectory);
+    const auto result = Trajectory::Builder{}.build(points);
+    ASSERT_TRUE(result);
+    trajectory.emplace(result.value());
   }
 };
 

--- a/common/autoware_trajectory/test/test_trajectory_container_trajectory_point.cpp
+++ b/common/autoware_trajectory/test/test_trajectory_container_trajectory_point.cpp
@@ -60,8 +60,9 @@ public:
       trajectory_point(8.11, 6.07), trajectory_point(8.76, 7.23), trajectory_point(9.36, 8.74),
       trajectory_point(10.0, 10.0)};
 
-    trajectory = Trajectory::Builder{}.build(points);
-    ASSERT_TRUE(trajectory);
+    const auto result = Trajectory::Builder{}.build(points);
+    ASSERT_TRUE(result);
+    trajectory.emplace(result.value());
   }
 };
 


### PR DESCRIPTION
## Description

just move `trajectory/detail/interpolated_array.hpp` to `trajectory/`.

depends https://github.com/autowarefoundation/autoware.core/pull/254

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
