### PR TITLE
fix(obstacle_stop): fix the brief stop decision logic

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/utils.cpp
@@ -201,8 +201,13 @@ double calc_possible_min_dist_from_obj_to_traj_poly(
 {
   const double object_possible_max_dist =
     calc_object_possible_max_dist_from_center(object->predicted_object.shape);
+  // The minimum lateral distance to the trajectory polygon is estimated by assuming that the
+  // ego-vehicle's front right or left corner is the furthest from the trajectory, in the very worst
+  // case
+  const double ego_possible_max_dist =
+    std::hypot(vehicle_info.max_longitudinal_offset_m, vehicle_info.vehicle_width_m / 2.0);
   const double possible_min_dist_to_traj_poly =
-    std::abs(object->get_dist_to_traj_lateral(traj_points)) - vehicle_info.vehicle_width_m / 2.0 -
+    std::abs(object->get_dist_to_traj_lateral(traj_points)) - ego_possible_max_dist -
     object_possible_max_dist;
   return possible_min_dist_to_traj_poly;
 }


### PR DESCRIPTION
## Description
- fixed the brief stop decision logic
- added several debug print

**before**
No stop decision even though the obstacle is enough close to the trajectory.
<img width="1477" height="1294" alt="image" src="https://github.com/user-attachments/assets/b61c11ec-b2ff-4af0-be5e-4aacdf1a537f" />

**after**
<img width="818" height="670" alt="image" src="https://github.com/user-attachments/assets/e24417b9-75f0-4562-abf1-5070833264e9" />


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
https://evaluation.tier4.jp/evaluation/reports/a9681a7b-3089-56fd-b6c3-f293d0884cea?project_id=prd_jt
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
