### PR TITLE
feat(autoware_ndt_scan_matcher): extend timeout for test case

### DIFF
--- a/localization/autoware_ndt_scan_matcher/CMakeLists.txt
+++ b/localization/autoware_ndt_scan_matcher/CMakeLists.txt
@@ -66,9 +66,11 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   ament_auto_add_gtest(standard_sequence_for_initial_pose_estimation
     test/test_cases/standard_sequence_for_initial_pose_estimation.cpp
+    TIMEOUT "300"
   )
   ament_auto_add_gtest(once_initialize_at_out_of_map_then_initialize_correctly
     test/test_cases/once_initialize_at_out_of_map_then_initialize_correctly.cpp
+    TIMEOUT "300"
   )
 endif()
 


### PR DESCRIPTION
## Description
I am currently trying to release Autoware Core in ROS Buildfarm, but the test for autoware_ndt_scan_matcher is failing due to timeout. ([Latest Log](https://build.ros2.org/job/Hdev__autoware_core__ubuntu_jammy_amd64/61/consoleFull))

<img width="1425" height="474" alt="image" src="https://github.com/user-attachments/assets/266d1f06-cb45-42c6-938c-93fa166b4730" />

This PR extends the timeout for ndt_scan_matcher test cases to make sure that we can finish test before timeout. 
I have confirmed that the tests take about 150 secs each on my Ryzen 3950x machine so I'm setting the new timeout to be 300 secs, but we might have to further extend the timeout if the buildfarm still fails to finish the test in time.

One of the reasons why it's taking so long could be the Build Type. I will also create pull request to autoware_cmake to set build type to release if CMAKE_BUILD_TYPE is not specified. ([Something similar to what nav2 to does in nav2_package.cmake](https://github.com/ros-navigation/navigation2/blob/9cd0f9fc977242a30f4921c8fdb99ada2ec61093/nav2_common/cmake/nav2_package.cmake#L21-L28)).

## Related links

- https://build.ros2.org/job/Hdev__autoware_core__ubuntu_jammy_amd64/61/consoleFull
- https://build.ros2.org/job/Hdev__autoware_core__ubuntu_jammy_amd64/61/testReport/(root)/projectroot/standard_sequence_for_initial_pose_estimation/

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Tested with the following colcon build & colcon test commands that are used in ROS buildfarm:
```
colcon build --build-base build_isolated --install-base install_isolated --test-result-base test_results --event-handlers console_cohesion+ --cmake-clean-cache --test-result-base /tmp/ws/test_results --cmake-args -DBUILD_TESTING=1 --packages-up-to autoware_ndt_scan_matcher

colcon test --build-base build_isolated --install-base install_isolated --test-result-base test_results --event-handlers console_direct+ --executor sequential --test-result-base /tmp/ws/test_results --packages-select autoware_ndt_scan_matcher
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
