### PR TITLE
fix(autoware_euclidean_cluster_object_detector): add early return for empty point cloud in voxel grid node

### DIFF
--- a/perception/autoware_euclidean_cluster_object_detector/src/voxel_grid_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster_object_detector/src/voxel_grid_based_euclidean_cluster_node.cpp
@@ -65,6 +65,11 @@ void VoxelGridBasedEuclideanClusterNode::onPointCloud(
     // NOTE: prevent pcl log spam
     RCLCPP_WARN_STREAM_THROTTLE(
       this->get_logger(), *this->get_clock(), 1000, "Empty sensor points!");
+    // Publish empty DetectedObjects and return early
+    autoware_perception_msgs::msg::DetectedObjects output;
+    output.header = input_msg->header;
+    cluster_pub_->publish(output);
+    return;
   }
   // cluster and build output msg
   autoware_perception_msgs::msg::DetectedObjects output;


### PR DESCRIPTION
## Description

Add early return after empty point cloud check in `voxel_grid_based_euclidean_cluster_node.cpp`. When an empty point cloud is received, the node now publishes an empty DetectedObjects message and returns early to prevent unnecessary processing and potential issues with PCL operations on empty data.

## Related links

**Parent Issue:**

- #710

## How was this PR tested?

- [x] Build passes
- [x] Existing functional tests pass (test_voxel_grid_based_euclidean_cluster_fusion, test_euclidean_cluster, test_utils)

Note: test_nodes failures are pre-existing environment issues (ROS_DOMAIN_ID configuration) that also occur on the main branch.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.