### PR TITLE
ci(build-and-test*): add clang-tidy

### DIFF
--- a/.github/workflows/build-and-test-daily.yaml
+++ b/.github/workflows/build-and-test-daily.yaml
@@ -83,6 +83,7 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1
         with:
           rosdistro: ${{ matrix.rosdistro }}
+          cache-key-element: daily-build
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           underlay-workspace: /opt/autoware
 
@@ -146,6 +147,7 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/clang-tidy@v1
         with:
           rosdistro: ${{ matrix.rosdistro }}
+          cache-key-element: daily-build
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           clang-tidy-config-url: https://raw.githubusercontent.com/autowarefoundation/autoware/main/.clang-tidy-ci
           underlay-workspace: /opt/autoware

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -83,6 +83,7 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1
         with:
           rosdistro: ${{ matrix.rosdistro }}
+          cache-key-element: build-and-test
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           build-pre-command: taskset --cpu-list 0-6
           underlay-workspace: /opt/autoware
@@ -154,6 +155,7 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/clang-tidy@v1
         with:
           rosdistro: ${{ matrix.rosdistro }}
+          cache-key-element: build-and-test
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
           clang-tidy-config-url: https://raw.githubusercontent.com/autowarefoundation/autoware/main/.clang-tidy-ci
           underlay-workspace: /opt/autoware


### PR DESCRIPTION
## Description

Pretty sure clang-tidy got tighter once we got to jazzy so I think not all the packages will pass it, even though it is a required CI for jazzy too.

This PR adds clang-tidy to:
- `build-and-test` (runs per commit pushed to main)
- `build-and-test-daily` (runs daily or by workflow dispatch)

😶‍🌫️ Also realized `build-and-test-daily` wasn't utilizing the existing `ccache`, now it does (read only).

🔢 Added `cache-key-element` to differentiate their implicit build cache. (this is not `ccache`)

## How was this PR tested?

- https://github.com/autowarefoundation/autoware_core/actions/runs/19986700919

Ok, this proves my suspicions:

<img width="1336" height="917" alt="image" src="https://github.com/user-attachments/assets/b9a78cd3-a691-4336-9761-53445df26d21" />

🟣 We should "un-require" jazzy-clang-tidy until we fix these.

### Build speed

#### 🐢 Before

**28m14s**

https://github.com/autowarefoundation/autoware_core/actions/runs/19948218044/job/57202481641

<img width="1325" height="1051" alt="image" src="https://github.com/user-attachments/assets/db04c2ce-0d58-4125-a200-b2fc416269eb" />

#### 🐇 After

**4m25s**

https://github.com/autowarefoundation/autoware_core/actions/runs/19986700919/job/57321677990

<img width="1312" height="1157" alt="image" src="https://github.com/user-attachments/assets/25c83633-7c56-4c40-860e-a0d9a927dca5" />
