### PR TITLE
fix(autoware_lanelet2_utils): add scoped header installation for ROS 2 compatibility

### DIFF
--- a/common/autoware_lanelet2_utils/CMakeLists.txt
+++ b/common/autoware_lanelet2_utils/CMakeLists.txt
@@ -46,7 +46,7 @@ if(BUILD_TESTING)
   endforeach()
 endif()
 
-ament_auto_package(INSTALL_TO_SHARE
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR INSTALL_TO_SHARE
   sample_map
   test_data
 )


### PR DESCRIPTION
## Description

This PR fixes the header installation warning for the `autoware_lanelet2_utils` package by adding the `USE_SCOPED_HEADER_INSTALL_DIR` option to `ament_auto_package()`.

### Warning Being Fixed

```
In this package, headers install destination is set to `include` by ament_auto_package. 
It is recommended to install `include/autoware_lanelet2_utils` instead and will be the 
default behavior of ament_auto_package from ROS 2 Kilted Kaiju. On distributions before 
Kilted, ament_auto_package behaves the same way when you use USE_SCOPED_HEADER_INSTALL_DIR option.
```

### Changes Made

- Added `USE_SCOPED_HEADER_INSTALL_DIR` to `ament_auto_package()` call in `/home/yutakakondo/src/autoware_core/common/autoware_lanelet2_utils/CMakeLists.txt`
- Maintained existing `INSTALL_TO_SHARE` functionality

## How was this PR tested?

### Build Test
```bash
colcon build --symlink-install --packages-select autoware_lanelet2_utils
```
Result: Build completes successfully without warnings

### Unit Tests
```bash
colcon test --packages-select autoware_lanelet2_utils
colcon test-result --all | grep autoware_lanelet2_utils
```
Result: All 131 tests pass (0 errors, 0 failures)

## Notes for reviewers

- This change is backward compatible with ROS 2 Humble and Jazzy
- Headers will now be installed to `include/autoware_lanelet2_utils/` instead of `include/`
- This aligns with ROS 2 best practices and prepares for Kilted Kaiju compatibility
- Part of issue #623 (Autoware.core support ROS2 JAZZY)

## Interface changes

None - this is an internal build system change that does not affect the API

## Effects on system behavior

None - this only affects the installation directory structure for headers