### PR TITLE
feat(autoware_lanelet2_utils): port get_conflicting_lanelets

### DIFF
--- a/common/autoware_lanelet2_utils/include/autoware/lanelet2_utils/topology.hpp
+++ b/common/autoware_lanelet2_utils/include/autoware/lanelet2_utils/topology.hpp
@@ -122,7 +122,7 @@ lanelet::ConstLanelets from_ids(
  * @param [in] lanelet input lanelet
  */
 lanelet::ConstLanelets get_conflicting_lanelets(
-  const lanelet::routing::RoutingGraphConstPtr & graph, const lanelet::ConstLanelet & lanelet);
+  const lanelet::ConstLanelet & lanelet, const lanelet::routing::RoutingGraphConstPtr & graph);
 }  // namespace autoware::experimental::lanelet2_utils
 
 #endif  // AUTOWARE__LANELET2_UTILS__TOPOLOGY_HPP_

--- a/common/autoware_lanelet2_utils/src/topology.cpp
+++ b/common/autoware_lanelet2_utils/src/topology.cpp
@@ -160,7 +160,7 @@ lanelet::ConstLanelets from_ids(
 }
 
 lanelet::ConstLanelets get_conflicting_lanelets(
-  const lanelet::routing::RoutingGraphConstPtr & graph, const lanelet::ConstLanelet & lanelet)
+  const lanelet::ConstLanelet & lanelet, const lanelet::routing::RoutingGraphConstPtr & graph)
 {
   const auto & llt_or_areas = graph->conflicting(lanelet);
   lanelet::ConstLanelets lanelets;

--- a/common/autoware_lanelet2_utils/test/topology.cpp
+++ b/common/autoware_lanelet2_utils/test/topology.cpp
@@ -224,7 +224,7 @@ TEST_F(TestWithIntersectionCrossingInverseMap, left_opposite_lanelet_null)
 TEST_F(TestWithIntersectionCrossingMap, empty_conflicting_lanelet)
 {
   const auto conflicting_lanelets = lanelet2_utils::get_conflicting_lanelets(
-    routing_graph_ptr_, lanelet_map_ptr_->laneletLayer.get(2312));
+    lanelet_map_ptr_->laneletLayer.get(2312), routing_graph_ptr_);
 
   ASSERT_EQ(conflicting_lanelets.size(), 0) << "Conflicting lanelets should be empty";
 }
@@ -232,7 +232,7 @@ TEST_F(TestWithIntersectionCrossingMap, empty_conflicting_lanelet)
 TEST_F(TestWithIntersectionCrossingMap, ordinary_conflicting_lanelet)
 {
   const auto conflicting_lanelets = lanelet2_utils::get_conflicting_lanelets(
-    routing_graph_ptr_, lanelet_map_ptr_->laneletLayer.get(2270));
+    lanelet_map_ptr_->laneletLayer.get(2270), routing_graph_ptr_);
 
   ASSERT_EQ(conflicting_lanelets.size(), 3) << "Size of the conflicting_lanelet doesn't match";
 


### PR DESCRIPTION
## Description
Port function `getConflictingLanelets` from `autoware_lanelet2_extension` to `autoware_lanelet2_utils/topology`.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
