### PR TITLE
feat(motion_velocity_planner_common): search closest collision point insead of first collision index

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/polygon_utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/polygon_utils.cpp
@@ -200,7 +200,7 @@ std::vector<geometry_msgs::msg::Pose> calculate_error_poses(
 
 std::optional<std::pair<geometry_msgs::msg::Point, double>> get_collision_point(
   const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
-  const geometry_msgs::msg::Point obj_position, const rclcpp::Time obj_stamp,
+  const geometry_msgs::msg::Point obj_position, [[maybe_unused]] const rclcpp::Time obj_stamp,
   const Polygon2d & obj_polygon, const double x_offset_to_bumper)
 {
   assert(traj_points.size() == traj_polygons.size());


### PR DESCRIPTION
## Description
Previously, get_collision_point() in motion_velocity_planner_common returned the collision point based only on the first polygon it detected a collision with. However, this calculation method proved inadequate in certain situations.

The issue arises specifically when the collision point is on the side of the vehicle body. This is more likely to occur with long vehicles or on curves with a high curvature (tight turns).

The polygon generation algorithm we currently use (which generates a convex hull based on vehicle footprints at 2m intervals) also exacerbates this problem.

To address this issue, the logic of get_collision_point() has been modified as follows:

Before: Returned the collision point with only the first detected obstacle polygon.
After: The function now searches all vehicle polygons along the path, extending up to one vehicle length ahead of the initial collision point. It then returns the closest (nearest) collision point found within this expanded search range.

Before:
<img width="3840" height="2160" alt="Screenshot from 2025-11-05 11-31-06" src="https://github.com/user-attachments/assets/ccda2400-9499-43f5-8c77-5595b8cd4fc2" />

After:
<img width="3840" height="2160" alt="Screenshot from 2025-11-05 11-26-42" src="https://github.com/user-attachments/assets/077ee355-4604-43d7-be55-dd7485664cb3" />



## Related links


## How was this PR tested?

(ADDED by @sasakisasaki ) It seems the tests are performed by using planning simulator as the PR description says.

## Notes for reviewers



## Interface changes

None.


## Effects on system behavior

None.
