### PR TITLE
feat(motion_velocity_planner_node): update pcl coordinate transformation

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
@@ -220,17 +220,17 @@ MotionVelocityPlannerNode::process_no_ground_pointcloud(
   geometry_msgs::msg::TransformStamped transform;
   const bool is_pcl_time_valid = (this->get_clock()->now() - rclcpp::Time(msg->header.stamp)) <
                                  rclcpp::Duration::from_seconds(1.0);
-  try {
-    if (is_pcl_time_valid) {
-      transform = tf_buffer_.lookupTransform(
-        "map", msg->header.frame_id, msg->header.stamp, rclcpp::Duration::from_seconds(0.05));
-    } else {
-      RCLCPP_WARN(get_logger(), "pcl time is invalid, using tf2::TimePointZero");
-      transform = tf_buffer_.lookupTransform("map", msg->header.frame_id, tf2::TimePointZero);
-    }
-  } catch (tf2::TransformException & e) {
-    RCLCPP_WARN(get_logger(), "no transform found for no_ground_pointcloud: %s", e.what());
-    return {};
+
+  if (
+    is_pcl_time_valid && tf_buffer_.canTransform("map", msg->header.frame_id, msg->header.stamp)) {
+    transform = tf_buffer_.lookupTransform(
+      "map", msg->header.frame_id, msg->header.stamp, rclcpp::Duration::from_seconds(0.05));
+  } else if (tf_buffer_.canTransform("map", msg->header.frame_id, tf2::TimePointZero)) {
+    transform = tf_buffer_.lookupTransform("map", msg->header.frame_id, tf2::TimePointZero);
+    RCLCPP_DEBUG(get_logger(), "pcl time is invalid, using tf2::TimePointZero");
+  } else {
+    RCLCPP_WARN(get_logger(), "no transform found for no_ground_pointcloud");
+    return std::nullopt;
   }
 
   pcl::PointCloud<pcl::PointXYZ> pc;


### PR DESCRIPTION
## Description
We will modify the system to transform the obstacle point cloud from the ego-centric coordinate system to the world coordinate system, using the ego-pose at the time of the point cloud's acquisition.

We understand that the current implementation is a result of various past issues. Therefore, we have ensured that no correction is applied if a valid correction time cannot be obtained.

## Related links
https://github.com/autowarefoundation/autoware_universe/pull/8839/files#diff-8abdd50961072dc725fdb3ccf44e392a37324e9b98d239224eaf2c30163ea88eL189-L190

## How was this PR tested?
compesation times are obtained well in
- psim with use_sim_time:= false (default)
- psim with use_sim_time:= true
- scenario_simulator

## Notes for reviewers

None.

## Interface changes

None.


## Effects on system behavior

None.
