### PR TITLE
perf(interpolation): optimize calc_closest_segment_indices

### DIFF
--- a/common/autoware_interpolation/include/autoware/interpolation/zero_order_hold.hpp
+++ b/common/autoware_interpolation/include/autoware/interpolation/zero_order_hold.hpp
@@ -29,25 +29,17 @@ inline std::vector<size_t> calc_closest_segment_indices(
   // throw exception for invalid arguments
   const auto validated_query_keys = validateKeys(base_keys, query_keys);
 
-  std::vector<size_t> closest_segment_indices(validated_query_keys.size());
+  std::vector<size_t> closest_segment_indices;
+  closest_segment_indices.reserve(validated_query_keys.size());
   size_t base_idx = 0;
-  const double last_segment_threshold = base_keys.back() - overlap_threshold;
-  for (size_t i = 0; i < validated_query_keys.size(); ++i) {
-    const double query_val = validated_query_keys[i];
-    // End condition: query is past the last segment
-    if (query_val > last_segment_threshold) {
-      std::fill(
-        closest_segment_indices.begin() + i, closest_segment_indices.end(), base_keys.size() - 1);
-      break;
-    }
+  for (auto query_val : validated_query_keys) {
     // Search for the base segment such that segment.first <= query < segment.second
     while (base_idx + 1 < base_keys.size() &&
            base_keys[base_idx + 1] - overlap_threshold < query_val) {
       ++base_idx;
     }
-    closest_segment_indices[i] = base_idx;
+    closest_segment_indices.push_back(base_idx);
   }
-
   return closest_segment_indices;
 }
 


### PR DESCRIPTION
## Description

Function `calc_closest_segment_indices` is used in many other function and can be the most expensive part of some time consuming operations (e.g., path resampling).
This PR improves the performance of `calc_closest_segment_indices` by changing the search to a sliding window approach, taking full advantage of the sorted inputs.

## Related links

**Private Links:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/T4DEV-16164)


## How was this PR tested?

Unit tests
Psim
Evaluator: https://evaluation.tier4.jp/evaluation/reports/cb83d129-9774-5bcc-a882-d66ea64f6cc8?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
