### PR TITLE
fix(trajectory): fix potential undefined behavior in closest()

### DIFF
--- a/common/autoware_trajectory/include/autoware/trajectory/utils/closest.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/utils/closest.hpp
@@ -92,7 +92,7 @@ double closest(
   const trajectory::Trajectory<TrajectoryPointType> & trajectory, const ArgPointType & point)
 {
   std::optional<double> s =
-    *closest_with_constraint(trajectory, point, [](const TrajectoryPointType &) { return true; });
+    closest_with_constraint(trajectory, point, [](const TrajectoryPointType &) { return true; });
   if (!s) {
     throw std::runtime_error("No closest point found.");  // This Exception should not be thrown.
   }


### PR DESCRIPTION
Remove too early dereference of std::optional before checking if it has a value.
The original code dereferenced the result of closest_with_constraint() before assigning to s, which could cause undefined behavior if the function returns std::nullopt.
Detected by Facebook Infer static analyzer (OPTIONAL_EMPTY_ACCESS).
```
autoware_trajectory/include/autoware/trajectory/utils/closest.hpp:95: error: Optional Empty Access
  accessing memory that is assigned an empty value during the call to `autoware::experimental::trajectory::closest_with_constraint()` on line 95. 
  93. {
  94.   std::optional<double> s =
  95.     *closest_with_constraint(trajectory, point, [](const TrajectoryPointType &) { return true; });
          ^
  96.   if (!s) {
  97.     throw std::runtime_error("No closest point found.");  // This Exception should not be thrown.
```

## Description

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
