### PR TITLE
fix: use SensorDataQoS for sensor data subscribers

### DIFF
--- a/localization/autoware_gyro_odometer/src/gyro_odometer_core.cpp
+++ b/localization/autoware_gyro_odometer/src/gyro_odometer_core.cpp
@@ -54,11 +54,11 @@ GyroOdometerNode::GyroOdometerNode(const rclcpp::NodeOptions & node_options)
   logger_configure_ = std::make_unique<autoware_utils_logging::LoggerLevelConfigure>(this);
 
   vehicle_twist_sub_ = create_subscription<geometry_msgs::msg::TwistWithCovarianceStamped>(
-    "vehicle/twist_with_covariance", rclcpp::QoS{100},
+    "vehicle/twist_with_covariance", rclcpp::SensorDataQoS(),
     std::bind(&GyroOdometerNode::callback_vehicle_twist, this, std::placeholders::_1));
 
   imu_sub_ = create_subscription<sensor_msgs::msg::Imu>(
-    "imu", rclcpp::QoS{100},
+    "imu", rclcpp::SensorDataQoS(),
     std::bind(&GyroOdometerNode::callback_imu, this, std::placeholders::_1));
 
   twist_raw_pub_ = create_publisher<geometry_msgs::msg::TwistStamped>("twist_raw", rclcpp::QoS{10});

--- a/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
+++ b/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
@@ -49,11 +49,11 @@ GNSSPoser::GNSSPoser(const rclcpp::NodeOptions & node_options)
 
   // Set subscribers and publishers
   nav_sat_fix_sub_ = create_subscription<sensor_msgs::msg::NavSatFix>(
-    "fix", rclcpp::QoS{1},
+    "fix", rclcpp::SensorDataQoS(),
     std::bind(&GNSSPoser::callback_nav_sat_fix, this, std::placeholders::_1));
   autoware_orientation_sub_ =
     create_subscription<autoware_sensing_msgs::msg::GnssInsOrientationStamped>(
-      "autoware_orientation", rclcpp::QoS{1},
+      "autoware_orientation", rclcpp::SensorDataQoS(),
       std::bind(&GNSSPoser::callback_gnss_ins_orientation_stamped, this, std::placeholders::_1));
 
   pose_pub_ = create_publisher<geometry_msgs::msg::PoseStamped>("gnss_pose", rclcpp::QoS{1});

--- a/sensing/autoware_vehicle_velocity_converter/src/vehicle_velocity_converter.cpp
+++ b/sensing/autoware_vehicle_velocity_converter/src/vehicle_velocity_converter.cpp
@@ -26,7 +26,7 @@ VehicleVelocityConverter::VehicleVelocityConverter(const rclcpp::NodeOptions & o
   speed_scale_factor_(declare_parameter<double>("speed_scale_factor"))
 {
   vehicle_report_sub_ = create_subscription<autoware_vehicle_msgs::msg::VelocityReport>(
-    "velocity_status", rclcpp::QoS{100},
+    "velocity_status", rclcpp::SensorDataQoS(),
     std::bind(&VehicleVelocityConverter::callback_velocity_report, this, std::placeholders::_1));
 
   twist_with_covariance_pub_ = create_publisher<geometry_msgs::msg::TwistWithCovarianceStamped>(


### PR DESCRIPTION
## Description

This PR updates sensor data subscribers to use `rclcpp::SensorDataQoS()` instead of `rclcpp::QoS{N}` to ensure compatibility with BEST_EFFORT publishers.

**Problem:**
- Subscribers using `rclcpp::QoS{N}` default to RELIABLE reliability policy
- RELIABLE subscribers cannot receive messages from BEST_EFFORT publishers
- Sensor data (IMU, GNSS, vehicle velocity) is typically published with BEST_EFFORT QoS for performance and real-time characteristics

**Solution:**
- Replace `rclcpp::QoS{N}` with `rclcpp::SensorDataQoS()` for sensor data subscribers
- `SensorDataQoS` provides appropriate defaults for sensor data:
  - History: keep_last(5)
  - Reliability: BEST_EFFORT
  - Durability: VOLATILE

**Modified packages:**
- `autoware_gyro_odometer`: vehicle_twist and imu subscribers
- `autoware_vehicle_velocity_converter`: velocity_status subscriber
- `autoware_gnss_poser`: fix and autoware_orientation subscribers

## Related links

**Parent Issue:**

- Related to #709 (Optimise high-frequency callbacks)

## How was this PR tested?

- Code review: Verified QoS changes follow ROS 2 best practices for sensor data
- The changes use standard ROS 2 `SensorDataQoS` class which is part of rclcpp API

## Notes for reviewers

This change improves compatibility with typical sensor driver implementations that publish with BEST_EFFORT QoS. The modified subscribers will now be able to receive sensor messages regardless of whether publishers use RELIABLE or BEST_EFFORT QoS.

The queue sizes were different across packages (1, 100), but `SensorDataQoS()` standardizes them to keep_last(5) which is appropriate for sensor data where we typically only need recent measurements.

## Interface changes

None.

## Effects on system behavior

**Improved compatibility:** Subscribers will now work with both RELIABLE and BEST_EFFORT publishers. This is especially important for sensor drivers that typically use BEST_EFFORT QoS for better real-time performance.

**Queue size change:** Queue depths are now standardized to 5 (from 1 or 100). This should not negatively impact functionality as sensor callbacks typically process recent data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)