### PR TITLE
fix(autoware_crop_box_filter): initialize transform variables on TF acquisition failure

### DIFF
--- a/sensing/autoware_crop_box_filter/src/crop_box_filter_node.cpp
+++ b/sensing/autoware_crop_box_filter/src/crop_box_filter_node.cpp
@@ -62,6 +62,9 @@ CropBoxFilter::CropBoxFilter(const rclcpp::NodeOptions & node_options)
         RCLCPP_ERROR(
           this->get_logger(), "Cannot get transform from %s to %s. Please check your TF tree.",
           tf_input_orig_frame_.c_str(), tf_input_frame_.c_str());
+        // Set identity transform and disable preprocessing when TF acquisition fails
+        need_preprocess_transform_ = false;
+        eigen_transform_preprocess_ = Eigen::Matrix4f::Identity(4, 4);
       } else {
         auto eigen_tf = tf2::transformToEigen(*tf_ptr);
         eigen_transform_preprocess_ = eigen_tf.matrix().cast<float>();
@@ -79,6 +82,9 @@ CropBoxFilter::CropBoxFilter(const rclcpp::NodeOptions & node_options)
         RCLCPP_ERROR(
           this->get_logger(), "Cannot get transform from %s to %s. Please check your TF tree.",
           tf_input_frame_.c_str(), tf_output_frame_.c_str());
+        // Set identity transform and disable postprocessing when TF acquisition fails
+        need_postprocess_transform_ = false;
+        eigen_transform_postprocess_ = Eigen::Matrix4f::Identity(4, 4);
       } else {
         auto eigen_tf = tf2::transformToEigen(*tf_ptr);
         eigen_transform_postprocess_ = eigen_tf.matrix().cast<float>();


### PR DESCRIPTION
## Description

Fix uninitialized transform variables when TF acquisition fails in `autoware_crop_box_filter`.

When `transform_listener_->get_transform()` fails, the variables `eigen_transform_preprocess_`, `eigen_transform_postprocess_`, `need_preprocess_transform_`, and `need_postprocess_transform_` were left uninitialized. This could lead to undefined behavior when these values are later used in `filter_pointcloud()`.

The fix initializes these variables on TF acquisition failure:
- Transform flags set to `false`
- Transform matrices set to identity matrices

## Related links

**Parent Issue:**

- #708

## How was this PR tested?

- [x] Build verification
- [x] Code review: initialization logic matches the pattern used when frames are equal (lines 56-57, 76-77)

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None. The fix prevents potential undefined behavior while maintaining the intended fallback behavior (no transformation when TF is unavailable).