### PR TITLE
perf(localization, sensing): reduce subscription queue size from 100 to 10

### DIFF
--- a/localization/autoware_gyro_odometer/src/gyro_odometer_core.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_core.cpp
@@ -54,11 +54,11 @@ GyroOdometerNode::GyroOdometerNode(const rclcpp::NodeOptions & node_options)
   logger_configure_ = std::make_unique<autoware_utils_logging::LoggerLevelConfigure>(this);
 
   vehicle_twist_sub_ = create_subscription<geometry_msgs::msg::TwistWithCovarianceStamped>(
-    "vehicle/twist_with_covariance", rclcpp::QoS{100},
+    "vehicle/twist_with_covariance", rclcpp::QoS{10},
     std::bind(&GyroOdometerNode::callback_vehicle_twist, this, std::placeholders::_1));
 
   imu_sub_ = create_subscription<sensor_msgs::msg::Imu>(
-    "imu", rclcpp::QoS{100},
+    "imu", rclcpp::QoS{10},
     std::bind(&GyroOdometerNode::callback_imu, this, std::placeholders::_1));
 
   twist_raw_pub_ = create_publisher<geometry_msgs::msg::TwistStamped>("twist_raw", rclcpp::QoS{10});

--- a/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -115,7 +115,7 @@ NDTScanMatcher::NDTScanMatcher(const rclcpp::NodeOptions & options)
     this, this->get_clock(), period_ns, std::bind(&NDTScanMatcher::callback_timer, this),
     timer_callback_group_);
   initial_pose_sub_ = this->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
-    "ekf_pose_with_covariance", 100,
+    "ekf_pose_with_covariance", 10,
     std::bind(&NDTScanMatcher::callback_initial_pose, this, std::placeholders::_1),
     initial_pose_sub_opt);
   sensor_points_sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(

--- a/sensing/autoware_vehicle_velocity_converter/src/vehicle_velocity_converter.cpp
+++ b/sensing/autoware_vehicle_velocity_converter/src/vehicle_velocity_converter.cpp
@@ -26,7 +26,7 @@ VehicleVelocityConverter::VehicleVelocityConverter(const rclcpp::NodeOptions & o
   speed_scale_factor_(declare_parameter<double>("speed_scale_factor"))
 {
   vehicle_report_sub_ = create_subscription<autoware_vehicle_msgs::msg::VelocityReport>(
-    "velocity_status", rclcpp::QoS{100},
+    "velocity_status", rclcpp::QoS{10},
     std::bind(&VehicleVelocityConverter::callback_velocity_report, this, std::placeholders::_1));
 
   twist_with_covariance_pub_ = create_publisher<geometry_msgs::msg::TwistWithCovarianceStamped>(


### PR DESCRIPTION
## Description

Reduce excessive subscription queue sizes from 100 to 10 to improve memory usage and reduce latency from processing stale data.

### Modified packages

| Package | Topic | Before | After |
|---------|-------|--------|-------|
| autoware_ndt_scan_matcher | ekf_pose_with_covariance | 100 | 10 |
| autoware_gyro_odometer | imu | 100 | 10 |
| autoware_gyro_odometer | vehicle/twist_with_covariance | 100 | 10 |
| autoware_vehicle_velocity_converter | velocity_status | 100 | 10 |

### Rationale

Queue size 100 is excessive for real-time control systems:
- IMU at 100Hz with queue 100 = **1 second** of buffered data (stale)
- IMU at 100Hz with queue 10 = **100ms** of buffered data (appropriate)
- Vehicle twist at 50Hz with queue 10 = **200ms** buffer

For autonomous driving, **latest data is more important than old data**. A queue of 10 provides sufficient buffer for processing jitter while avoiding stale data accumulation.

This aligns with:
- ROS 2 default QoS queue size of 10
- Autoware's real-time control requirements (30-50Hz control loop)

## Related links

**Parent Issue:**

- #709

## How was this PR tested?

- [x] Build verification for all modified packages

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

Improved memory efficiency and reduced latency when processing high-frequency sensor data.