### PR TITLE
feat(autoware_lanelet2_map_visualizer): add new maker

### DIFF
--- a/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization_node.cpp
+++ b/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization_node.cpp
@@ -135,8 +135,8 @@ void Lanelet2MapVisualizationNode::on_map_bin(
   std::vector<lanelet::BusStopAreaConstPtr> bus_stop_reg_elems =
     lanelet::utils::query::busStopAreas(all_lanelets);
   lanelet::ConstLineStrings3d waypoints = lanelet::utils::query::getAllWaypoints(viz_lanelet_map);
-  lanelet::ConstPolygons3d map_filter_areas =
-    lanelet::utils::query::getAllPolygonsByType(viz_lanelet_map, "map_area_filter");
+  lanelet::ConstPolygons3d obstacle_removal_areas =
+    lanelet::utils::query::getAllPolygonsByType(viz_lanelet_map, "obstacle_removal_area");
 
   std_msgs::msg::ColorRGBA cl_road;
   std_msgs::msg::ColorRGBA cl_shoulder;
@@ -166,7 +166,7 @@ void Lanelet2MapVisualizationNode::on_map_bin(
   std_msgs::msg::ColorRGBA cl_bus_stop_area;
   std_msgs::msg::ColorRGBA cl_bicycle_lane;
   std_msgs::msg::ColorRGBA cl_waypoints;
-  std_msgs::msg::ColorRGBA cl_map_area_filter;
+  std_msgs::msg::ColorRGBA cl_obstacle_removal_area;
   set_color(&cl_road, 0.27, 0.27, 0.27, 0.999);
   set_color(&cl_shoulder, 0.15, 0.15, 0.15, 0.999);
   set_color(&cl_cross, 0.27, 0.3, 0.27, 0.5);
@@ -195,7 +195,7 @@ void Lanelet2MapVisualizationNode::on_map_bin(
   set_color(&cl_bus_stop_area, 0.863, 0.863, 0.863, 0.5);
   set_color(&cl_bicycle_lane, 0.0, 0.3843, 0.6274, 0.5);
   set_color(&cl_waypoints, 0.6, 0.4, 0.3, 0.999);
-  set_color(&cl_map_area_filter, 0.2, 0.2, 0.5, 0.5);
+  set_color(&cl_obstacle_removal_area, 0.2, 0.2, 0.5, 0.5);
 
   visualization_msgs::msg::MarkerArray map_marker_array;
 
@@ -328,8 +328,8 @@ void Lanelet2MapVisualizationNode::on_map_bin(
     &map_marker_array,
     lanelet::visualization::lineStringsAsMarkerArray(waypoints, "waypoints", cl_waypoints, 0.02));
   insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::mapFilterAreaAsMarkerArray(map_filter_areas, cl_map_area_filter));
+    &map_marker_array, lanelet::visualization::obstacleRemovalAreaAsMarkerArray(
+                         obstacle_removal_areas, cl_obstacle_removal_area));
 
   pub_marker_->publish(map_marker_array);
 }


### PR DESCRIPTION
## Description
add new maker type for `obstacle_removal_area`

## Related links
lanelet2extension PR:
https://github.com/autowarefoundation/autoware_lanelet2_extension/pull/96
https://github.com/autowarefoundation/autoware_lanelet2_extension/pull/100

## How was this PR tested?
visualized as the following:
<img width="1252" height="1302" alt="Screenshot from 2026-02-03 15-12-51" src="https://github.com/user-attachments/assets/5608c7dd-e7e3-4782-a25e-9868c7e640d0" />

## Notes for reviewers
New released version of lanelet2extension is required

## Interface changes

None.



## Effects on system behavior

None.
