### PR TITLE
feat(object_recognition_utils): add test for public api compile check

### DIFF
--- a/common/autoware_object_recognition_utils/test/src/test_public_api_compile_check.cpp
+++ b/common/autoware_object_recognition_utils/test/src/test_public_api_compile_check.cpp
@@ -1,0 +1,15 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/object_recognition_utils/object_recognition_utils.hpp"


### PR DESCRIPTION
Add compile check for public API headers

This change adds a minimal test source that includes the package’s public API header.

Previously, some public headers were not compiled as part of this package’s build and were only validated indirectly by downstream packages.

The new test ensures that the exported headers are self-contained and buildable in isolation, allowing issues to be caught earlier in this package’s tests.

Example headers:
- geometry.hpp
- transform.hpp
- object_recognition_utils.hpp

These headers were not included by any tests or cpp files so they were not compiled at all. Their compilation were only validated by downstream packages.

No runtime behavior is added and no production code is affected.