### PR TITLE
chore(CODEOWNERS-manual): set global code owners for files starting with "."

### DIFF
--- a/.github/CODEOWNERS-manual
+++ b/.github/CODEOWNERS-manual
@@ -1,1 +1,1 @@
-.github/** @autowarefoundation/autoware-core-global-codeowners
+.* @autowarefoundation/autoware-core-global-codeowners

--- a/.github/CODEOWNERS-manual
+++ b/.github/CODEOWNERS-manual
@@ -1,2 +1,1 @@
-* @autowarefoundation/autoware-core-global-codeowners
-.* @autowarefoundation/autoware-core-global-codeowners
+.github/** @autowarefoundation/autoware-core-global-codeowners


### PR DESCRIPTION
Reverts autowarefoundation/autoware.core#247

The above PR was meant to add autoware-core-global-codeowners as a default code reviewer if there are no code-owners, but it actually overrides the code reviewer for all the PR.

We are reverting it until we find a good solution. 