### PR TITLE
ci(update-codeowners): don't add tag

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -25,7 +25,6 @@
     - source: .github/workflows/sync-files.yaml
     - source: .github/workflows/update-codeowners-from-packages.yaml
       pre-commands: |
-        sd "            tag:update-codeowners-from-packages\n" "            tag:update-codeowners-from-packages\n            run:build-and-test-differential\n" {source}
         sd "          auto-merge-method: squash\n" "          auto-merge-method: squash\n          global-codeowners: \"@autowarefoundation/autoware-core-global-codeowners\"\n" {source}
     - source: .clang-format
     - source: .clang-tidy

--- a/.github/workflows/update-codeowners-from-packages.yaml
+++ b/.github/workflows/update-codeowners-from-packages.yaml
@@ -38,6 +38,5 @@ jobs:
           pr-labels: |
             tag:bot
             tag:update-codeowners-from-packages
-            run:build-and-test-differential
           auto-merge-method: squash
           global-codeowners: "@autowarefoundation/autoware-core-global-codeowners"


### PR DESCRIPTION
## Description

- https://github.com/autowarefoundation/autoware_core/pull/776

This tag is not needed anymore for this change.

## How was this PR tested?

---

https://github.com/autowarefoundation/autoware_core/actions/runs/20503894290

- https://github.com/autowarefoundation/autoware_core/pull/778 ✅

---

https://github.com/autowarefoundation/autoware_core/actions/runs/20503928442

- https://github.com/autowarefoundation/autoware_core/pull/775 ✅