### PR TITLE
fix(test_utils): add missing lane ids in `makeBehaviorNormalRoute()`

### DIFF
--- a/testing/autoware_test_utils/src/autoware_test_utils.cpp
+++ b/testing/autoware_test_utils/src/autoware_test_utils.cpp
@@ -265,7 +265,7 @@ LaneletRoute makeBehaviorNormalRoute()
   route.goal_pose =
     createPose({3778.362060546875, 73721.2734375, -0.5107480274693206, 0.8597304533609347});
 
-  std::vector<int> primitive_ids = {9102, 9178, 54, 112};
+  std::vector<int> primitive_ids = {9102, 9540, 9546, 9178, 54, 112};
   for (int id : primitive_ids) {
     route.segments.push_back(createLaneletSegment(id));
   }


### PR DESCRIPTION
## Description

This PR fixes `makeBehaviorNormalRoute()` for the route to have all the necessary lanelet segments.

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
