### PR TITLE
fix(autoware_gnss_poser): recreate executor after cancel in tests

### DIFF
--- a/sensing/autoware_gnss_poser/test/test_gnss_poser_node.cpp
+++ b/sensing/autoware_gnss_poser/test/test_gnss_poser_node.cpp
@@ -404,6 +404,10 @@ TEST_F(GNSSPoserTest, TestOrientationSources)
     executor_thread_.join();
   }
   gnss_poser_node_.reset();
+  executor_.reset();
+
+  // Recreate executor
+  executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
 
   // Create node without using GNSS-INS orientation
   rclcpp::NodeOptions options;
@@ -475,6 +479,10 @@ TEST_F(GNSSPoserTest, TestPositionBufferMethods)
     executor_thread_.join();
   }
   gnss_poser_node_.reset();
+  executor_.reset();
+
+  // Recreate executor
+  executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
 
   // Create node using position buffer
   rclcpp::NodeOptions options;
@@ -591,6 +599,10 @@ TEST_F(GNSSPoserTest, TestMedianPosition)
     executor_thread_.join();
   }
   gnss_poser_node_.reset();
+  executor_.reset();
+
+  // Recreate executor
+  executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
 
   // Create node using median method
   rclcpp::NodeOptions options;


### PR DESCRIPTION
## Description

Fix test failures in `autoware_gnss_poser` caused by reusing a cancelled executor.

After calling `executor_->cancel()`, the executor needs to be recreated before spinning again. The following tests were affected:
- `TestOrientationSources`
- `TestPositionBufferMethods`
- `TestMedianPosition`

## Related links

**Parent Issue:**

- None

## How was this PR tested?

- Built `autoware_gnss_poser` package with `colcon build --packages-select autoware_gnss_poser`
- Ran `colcon test --packages-select autoware_gnss_poser`
- Verified all 9 tests pass including `TestPositionBufferMethods` which was previously failing

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.