### PR TITLE
feat(autoware_pyplot): adds stem plot support

### DIFF
--- a/testing/autoware_pyplot/include/autoware/pyplot/axes.hpp
+++ b/testing/autoware_pyplot/include/autoware/pyplot/axes.hpp
@@ -115,6 +115,10 @@ public:
     const pybind11::tuple & args = pybind11::tuple(),
     const pybind11::dict & kwargs = pybind11::dict()) const;
 
+  PyObjectWrapper stem(
+    const pybind11::tuple & args = pybind11::tuple(),
+    const pybind11::dict & kwargs = pybind11::dict()) const;
+
   PyObjectWrapper text(
     const pybind11::tuple & args = pybind11::tuple(),
     const pybind11::dict & kwargs = pybind11::dict()) const;
@@ -147,6 +151,7 @@ private:
   pybind11::object set_ylabel_attr;
   pybind11::object set_ylim_attr;
   pybind11::object set_zlim_attr;
+  pybind11::object stem_attr;
   pybind11::object text_attr;
   pybind11::object view_init_attr;
 

--- a/testing/autoware_pyplot/include/autoware/pyplot/pyplot.hpp
+++ b/testing/autoware_pyplot/include/autoware/pyplot/pyplot.hpp
@@ -92,6 +92,10 @@ public:
     const pybind11::tuple & args = pybind11::tuple(),
     const pybind11::dict & kwargs = pybind11::dict());
 
+  PyObjectWrapper stem(
+    const pybind11::tuple & args = pybind11::tuple(),
+    const pybind11::dict & kwargs = pybind11::dict());
+
   axes::Axes subplot(const pybind11::dict & kwargs = pybind11::dict());
   axes::Axes subplot(int cri);
 
@@ -138,6 +142,7 @@ private:
   pybind11::object savefig_attr;
   pybind11::object scatter_attr;
   pybind11::object show_attr;
+  pybind11::object stem_attr;
   pybind11::object subplot_attr;
   pybind11::object subplots_attr;
   pybind11::object title_attr;

--- a/testing/autoware_pyplot/src/axes.cpp
+++ b/testing/autoware_pyplot/src/axes.cpp
@@ -118,6 +118,11 @@ PyObjectWrapper Axes::set_xlim(const pybind11::tuple & args, const pybind11::dic
   return PyObjectWrapper{set_xlim_attr(*args, **kwargs)};
 }
 
+PyObjectWrapper Axes::stem(const pybind11::tuple & args, const pybind11::dict & kwargs) const
+{
+  return PyObjectWrapper{stem_attr(*args, **kwargs)};
+}
+
 PyObjectWrapper Axes::set_ylabel(const pybind11::tuple & args, const pybind11::dict & kwargs) const
 {
   return PyObjectWrapper{set_ylabel_attr(*args, **kwargs)};
@@ -163,6 +168,7 @@ void Axes::load_attrs()
   LOAD_FUNC_ATTR(quiver, self_);
   LOAD_FUNC_ATTR(plot, self_);
   LOAD_FUNC_ATTR(scatter, self_);
+  LOAD_FUNC_ATTR(stem, self_);
   LOAD_FUNC_ATTR(set_aspect, self_);
   LOAD_FUNC_ATTR(set_title, self_);
   LOAD_FUNC_ATTR(set_xlabel, self_);

--- a/testing/autoware_pyplot/src/pyplot.cpp
+++ b/testing/autoware_pyplot/src/pyplot.cpp
@@ -43,6 +43,7 @@ void PyPlot::load_attrs()
   LOAD_FUNC_ATTR(savefig, mod);
   LOAD_FUNC_ATTR(scatter, mod);
   LOAD_FUNC_ATTR(show, mod);
+  LOAD_FUNC_ATTR(stem, mod);
   LOAD_FUNC_ATTR(subplot, mod);
   LOAD_FUNC_ATTR(subplots, mod);
   LOAD_FUNC_ATTR(title, mod);
@@ -130,6 +131,11 @@ PyObjectWrapper PyPlot::savefig(const pybind11::tuple & args, const pybind11::di
 PyObjectWrapper PyPlot::show(const pybind11::tuple & args, const pybind11::dict & kwargs)
 {
   return PyObjectWrapper{show_attr(*args, **kwargs)};
+}
+
+PyObjectWrapper PyPlot::stem(const pybind11::tuple & args, const pybind11::dict & kwargs)
+{
+  return PyObjectWrapper{stem_attr(*args, **kwargs)};
 }
 
 axes::Axes PyPlot::subplot(const pybind11::dict & kwargs)


### PR DESCRIPTION
## Description

Adds `stem` plot support to `autoware_pyplot`

Example of stem support.
 
```c++
plot.set_title(Args("Wait Times"));

// Stem plot is perfect for sparse events like stops
plot.stem(Args(std::vector{1, 2, 3, 4, 5}, std::vector{5, 4, 3, 4, 5}));
```

<img width="751" height="636" alt="image" src="https://github.com/user-attachments/assets/e7b8a3e8-a51e-4cb9-896a-18da250a4d5a" />

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
