### PR TITLE
fix(behavior_velocity_planner): fix namespace resolution failure

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/util.hpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/include/autoware/behavior_velocity_planner_common/utilization/util.hpp
@@ -259,15 +259,15 @@ lanelet::Ids collectConnectedLaneIds(
   const int64_t lane_id, const std::shared_ptr<route_handler::RouteHandler> & route_handler);
 
 PathWithLaneId fromTrajectory(
-  const experimental::trajectory::Trajectory<
+  const autoware::experimental::trajectory::Trajectory<
     autoware_internal_planning_msgs::msg::PathPointWithLaneId> & path,
   const std::vector<geometry_msgs::msg::Point> & left_bound,
   const std::vector<geometry_msgs::msg::Point> & right_bound);
 
 void toTrajectory(
   const PathWithLaneId & path_msg,
-  experimental::trajectory::Trajectory<autoware_internal_planning_msgs::msg::PathPointWithLaneId> &
-    path);
+  autoware::experimental::trajectory::Trajectory<
+    autoware_internal_planning_msgs::msg::PathPointWithLaneId> & path);
 
 }  // namespace planning_utils
 }  // namespace autoware::behavior_velocity_planner


### PR DESCRIPTION
## Description

This PR fixes namespace resolution failure in `behavior_velocity_planner_common` package.

In #681, the `behavior_velocity_planner` modules were moved to `autoware::behavior_velocity_planner::experimental` namespace. As a result, the `Trajectory` class in `autoware::experimental::trajectory` namespace could no longer be referenced relatively. To address this, the `Trajectory` class is now referenced using its fully qualified (global) namespace.

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
