### PR TITLE
fix(motion_velocity_planner): prevent sudden yaw changes by adjusting overlap threshold for stop point insertion

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
@@ -367,8 +367,8 @@ void MotionVelocityPlannerNode::insert_stop(
   const double overlap_threshold = 5e-2;
   const auto seg_idx =
     autoware::motion_utils::findNearestSegmentIndex(trajectory.points, stop_point);
-  const auto insert_idx =
-    autoware::motion_utils::insertTargetPoint(seg_idx, stop_point, trajectory.points, overlap_threshold);
+  const auto insert_idx = autoware::motion_utils::insertTargetPoint(
+    seg_idx, stop_point, trajectory.points, overlap_threshold);
   if (insert_idx) {
     for (auto idx = *insert_idx; idx < trajectory.points.size(); ++idx)
       trajectory.points[idx].longitudinal_velocity_mps = 0.0;


### PR DESCRIPTION
## Description

In `autoware_motion_velocity_planner`, stop_points received from each submodule are embedded into the trajectory. However, when embedding stop_points from the road_user_stop module, I observed a phenomenon where the yaw angle of the trajectory near the insertion point becomes extremely large.
The positional relationship of points when the yaw angle becomes extremely large is shown below.

<img width="1807" height="526" alt="image" src="https://github.com/user-attachments/assets/a62f0a4d-45b8-4575-9f18-3cda0e137fc4" />


As can be seen from the plot, the stop_point is very close to an existing trajectory point.

The following code handles stop point insertion, but it doesn't consider the positional relationship with existing trajectory points, which is believed to be causing this phenomenon.
https://github.com/autowarefoundation/autoware_core/blob/main/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp#L361-L375
```
void MotionVelocityPlannerNode::insert_stop(
  autoware_planning_msgs::msg::Trajectory & trajectory,
  const geometry_msgs::msg::Point & stop_point) const
{
  const auto seg_idx =
    autoware::motion_utils::findNearestSegmentIndex(trajectory.points, stop_point);
  const auto insert_idx =
    autoware::motion_utils::insertTargetPoint(seg_idx, stop_point, trajectory.points);
  if (insert_idx) {
    for (auto idx = *insert_idx; idx < trajectory.points.size(); ++idx)
      trajectory.points[idx].longitudinal_velocity_mps = 0.0;
  } else {
    RCLCPP_WARN(get_logger(), "Failed to insert stop point");
  }
}
```


Other modules implement a threshold to prevent stop_points from overlapping with existing trajectory points when embedding them as a countermeasure against similar phenomena.
https://github.com/autowarefoundation/autoware_core/blob/main/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp#L737-L759
```
std::optional<geometry_msgs::msg::Pose> insertDecelPoint(
  const geometry_msgs::msg::Point & stop_point, PathWithLaneId & output,
  const float target_velocity)
{
  // TODO(tanaka): consider proper overlap threshold for inserting decel point
  const double overlap_threshold = 5e-2;
  // TODO(murooka): remove this function for u-turn and crossing-path
  const size_t base_idx =
    autoware::motion_utils::findNearestSegmentIndex(output.points, stop_point);
  const auto insert_idx = autoware::motion_utils::insertTargetPoint(
    base_idx, stop_point, output.points, overlap_threshold);

  if (!insert_idx) {
    return {};
  }

  for (size_t i = insert_idx.value(); i < output.points.size(); ++i) {
    const auto & original_velocity = output.points.at(i).point.longitudinal_velocity_mps;
    output.points.at(i).point.longitudinal_velocity_mps =
      std::min(original_velocity, target_velocity);
  }
  return autoware_utils_geometry::get_pose(output.points.at(insert_idx.value()));
}
```


Following this approach, I will implement a same threshold in `autoware_motion_velocity_planner`.

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- [x] Verified that the sudden yaw changes observed with the original code at specific locations were resolved after the changes using actual rosbag data
  - Tested using planning_simulator and perception_reproducer
- [x] Passed TIERIV's internal CI checks
  - [x] [Test link part 1](https://evaluation.tier4.jp/evaluation/reports/37415a07-0478-5af2-a3cd-79feb67aa552?project_id=prd_jt)
  - [x] [Test link part 2](https://evaluation.tier4.jp/evaluation/reports/2ae70a68-0dd5-58fe-85b5-9e36fba1e67a?project_id=prd_jt)
  - [x] [Test link part 3](https://evaluation.tier4.jp/evaluation/reports/37415a07-0478-5af2-a3cd-79feb67aa552?project_id=prd_jt)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
