### PR TITLE
fix(object_recognition_utils): init empty tf2::Transform and use the transform

### DIFF
--- a/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/transform.hpp
+++ b/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/transform.hpp
@@ -77,8 +77,6 @@ bool transformObjects(
   if (input_msg.header.frame_id != target_frame_id) {
     output_msg.header.frame_id = target_frame_id;
     tf2::Transform tf_target2objects_world;
-    tf2::Transform tf_target2objects;
-    tf2::Transform tf_objects_world2objects;
     {
       const auto ros_target2objects_world = detail::getTransform(
         tf_buffer, input_msg.header.frame_id, target_frame_id, input_msg.header.stamp);
@@ -88,9 +86,10 @@ bool transformObjects(
       tf2::fromMsg(*ros_target2objects_world, tf_target2objects_world);
     }
     for (auto & object : output_msg.objects) {
+      tf2::Transform tf_objects_world2objects;
       auto & pose_with_cov = object.kinematics.pose_with_covariance;
       tf2::fromMsg(pose_with_cov.pose, tf_objects_world2objects);
-      tf_target2objects = tf_target2objects_world * tf_objects_world2objects;
+      tf2::Transform tf_target2objects = tf_target2objects_world * tf_objects_world2objects;
       // transform pose, frame difference and object pose
       tf2::toMsg(tf_target2objects, pose_with_cov.pose);
       // transform covariance, only the frame difference
@@ -109,8 +108,6 @@ bool transformObjectsWithFeature(
   if (input_msg.header.frame_id != target_frame_id) {
     output_msg.header.frame_id = target_frame_id;
     tf2::Transform tf_target2objects_world = tf2::Transform::getIdentity();
-    tf2::Transform tf_target2objects;
-    tf2::Transform tf_objects_world2objects;
     const auto ros_target2objects_world = detail::getTransform(
       tf_buffer, input_msg.header.frame_id, target_frame_id, input_msg.header.stamp);
     if (!ros_target2objects_world) {
@@ -124,10 +121,11 @@ bool transformObjectsWithFeature(
       return false;
     }
     for (auto & feature_object : output_msg.feature_objects) {
+      tf2::Transform tf_objects_world2objects;
       // transform object
       tf2::fromMsg(
         feature_object.object.kinematics.pose_with_covariance.pose, tf_objects_world2objects);
-      tf_target2objects = tf_target2objects_world * tf_objects_world2objects;
+      tf2::Transform tf_target2objects = tf_target2objects_world * tf_objects_world2objects;
       tf2::toMsg(tf_target2objects, feature_object.object.kinematics.pose_with_covariance.pose);
 
       // transform cluster


### PR DESCRIPTION
## Description

- Part of: https://github.com/autowarefoundation/autoware_universe/issues/11418

This PR is as simple as initializing an empty homogeneous transformation matrix with identity.

```diff
- tf2::Transform tf_target2objects_world;
+ tf2::Transform tf_target2objects_world = tf2::Transform::getIdentity();
``` 

You might be wondering, autoware_core already supports Jazzy, where did this issue come from?

https://github.com/autowarefoundation/autoware_universe/blob/bf501c32e029d74e11bac0acdb5197a22ed4598a/perception/autoware_cluster_merger/src/cluster_merger_node.cpp#L54-L60

Only autoware universe makes use of that `autoware::object_recognition_utils::transformObjectsWithFeature()` function.

There are no usages in core, it was missed.

## How was this PR tested?

### Before

```bash
In file included from /opt/ros/jazzy/include/tf2/tf2/LinearMath/Matrix3x3.hpp:19,
                 from /opt/ros/jazzy/include/tf2/tf2/LinearMath/Transform.hpp:21,
                 from /opt/ros/jazzy/include/tf2/tf2/buffer_core.hpp:47,
                 from /opt/ros/jazzy/include/tf2_ros/tf2_ros/async_buffer_interface.hpp:39,
                 from /opt/ros/jazzy/include/tf2_ros/tf2_ros/buffer.hpp:42,
                 from /opt/ros/jazzy/include/tf2_ros/tf2_ros/buffer.h:35,
                 from /home/mfc/projects/autoware/install/autoware_utils_tf/include/autoware_utils_tf/transform_listener.hpp:22,
                 from /home/mfc/projects/autoware/install/autoware_utils/include/autoware_utils/ros/transform_listener.hpp:21,
                 from /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_cluster_merger/src/cluster_merger_node.hpp:18,
                 from /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_cluster_merger/src/cluster_merger_node.cpp:15:
In member function ‘tf2Scalar tf2::Vector3::dot(const tf2::Vector3&) const’,
    inlined from ‘tf2::Vector3 tf2::Transform::operator()(const tf2::Vector3&) const’ at /opt/ros/jazzy/include/tf2/tf2/LinearMath/Transform.hpp:97:18,
    inlined from ‘tf2::Transform tf2::Transform::operator*(const tf2::Transform&) const’ at /opt/ros/jazzy/include/tf2/tf2/LinearMath/Transform.hpp:256:10,
    inlined from ‘bool autoware::object_recognition_utils::transformObjectsWithFeature(const T&, const std::string&, const tf2_ros::Buffer&, T&) [with T = tier4_perception_msgs::msg::DetectedObjectsWithFeature_<std::allocator<void> >]’ at /home/mfc/projects/autoware/install/autoware_object_recognition_utils/include/autoware/object_recognition_utils/transform.hpp:129:25:
/opt/ros/jazzy/include/tf2/tf2/LinearMath/Vector3.hpp:126:34: error: ‘tf_target2objects_world.tf2::Transform::m_basis.tf2::Matrix3x3::m_el[2].tf2::Vector3::m_floats[0]’ may be used uninitialized [-Werror=maybe-uninitialized]
  126 |                 return m_floats[0] * v.m_floats[0] + m_floats[1] * v.m_floats[1] +m_floats[2] * v.m_floats[2];
      |                        ~~~~~~~~~~^
In file included from /home/mfc/projects/autoware/install/autoware_object_recognition_utils/include/autoware/object_recognition_utils/object_recognition_utils.hpp:23,
                 from /home/mfc/projects/autoware/src/universe/autoware_universe/perception/autoware_cluster_merger/src/cluster_merger_node.cpp:17:
```

### After

Compiles and passes the tests locally with jazzy.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
