### PR TITLE
feat(adapi_specs): rename control command api

### DIFF
--- a/api/autoware_adapi_specs/include/autoware/adapi_specs/control.hpp
+++ b/api/autoware_adapi_specs/include/autoware/adapi_specs/control.hpp
@@ -1,0 +1,66 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__ADAPI_SPECS__CONTROL_HPP_
+#define AUTOWARE__ADAPI_SPECS__CONTROL_HPP_
+
+#include <rclcpp/qos.hpp>
+
+#include <autoware_adapi_v1_msgs/msg/acceleration_command.hpp>
+#include <autoware_adapi_v1_msgs/msg/pedals_command.hpp>
+#include <autoware_adapi_v1_msgs/msg/steering_command.hpp>
+#include <autoware_adapi_v1_msgs/msg/velocity_command.hpp>
+
+namespace autoware::adapi_specs::control
+{
+
+struct PedalsCommand
+{
+  using Message = autoware_adapi_v1_msgs::msg::PedalsCommand;
+  static constexpr char name[] = "/api/control/command/pedals";
+  static constexpr size_t depth = 1;
+  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+};
+
+struct AccelerationCommand
+{
+  using Message = autoware_adapi_v1_msgs::msg::AccelerationCommand;
+  static constexpr char name[] = "/api/control/command/acceleration";
+  static constexpr size_t depth = 1;
+  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+};
+
+struct VelocityCommand
+{
+  using Message = autoware_adapi_v1_msgs::msg::VelocityCommand;
+  static constexpr char name[] = "/api/control/command/velocity";
+  static constexpr size_t depth = 1;
+  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+};
+
+struct SteeringCommand
+{
+  using Message = autoware_adapi_v1_msgs::msg::SteeringCommand;
+  static constexpr char name[] = "/api/control/command/steering";
+  static constexpr size_t depth = 1;
+  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+};
+
+}  // namespace autoware::adapi_specs::control
+
+#endif  // AUTOWARE__ADAPI_SPECS__CONTROL_HPP_

--- a/api/autoware_adapi_specs/include/autoware/adapi_specs/vehicle.hpp
+++ b/api/autoware_adapi_specs/include/autoware/adapi_specs/vehicle.hpp
@@ -17,14 +17,10 @@
 
 #include <rclcpp/qos.hpp>
 
-#include <autoware_adapi_v1_msgs/msg/acceleration_command.hpp>
 #include <autoware_adapi_v1_msgs/msg/door_status_array.hpp>
-#include <autoware_adapi_v1_msgs/msg/pedals_command.hpp>
-#include <autoware_adapi_v1_msgs/msg/steering_command.hpp>
 #include <autoware_adapi_v1_msgs/msg/vehicle_kinematics.hpp>
 #include <autoware_adapi_v1_msgs/msg/vehicle_metrics.hpp>
 #include <autoware_adapi_v1_msgs/msg/vehicle_status.hpp>
-#include <autoware_adapi_v1_msgs/msg/velocity_command.hpp>
 #include <autoware_adapi_v1_msgs/srv/get_door_layout.hpp>
 #include <autoware_adapi_v1_msgs/srv/get_vehicle_dimensions.hpp>
 #include <autoware_adapi_v1_msgs/srv/set_door_command.hpp>
@@ -84,42 +80,6 @@ struct DoorStatus
   static constexpr size_t depth = 1;
   static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
-};
-
-struct PedalsCommand
-{
-  using Message = autoware_adapi_v1_msgs::msg::PedalsCommand;
-  static constexpr char name[] = "/api/vehicle/command/pedals";
-  static constexpr size_t depth = 1;
-  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
-  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-};
-
-struct AccelerationCommand
-{
-  using Message = autoware_adapi_v1_msgs::msg::AccelerationCommand;
-  static constexpr char name[] = "/api/vehicle/command/acceleration";
-  static constexpr size_t depth = 1;
-  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
-  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-};
-
-struct VelocityCommand
-{
-  using Message = autoware_adapi_v1_msgs::msg::VelocityCommand;
-  static constexpr char name[] = "/api/vehicle/command/velocity";
-  static constexpr size_t depth = 1;
-  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
-  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-};
-
-struct SteeringCommand
-{
-  using Message = autoware_adapi_v1_msgs::msg::SteeringCommand;
-  static constexpr char name[] = "/api/vehicle/command/steering";
-  static constexpr size_t depth = 1;
-  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
-  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
 };
 
 }  // namespace autoware::adapi_specs::vehicle


### PR DESCRIPTION
## Description

Rename command API. This is not yet released so does not affect compatibility.

>The name "vehicle command" is confusing with the actual value of the vehicle.
This API is a target value, so rename it to "control command" before release.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware-documentation/pull/675
- https://github.com/autowarefoundation/autoware_universe/pull/10834

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

None

## Notes for reviewers

Should be merged with https://github.com/autowarefoundation/autoware_universe/pull/10834.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
