### PR TITLE
ci(build-test-tidy-pr): skip if only .md files are changed

### DIFF
--- a/.github/workflows/build-test-tidy-pr.yaml
+++ b/.github/workflows/build-test-tidy-pr.yaml
@@ -13,7 +13,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check_if_relevant_files_changed:
+    runs-on: ubuntu-latest
+    outputs:
+      run_required: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed-files
+        uses: step-security/changed-files@v46
+        with:
+          since_last_remote_commit: true
+          files_ignore: |
+            **.md
+            **/CODEOWNERS
+            **/CODEOWNERS-manual
+
+      - name: Log decision
+        run: |
+          if [[ "${{ steps.changed-files.outputs.any_changed }}" == "true" ]]; then
+            echo "🚀 Run is required! Relevant changes detected."
+            echo "📂 List of modified files:"
+            for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+              echo "  📝 $file"
+            done
+          else
+            echo "⏭️ No relevant changes detected."
+            echo "💤 This run will be skipped to save resources."
+          fi
+        shell: bash
+
   require-label:
+    needs:
+      - check_if_relevant_files_changed
+    if: needs.check_if_relevant_files_changed.outputs.run_required == 'true'
     uses: autowarefoundation/autoware-github-actions/.github/workflows/require-label.yaml@v1
     with:
       label: run:build-and-test-differential


### PR DESCRIPTION
## Description

Skip this workflow if there are no relevant files modified.

Even if there is no label added to the PR, without relevant file modifications, we should skip it.

This should eliminate unnecessary runs at the initial stages to save time and resources.

We can extend the list of ignored files in the future. 🔮

## How was this PR tested?

### Without label to make sure it fails ✅
---

https://github.com/autowarefoundation/autoware_core/actions/runs/20492944429/job/58888214631

<img width="649" height="508" alt="image" src="https://github.com/user-attachments/assets/1929dd95-7ad6-4f67-a00c-11069fc01841" />

---

### With the label it works as required ✅

<img width="652" height="509" alt="image" src="https://github.com/user-attachments/assets/cf66308a-b293-4d07-a3bf-fba541196430" />

---

### When no relevant files are changed ❓

I would like to test this after it is merged.
Expected behavior:
- Even if there is no label, it should skip the checks and count as success.
- Adding `run:build-and-test-differential` label shouldn't matter if there are no relevant files changed.