### PR TITLE
feat(polygon_utils): move calculate_error_poses to header file

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/polygon_utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/polygon_utils.hpp
@@ -97,6 +97,14 @@ std::vector<double> calc_front_outer_wheel_off_tracking(
   const std::vector<TrajectoryPoint> & traj_points, const VehicleInfo & vehicle_info);
 
 /**
+ * @brief estimate the future ego pose with assuming that the pose error against the reference path
+ * will decrease to zero by the time_to_convergence.
+ **/
+std::vector<geometry_msgs::msg::Pose> calculate_error_poses(
+  const std::vector<TrajectoryPoint> & traj_points,
+  const geometry_msgs::msg::Pose & current_ego_pose, const double time_to_convergence);
+
+/**
  * @brief return MultiPolygon whose each element represents a convex polygon comprising footprint
  * at the corresponding index position + footprint at the previous index position
  * @param enable_to_consider_current_pose if true, `current_ego_pose`


### PR DESCRIPTION
## Description
The `motion_velocity_planner::polygon_utils::calculate_error_poses` function is currently only used within `create_one_step_polygons`. This PR moving its declaration to the header file to allow external functions to reuse it. This will enable the creation of functions similar to `create_one_step_polygons` (e.g., a function to get polygons only in front of the ego's front bumper).

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- (ADDED by @sasakisasaki ) CI passed as [this result](https://github.com/autowarefoundation/autoware_core/actions/runs/18579580685/job/52971667269?pr=676)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
