### PR TITLE
fix(path_generator): preserve goal position in intersection check

### DIFF
--- a/planning/autoware_path_generator/src/node.cpp
+++ b/planning/autoware_path_generator/src/node.cpp
@@ -314,15 +314,8 @@ std::optional<PathWithLaneId> PathGenerator::generate_path(
     s_end = std::min(s_end, lanelet::geometry::length2d(lanelet::LaneletSequence(lanelets)));
   }
 
-  const auto s_intersection = utils::get_first_intersection_arc_length(
-    lanelets, std::max(0., s_start - vehicle_info_.max_longitudinal_offset_m),
-    s_end + vehicle_info_.max_longitudinal_offset_m, vehicle_info_.vehicle_length_m);
-  if (s_intersection) {
-    s_end =
-      std::min(s_end, std::max(0., *s_intersection - vehicle_info_.max_longitudinal_offset_m));
-  }
-
   std::optional<lanelet::ConstLanelet> goal_lanelet_for_path = std::nullopt;
+  std::optional<double> s_goal_position = std::nullopt;
   for (auto [it, s] = std::make_tuple(lanelets.begin(), 0.); it != lanelets.end(); ++it) {
     const auto & lane_id = it->id();
     if (std::any_of(lanelets.begin(), it, [lane_id](const lanelet::ConstLanelet & lanelet) {
@@ -340,6 +333,7 @@ std::optional<PathWithLaneId> PathGenerator::generate_path(
         s + lanelet::utils::getArcCoordinates({*it}, planner_data_.goal_pose).length;
       if (s_goal < s_end) {
         goal_lanelet_for_path = *it;
+        s_goal_position = s_goal;
         s_end = s_goal;
       }
     }
@@ -347,6 +341,20 @@ std::optional<PathWithLaneId> PathGenerator::generate_path(
     if (s >= s_end + vehicle_info_.max_longitudinal_offset_m) {
       lanelets.erase(std::next(it), lanelets.end());
       break;
+    }
+  }
+
+  const auto s_intersection = utils::get_first_intersection_arc_length(
+    lanelets, std::max(0., s_start - vehicle_info_.max_longitudinal_offset_m),
+    s_end + vehicle_info_.max_longitudinal_offset_m, vehicle_info_.vehicle_length_m);
+  if (s_intersection) {
+    const auto s_intersection_cut =
+      std::max(0., *s_intersection - vehicle_info_.max_longitudinal_offset_m);
+    // If goal is set, don't cut s_end shorter than goal position
+    if (s_goal_position && s_intersection_cut < *s_goal_position) {
+      s_end = std::min(s_end, *s_goal_position);
+    } else {
+      s_end = std::min(s_end, s_intersection_cut);
     }
   }
 


### PR DESCRIPTION
## Description
This PR fixes an issue where the path was unintentionally cut at a loop intersection before reaching the goal.
Previously, the intersection check was performed independently of the goal position. If a self-intersection (loop) existed before the goal, the path was cut at that intersection point, preventing the vehicle from reaching the goal.

This commit modifies the logic to:
1. Identify the goal position on the path first.
2. Ensure the path is not cut by an intersection if the intersection occurs before the goal position.
 
## Related links
Internal: https://star4.slack.com/archives/C017VB9UG1L/p1765177561159589

## How was this PR tested?
https://evaluation.tier4.jp/evaluation/reports/0903fbf1-c5bb-5dea-97fe-9cb00cecf828/tests/3900eb82-5400-5d24-bb52-61415eb23ab8?project_id=X8ft5pPN

## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
