### PR TITLE
fix(ekf_localizer): change diagnostic severity

### DIFF
--- a/localization/autoware_ekf_localizer/README.md
+++ b/localization/autoware_ekf_localizer/README.md
@@ -191,7 +191,6 @@ Note that, although the dimension gets larger since the analytical expansion can
 ### The conditions that result in a WARN state
 
 - The node is not in the activate state.
-- The initial pose is not set.
 - The number of consecutive no measurement update via the Pose/Twist topic exceeds the `pose_no_update_count_threshold_warn`/`twist_no_update_count_threshold_warn`.
 - The timestamp of the Pose/Twist topic is beyond the delay compensation range.
 - The Pose/Twist topic is beyond the range of Mahalanobis distance for covariance estimation.
@@ -199,6 +198,7 @@ Note that, although the dimension gets larger since the analytical expansion can
 
 ### The conditions that result in an ERROR state
 
+- The initial pose is not set.
 - The number of consecutive no measurement update via the Pose/Twist topic exceeds the `pose_no_update_count_threshold_error`/`twist_no_update_count_threshold_error`.
 - The covariance ellipse is bigger than threshold `error_ellipse_size` for long axis or `error_ellipse_size_lateral_direction` for lateral_direction.
 

--- a/localization/autoware_ekf_localizer/src/diagnostics.cpp
+++ b/localization/autoware_ekf_localizer/src/diagnostics.cpp
@@ -53,8 +53,8 @@ diagnostic_msgs::msg::DiagnosticStatus check_set_initialpose(const bool is_set_i
   stat.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
   stat.message = "OK";
   if (!is_set_initialpose) {
-    stat.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
-    stat.message = "[WARN]initial pose is not set";
+    stat.level = diagnostic_msgs::msg::DiagnosticStatus::ERROR;
+    stat.message = "[ERROR]initial pose is not set";
   }
 
   return stat;

--- a/localization/autoware_ekf_localizer/test/test_diagnostics.cpp
+++ b/localization/autoware_ekf_localizer/test/test_diagnostics.cpp
@@ -56,7 +56,7 @@ TEST(TestEkfDiagnostics, check_set_initialpose)
 
   is_set_initialpose = false;
   stat = check_set_initialpose(is_set_initialpose);
-  EXPECT_EQ(stat.level, diagnostic_msgs::msg::DiagnosticStatus::WARN);
+  EXPECT_EQ(stat.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
 }
 
 TEST(TestEkfDiagnostics, check_measurement_updated)

--- a/localization/autoware_ekf_localizer/test/test_diagnostics.cpp
+++ b/localization/autoware_ekf_localizer/test/test_diagnostics.cpp
@@ -298,14 +298,24 @@ protected:
     autoware::ekf_localizer::EKFLocalizer * ekf_localizer,
     const geometry_msgs::msg::PoseStamped & current_ekf_pose, const rclcpp::Time & current_time)
   {
-    // Create diagnostic status array similar to timer_callback
+    // Create diagnostic status array matching timer_callback early-return logic
     std::vector<diagnostic_msgs::msg::DiagnosticStatus> diag_status_array;
 
     // Check process activation status
     diag_status_array.push_back(check_process_activated(ekf_localizer->is_activated_));
 
+    if (!ekf_localizer->is_activated_) {
+      ekf_localizer->update_diagnostics(diag_status_array, current_time);
+      return;
+    }
+
     // Check initial pose status
     diag_status_array.push_back(check_set_initialpose(ekf_localizer->is_set_initialpose_));
+
+    if (!ekf_localizer->is_set_initialpose_) {
+      ekf_localizer->update_diagnostics(diag_status_array, current_time);
+      return;
+    }
 
     // Add diagnostics for pose and twist if activated and initial pose is set
     if (ekf_localizer->is_activated_ && ekf_localizer->is_set_initialpose_) {
@@ -825,9 +835,9 @@ TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_updated_when_initialpose_not_set
   // Update diagnostics (simulating early return in timer_callback)
   update_diagnostics(ekf_localizer.get(), current_ekf_pose, current_time);
 
-  // Merged status should reflect that initial pose is not set (WARN)
+  // Merged status should reflect that initial pose is not set (ERROR)
   auto merged_status = get_merged_diagnostic_status(ekf_localizer.get());
-  EXPECT_EQ(merged_status.level, diagnostic_msgs::msg::DiagnosticStatus::WARN);
+  EXPECT_EQ(merged_status.level, diagnostic_msgs::msg::DiagnosticStatus::ERROR);
   EXPECT_TRUE(merged_status.message.find("initial pose is not set") != std::string::npos);
 
   force_diagnostics_update(ekf_localizer.get());


### PR DESCRIPTION
## Description
I have submitted this PR to change the diagnostic severity for initialpose message reception. While ekf_localizer currently outputs a **WARN** level diagnostic, the updated implementation will output an **ERROR**.

### Rational

The initialpose message is also monitored via [topic_state_monitor](https://github.com/autowarefoundation/autoware_universe/blob/60b65760b4b1b97568bd0c3a7634b836d02c40b2/system/autoware_component_state_monitor/config/topics.yaml#L27-L38). topic_state_monitor outputs an ERROR when initialpose is not transmitted. Currently, autoware_ekf_localizer and topic_state_monitor lack consistency in their interpretation of this situation.

To resolve this inconsistency, this PR aligns the diagnostic severity across both components.


## Related links

- [TIER IV internal link](https://tier4.atlassian.net/wiki/spaces/XFST/pages/4864868823/Node+topic_state_monitor+Phase+1.+X2+4.4.0?focusedCommentId=4871323676)


<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

1. Clone Autoware and do vcs import.
2. Cherry-pick the changes of this pull-request and the related one above in each src repo. `git remote add takam5f2 git@github.com:takam5f2/autoware_core.git && git fetch takam5f2` and ` git checkout change/change-diagnostic-severity-of-initialpose-reception `
3. Build Autoware or autoware_ekf_localizer via `colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-w" -DBUILD_TESTING=true  --packages-select autoware_ekf_localizer`
4. Run unit tests `colcon test --packages-select autoware_ekf_localizer` and confirm the result `colcon test-result --all --verbose --test-result-base build/autoware_ekf_localizer`
5. Open `build/autoware_ekf_localizer/test_results/autoware_ekf_localizer/test_diagnostics.gtest.xml` and check whether there is no error.

## Notes for reviewers

None.

## Interface changes

I've changed diagnostic severity from warning to error when `ekf_localizer` didn't accept `/initialpose3d`.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
