### PR TITLE
fix(path_generator): cut path before loop prior to intersection check

### DIFF
--- a/planning/autoware_path_generator/src/node.cpp
+++ b/planning/autoware_path_generator/src/node.cpp
@@ -313,14 +313,6 @@ std::optional<PathWithLaneId> PathGenerator::generate_path(
     s_end = std::min(s_end, lanelet::geometry::length2d(lanelet::LaneletSequence(lanelets)));
   }
 
-  const auto s_intersection = utils::get_first_intersection_arc_length(
-    lanelets, std::max(0., s_start - vehicle_info_.max_longitudinal_offset_m),
-    s_end + vehicle_info_.max_longitudinal_offset_m, vehicle_info_.vehicle_length_m);
-  if (s_intersection) {
-    s_end =
-      std::min(s_end, std::max(0., *s_intersection - vehicle_info_.max_longitudinal_offset_m));
-  }
-
   std::optional<lanelet::ConstLanelet> goal_lanelet_for_path = std::nullopt;
   for (auto [it, s] = std::make_tuple(lanelets.begin(), 0.); it != lanelets.end(); ++it) {
     const auto & lane_id = it->id();
@@ -347,6 +339,14 @@ std::optional<PathWithLaneId> PathGenerator::generate_path(
       lanelets.erase(std::next(it), lanelets.end());
       break;
     }
+  }
+
+  const auto s_intersection = utils::get_first_intersection_arc_length(
+    lanelets, std::max(0., s_start - vehicle_info_.max_longitudinal_offset_m),
+    s_end + vehicle_info_.max_longitudinal_offset_m, vehicle_info_.vehicle_length_m);
+  if (s_intersection) {
+    s_end =
+      std::min(s_end, std::max(0., *s_intersection - vehicle_info_.max_longitudinal_offset_m));
   }
 
   return generate_path(lanelets, s_start, s_end, goal_lanelet_for_path, params);


### PR DESCRIPTION
## Description

This PR fixes `path_generator`'s path cut feature. Path will be cut before the first loop prior to intersection check to prevent unintended cut at the loop.

## Related links

Internal: https://tier4.enterprise.slack.com/archives/C017VB9UG1L/p1764209654461839?thread_ts=1763082550.481979&channel=C017VB9UG1L&message_ts=1764209654.461839

## How was this PR tested?

https://evaluation.tier4.jp/evaluation/reports/4262dd02-3720-57fa-9b24-04d3da0db308?project_id=prd_jt

https://evaluation.tier4.jp/evaluation/reports/70d1c576-6e1f-53e5-828b-6758dec4cf4e?project_id=autoware_dev

Without this PR, the following scenario fails:
https://evaluation.tier4.jp/evaluation/reports/e0dea671-7a7c-5593-9d6f-35dd0f0af531/tests/ede93fb1-a502-56c6-be0b-f8da4713c017/baee2c82-a0bf-5a83-8d0d-032d7108d976/178d6a91-3dbd-5e00-b069-480eb74c7ccd?project_id=X8ft5pPN

With this PR, it succeeds:

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
