### PR TITLE
chore(autoware_crop_box_filter): add missing JSON schema

### DIFF
--- a/sensing/autoware_crop_box_filter/schema/crop_box_filter_node.schema.json
+++ b/sensing/autoware_crop_box_filter/schema/crop_box_filter_node.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Parameters for Gnss Poser Node",
+  "title": "Parameters for Crop Box Filter Node",
   "type": "object",
   "definitions": {
     "crop_box_filter": {


### PR DESCRIPTION
## Description

No code changes. 
This PR adds the missing JSON parameter schema as per [the Autoware Docs](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/parameters/#json-schema).