### PR TITLE
fix(autoware_euclidean_cluster_object_detector): add empty point cloud check

### DIFF
--- a/perception/autoware_euclidean_cluster_object_detector/src/euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster_object_detector/src/euclidean_cluster_node.cpp
@@ -54,8 +54,7 @@ void EuclideanClusterNode::onPointCloud(
   // Check for empty point cloud
   if (input_msg->data.empty() || input_msg->width * input_msg->height == 0) {
     RCLCPP_WARN_THROTTLE(
-      get_logger(), *get_clock(), 5000,
-      "Received empty point cloud, skipping processing.");
+      get_logger(), *get_clock(), 5000, "Received empty point cloud, skipping processing.");
     // Publish empty DetectedObjects
     autoware_perception_msgs::msg::DetectedObjects output;
     output.header = input_msg->header;


### PR DESCRIPTION
## Description

- Add empty point cloud check in `euclidean_cluster_node.cpp`
- When an empty point cloud is received, the node now publishes an empty DetectedObjects message and returns early
- This prevents potential issues with PCL operations on empty data and reduces log spam

## Related links

**Parent Issue:**

- #708

## How was this PR tested?

- [x] Build passes
- [x] Existing tests pass

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.