### PR TITLE
fix(ground_filter): remove unused struct member

### DIFF
--- a/perception/autoware_ground_filter/src/ground_filter.hpp
+++ b/perception/autoware_ground_filter/src/ground_filter.hpp
@@ -132,7 +132,6 @@ struct GroundFilterParameter
   float global_slope_max_angle_rad;
   float local_slope_max_angle_rad;
   float global_slope_max_ratio;
-  float local_slope_max_ratio;
   float radial_divider_angle_rad;
 
   bool use_recheck_ground_cluster;
@@ -156,7 +155,6 @@ public:
   {
     // calculate derived parameters
     param_.global_slope_max_ratio = std::tan(param_.global_slope_max_angle_rad);
-    param_.local_slope_max_ratio = std::tan(param_.local_slope_max_angle_rad);
 
     // initialize grid pointer
     grid_ptr_ = std::make_unique<Grid>(


### PR DESCRIPTION
## Description

Found by facebook/infer static analysis tool
```
src/core/autoware_core/perception/autoware_ground_filter/src/node.cpp:133: error: Uninitialized Value
  `__param_0.radial_dividers_num` is read without initialization during the call to `std::make_unique()`. 
  131.       param.virtual_lidar_z = virtual_lidar_z_;
  132. 
  133.       ground_filter_ptr_ = std::make_unique<GroundFilter>(param);
                                  ^
  134.     }
  135.   }
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
