### PR TITLE
fix(motion_velocity_planner): fix Unnecessary Copy Assignment Movable

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_planning_factor.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_planning_factor.cpp
@@ -164,23 +164,6 @@ TEST_F(PlanningFactorTest, TestWithPointCloudObstacle)
 {
   InitializeEgoData();
 
-  // prepare point cloud obstacle
-  pcl::PointCloud<pcl::PointXYZ>::Ptr single_point(new pcl::PointCloud<pcl::PointXYZ>);
-
-  single_point->width = 1;
-  single_point->height = 1;
-  single_point->is_dense = true;
-  single_point->header.frame_id = "map";
-
-  const float point_x = 20.0f;
-  const float point_y = 0.0f;
-  const float point_z = 1.0f;
-
-  single_point->points.resize(single_point->width * single_point->height);
-  single_point->points[0].x = point_x;
-  single_point->points[0].y = point_y;
-  single_point->points[0].z = point_z;
-
   auto planner_data = std::make_shared<autoware::motion_velocity_planner::PlannerData>(*node_);
   planner_data->current_odometry = odometry_;
 
@@ -191,9 +174,25 @@ TEST_F(PlanningFactorTest, TestWithPointCloudObstacle)
     node_->get_clock()->now().seconds() * 1e6 + node_->get_clock()->now().nanoseconds() / 1e3);
   constexpr uint64_t pointcloud_period_us = 1e5;
 
+  const float point_x = 20.0f;
+  const float point_y = 0.0f;
+  const float point_z = 1.0f;
+
   for (size_t i = 0; i < count + 1; ++i) {
     module_->publish_planning_factor();
+
+    // prepare point cloud obstacle
+    pcl::PointCloud<pcl::PointXYZ>::Ptr single_point(new pcl::PointCloud<pcl::PointXYZ>);
     single_point->header.stamp = time_us + i * pointcloud_period_us;
+    single_point->width = 1;
+    single_point->height = 1;
+    single_point->is_dense = true;
+    single_point->header.frame_id = "map";
+    single_point->points.resize(1);
+    single_point->points[0].x = point_x;
+    single_point->points[0].y = point_y;
+    single_point->points[0].z = point_z;
+
     planner_data->no_ground_pointcloud.preprocess_pointcloud(
       std::move(*single_point), trajectory_.points, odometry_, 100.0, planner_data->vehicle_info_,
       planner_data->trajectory_polygon_collision_check, planner_data->ego_nearest_dist_threshold,

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_planning_factor.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_planning_factor.cpp
@@ -172,10 +172,14 @@ TEST_F(PlanningFactorTest, TestWithPointCloudObstacle)
   single_point->is_dense = true;
   single_point->header.frame_id = "map";
 
+  const float point_x = 20.0f;
+  const float point_y = 0.0f;
+  const float point_z = 1.0f;
+
   single_point->points.resize(single_point->width * single_point->height);
-  single_point->points[0].x = 20.0;
-  single_point->points[0].y = 0.0;
-  single_point->points[0].z = 1.0f;
+  single_point->points[0].x = point_x;
+  single_point->points[0].y = point_y;
+  single_point->points[0].z = point_z;
 
   auto planner_data = std::make_shared<autoware::motion_velocity_planner::PlannerData>(*node_);
   planner_data->current_odometry = odometry_;
@@ -211,7 +215,7 @@ TEST_F(PlanningFactorTest, TestWithPointCloudObstacle)
   EXPECT_EQ(safety_factor.type, autoware_internal_planning_msgs::msg::SafetyFactor::POINTCLOUD);
   EXPECT_FALSE(safety_factor.is_safe);
   ASSERT_EQ(safety_factor.points.size(), 1);
-  EXPECT_NEAR(safety_factor.points.front().x, single_point->points[0].x, 1.0);
-  EXPECT_NEAR(safety_factor.points.front().y, single_point->points[0].y, 1.0);
-  EXPECT_NEAR(safety_factor.points.front().z, single_point->points[0].z, 1.0);
+  EXPECT_NEAR(safety_factor.points.front().x, point_x, 1.0);
+  EXPECT_NEAR(safety_factor.points.front().y, point_y, 1.0);
+  EXPECT_NEAR(safety_factor.points.front().z, point_z, 1.0);
 }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp
@@ -232,7 +232,7 @@ public:
       const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check,
       const double ego_nearest_dist_threshold, const double ego_nearest_yaw_threshold)
     {
-      pointcloud = arg_pointcloud;
+      pointcloud = std::move(arg_pointcloud);
       const auto preprocessed_result = filter_and_cluster_point_clouds(
         raw_trajectory, current_odometry, min_deceleration_distance, vehicle_info,
         trajectory_polygon_collision_check, ego_nearest_dist_threshold, ego_nearest_yaw_threshold);


### PR DESCRIPTION
## Description

This is `Unnecessary Copy Assignment Movable` warning by facebook/infer, a static analysis tool.
Even thouth the caller passes the pointcloud argument by a rvalue reference, the callee is using it as an lvalue.
```
autoware_motion_velocity_planner_common/include/autoware/motion_velocity_planner_common/planner_data.hpp:235: error: Unnecessary Copy Assignment Movable
  `arg_pointcloud` is copy assigned into field `pointcloud` but is not modified afterwards. Rather than copying into the field, move into it instead.
  233.       const double ego_nearest_dist_threshold, const double ego_nearest_yaw_threshold)
  234.     {
  235.       pointcloud = arg_pointcloud;
             ^
  236.       const auto preprocessed_result = filter_and_cluster_point_clouds(
  237.         raw_trajectory, current_odometry, min_deceleration_distance, vehicle_info,

```

Also, fixed a bug in `TEST_F(PlanningFactorTest, TestWithPointCloudObstacle)`.
The pointcloud was emptied every time in the for loop by `std::move(*single_point)`.
Pointed by @xmfcx , thank you!

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Unit test
```
$ colcon test --packages-select autoware_motion_velocity_obstacle_stop_module
Starting >>> autoware_motion_velocity_obstacle_stop_module
Finished <<< autoware_motion_velocity_obstacle_stop_module [3.85s]          

Summary: 1 package finished [4.77s]
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
