### PR TITLE
refactor(planning, common): replace lanelet2_extension function

### DIFF
--- a/planning/autoware_mission_planner/package.xml
+++ b/planning/autoware_mission_planner/package.xml
@@ -21,6 +21,7 @@
   <depend>autoware_component_interface_specs</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>
+  <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
@@ -17,6 +17,7 @@
 #include "service_utils.hpp"
 
 #include <autoware/lanelet2_utils/conversion.hpp>
+#include <autoware/lanelet2_utils/nn_search.hpp>
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/route_checker.hpp>
@@ -504,11 +505,13 @@ bool MissionPlanner::check_reroute_safety(
       start_lanelets.push_back(lanelet);
     }
     // closest lanelet in start lanelets
-    lanelet::ConstLanelet closest_lanelet;
-    if (!lanelet::utils::query::getClosestLanelet(start_lanelets, current_pose, &closest_lanelet)) {
+    const auto closest_lanelet_opt =
+      experimental::lanelet2_utils::get_closest_lanelet(start_lanelets, current_pose);
+    if (!closest_lanelet_opt) {
       RCLCPP_ERROR(get_logger(), "Check reroute safety failed. Cannot find the closest lanelet.");
       return false;
     }
+    const auto & closest_lanelet = closest_lanelet_opt.value();
 
     const auto & centerline_2d = lanelet::utils::to2D(closest_lanelet.centerline());
     const auto lanelet_point = lanelet::utils::conversion::toLaneletPoint(current_pose.position);
@@ -527,11 +530,13 @@ bool MissionPlanner::check_reroute_safety(
       start_lanelets.push_back(lanelet);
     }
     // closest lanelet in start lanelets
-    lanelet::ConstLanelet closest_lanelet;
-    if (!lanelet::utils::query::getClosestLanelet(start_lanelets, current_pose, &closest_lanelet)) {
+    const auto closest_lanelet_opt =
+      experimental::lanelet2_utils::get_closest_lanelet(start_lanelets, current_pose);
+    if (!closest_lanelet_opt) {
       RCLCPP_ERROR(get_logger(), "Check reroute safety failed. Cannot find the closest lanelet.");
       return false;
     }
+    const auto & closest_lanelet = closest_lanelet_opt.value();
 
     const auto & centerline_2d = lanelet::utils::to2D(closest_lanelet.centerline());
     const auto lanelet_point = lanelet::utils::conversion::toLaneletPoint(current_pose.position);

--- a/planning/autoware_path_generator/src/node.cpp
+++ b/planning/autoware_path_generator/src/node.cpp
@@ -440,10 +440,10 @@ bool PathGenerator::update_current_lanelet(
   const geometry_msgs::msg::Pose & current_pose, const Params & params)
 {
   if (!current_lanelet_) {
-    lanelet::ConstLanelet current_lanelet;
-    if (lanelet::utils::query::getClosestLanelet(
-          planner_data_.route_lanelets, current_pose, &current_lanelet)) {
-      current_lanelet_ = current_lanelet;
+    if (
+      const auto current_lanelet_opt = experimental::lanelet2_utils::get_closest_lanelet(
+        planner_data_.route_lanelets, current_pose)) {
+      current_lanelet_ = current_lanelet_opt.value();
       return true;
     }
     return false;
@@ -470,8 +470,10 @@ bool PathGenerator::update_current_lanelet(
     return true;
   }
 
-  if (lanelet::utils::query::getClosestLanelet(
-        planner_data_.route_lanelets, current_pose, &*current_lanelet_)) {
+  if (
+    const auto closest_lanelet_opt = experimental::lanelet2_utils::get_closest_lanelet(
+      planner_data_.route_lanelets, current_pose)) {
+    current_lanelet_ = closest_lanelet_opt;
     return true;
   }
 

--- a/planning/autoware_path_generator/test/utils_test.hpp
+++ b/planning/autoware_path_generator/test/utils_test.hpp
@@ -18,6 +18,7 @@
 #include "autoware/path_generator/utils.hpp"
 
 #include <autoware/lanelet2_utils/conversion.hpp>
+#include <autoware/lanelet2_utils/nn_search.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_test_utils/autoware_test_utils.hpp>
 #include <autoware_test_utils/mock_data_parser.hpp>
@@ -135,12 +136,12 @@ protected:
 
   lanelet::ConstLanelet get_lanelet_closest_to_pose(const geometry_msgs::msg::Pose & pose) const
   {
-    lanelet::ConstLanelet lanelet;
-    if (!lanelet::utils::query::getClosestLanelet(
-          planner_data_.preferred_lanelets, pose, &lanelet)) {
+    const auto closest_lanelet_opt =
+      experimental::lanelet2_utils::get_closest_lanelet(planner_data_.preferred_lanelets, pose);
+    if (!closest_lanelet_opt) {
       throw std::runtime_error("Failed to get the closest lanelet to the given point.");
     }
-    return lanelet;
+    return closest_lanelet_opt.value();
   }
 
   lanelet::ConstLanelets get_lanelets_from_ids(const lanelet::Ids & ids) const

--- a/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
+++ b/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
@@ -257,8 +257,8 @@ public:
    */
   bool getClosestLaneletWithinRoute(
     const Pose & search_pose, lanelet::ConstLanelet * closest_lanelet) const;
-  bool getClosestPreferredLaneletWithinRoute(
-    const Pose & search_pose, lanelet::ConstLanelet * closest_lanelet) const;
+  std::optional<lanelet::ConstLanelet> getClosestPreferredLaneletWithinRoute(
+    const Pose & search_pose) const;
   bool getClosestLaneletWithConstrainsWithinRoute(
     const Pose & search_pose, lanelet::ConstLanelet * closest_lanelet, const double dist_threshold,
     const double yaw_threshold) const;

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -1045,11 +1045,10 @@ bool RouteHandler::getClosestLaneletWithinRoute(
   return true;
 }
 
-bool RouteHandler::getClosestPreferredLaneletWithinRoute(
-  const Pose & search_pose, lanelet::ConstLanelet * closest_lanelet) const
+std::optional<lanelet::ConstLanelet> RouteHandler::getClosestPreferredLaneletWithinRoute(
+  const Pose & search_pose) const
 {
-  return lanelet::utils::query::getClosestLanelet(
-    preferred_lanelets_, search_pose, closest_lanelet);
+  return experimental::lanelet2_utils::get_closest_lanelet(preferred_lanelets_, search_pose);
 }
 
 bool RouteHandler::getClosestLaneletWithConstrainsWithinRoute(
@@ -2071,8 +2070,12 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
       std::remove_if(
         candidates.begin(), candidates.end(), [&](const auto & l) { return !isRoadLanelet(l); }),
       candidates.end());
-    if (lanelet::utils::query::getClosestLanelet(candidates, start_checkpoint, &start_lanelet))
+    if (const auto closest_lanelet =
+          experimental::lanelet2_utils::get_closest_lanelet(candidates, start_checkpoint);
+        closest_lanelet) {
+      start_lanelet = closest_lanelet.value();
       start_lanelets = {start_lanelet};
+    }
   }
   if (start_lanelets.empty()) {
     RCLCPP_WARN_STREAM(
@@ -2098,14 +2101,14 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
   // set it as goal_lanelet.
   // this is to select the same lane as much as possible when rerouting with waypoints.
   const auto findGoalClosestPreferredLanelet = [&]() -> std::optional<lanelet::ConstLanelet> {
-    lanelet::ConstLanelet closest_lanelet;
-    if (getClosestPreferredLaneletWithinRoute(goal_checkpoint, &closest_lanelet)) {
+    if (const auto closest_lanelet = getClosestPreferredLaneletWithinRoute(goal_checkpoint)) {
       if (std::find(candidates.begin(), candidates.end(), closest_lanelet) != candidates.end()) {
-        if (lanelet::utils::isInLanelet(goal_checkpoint, closest_lanelet)) {
+        if (lanelet::utils::isInLanelet(goal_checkpoint, closest_lanelet.value())) {
           return closest_lanelet;
         }
       }
     }
+    lanelet::ConstLanelet closest_lanelet;
     if (getClosestLaneletWithinRoute(goal_checkpoint, &closest_lanelet)) {
       if (std::find(candidates.begin(), candidates.end(), closest_lanelet) != candidates.end()) {
         if (lanelet::utils::isInLanelet(goal_checkpoint, closest_lanelet)) {
@@ -2127,7 +2130,9 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
   if (auto closest_lanelet = findGoalClosestPreferredLanelet()) {
     goal_lanelet = closest_lanelet.value();
   } else {
-    if (!lanelet::utils::query::getClosestLanelet(candidates, goal_checkpoint, &goal_lanelet)) {
+    closest_lanelet =
+      experimental::lanelet2_utils::get_closest_lanelet(candidates, goal_checkpoint);
+    if (!closest_lanelet) {
       RCLCPP_WARN_STREAM(
         logger_, "Failed to find closest lanelet."
                    << std::endl
@@ -2135,6 +2140,7 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
                    << " - goal checkpoint: " << toString(goal_checkpoint) << std::endl);
       return false;
     }
+    goal_lanelet = closest_lanelet.value();
   }
 
   lanelet::Optional<lanelet::routing::Route> optional_route;
@@ -2168,9 +2174,8 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
       continue;
     }
     is_route_found = true;
-    lanelet::ConstLanelet preferred_lane{};
-    if (getClosestPreferredLaneletWithinRoute(start_checkpoint, &preferred_lane)) {
-      if (st_llt.id() == preferred_lane.id()) {
+    if (const auto preferred_lane = getClosestPreferredLaneletWithinRoute(start_checkpoint)) {
+      if (st_llt.id() == preferred_lane.value().id()) {
         shortest_path = optional_route->shortestPath();
         start_lanelet = st_llt;
         break;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner_common/src/utilization/util.cpp
@@ -17,6 +17,7 @@
 #include "autoware/behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 
+#include <autoware/lanelet2_utils/nn_search.hpp>
 #include <autoware/lanelet2_utils/topology.hpp>
 #include <autoware/trajectory/utils/pretty_build.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
@@ -646,9 +647,10 @@ std::optional<int64_t> getNearestLaneId(
     lanes.push_back(lanelet_map->laneletLayer.get(lane_id));
   }
 
-  lanelet::Lanelet closest_lane;
-  if (lanelet::utils::query::getClosestLanelet(lanes, current_pose, &closest_lane)) {
-    return closest_lane.id();
+  if (
+    const auto closest_lanelet_opt =
+      experimental::lanelet2_utils::get_closest_lanelet(lanes, current_pose)) {
+    return closest_lanelet_opt.value().id();
   }
   return std::nullopt;
 }


### PR DESCRIPTION
## Description

`lanelet::utils::query::getClosestLanelet` would be deprecated, and `lanelet2_utils::get_closest_lanelet` will be used instead

lanelet2_extension function would be deprecated after this PR

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- https://evaluation.tier4.jp/evaluation/reports/9323e89e-8215-5a52-863b-b8c1a8abf957?project_id=autoware_dev

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
