### PR TITLE
refactor(path_generator): remove refine_goal

### DIFF
--- a/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
+++ b/planning/autoware_path_generator/include/autoware/path_generator/utils.hpp
@@ -190,17 +190,6 @@ PathRange<std::optional<double>> get_arc_length_on_centerline(
   const std::optional<double> & s_right_bound);
 
 /**
- * @brief Recreate the goal pose to prevent the goal point being too far from the lanelet, which
- *  causes the path to twist near the goal.
- * @details Return the goal point projected on the straight line of the segment of lanelet
- *  closest to the original goal.
- * @param [in] goal original goal pose
- * @param [in] goal_lanelet lanelet containing the goal pose
- */
-geometry_msgs::msg::Pose refine_goal(
-  const geometry_msgs::msg::Pose & goal, const lanelet::ConstLanelet & goal_lanelet);
-
-/**
  * @brief Recreate the path with a given goal pose.
  * @param input Input path.
  * @param refined_goal Goal pose.


### PR DESCRIPTION
## Description

Remove unnecessary `refine_goal` function.


This function checks if goal_pose is in goal lanelet, 
```
  const auto goal_point_on_lanelet = lanelet::utils::conversion::toLaneletPoint(goal.position);
  const double distance = boost::geometry::distance(
    goal_lanelet.polygon2d().basicPolygon(),
    lanelet::utils::to2D(goal_point_on_lanelet).basicPoint());

  // You are almost at the goal
  if (distance < std::numeric_limits<double>::epsilon()) {
    return goal;
  }
```
If not, refine goal pose along goal lanelet centerline.

But we can not set goal outside of lane even if we set
```
    check_footprint_inside_lanes: false
```
in mission planner



## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

in psim

with PR smooth goal connection woks

![image](https://github.com/user-attachments/assets/c2786cca-da44-43a2-9840-9cda84e914c6)

and  confirmed this feature never works

> if not refine goal pose along goal lanelet centerline.
But we can not set goal outside of lane even if we set
    check_footprint_inside_lanes: false
in mission planner



## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
