### PR TITLE
test(autoware_osqp_interface): add tests for missed lines

### DIFF
--- a/common/autoware_osqp_interface/test/test_osqp_interface.cpp
+++ b/common/autoware_osqp_interface/test/test_osqp_interface.cpp
@@ -160,5 +160,41 @@ TEST(TestOsqpInterface, BasicQp)
     check_result(result);
     EXPECT_EQ(osqp.getTakenIter(), 1);
   }
+
+  // update settings
+  {
+    autoware::osqp_interface::OSQPInterface osqp(P, A, q, l, u, 1e-6);
+
+    osqp.updateP(P);
+    osqp.updateCscP(calCSCMatrixTrapezoidal(P));
+    osqp.updateA(A);
+    osqp.updateCscA(calCSCMatrix(A));
+    osqp.updateQ(q);
+    osqp.updateL(l);
+    osqp.updateU(u);
+    osqp.updateBounds(l, u);
+    osqp.updateEpsAbs(1e-6);
+    osqp.updateEpsRel(1e-6);
+    osqp.updateMaxIter(1000);
+    osqp.updateVerbose(true);
+    osqp.updateRhoInterval(10);
+    osqp.updateRho(0.1);
+    osqp.updateAlpha(1.6);
+    osqp.updateScaling(10);
+    osqp.updatePolish(true);
+    osqp.updatePolishRefinementIteration(10);
+    osqp.updateCheckTermination(1);
+
+    EXPECT_NO_THROW(osqp.optimize());
+  }
+
+  // get status
+  {
+    autoware::osqp_interface::OSQPInterface osqp(P, A, q, l, u, 1e-6);
+    osqp.optimize();
+    osqp.updatePolish(true);
+    EXPECT_EQ(osqp.getStatus(), 1);
+    EXPECT_EQ(osqp.getStatusMessage(), "solved");
+  }
 }
 }  // namespace


### PR DESCRIPTION
## Description

## Related links

**Parent Issue:**

https://github.com/autowarefoundation/autoware.core/issues/164

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
