### PR TITLE
fix(velocity_smoother): remove dead store in jerk_filtered_smoother

### DIFF
--- a/planning/autoware_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
+++ b/planning/autoware_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp
@@ -300,7 +300,6 @@ bool JerkFilteredSmoother::apply(
     A(constr_idx, IDX_A0) = 1.0;  // a0
     upper_bound[constr_idx] = a0;
     lower_bound[constr_idx] = a0;
-    ++constr_idx;
   }
   time_keeper_->end_track("initOptimization");
 


### PR DESCRIPTION
Remove unnecessary increment of `constr_idx` after the last constraint setup.
The variable is never read after this point, making it a dead store.
Detected by Facebook Infer static analyzer (DEAD_STORE).
```
src/core/autoware_core/planning/autoware_velocity_smoother/src/smoother/jerk_filtered_smoother.cpp:303: error: Dead Store
  The value written to `&constr_idx` is never used. 
  301.     upper_bound[constr_idx] = a0;
  302.     lower_bound[constr_idx] = a0;
  303.     ++constr_idx;
           ^
  304.   }
  305.   time_keeper_->end_track("initOptimization");

```

## Description

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
