### PR TITLE
feat(obstacle_stop): add height and size filter

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/config/obstacle_stop.param.yaml
@@ -80,6 +80,14 @@
             is_moving_obstacle: # [m] additional stop margin for moving obstacle
               default: 0.0
 
+        detection_height: # [m] height range for collision detection from the ground.
+          top_limit:
+            default: 50.0
+            unknown: 1.0
+          bottom_limit: -50.0
+
+        min_object_length: 0.1 # [m] minimum object length to consider for stop planning
+
         min_velocity_to_reach_collision_point: 2.0 # minimum velocity margin to calculate time to reach collision [m/s]
         stop_obstacle_hold_time_threshold : 1.0 # maximum time for holding closest stop obstacle
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/parameters.hpp
@@ -114,6 +114,14 @@ struct ObstacleFilteringParam
     };
   } lateral_margin;
 
+  struct DetectionHeightParam
+  {
+    double top_limit{};
+    double bottom_limit{};
+  } detection_height;
+
+  double min_object_length{};
+
   double min_velocity_to_reach_collision_point{};
   double stop_obstacle_hold_time_threshold{};
 
@@ -154,6 +162,14 @@ struct ObstacleFilteringParam
       node, param_prefix + "lateral_margin.additional.is_stop_obstacle", label_str);
     lateral_margin.additional_is_moving_margin = get_object_parameter<double>(
       node, param_prefix + "lateral_margin.additional.is_moving_obstacle", label_str);
+
+    detection_height.top_limit =
+      get_object_parameter<double>(node, param_prefix + "detection_height.top_limit", label_str);
+    detection_height.bottom_limit =
+      get_object_parameter<double>(node, param_prefix + "detection_height.bottom_limit", label_str);
+
+    min_object_length =
+      get_object_parameter<double>(node, param_prefix + "min_object_length", label_str);
 
     min_velocity_to_reach_collision_point = get_object_parameter<double>(
       node, param_prefix + "min_velocity_to_reach_collision_point", label_str);


### PR DESCRIPTION
## Description
I added parameters to define the height range and the minimum object size for collision checking. This is primarily intended to ignore "Unknown" objects that are far from the ground or sufficiently small.

## Related links
launch PR: https://github.com/autowarefoundation/autoware_launch/pull/1742

## How was this PR tested?
some typical situations in psim

**ignore floating unknown**
<img width="2216" height="1913" alt="image" src="https://github.com/user-attachments/assets/3798c1aa-f053-4ebf-8966-cea75b1da448" />


**ignore small unknown**
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/90d4241e-4921-498b-a184-b16c618e632f" />


passed tier4 scenario tests 


## Notes for reviewers

None.

## Effects on system behavior

None.
