### PR TITLE
fix(trajectory): add at least one prev/next lanelet for generating reference_path

### DIFF
--- a/common/autoware_trajectory/src/utils/reference_path.cpp
+++ b/common/autoware_trajectory/src/utils/reference_path.cpp
@@ -284,9 +284,14 @@ public:
       >+--+--+--+--+ last_waypoints --+--+--+--+--+> >+--+--+--+--+ next_waypoints --+--+--+--+--+>
      */
     auto & last_waypoints_mut = reference_points_chunks_.back().points;
-    last_waypoints_mut.insert(
-      last_waypoints_mut.end(), user_defined_reference_points.begin(),
-      user_defined_reference_points.end());
+    // NOTE(soblin): if two custom centerlines are subsequent, waypoints can be duplicate
+    for (const auto & user_defined_reference_point : user_defined_reference_points) {
+      const auto last_added_point_id = last_waypoints_mut.back().point.id();
+      const auto to_add_point_id = user_defined_reference_point.point.id();
+      if (last_added_point_id != to_add_point_id) {
+        last_waypoints_mut.push_back(user_defined_reference_point);
+      }
+    }
     const auto [_, new_end] = compute_smooth_interval(
       user_defined_reference_points, current_lanelet_distance_from_route_start, defined_lanelet,
       connection_from_default_point_gradient);
@@ -717,6 +722,7 @@ struct LaneletSequenceWithRange
 /**
  * @brief extend given lanelet sequence backward/forward so that s_start, s_end is within
  * output lanelet sequence
+ * @detail extended lanelet sequence must contain the previous/next lanelet of `lanelet_sequence`
  * @param s_start start arc length
  * @param s_end end arc length
  * @return extended lanelet sequence, new start arc length, new end arc length
@@ -734,10 +740,11 @@ LaneletSequenceWithRange supplement_lanelet_sequence(
   auto new_s_end = s_end;
 
   std::set<lanelet::Id> visited_prev_lane_ids{extended_lanelet_sequence.front().id()};
-  while (new_s_start < 0.0) {
+  bool added_first_prev_lane{false};
+  while (!added_first_prev_lane || new_s_start < 0.0) {
     const auto previous_lanes = previous_lanelets(extended_lanelet_sequence.front(), routing_graph);
     if (previous_lanes.empty()) {
-      new_s_start = 0.0;
+      new_s_start = std::max(new_s_start, 0.0);
       break;
     }
     // take the longest previous lane to construct underlying lanelets
@@ -753,6 +760,7 @@ LaneletSequenceWithRange supplement_lanelet_sequence(
     visited_prev_lane_ids.insert(longest_previous_lane.id());
     new_s_start += lanelet::geometry::length2d(longest_previous_lane);
     new_s_end += lanelet::geometry::length2d(longest_previous_lane);
+    added_first_prev_lane = true;
   }
 
   std::set<lanelet::Id> visited_next_lane_ids{extended_lanelet_sequence.back().id()};
@@ -760,7 +768,9 @@ LaneletSequenceWithRange supplement_lanelet_sequence(
          lanelet::geometry::length2d(lanelet::LaneletSequence(extended_lanelet_sequence))) {
     const auto next_lanes = following_lanelets(extended_lanelet_sequence.back(), routing_graph);
     if (next_lanes.empty()) {
-      new_s_end = lanelet::geometry::length2d(lanelet::LaneletSequence(extended_lanelet_sequence));
+      new_s_end = std::min(
+        new_s_end,
+        lanelet::geometry::length2d(lanelet::LaneletSequence(extended_lanelet_sequence)));
       break;
     }
     // take the longest previous lane to construct underlying lanelets


### PR DESCRIPTION
## Description

`referene_path` is generated from (1) custom centerline and (2) native centerline. Those centerline are gathered from `reference_lanelets`, which is before/after from `current_route_lanelet` by specified length w.r.t ego's pose on `current_route_lanelet`. However, when the path is generated from subsequent custom centerlines of Lanelet1 and Lanelet2, when ego passed Lanelet1 by `backward_length`, current implementation skips Lanelet1 from `reference_lanelets`.

In this situation, due to "smooth_connection" process, custom centerline points of Lanelet2 may have negative `s` value at the beginning of Lanelet2, thus they are overridden by native centerline points in `consolidate_user_defined_waypoints_and_native_centerline` function, causing unexpected smooth connection as shown in the first video.

<img width="841" height="294" alt="image" src="https://github.com/user-attachments/assets/e35470cb-38ad-4dbc-8268-626d11ff7631" />

### solution

as the `reference_lanelets`, the lanelet before `current_lanelet` is always included in order to use the custom centerline there if it exists. Also fixed the bug where `s_start` end `s_end` are clamped to 0.0 or the total length of `reference_lanelets`.

### before this PR

on the route lane sequence `[29125, 29123, 29124, 29129]`, when ego entered `29123` above case happens.

https://github.com/user-attachments/assets/7f9104d6-0cd7-46aa-9bda-d5e563362cf7

### after this PR

https://github.com/user-attachments/assets/ac641b97-34c4-4319-8729-ae4e5f618f67

## Related links

[Internal Slack Linl](https://star4.slack.com/archives/C07K1PPNPTR/p1765789123814809?thread_ts=1764848061.086639&cid=C07K1PPNPTR)

## How was this PR tested?

- Pilot.Auto latest
  - [Common](https://evaluation.tier4.jp/evaluation/reports/38f47211-ab0c-5ef2-ac8e-4e020795e685?project_id=prd_jt)
  - [FuncVerification](https://evaluation.tier4.jp/evaluation/reports/38f47211-ab0c-5ef2-ac8e-4e020795e685?project_id=prd_jt)
  - [DLR](https://evaluation.tier4.jp/evaluation/reports/67e05e83-cd2c-5b8b-a344-1375b35b3feb?project_id=prd_jt)
- [Pilot.Auto Product Release](https://evaluation.tier4.jp/evaluation/reports/1fc14458-12e5-5467-8abf-b9c5df4c29c9?project_id=X8ft5pPN)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
