### PR TITLE
feat(motion_velocity_planner_common): expose resample_trajectory_points()

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/utils.hpp
@@ -63,6 +63,9 @@ std::vector<T> concat_vectors(std::vector<T> first_vector, std::vector<T> second
   return first_vector;
 }
 
+std::vector<TrajectoryPoint> resample_trajectory_points(
+  const std::vector<TrajectoryPoint> & traj_points, const double interval);
+
 /**
  * @brief crop part of the `traj_points` from `current_pose`, resample it by
  * `decimate_trajectory_step_length`, and extend the end by `goal_extended_trajectory_length`


### PR DESCRIPTION
## Description
Make the resample_trajectory_points function public by adding it to the header file. This change is necessary to allow its use in the obstacle_slow_down module.

## Related links
obstacle_slow_down PR: https://github.com/autowarefoundation/autoware_universe/pull/11498

## How was this PR tested?
psim and tier4 scenario test

## Notes for reviewers

None.

## Interface changes

None.



## Effects on system behavior

None.
