### PR TITLE
feat(obstacle_stop): hold behavior stop margin

### DIFF
--- a/planning/autoware_core_planning/config/motion_velocity_planner/obstacle_stop.param.yaml
+++ b/planning/autoware_core_planning/config/motion_velocity_planner/obstacle_stop.param.yaml
@@ -9,6 +9,7 @@
         stop_margin : 5.0 # longitudinal margin to obstacle [m]
         terminal_stop_margin : 3.0 # Stop margin at the goal. This value cannot exceed stop margin. [m]
         min_behavior_stop_margin: 3.0 # [m]
+        behavior_stop_margin_hold_time: 2.0 # [s] time to hold the min_behavior_stop_margin after disappearing the behavior stop point
 
         max_negative_velocity: -1.0 # [m/s] maximum velocity of opposing traffic to consider stop planning
         stop_margin_opposing_traffic: 10.0 # Ideal stop-margin from moving opposing obstacle when ego comes to a stop

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
@@ -9,6 +9,7 @@
         stop_margin : 5.0 # longitudinal margin to obstacle [m]
         terminal_stop_margin : 3.0 # Stop margin at the goal. This value cannot exceed stop margin. [m]
         min_behavior_stop_margin: 3.0 # [m]
+        behavior_stop_margin_hold_time: 2.0 # [s] time to hold the min_behavior_stop_margin after disappearing the behavior stop point
 
         max_negative_velocity: -1.0 # [m/s] maximum velocity of opposing traffic to consider stop planning
         stop_margin_opposing_traffic: 10.0 # Ideal stop-margin from moving opposing obstacle when ego comes to a stop

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.hpp
@@ -105,6 +105,8 @@ private:
   std::vector<StopObstacle> prev_closest_stop_obstacles_{};
   std::vector<StopObstacle> prev_stop_obstacles_{};
   std::deque<PointcloudStopCandidate> pointcloud_stop_candidates{};
+  std::optional<std::pair<rclcpp::Time, double>> last_observed_behavior_stop_time_and_margin_{
+    std::nullopt};
 
   autoware::motion_velocity_planner::obstacle_stop::PathLengthBuffer path_length_buffer_;
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/parameters.hpp
@@ -245,6 +245,7 @@ struct StopPlanningParam
   double stop_margin{};
   double terminal_stop_margin{};
   double min_behavior_stop_margin{};
+  double behavior_stop_margin_hold_time{};
   double max_negative_velocity{};
   double stop_margin_opposing_traffic{};
   double effective_deceleration_opposing_traffic{};
@@ -275,6 +276,8 @@ struct StopPlanningParam
       get_or_declare_parameter<double>(node, "obstacle_stop.stop_planning.terminal_stop_margin");
     min_behavior_stop_margin = get_or_declare_parameter<double>(
       node, "obstacle_stop.stop_planning.min_behavior_stop_margin");
+    behavior_stop_margin_hold_time = get_or_declare_parameter<double>(
+      node, "obstacle_stop.stop_planning.behavior_stop_margin_hold_time");
     max_negative_velocity =
       get_or_declare_parameter<double>(node, "obstacle_stop.stop_planning.max_negative_velocity");
     stop_margin_opposing_traffic = get_or_declare_parameter<double>(


### PR DESCRIPTION
## Description
This PR consists of the following changes.
Feature: Implemented a feature to hold the behavior adjusted stop margin for the duration specified by `behavior_stop_margin_hold_time.`

Change: Modified the system to use a behavior-adaptive stop margin instead of a constant distance when a stop point.
In the previous code, `min_behavior_stop_margin` is used as the margin length if required.
After this PR, for such cases, stop_margin is calculated to fit the behavior stop point and `min_behavior_stop_margin` is used only for the clamp length for this margin.

## Related links
launch PR: https://github.com/autowarefoundation/autoware_launch/pull/1670
issue: https://github.com/autowarefoundation/autoware_core/issues/516

## How was this PR tested?
psim and tie4 scenario test


hold behavior:
[hold.webm](https://github.com/user-attachments/assets/622ed44f-926b-4b90-8e00-df0ae97b8055)

adaptive margin:
[position.webm](https://github.com/user-attachments/assets/1fe897e2-fe47-4b1e-acdc-46e0b1b6e802)


## Notes for reviewers

## Interface changes

None.



## Effects on system behavior

None.
