### PR TITLE
fix(autoware_ground_filter): add empty point cloud check

### DIFF
--- a/perception/autoware_ground_filter/include/autoware/ground_filter/node.hpp
+++ b/perception/autoware_ground_filter/include/autoware/ground_filter/node.hpp
@@ -359,7 +359,7 @@ protected:
     }
 
     // Check for empty point cloud
-    if (cloud->width * cloud->height == 0 || cloud->data.empty()) {
+    if (cloud->data.empty() || cloud->width * cloud->height == 0) {
       RCLCPP_WARN(this->get_logger(), "Received empty PointCloud");
       return false;
     }


### PR DESCRIPTION
## Description

- Add empty point cloud check in ground_filter node
- When an empty point cloud is received, the node publishes empty results and returns early
- This prevents potential issues with processing empty data

## Related links

**Parent Issue:**

- #710

## How was this PR tested?

- [x] Build passes
- [x] Existing tests pass (no unit tests present in package)

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.