### PR TITLE
refactor(`ndt_scan_matcher`): to be testable

### DIFF
--- a/localization/autoware_ndt_scan_matcher/CMakeLists.txt
+++ b/localization/autoware_ndt_scan_matcher/CMakeLists.txt
@@ -92,6 +92,11 @@ if(BUILD_TESTING)
     test/test_cases/visualize_point_score_test.cpp
   )
   target_link_libraries(visualize_point_score_test ${PROJECT_NAME})
+
+  ament_auto_add_gtest(preprocess_sensor_points_test
+    test/test_cases/preprocess_sensor_points_test.cpp
+  )
+  target_link_libraries(preprocess_sensor_points_test ${PROJECT_NAME})
 endif()
 
 autoware_ament_auto_package(

--- a/localization/autoware_ndt_scan_matcher/CMakeLists.txt
+++ b/localization/autoware_ndt_scan_matcher/CMakeLists.txt
@@ -76,6 +76,10 @@ if(BUILD_TESTING)
     test/test_cases/rotate_covariance_test.cpp
   )
   target_link_libraries(rotate_covariance_test ${PROJECT_NAME})
+
+  ament_auto_add_gtest(map_update_module_test
+    test/test_cases/map_update_module_test.cpp
+  )
 endif()
 
 autoware_ament_auto_package(

--- a/localization/autoware_ndt_scan_matcher/CMakeLists.txt
+++ b/localization/autoware_ndt_scan_matcher/CMakeLists.txt
@@ -86,6 +86,12 @@ if(BUILD_TESTING)
   ament_auto_add_gtest(map_update_module_test
     test/test_cases/map_update_module_test.cpp
   )
+  target_link_libraries(map_update_module_test ${PROJECT_NAME})
+
+  ament_auto_add_gtest(visualize_point_score_test
+    test/test_cases/visualize_point_score_test.cpp
+  )
+  target_link_libraries(visualize_point_score_test ${PROJECT_NAME})
 endif()
 
 autoware_ament_auto_package(

--- a/localization/autoware_ndt_scan_matcher/CMakeLists.txt
+++ b/localization/autoware_ndt_scan_matcher/CMakeLists.txt
@@ -43,6 +43,7 @@ else()
 endif()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/covariance_estimation.cpp
   src/map_update_module.cpp
   src/ndt_scan_matcher_core.cpp
   src/particle.cpp
@@ -76,6 +77,11 @@ if(BUILD_TESTING)
     test/test_cases/rotate_covariance_test.cpp
   )
   target_link_libraries(rotate_covariance_test ${PROJECT_NAME})
+
+  ament_auto_add_gtest(covariance_estimation_test
+    test/test_cases/covariance_estimation_test.cpp
+  )
+  target_link_libraries(covariance_estimation_test ${PROJECT_NAME})
 
   ament_auto_add_gtest(map_update_module_test
     test/test_cases/map_update_module_test.cpp

--- a/localization/autoware_ndt_scan_matcher/CMakeLists.txt
+++ b/localization/autoware_ndt_scan_matcher/CMakeLists.txt
@@ -72,6 +72,10 @@ if(BUILD_TESTING)
     test/test_cases/once_initialize_at_out_of_map_then_initialize_correctly.cpp
     TIMEOUT "300"
   )
+  ament_auto_add_gtest(rotate_covariance_test
+    test/test_cases/rotate_covariance_test.cpp
+  )
+  target_link_libraries(rotate_covariance_test ${PROJECT_NAME})
 endif()
 
 autoware_ament_auto_package(

--- a/localization/autoware_ndt_scan_matcher/CMakeLists.txt
+++ b/localization/autoware_ndt_scan_matcher/CMakeLists.txt
@@ -81,22 +81,20 @@ if(BUILD_TESTING)
   ament_auto_add_gtest(covariance_estimation_test
     test/test_cases/covariance_estimation_test.cpp
   )
+  target_include_directories(covariance_estimation_test PRIVATE src)
   target_link_libraries(covariance_estimation_test ${PROJECT_NAME})
 
   ament_auto_add_gtest(map_update_module_test
     test/test_cases/map_update_module_test.cpp
   )
+  target_include_directories(map_update_module_test PRIVATE src)
   target_link_libraries(map_update_module_test ${PROJECT_NAME})
 
   ament_auto_add_gtest(visualize_point_score_test
     test/test_cases/visualize_point_score_test.cpp
   )
+  target_include_directories(visualize_point_score_test PRIVATE src)
   target_link_libraries(visualize_point_score_test ${PROJECT_NAME})
-
-  ament_auto_add_gtest(preprocess_sensor_points_test
-    test/test_cases/preprocess_sensor_points_test.cpp
-  )
-  target_link_libraries(preprocess_sensor_points_test ${PROJECT_NAME})
 endif()
 
 autoware_ament_auto_package(

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/covariance_estimation.hpp
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/covariance_estimation.hpp
@@ -1,0 +1,49 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__NDT_SCAN_MATCHER__COVARIANCE_ESTIMATION_HPP_
+#define AUTOWARE__NDT_SCAN_MATCHER__COVARIANCE_ESTIMATION_HPP_
+
+#include "hyper_parameters.hpp"
+
+#include <autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h>
+#include <autoware_utils_geometry/geometry.hpp>
+
+#include <geometry_msgs/msg/pose_array.hpp>
+
+#include <Eigen/Core>
+
+namespace autoware::ndt_scan_matcher
+{
+
+using PointSource = pcl::PointXYZ;
+using PointTarget = pcl::PointXYZ;
+using NdtType = pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>;
+
+struct CovarianceComputationResult
+{
+  Eigen::Matrix2d covariance{Eigen::Matrix2d::Zero()};
+  geometry_msgs::msg::PoseArray ndt_result_poses;
+  geometry_msgs::msg::PoseArray ndt_initial_poses;
+};
+
+/// Compute covariance and the auxiliary pose arrays without publishing/logging.
+CovarianceComputationResult compute_covariance_estimate(
+  const pclomp::NdtResult & ndt_result, const Eigen::Matrix4f & initial_pose_matrix,
+  const HyperParameters::Covariance & param, const std::shared_ptr<NdtType> & ndt_ptr,
+  const rclcpp::Time & stamp, const std::string & map_frame);
+
+}  // namespace autoware::ndt_scan_matcher
+
+#endif  // AUTOWARE__NDT_SCAN_MATCHER__COVARIANCE_ESTIMATION_HPP_

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/covariance_estimation.hpp
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/covariance_estimation.hpp
@@ -17,12 +17,12 @@
 
 #include "hyper_parameters.hpp"
 
-#include <autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h>
+#include <Eigen/Core>
 #include <autoware_utils_geometry/geometry.hpp>
 
 #include <geometry_msgs/msg/pose_array.hpp>
 
-#include <Eigen/Core>
+#include <autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h>
 
 namespace autoware::ndt_scan_matcher
 {

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/map_update_module.hpp
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/map_update_module.hpp
@@ -108,7 +108,8 @@ public:
     }
 
     const auto end = std::chrono::steady_clock::now();
-    const double execution_ms = std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(end - start).count();
+    const double execution_ms =
+      std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(end - start).count();
 
     return MapUpdateResult{added, removed, updated, execution_ms};
   }

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -221,6 +221,13 @@ private:
   HyperParameters param_;
 };
 
+namespace detail
+{
+pcl::PointCloud<pcl::PointXYZRGB>::Ptr colorize_point_scores(
+  const pcl::PointCloud<pcl::PointXYZI> & nvs_points_in_map_ptr_i, const float lower_nvs,
+  const float upper_nvs);
+}  // namespace detail
+
 }  // namespace autoware::ndt_scan_matcher
 
 #endif  // AUTOWARE__NDT_SCAN_MATCHER__NDT_SCAN_MATCHER_CORE_HPP_

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -18,6 +18,7 @@
 #define FMT_HEADER_ONLY
 
 #include "hyper_parameters.hpp"
+#include "covariance_estimation.hpp"
 #include "map_update_module.hpp"
 #include "ndt_omp/multigrid_ndt_omp.h"
 

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -17,8 +17,8 @@
 
 #define FMT_HEADER_ONLY
 
-#include "hyper_parameters.hpp"
 #include "covariance_estimation.hpp"
+#include "hyper_parameters.hpp"
 #include "map_update_module.hpp"
 #include "ndt_omp/multigrid_ndt_omp.h"
 

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -198,9 +198,6 @@ private:
 
   std::shared_ptr<NdtResource> ndt_resource_;
   std::shared_ptr<NormalDistributionsTransform> & ndt_ptr_;
-
-  Eigen::Matrix4f base_to_sensor_matrix_;
-
   std::mutex & ndt_ptr_mtx_;
   std::unique_ptr<autoware::localization_util::SmartPoseBuffer> initial_pose_buffer_;
 

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -143,6 +143,20 @@ private:
     const pclomp::NdtResult & ndt_result, const Eigen::Matrix4f & initial_pose_matrix,
     const rclcpp::Time & sensor_ros_time);
 
+  struct PreprocessResult;
+  struct ScanMatchingOutput;
+
+  // Unit test helper to exercise private preprocessing and scan-matching steps.
+  friend class NDTScanMatcherTestHelper;
+  std::optional<PreprocessResult> preprocess_sensor_points(
+    sensor_msgs::msg::PointCloud2::ConstSharedPtr sensor_points_msg_in_sensor_frame,
+    const std::chrono::system_clock::time_point & exe_start_time);
+  std::optional<ScanMatchingOutput> run_scan_matching(
+    const PreprocessResult & preprocess_result,
+    const std::chrono::system_clock::time_point & exe_start_time);
+  void publish_scan_matching_outputs(
+    const ScanMatchingOutput & output, const rclcpp::Time & sensor_ros_time);
+
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr visualize_point_score(
     const pcl::shared_ptr<pcl::PointCloud<PointSource>> & sensor_points_in_map_ptr,
     const float & lower_nvs, const float & upper_nvs);

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -72,6 +72,7 @@ class NDTScanMatcher : public rclcpp::Node
   using PointTarget = pcl::PointXYZ;
   using NormalDistributionsTransform =
     pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>;
+  using NdtResource = SharedNdtResource<NormalDistributionsTransform>;
 
 public:
   explicit NDTScanMatcher(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
@@ -195,11 +196,12 @@ private:
 
   rclcpp::CallbackGroup::SharedPtr timer_callback_group_;
 
-  std::shared_ptr<NormalDistributionsTransform> ndt_ptr_;
+  std::shared_ptr<NdtResource> ndt_resource_;
+  std::shared_ptr<NormalDistributionsTransform> & ndt_ptr_;
 
   Eigen::Matrix4f base_to_sensor_matrix_;
 
-  std::mutex ndt_ptr_mtx_;
+  std::mutex & ndt_ptr_mtx_;
   std::unique_ptr<autoware::localization_util::SmartPoseBuffer> initial_pose_buffer_;
 
   // Keep latest position for dynamic map loading

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -17,7 +17,6 @@
 
 #define FMT_HEADER_ONLY
 
-#include "covariance_estimation.hpp"
 #include "hyper_parameters.hpp"
 #include "map_update_module.hpp"
 #include "ndt_omp/multigrid_ndt_omp.h"
@@ -143,20 +142,6 @@ private:
     const pclomp::NdtResult & ndt_result, const Eigen::Matrix4f & initial_pose_matrix,
     const rclcpp::Time & sensor_ros_time);
 
-  struct PreprocessResult;
-  struct ScanMatchingOutput;
-
-  // Unit test helper to exercise private preprocessing and scan-matching steps.
-  friend class NDTScanMatcherTestHelper;
-  std::optional<PreprocessResult> preprocess_sensor_points(
-    sensor_msgs::msg::PointCloud2::ConstSharedPtr sensor_points_msg_in_sensor_frame,
-    const std::chrono::system_clock::time_point & exe_start_time);
-  std::optional<ScanMatchingOutput> run_scan_matching(
-    const PreprocessResult & preprocess_result,
-    const std::chrono::system_clock::time_point & exe_start_time);
-  void publish_scan_matching_outputs(
-    const ScanMatchingOutput & output, const rclcpp::Time & sensor_ros_time);
-
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr visualize_point_score(
     const pcl::shared_ptr<pcl::PointCloud<PointSource>> & sensor_points_in_map_ptr,
     const float & lower_nvs, const float & upper_nvs);
@@ -234,13 +219,6 @@ private:
 
   HyperParameters param_;
 };
-
-namespace detail
-{
-pcl::PointCloud<pcl::PointXYZRGB>::Ptr colorize_point_scores(
-  const pcl::PointCloud<pcl::PointXYZI> & nvs_points_in_map_ptr_i, const float lower_nvs,
-  const float upper_nvs);
-}  // namespace detail
 
 }  // namespace autoware::ndt_scan_matcher
 

--- a/localization/autoware_ndt_scan_matcher/src/covariance_estimation.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/covariance_estimation.cpp
@@ -1,0 +1,82 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <autoware/ndt_scan_matcher/covariance_estimation.hpp>
+
+#include <autoware/ndt_scan_matcher/ndt_omp/estimate_covariance.hpp>
+#include <autoware/localization_util/util_func.hpp>
+
+namespace autoware::ndt_scan_matcher
+{
+
+CovarianceComputationResult compute_covariance_estimate(
+  const pclomp::NdtResult & ndt_result, const Eigen::Matrix4f & initial_pose_matrix,
+  const HyperParameters::Covariance & param, const std::shared_ptr<NdtType> & ndt_ptr,
+  const rclcpp::Time & stamp, const std::string & map_frame)
+{
+  CovarianceComputationResult result{};
+
+  result.ndt_result_poses.header.stamp = stamp;
+  result.ndt_result_poses.header.frame_id = map_frame;
+  result.ndt_initial_poses.header.stamp = stamp;
+  result.ndt_initial_poses.header.frame_id = map_frame;
+
+  result.ndt_result_poses.poses.push_back(
+    autoware::localization_util::matrix4f_to_pose(ndt_result.pose));
+  result.ndt_initial_poses.poses.push_back(
+    autoware::localization_util::matrix4f_to_pose(initial_pose_matrix));
+
+  switch (param.covariance_estimation.covariance_estimation_type) {
+    case CovarianceEstimationType::LAPLACE_APPROXIMATION: {
+      result.covariance = pclomp::estimate_xy_covariance_by_laplace_approximation(ndt_result.hessian);
+      break;
+    }
+    case CovarianceEstimationType::MULTI_NDT: {
+      const std::vector<Eigen::Matrix4f> poses_to_search = pclomp::propose_poses_to_search(
+        ndt_result, param.covariance_estimation.initial_pose_offset_model_x,
+        param.covariance_estimation.initial_pose_offset_model_y);
+      const pclomp::ResultOfMultiNdtCovarianceEstimation multi_ndt_result =
+        estimate_xy_covariance_by_multi_ndt(ndt_result, ndt_ptr, poses_to_search);
+      for (size_t i = 0; i < multi_ndt_result.ndt_initial_poses.size(); ++i) {
+        result.ndt_result_poses.poses.push_back(
+          autoware::localization_util::matrix4f_to_pose(multi_ndt_result.ndt_results[i].pose));
+        result.ndt_initial_poses.poses.push_back(
+          autoware::localization_util::matrix4f_to_pose(multi_ndt_result.ndt_initial_poses[i]));
+      }
+      result.covariance = multi_ndt_result.covariance;
+      break;
+    }
+    case CovarianceEstimationType::MULTI_NDT_SCORE: {
+      const std::vector<Eigen::Matrix4f> poses_to_search = pclomp::propose_poses_to_search(
+        ndt_result, param.covariance_estimation.initial_pose_offset_model_x,
+        param.covariance_estimation.initial_pose_offset_model_y);
+      const auto multi_ndt_score_result = estimate_xy_covariance_by_multi_ndt_score(
+        ndt_result, ndt_ptr, poses_to_search, param.covariance_estimation.temperature);
+      for (const auto & sub_initial_pose_matrix : poses_to_search) {
+        result.ndt_initial_poses.poses.push_back(
+          autoware::localization_util::matrix4f_to_pose(sub_initial_pose_matrix));
+      }
+      result.covariance = multi_ndt_score_result.covariance;
+      break;
+    }
+    case CovarianceEstimationType::FIXED_VALUE:
+    default:
+      result.covariance = Eigen::Matrix2d::Identity() * param.output_pose_covariance[0 + 6 * 0];
+      break;
+  }
+
+  return result;
+}
+
+}  // namespace autoware::ndt_scan_matcher

--- a/localization/autoware_ndt_scan_matcher/src/covariance_estimation.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/covariance_estimation.cpp
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <autoware/ndt_scan_matcher/covariance_estimation.hpp>
-
-#include <autoware/ndt_scan_matcher/ndt_omp/estimate_covariance.hpp>
 #include <autoware/localization_util/util_func.hpp>
+#include <autoware/ndt_scan_matcher/covariance_estimation.hpp>
+#include <autoware/ndt_scan_matcher/ndt_omp/estimate_covariance.hpp>
 
 namespace autoware::ndt_scan_matcher
 {
@@ -39,7 +38,8 @@ CovarianceComputationResult compute_covariance_estimate(
 
   switch (param.covariance_estimation.covariance_estimation_type) {
     case CovarianceEstimationType::LAPLACE_APPROXIMATION: {
-      result.covariance = pclomp::estimate_xy_covariance_by_laplace_approximation(ndt_result.hessian);
+      result.covariance =
+        pclomp::estimate_xy_covariance_by_laplace_approximation(ndt_result.hessian);
       break;
     }
     case CovarianceEstimationType::MULTI_NDT: {

--- a/localization/autoware_ndt_scan_matcher/src/covariance_estimation.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/covariance_estimation.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <autoware/ndt_scan_matcher/ndt_omp/estimate_covariance.hpp>
-#include <autoware/localization_util/util_func.hpp>
-
 #include "covariance_estimation.hpp"
+
+#include <autoware/localization_util/util_func.hpp>
+#include <autoware/ndt_scan_matcher/ndt_omp/estimate_covariance.hpp>
 
 namespace autoware::ndt_scan_matcher
 {
@@ -39,7 +39,8 @@ CovarianceComputationResult compute_covariance_estimate(
 
   switch (param.covariance_estimation.covariance_estimation_type) {
     case CovarianceEstimationType::LAPLACE_APPROXIMATION: {
-      result.covariance = pclomp::estimate_xy_covariance_by_laplace_approximation(ndt_result.hessian);
+      result.covariance =
+        pclomp::estimate_xy_covariance_by_laplace_approximation(ndt_result.hessian);
       break;
     }
     case CovarianceEstimationType::MULTI_NDT: {

--- a/localization/autoware_ndt_scan_matcher/src/covariance_estimation.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/covariance_estimation.cpp
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <autoware/localization_util/util_func.hpp>
-#include <autoware/ndt_scan_matcher/covariance_estimation.hpp>
 #include <autoware/ndt_scan_matcher/ndt_omp/estimate_covariance.hpp>
+#include <autoware/localization_util/util_func.hpp>
+
+#include "covariance_estimation.hpp"
 
 namespace autoware::ndt_scan_matcher
 {
@@ -38,8 +39,7 @@ CovarianceComputationResult compute_covariance_estimate(
 
   switch (param.covariance_estimation.covariance_estimation_type) {
     case CovarianceEstimationType::LAPLACE_APPROXIMATION: {
-      result.covariance =
-        pclomp::estimate_xy_covariance_by_laplace_approximation(ndt_result.hessian);
+      result.covariance = pclomp::estimate_xy_covariance_by_laplace_approximation(ndt_result.hessian);
       break;
     }
     case CovarianceEstimationType::MULTI_NDT: {

--- a/localization/autoware_ndt_scan_matcher/src/covariance_estimation.hpp
+++ b/localization/autoware_ndt_scan_matcher/src/covariance_estimation.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__NDT_SCAN_MATCHER__COVARIANCE_ESTIMATION_HPP_
-#define AUTOWARE__NDT_SCAN_MATCHER__COVARIANCE_ESTIMATION_HPP_
+#ifndef AUTOWARE__NDT_SCAN_MATCHER__COVARIANCE_ESTIMATION_INTERNAL_HPP_
+#define AUTOWARE__NDT_SCAN_MATCHER__COVARIANCE_ESTIMATION_INTERNAL_HPP_
 
 #include "hyper_parameters.hpp"
 
@@ -46,4 +46,4 @@ CovarianceComputationResult compute_covariance_estimate(
 
 }  // namespace autoware::ndt_scan_matcher
 
-#endif  // AUTOWARE__NDT_SCAN_MATCHER__COVARIANCE_ESTIMATION_HPP_
+#endif  // AUTOWARE__NDT_SCAN_MATCHER__COVARIANCE_ESTIMATION_INTERNAL_HPP_

--- a/localization/autoware_ndt_scan_matcher/src/covariance_estimation.hpp
+++ b/localization/autoware_ndt_scan_matcher/src/covariance_estimation.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__NDT_SCAN_MATCHER__COVARIANCE_ESTIMATION_INTERNAL_HPP_
-#define AUTOWARE__NDT_SCAN_MATCHER__COVARIANCE_ESTIMATION_INTERNAL_HPP_
+#ifndef COVARIANCE_ESTIMATION_HPP_
+#define COVARIANCE_ESTIMATION_HPP_
 
 #include "hyper_parameters.hpp"
 
@@ -46,4 +46,4 @@ CovarianceComputationResult compute_covariance_estimate(
 
 }  // namespace autoware::ndt_scan_matcher
 
-#endif  // AUTOWARE__NDT_SCAN_MATCHER__COVARIANCE_ESTIMATION_INTERNAL_HPP_
+#endif  // COVARIANCE_ESTIMATION_HPP_

--- a/localization/autoware_ndt_scan_matcher/src/map_update_module.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/map_update_module.cpp
@@ -14,6 +14,8 @@
 
 #include <autoware/ndt_scan_matcher/map_update_module.hpp>
 
+#include "map_update_module_internal.hpp"
+
 #include <memory>
 #include <string>
 
@@ -304,7 +306,7 @@ bool MapUpdateModule::update_ndt(
     return false;  // No update
   }
 
-  MapUpdateModule::MapUpdateDiff diff;
+  detail::MapUpdateDiff diff;
 
   // Add pcd
   for (auto & map : maps_to_add) {
@@ -318,7 +320,7 @@ bool MapUpdateModule::update_ndt(
     diff.removals.push_back(map_id_to_remove);
   }
 
-  const auto map_update_result = apply_map_update(ndt, diff);
+  const auto map_update_result = detail::apply_map_update(ndt, diff);
 
   if (!map_update_result.updated) {
     return false;  // No update

--- a/localization/autoware_ndt_scan_matcher/src/map_update_module.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/map_update_module.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <autoware/ndt_scan_matcher/map_update_module.hpp>
-
 #include "map_update_module_internal.hpp"
+
+#include <autoware/ndt_scan_matcher/map_update_module.hpp>
 
 #include <memory>
 #include <string>

--- a/localization/autoware_ndt_scan_matcher/src/map_update_module.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/map_update_module.cpp
@@ -217,8 +217,10 @@ void MapUpdateModule::update_map(
     dummy_ptr.reset();
   }
 
-  secondary_ndt_ptr_.reset(new NdtType);
-  *secondary_ndt_ptr_ = *ndt_ptr_;
+  {
+    std::lock_guard<std::mutex> lock(*ndt_ptr_mutex_);
+    secondary_ndt_ptr_.reset(new NdtType(*ndt_ptr_));
+  }
 
   // Memorize the position of the last update
   last_update_position_mtx_.lock();

--- a/localization/autoware_ndt_scan_matcher/src/map_update_module_internal.hpp
+++ b/localization/autoware_ndt_scan_matcher/src/map_update_module_internal.hpp
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__NDT_SCAN_MATCHER__MAP_UPDATE_MODULE_INTERNAL_HPP_
-#define AUTOWARE__NDT_SCAN_MATCHER__MAP_UPDATE_MODULE_INTERNAL_HPP_
+#ifndef MAP_UPDATE_MODULE_INTERNAL_HPP_
+#define MAP_UPDATE_MODULE_INTERNAL_HPP_
+
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
 
 #include <chrono>
 #include <string>
 #include <vector>
-
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
 
 namespace autoware::ndt_scan_matcher::detail
 {
@@ -79,4 +79,4 @@ MapUpdateResult apply_map_update(NdtT & ndt, const DiffT & diff)
 
 }  // namespace autoware::ndt_scan_matcher::detail
 
-#endif  // AUTOWARE__NDT_SCAN_MATCHER__MAP_UPDATE_MODULE_INTERNAL_HPP_
+#endif  // MAP_UPDATE_MODULE_INTERNAL_HPP_

--- a/localization/autoware_ndt_scan_matcher/src/map_update_module_internal.hpp
+++ b/localization/autoware_ndt_scan_matcher/src/map_update_module_internal.hpp
@@ -1,0 +1,82 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__NDT_SCAN_MATCHER__MAP_UPDATE_MODULE_INTERNAL_HPP_
+#define AUTOWARE__NDT_SCAN_MATCHER__MAP_UPDATE_MODULE_INTERNAL_HPP_
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+namespace autoware::ndt_scan_matcher::detail
+{
+
+template <typename CloudPtrT>
+struct MapUpdateDiffTemplate
+{
+  struct Addition
+  {
+    CloudPtrT cloud;
+    std::string id;
+  };
+
+  std::vector<Addition> additions;
+  std::vector<std::string> removals;
+};
+
+struct MapUpdateResult
+{
+  std::size_t added{0};
+  std::size_t removed{0};
+  bool updated{false};
+  double execution_time_ms{0.0};
+};
+
+using MapUpdateDiff = MapUpdateDiffTemplate<pcl::PointCloud<pcl::PointXYZ>::Ptr>;
+
+template <typename NdtT, typename DiffT>
+MapUpdateResult apply_map_update(NdtT & ndt, const DiffT & diff)
+{
+  const auto start = std::chrono::steady_clock::now();
+
+  std::size_t added = 0;
+  for (const auto & addition : diff.additions) {
+    ndt.addTarget(addition.cloud, addition.id);
+    ++added;
+  }
+
+  std::size_t removed = 0;
+  for (const auto & id : diff.removals) {
+    ndt.removeTarget(id);
+    ++removed;
+  }
+
+  const bool updated = (added + removed) > 0;
+  if (updated) {
+    ndt.createVoxelKdtree();
+  }
+
+  const auto end = std::chrono::steady_clock::now();
+  const double execution_ms =
+    std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(end - start).count();
+
+  return MapUpdateResult{added, removed, updated, execution_ms};
+}
+
+}  // namespace autoware::ndt_scan_matcher::detail
+
+#endif  // AUTOWARE__NDT_SCAN_MATCHER__MAP_UPDATE_MODULE_INTERNAL_HPP_

--- a/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -664,8 +664,7 @@ std::optional<NDTScanMatcher::ScanMatchingOutput> NDTScanMatcher::run_scan_match
     const double default_cov_yy = param_.covariance.output_pose_covariance[7];
     const Eigen::Matrix2d estimated_covariance_2d_adj = pclomp::adjust_diagonal_covariance(
       estimated_covariance_2d_scaled, ndt_result.pose, default_cov_xx, default_cov_yy);
-    Eigen::Map<Eigen::Matrix<double, 6, 6, Eigen::RowMajor>> ndt_cov_matrix(
-      ndt_covariance.data());
+    Eigen::Map<Eigen::Matrix<double, 6, 6, Eigen::RowMajor>> ndt_cov_matrix(ndt_covariance.data());
     ndt_cov_matrix.topLeftCorner<2, 2>() = estimated_covariance_2d_adj;
   }
 
@@ -745,11 +744,9 @@ void NDTScanMatcher::publish_scan_matching_outputs(
   exe_time_pub_->publish(make_float32_stamped(sensor_ros_time, output.exe_time_ms));
   transform_probability_pub_->publish(
     make_float32_stamped(sensor_ros_time, output.ndt_result.transform_probability));
-  nearest_voxel_transformation_likelihood_pub_->publish(
-    make_float32_stamped(
-      sensor_ros_time, output.ndt_result.nearest_voxel_transformation_likelihood));
-  iteration_num_pub_->publish(
-    make_int32_stamped(sensor_ros_time, output.ndt_result.iteration_num));
+  nearest_voxel_transformation_likelihood_pub_->publish(make_float32_stamped(
+    sensor_ros_time, output.ndt_result.nearest_voxel_transformation_likelihood));
+  iteration_num_pub_->publish(make_int32_stamped(sensor_ros_time, output.ndt_result.iteration_num));
   publish_tf(sensor_ros_time, output.result_pose_msg);
   publish_pose(sensor_ros_time, output.result_pose_msg, output.ndt_covariance, output.is_converged);
   publish_marker(sensor_ros_time, output.transformation_msg_array);
@@ -782,9 +779,8 @@ void NDTScanMatcher::publish_scan_matching_outputs(
 
     no_ground_transform_probability_pub_->publish(
       make_float32_stamped(sensor_ros_time, output.no_ground_transform_probability));
-    no_ground_nearest_voxel_transformation_likelihood_pub_->publish(
-      make_float32_stamped(
-        sensor_ros_time, output.no_ground_nearest_voxel_transformation_likelihood));
+    no_ground_nearest_voxel_transformation_likelihood_pub_->publish(make_float32_stamped(
+      sensor_ros_time, output.no_ground_nearest_voxel_transformation_likelihood));
   }
 }
 

--- a/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -15,13 +15,15 @@
 #include <autoware/localization_util/matrix_type.hpp>
 #include <autoware/localization_util/tree_structured_parzen_estimator.hpp>
 #include <autoware/localization_util/util_func.hpp>
-#include <autoware/ndt_scan_matcher/covariance_estimation.hpp>
+#include "covariance_estimation.hpp"
 #include <autoware/ndt_scan_matcher/ndt_omp/estimate_covariance.hpp>
 #include <autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp>
 #include <autoware/ndt_scan_matcher/particle.hpp>
 #include <autoware/qos_utils/qos_compatibility.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_utils_pcl/transforms.hpp>
+
+#include "visualize_point_score.hpp"
 
 #include <pcl_conversions/pcl_conversions.h>
 
@@ -664,7 +666,8 @@ std::optional<NDTScanMatcher::ScanMatchingOutput> NDTScanMatcher::run_scan_match
     const double default_cov_yy = param_.covariance.output_pose_covariance[7];
     const Eigen::Matrix2d estimated_covariance_2d_adj = pclomp::adjust_diagonal_covariance(
       estimated_covariance_2d_scaled, ndt_result.pose, default_cov_xx, default_cov_yy);
-    Eigen::Map<Eigen::Matrix<double, 6, 6, Eigen::RowMajor>> ndt_cov_matrix(ndt_covariance.data());
+    Eigen::Map<Eigen::Matrix<double, 6, 6, Eigen::RowMajor>> ndt_cov_matrix(
+      ndt_covariance.data());
     ndt_cov_matrix.topLeftCorner<2, 2>() = estimated_covariance_2d_adj;
   }
 
@@ -744,9 +747,11 @@ void NDTScanMatcher::publish_scan_matching_outputs(
   exe_time_pub_->publish(make_float32_stamped(sensor_ros_time, output.exe_time_ms));
   transform_probability_pub_->publish(
     make_float32_stamped(sensor_ros_time, output.ndt_result.transform_probability));
-  nearest_voxel_transformation_likelihood_pub_->publish(make_float32_stamped(
-    sensor_ros_time, output.ndt_result.nearest_voxel_transformation_likelihood));
-  iteration_num_pub_->publish(make_int32_stamped(sensor_ros_time, output.ndt_result.iteration_num));
+  nearest_voxel_transformation_likelihood_pub_->publish(
+    make_float32_stamped(
+      sensor_ros_time, output.ndt_result.nearest_voxel_transformation_likelihood));
+  iteration_num_pub_->publish(
+    make_int32_stamped(sensor_ros_time, output.ndt_result.iteration_num));
   publish_tf(sensor_ros_time, output.result_pose_msg);
   publish_pose(sensor_ros_time, output.result_pose_msg, output.ndt_covariance, output.is_converged);
   publish_marker(sensor_ros_time, output.transformation_msg_array);
@@ -779,8 +784,9 @@ void NDTScanMatcher::publish_scan_matching_outputs(
 
     no_ground_transform_probability_pub_->publish(
       make_float32_stamped(sensor_ros_time, output.no_ground_transform_probability));
-    no_ground_nearest_voxel_transformation_likelihood_pub_->publish(make_float32_stamped(
-      sensor_ros_time, output.no_ground_nearest_voxel_transformation_likelihood));
+    no_ground_nearest_voxel_transformation_likelihood_pub_->publish(
+      make_float32_stamped(
+        sensor_ros_time, output.no_ground_nearest_voxel_transformation_likelihood));
   }
 }
 

--- a/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -877,13 +877,10 @@ Eigen::Matrix2d NDTScanMatcher::estimate_covariance(
   return cov_result.covariance;
 }
 
-pcl::PointCloud<pcl::PointXYZRGB>::Ptr NDTScanMatcher::visualize_point_score(
-  const pcl::shared_ptr<pcl::PointCloud<PointSource>> & sensor_points_in_map_ptr,
-  const float & lower_nvs, const float & upper_nvs)
+pcl::PointCloud<pcl::PointXYZRGB>::Ptr detail::colorize_point_scores(
+  const pcl::PointCloud<pcl::PointXYZI> & nvs_points_in_map_ptr_i, const float lower_nvs,
+  const float upper_nvs)
 {
-  pcl::PointCloud<pcl::PointXYZI> nvs_points_in_map_ptr_i;
-  nvs_points_in_map_ptr_i =
-    ndt_ptr_->calculateNearestVoxelScoreEachPoint(*sensor_points_in_map_ptr);
   pcl::PointCloud<pcl::PointXYZRGB>::Ptr nvs_points_in_map_ptr_rgb{
     new pcl::PointCloud<pcl::PointXYZRGB>};
 
@@ -901,6 +898,16 @@ pcl::PointCloud<pcl::PointXYZRGB>::Ptr NDTScanMatcher::visualize_point_score(
     nvs_points_in_map_ptr_rgb->points.push_back(point);
   }
   return nvs_points_in_map_ptr_rgb;
+}
+
+pcl::PointCloud<pcl::PointXYZRGB>::Ptr NDTScanMatcher::visualize_point_score(
+  const pcl::shared_ptr<pcl::PointCloud<PointSource>> & sensor_points_in_map_ptr,
+  const float & lower_nvs, const float & upper_nvs)
+{
+  const pcl::PointCloud<pcl::PointXYZI> nvs_points_in_map_ptr_i =
+    ndt_ptr_->calculateNearestVoxelScoreEachPoint(*sensor_points_in_map_ptr);
+
+  return detail::colorize_point_scores(nvs_points_in_map_ptr_i, lower_nvs, upper_nvs);
 }
 
 void NDTScanMatcher::add_regularization_pose(const rclcpp::Time & sensor_ros_time)

--- a/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -603,10 +603,9 @@ bool NDTScanMatcher::callback_sensor_points_main(
     const double default_cov_yy = param_.covariance.output_pose_covariance[7];
     const Eigen::Matrix2d estimated_covariance_2d_adj = pclomp::adjust_diagonal_covariance(
       estimated_covariance_2d_scaled, ndt_result.pose, default_cov_xx, default_cov_yy);
-    ndt_covariance[0 + 6 * 0] = estimated_covariance_2d_adj(0, 0);
-    ndt_covariance[1 + 6 * 1] = estimated_covariance_2d_adj(1, 1);
-    ndt_covariance[1 + 6 * 0] = estimated_covariance_2d_adj(1, 0);
-    ndt_covariance[0 + 6 * 1] = estimated_covariance_2d_adj(0, 1);
+    Eigen::Map<Eigen::Matrix<double, 6, 6, Eigen::RowMajor>> ndt_cov_matrix(
+      ndt_covariance.data());
+    ndt_cov_matrix.topLeftCorner<2, 2>() = estimated_covariance_2d_adj;
   }
 
   // check distance_initial_to_result

--- a/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "covariance_estimation.hpp"
+#include "visualize_point_score.hpp"
+
 #include <autoware/localization_util/matrix_type.hpp>
 #include <autoware/localization_util/tree_structured_parzen_estimator.hpp>
 #include <autoware/localization_util/util_func.hpp>
-#include "covariance_estimation.hpp"
 #include <autoware/ndt_scan_matcher/ndt_omp/estimate_covariance.hpp>
 #include <autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp>
 #include <autoware/ndt_scan_matcher/particle.hpp>
 #include <autoware/qos_utils/qos_compatibility.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_utils_pcl/transforms.hpp>
-
-#include "visualize_point_score.hpp"
 
 #include <pcl_conversions/pcl_conversions.h>
 
@@ -666,8 +666,7 @@ std::optional<NDTScanMatcher::ScanMatchingOutput> NDTScanMatcher::run_scan_match
     const double default_cov_yy = param_.covariance.output_pose_covariance[7];
     const Eigen::Matrix2d estimated_covariance_2d_adj = pclomp::adjust_diagonal_covariance(
       estimated_covariance_2d_scaled, ndt_result.pose, default_cov_xx, default_cov_yy);
-    Eigen::Map<Eigen::Matrix<double, 6, 6, Eigen::RowMajor>> ndt_cov_matrix(
-      ndt_covariance.data());
+    Eigen::Map<Eigen::Matrix<double, 6, 6, Eigen::RowMajor>> ndt_cov_matrix(ndt_covariance.data());
     ndt_cov_matrix.topLeftCorner<2, 2>() = estimated_covariance_2d_adj;
   }
 
@@ -747,11 +746,9 @@ void NDTScanMatcher::publish_scan_matching_outputs(
   exe_time_pub_->publish(make_float32_stamped(sensor_ros_time, output.exe_time_ms));
   transform_probability_pub_->publish(
     make_float32_stamped(sensor_ros_time, output.ndt_result.transform_probability));
-  nearest_voxel_transformation_likelihood_pub_->publish(
-    make_float32_stamped(
-      sensor_ros_time, output.ndt_result.nearest_voxel_transformation_likelihood));
-  iteration_num_pub_->publish(
-    make_int32_stamped(sensor_ros_time, output.ndt_result.iteration_num));
+  nearest_voxel_transformation_likelihood_pub_->publish(make_float32_stamped(
+    sensor_ros_time, output.ndt_result.nearest_voxel_transformation_likelihood));
+  iteration_num_pub_->publish(make_int32_stamped(sensor_ros_time, output.ndt_result.iteration_num));
   publish_tf(sensor_ros_time, output.result_pose_msg);
   publish_pose(sensor_ros_time, output.result_pose_msg, output.ndt_covariance, output.is_converged);
   publish_marker(sensor_ros_time, output.transformation_msg_array);
@@ -784,9 +781,8 @@ void NDTScanMatcher::publish_scan_matching_outputs(
 
     no_ground_transform_probability_pub_->publish(
       make_float32_stamped(sensor_ros_time, output.no_ground_transform_probability));
-    no_ground_nearest_voxel_transformation_likelihood_pub_->publish(
-      make_float32_stamped(
-        sensor_ros_time, output.no_ground_nearest_voxel_transformation_likelihood));
+    no_ground_nearest_voxel_transformation_likelihood_pub_->publish(make_float32_stamped(
+      sensor_ros_time, output.no_ground_nearest_voxel_transformation_likelihood));
   }
 }
 

--- a/localization/autoware_ndt_scan_matcher/src/visualize_point_score.hpp
+++ b/localization/autoware_ndt_scan_matcher/src/visualize_point_score.hpp
@@ -1,0 +1,29 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__NDT_SCAN_MATCHER__VISUALIZE_POINT_SCORE_HPP_
+#define AUTOWARE__NDT_SCAN_MATCHER__VISUALIZE_POINT_SCORE_HPP_
+
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+namespace autoware::ndt_scan_matcher::detail
+{
+
+pcl::PointCloud<pcl::PointXYZRGB>::Ptr colorize_point_scores(
+  const pcl::PointCloud<pcl::PointXYZI> & nvs_points_in_map_ptr_i, float lower_nvs, float upper_nvs);
+
+}  // namespace autoware::ndt_scan_matcher::detail
+
+#endif  // AUTOWARE__NDT_SCAN_MATCHER__VISUALIZE_POINT_SCORE_HPP_

--- a/localization/autoware_ndt_scan_matcher/src/visualize_point_score.hpp
+++ b/localization/autoware_ndt_scan_matcher/src/visualize_point_score.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__NDT_SCAN_MATCHER__VISUALIZE_POINT_SCORE_HPP_
-#define AUTOWARE__NDT_SCAN_MATCHER__VISUALIZE_POINT_SCORE_HPP_
+#ifndef VISUALIZE_POINT_SCORE_HPP_
+#define VISUALIZE_POINT_SCORE_HPP_
 
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
@@ -22,8 +22,9 @@ namespace autoware::ndt_scan_matcher::detail
 {
 
 pcl::PointCloud<pcl::PointXYZRGB>::Ptr colorize_point_scores(
-  const pcl::PointCloud<pcl::PointXYZI> & nvs_points_in_map_ptr_i, float lower_nvs, float upper_nvs);
+  const pcl::PointCloud<pcl::PointXYZI> & nvs_points_in_map_ptr_i, float lower_nvs,
+  float upper_nvs);
 
 }  // namespace autoware::ndt_scan_matcher::detail
 
-#endif  // AUTOWARE__NDT_SCAN_MATCHER__VISUALIZE_POINT_SCORE_HPP_
+#endif  // VISUALIZE_POINT_SCORE_HPP_

--- a/localization/autoware_ndt_scan_matcher/test/test_cases/covariance_estimation_test.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_cases/covariance_estimation_test.cpp
@@ -13,11 +13,10 @@
 // limitations under the License.
 
 #include <autoware/ndt_scan_matcher/covariance_estimation.hpp>
-
 #include <autoware/ndt_scan_matcher/ndt_omp/estimate_covariance.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 #include <gtest/gtest.h>
-#include <rclcpp/rclcpp.hpp>
 
 namespace autoware::ndt_scan_matcher
 {
@@ -36,8 +35,8 @@ TEST(CovarianceEstimation, LaplaceApproximationMatchesPclomp)
   const Eigen::Matrix4f initial_pose_matrix = Eigen::Matrix4f::Identity();
   const rclcpp::Time stamp{0, 0, RCL_ROS_TIME};
 
-  const auto result = compute_covariance_estimate(
-    ndt_result, initial_pose_matrix, param, ndt_ptr, stamp, "map");
+  const auto result =
+    compute_covariance_estimate(ndt_result, initial_pose_matrix, param, ndt_ptr, stamp, "map");
 
   const auto expected = pclomp::estimate_xy_covariance_by_laplace_approximation(ndt_result.hessian);
 
@@ -61,8 +60,8 @@ TEST(CovarianceEstimation, FixedValueUsesConfiguredDiagonal)
   const Eigen::Matrix4f initial_pose_matrix = Eigen::Matrix4f::Identity();
   const rclcpp::Time stamp{0, 0, RCL_ROS_TIME};
 
-  const auto result = compute_covariance_estimate(
-    ndt_result, initial_pose_matrix, param, ndt_ptr, stamp, "map");
+  const auto result =
+    compute_covariance_estimate(ndt_result, initial_pose_matrix, param, ndt_ptr, stamp, "map");
 
   const Eigen::Matrix2d expected = Eigen::Matrix2d::Identity() * kDiag;
   EXPECT_TRUE(result.covariance.isApprox(expected));

--- a/localization/autoware_ndt_scan_matcher/test/test_cases/covariance_estimation_test.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_cases/covariance_estimation_test.cpp
@@ -1,0 +1,73 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <autoware/ndt_scan_matcher/covariance_estimation.hpp>
+
+#include <autoware/ndt_scan_matcher/ndt_omp/estimate_covariance.hpp>
+
+#include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
+
+namespace autoware::ndt_scan_matcher
+{
+
+TEST(CovarianceEstimation, LaplaceApproximationMatchesPclomp)
+{
+  pclomp::NdtResult ndt_result;
+  ndt_result.pose = Eigen::Matrix4f::Identity();
+  ndt_result.hessian = Eigen::Matrix<double, 6, 6>::Identity();
+
+  HyperParameters::Covariance param;
+  param.covariance_estimation.covariance_estimation_type =
+    CovarianceEstimationType::LAPLACE_APPROXIMATION;
+
+  auto ndt_ptr = std::make_shared<NdtType>();
+  const Eigen::Matrix4f initial_pose_matrix = Eigen::Matrix4f::Identity();
+  const rclcpp::Time stamp{0, 0, RCL_ROS_TIME};
+
+  const auto result = compute_covariance_estimate(
+    ndt_result, initial_pose_matrix, param, ndt_ptr, stamp, "map");
+
+  const auto expected = pclomp::estimate_xy_covariance_by_laplace_approximation(ndt_result.hessian);
+
+  EXPECT_TRUE(result.covariance.isApprox(expected));
+  ASSERT_EQ(1U, result.ndt_result_poses.poses.size());
+  ASSERT_EQ(1U, result.ndt_initial_poses.poses.size());
+}
+
+TEST(CovarianceEstimation, FixedValueUsesConfiguredDiagonal)
+{
+  pclomp::NdtResult ndt_result;
+  ndt_result.pose = Eigen::Matrix4f::Identity();
+
+  HyperParameters::Covariance param;
+  param.covariance_estimation.covariance_estimation_type = CovarianceEstimationType::FIXED_VALUE;
+  param.output_pose_covariance.fill(0.0);
+  constexpr double kDiag = 2.5;
+  param.output_pose_covariance[0] = kDiag;
+
+  auto ndt_ptr = std::make_shared<NdtType>();
+  const Eigen::Matrix4f initial_pose_matrix = Eigen::Matrix4f::Identity();
+  const rclcpp::Time stamp{0, 0, RCL_ROS_TIME};
+
+  const auto result = compute_covariance_estimate(
+    ndt_result, initial_pose_matrix, param, ndt_ptr, stamp, "map");
+
+  const Eigen::Matrix2d expected = Eigen::Matrix2d::Identity() * kDiag;
+  EXPECT_TRUE(result.covariance.isApprox(expected));
+  ASSERT_EQ(1U, result.ndt_result_poses.poses.size());
+  ASSERT_EQ(1U, result.ndt_initial_poses.poses.size());
+}
+
+}  // namespace autoware::ndt_scan_matcher

--- a/localization/autoware_ndt_scan_matcher/test/test_cases/covariance_estimation_test.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_cases/covariance_estimation_test.cpp
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <autoware/ndt_scan_matcher/covariance_estimation.hpp>
+#include "covariance_estimation.hpp"
+
 #include <autoware/ndt_scan_matcher/ndt_omp/estimate_covariance.hpp>
-#include <rclcpp/rclcpp.hpp>
 
 #include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
 
 namespace autoware::ndt_scan_matcher
 {
@@ -35,8 +36,8 @@ TEST(CovarianceEstimation, LaplaceApproximationMatchesPclomp)
   const Eigen::Matrix4f initial_pose_matrix = Eigen::Matrix4f::Identity();
   const rclcpp::Time stamp{0, 0, RCL_ROS_TIME};
 
-  const auto result =
-    compute_covariance_estimate(ndt_result, initial_pose_matrix, param, ndt_ptr, stamp, "map");
+  const auto result = compute_covariance_estimate(
+    ndt_result, initial_pose_matrix, param, ndt_ptr, stamp, "map");
 
   const auto expected = pclomp::estimate_xy_covariance_by_laplace_approximation(ndt_result.hessian);
 
@@ -60,8 +61,8 @@ TEST(CovarianceEstimation, FixedValueUsesConfiguredDiagonal)
   const Eigen::Matrix4f initial_pose_matrix = Eigen::Matrix4f::Identity();
   const rclcpp::Time stamp{0, 0, RCL_ROS_TIME};
 
-  const auto result =
-    compute_covariance_estimate(ndt_result, initial_pose_matrix, param, ndt_ptr, stamp, "map");
+  const auto result = compute_covariance_estimate(
+    ndt_result, initial_pose_matrix, param, ndt_ptr, stamp, "map");
 
   const Eigen::Matrix2d expected = Eigen::Matrix2d::Identity() * kDiag;
   EXPECT_TRUE(result.covariance.isApprox(expected));

--- a/localization/autoware_ndt_scan_matcher/test/test_cases/covariance_estimation_test.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_cases/covariance_estimation_test.cpp
@@ -15,9 +15,9 @@
 #include "covariance_estimation.hpp"
 
 #include <autoware/ndt_scan_matcher/ndt_omp/estimate_covariance.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 #include <gtest/gtest.h>
-#include <rclcpp/rclcpp.hpp>
 
 namespace autoware::ndt_scan_matcher
 {
@@ -36,8 +36,8 @@ TEST(CovarianceEstimation, LaplaceApproximationMatchesPclomp)
   const Eigen::Matrix4f initial_pose_matrix = Eigen::Matrix4f::Identity();
   const rclcpp::Time stamp{0, 0, RCL_ROS_TIME};
 
-  const auto result = compute_covariance_estimate(
-    ndt_result, initial_pose_matrix, param, ndt_ptr, stamp, "map");
+  const auto result =
+    compute_covariance_estimate(ndt_result, initial_pose_matrix, param, ndt_ptr, stamp, "map");
 
   const auto expected = pclomp::estimate_xy_covariance_by_laplace_approximation(ndt_result.hessian);
 
@@ -61,8 +61,8 @@ TEST(CovarianceEstimation, FixedValueUsesConfiguredDiagonal)
   const Eigen::Matrix4f initial_pose_matrix = Eigen::Matrix4f::Identity();
   const rclcpp::Time stamp{0, 0, RCL_ROS_TIME};
 
-  const auto result = compute_covariance_estimate(
-    ndt_result, initial_pose_matrix, param, ndt_ptr, stamp, "map");
+  const auto result =
+    compute_covariance_estimate(ndt_result, initial_pose_matrix, param, ndt_ptr, stamp, "map");
 
   const Eigen::Matrix2d expected = Eigen::Matrix2d::Identity() * kDiag;
   EXPECT_TRUE(result.covariance.isApprox(expected));

--- a/localization/autoware_ndt_scan_matcher/test/test_cases/map_update_module_test.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_cases/map_update_module_test.cpp
@@ -15,7 +15,6 @@
 #include <autoware/ndt_scan_matcher/map_update_module.hpp>
 
 #include <gtest/gtest.h>
-#include <gmock/gmock.h>
 
 #include <memory>
 #include <string>
@@ -52,8 +51,10 @@ TEST(MapUpdateModuleTest, AppliesAddsAndRemovals)
   EXPECT_EQ(1U, result.added);
   EXPECT_EQ(1U, result.removed);
   EXPECT_TRUE(ndt.kdtree_built);
-  EXPECT_THAT(ndt.added_ids, ::testing::ElementsAre("cell_a"));
-  EXPECT_THAT(ndt.removed_ids, ::testing::ElementsAre("cell_b"));
+  ASSERT_EQ(1U, ndt.added_ids.size());
+  EXPECT_EQ("cell_a", ndt.added_ids.front());
+  ASSERT_EQ(1U, ndt.removed_ids.size());
+  EXPECT_EQ("cell_b", ndt.removed_ids.front());
 }
 
 TEST(MapUpdateModuleTest, NoChangesSkipsKdtree)

--- a/localization/autoware_ndt_scan_matcher/test/test_cases/map_update_module_test.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_cases/map_update_module_test.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <autoware/ndt_scan_matcher/map_update_module.hpp>
+#include "map_update_module_internal.hpp"
 
 #include <gtest/gtest.h>
 
@@ -36,7 +36,7 @@ struct FakeNdt
 };
 }  // namespace
 
-using Diff = autoware::ndt_scan_matcher::MapUpdateDiffTemplate<FakeNdt::CloudPtr>;
+using Diff = autoware::ndt_scan_matcher::detail::MapUpdateDiffTemplate<FakeNdt::CloudPtr>;
 
 TEST(MapUpdateModuleTest, AppliesAddsAndRemovals)
 {
@@ -45,7 +45,7 @@ TEST(MapUpdateModuleTest, AppliesAddsAndRemovals)
   diff.additions.push_back({std::make_shared<int>(1), "cell_a"});
   diff.removals.push_back("cell_b");
 
-  const auto result = autoware::ndt_scan_matcher::MapUpdateModule::apply_map_update(ndt, diff);
+  const auto result = autoware::ndt_scan_matcher::detail::apply_map_update(ndt, diff);
 
   EXPECT_TRUE(result.updated);
   EXPECT_EQ(1U, result.added);
@@ -62,7 +62,7 @@ TEST(MapUpdateModuleTest, NoChangesSkipsKdtree)
   FakeNdt ndt;
   Diff diff;
 
-  const auto result = autoware::ndt_scan_matcher::MapUpdateModule::apply_map_update(ndt, diff);
+  const auto result = autoware::ndt_scan_matcher::detail::apply_map_update(ndt, diff);
 
   EXPECT_FALSE(result.updated);
   EXPECT_EQ(0U, result.added);
@@ -76,7 +76,7 @@ TEST(MapUpdateModuleTest, AddsOnlyBuildsKdtree)
   Diff diff;
   diff.additions.push_back({std::make_shared<int>(42), "cell_x"});
 
-  const auto result = autoware::ndt_scan_matcher::MapUpdateModule::apply_map_update(ndt, diff);
+  const auto result = autoware::ndt_scan_matcher::detail::apply_map_update(ndt, diff);
 
   EXPECT_TRUE(result.updated);
   EXPECT_EQ(1U, result.added);

--- a/localization/autoware_ndt_scan_matcher/test/test_cases/map_update_module_test.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_cases/map_update_module_test.cpp
@@ -1,0 +1,84 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <autoware/ndt_scan_matcher/map_update_module.hpp>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace
+{
+struct FakeNdt
+{
+  using CloudPtr = std::shared_ptr<int>;
+
+  void addTarget(const CloudPtr &, const std::string & id) { added_ids.push_back(id); }
+  void removeTarget(const std::string & id) { removed_ids.push_back(id); }
+  void createVoxelKdtree() { kdtree_built = true; }
+
+  std::vector<std::string> added_ids;
+  std::vector<std::string> removed_ids;
+  bool kdtree_built{false};
+};
+}  // namespace
+
+using Diff = autoware::ndt_scan_matcher::MapUpdateDiffTemplate<FakeNdt::CloudPtr>;
+
+TEST(MapUpdateModuleTest, AppliesAddsAndRemovals)
+{
+  FakeNdt ndt;
+  Diff diff;
+  diff.additions.push_back({std::make_shared<int>(1), "cell_a"});
+  diff.removals.push_back("cell_b");
+
+  const auto result = autoware::ndt_scan_matcher::MapUpdateModule::apply_map_update(ndt, diff);
+
+  EXPECT_TRUE(result.updated);
+  EXPECT_EQ(1U, result.added);
+  EXPECT_EQ(1U, result.removed);
+  EXPECT_TRUE(ndt.kdtree_built);
+  EXPECT_THAT(ndt.added_ids, ::testing::ElementsAre("cell_a"));
+  EXPECT_THAT(ndt.removed_ids, ::testing::ElementsAre("cell_b"));
+}
+
+TEST(MapUpdateModuleTest, NoChangesSkipsKdtree)
+{
+  FakeNdt ndt;
+  Diff diff;
+
+  const auto result = autoware::ndt_scan_matcher::MapUpdateModule::apply_map_update(ndt, diff);
+
+  EXPECT_FALSE(result.updated);
+  EXPECT_EQ(0U, result.added);
+  EXPECT_EQ(0U, result.removed);
+  EXPECT_FALSE(ndt.kdtree_built);
+}
+
+TEST(MapUpdateModuleTest, AddsOnlyBuildsKdtree)
+{
+  FakeNdt ndt;
+  Diff diff;
+  diff.additions.push_back({std::make_shared<int>(42), "cell_x"});
+
+  const auto result = autoware::ndt_scan_matcher::MapUpdateModule::apply_map_update(ndt, diff);
+
+  EXPECT_TRUE(result.updated);
+  EXPECT_EQ(1U, result.added);
+  EXPECT_EQ(0U, result.removed);
+  EXPECT_TRUE(ndt.kdtree_built);
+}

--- a/localization/autoware_ndt_scan_matcher/test/test_cases/preprocess_sensor_points_test.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_cases/preprocess_sensor_points_test.cpp
@@ -43,15 +43,9 @@ private:
 class PreprocessSensorPointsTest : public TestNDTScanMatcher
 {
 protected:
-  static void SetUpTestSuite()
-  {
-    rclcpp::init(0, nullptr);
-  }
+  static void SetUpTestSuite() { rclcpp::init(0, nullptr); }
 
-  static void TearDownTestSuite()
-  {
-    rclcpp::shutdown();
-  }
+  static void TearDownTestSuite() { rclcpp::shutdown(); }
 
   void SetUp() override
   {

--- a/localization/autoware_ndt_scan_matcher/test/test_cases/preprocess_sensor_points_test.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_cases/preprocess_sensor_points_test.cpp
@@ -1,0 +1,88 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "test_fixture.hpp"
+#include "test_util.hpp"
+
+#include <autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+
+namespace autoware::ndt_scan_matcher
+{
+class NDTScanMatcherTestHelper
+{
+public:
+  explicit NDTScanMatcherTestHelper(const std::shared_ptr<NDTScanMatcher> & node) : node_(node) {}
+
+  std::optional<NDTScanMatcher::PreprocessResult> preprocess(
+    const sensor_msgs::msg::PointCloud2::ConstSharedPtr & msg) const
+  {
+    return node_->preprocess_sensor_points(msg, std::chrono::system_clock::now());
+  }
+
+private:
+  std::shared_ptr<NDTScanMatcher> node_;
+};
+}  // namespace autoware::ndt_scan_matcher
+
+class PreprocessSensorPointsTest : public TestNDTScanMatcher
+{
+protected:
+  static void SetUpTestSuite()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestSuite()
+  {
+    rclcpp::shutdown();
+  }
+
+  void SetUp() override
+  {
+    TestNDTScanMatcher::SetUp();
+    helper_ = std::make_unique<autoware::ndt_scan_matcher::NDTScanMatcherTestHelper>(node_);
+  }
+
+  std::unique_ptr<autoware::ndt_scan_matcher::NDTScanMatcherTestHelper> helper_;
+};
+
+TEST_F(PreprocessSensorPointsTest, ReturnsNulloptWhenPointCloudEmpty)
+{
+  auto empty_cloud = std::make_shared<sensor_msgs::msg::PointCloud2>();
+  empty_cloud->header.frame_id = "sensor_frame";
+  empty_cloud->header.stamp = rclcpp::Time(0, 0, RCL_ROS_TIME).to_builtin_time();
+  empty_cloud->width = 0;
+  empty_cloud->height = 0;
+
+  const auto result = helper_->preprocess(empty_cloud);
+
+  EXPECT_FALSE(result);  // Early exit on empty cloud
+}
+
+TEST_F(PreprocessSensorPointsTest, SucceedsWithValidPointCloud)
+{
+  auto cloud_msg = std::make_shared<sensor_msgs::msg::PointCloud2>(make_default_sensor_pcd());
+
+  const auto result = helper_->preprocess(cloud_msg);
+
+  ASSERT_TRUE(result);
+  EXPECT_EQ(result->sensor_ros_time, cloud_msg->header.stamp);
+  ASSERT_NE(result->sensor_points_in_baselink_frame, nullptr);
+  EXPECT_GT(result->sensor_points_in_baselink_frame->size(), 0U);
+}

--- a/localization/autoware_ndt_scan_matcher/test/test_cases/rotate_covariance_test.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_cases/rotate_covariance_test.cpp
@@ -14,11 +14,10 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-
-#include <gtest/gtest.h>
-
 #include <array>
 #include <cmath>
+
+#include <gtest/gtest.h>
 
 namespace autoware::ndt_scan_matcher
 {

--- a/localization/autoware_ndt_scan_matcher/test/test_cases/rotate_covariance_test.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_cases/rotate_covariance_test.cpp
@@ -1,0 +1,78 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <array>
+#include <cmath>
+
+#include <gtest/gtest.h>
+
+namespace autoware::ndt_scan_matcher
+{
+std::array<double, 36> rotate_position_covariance(
+  const std::array<double, 36> & src_covariance, const Eigen::Matrix3d & rotation);
+}  // namespace autoware::ndt_scan_matcher
+
+namespace
+{
+void expect_arrays_close(const std::array<double, 36> & lhs, const std::array<double, 36> & rhs)
+{
+  constexpr double kEpsilon = 1e-12;
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    EXPECT_NEAR(lhs[i], rhs[i], kEpsilon) << "Mismatch at index " << i;
+  }
+}
+}  // namespace
+
+TEST(RotatePositionCovarianceTest, KeepsCovarianceWithIdentityRotation)
+{
+  std::array<double, 36> src_covariance{};
+  for (size_t i = 0; i < src_covariance.size(); ++i) {
+    src_covariance[i] = static_cast<double>(i);
+  }
+
+  const Eigen::Matrix3d identity = Eigen::Matrix3d::Identity();
+
+  const auto rotated =
+    autoware::ndt_scan_matcher::rotate_position_covariance(src_covariance, identity);
+
+  expect_arrays_close(src_covariance, rotated);
+}
+
+TEST(RotatePositionCovarianceTest, MatchesLegacyImplementation)
+{
+  std::array<double, 36> src_covariance{};
+  for (size_t i = 0; i < src_covariance.size(); ++i) {
+    src_covariance[i] = static_cast<double>(i + 1);
+  }
+
+  const Eigen::Matrix3d rotation =
+    Eigen::AngleAxisd(M_PI / 4.0, Eigen::Vector3d::UnitZ()).toRotationMatrix();
+
+  // Expected outcome: treat the 6x6 pose covariance as row-major [x y z roll pitch yaw];
+  // apply the rotation to the position block (top-left 3x3) and leave orientation/cross terms
+  // untouched.
+  std::array<double, 36> expected = src_covariance;
+  using Covariance6d = Eigen::Matrix<double, 6, 6, Eigen::RowMajor>;
+  const Eigen::Map<const Covariance6d> src_cov_matrix(src_covariance.data());
+  Eigen::Map<Covariance6d> expected_cov_matrix(expected.data());
+  expected_cov_matrix.topLeftCorner<3, 3>() =
+    rotation * src_cov_matrix.topLeftCorner<3, 3>() * rotation.transpose();
+
+  const auto rotated =
+    autoware::ndt_scan_matcher::rotate_position_covariance(src_covariance, rotation);
+
+  expect_arrays_close(expected, rotated);
+}

--- a/localization/autoware_ndt_scan_matcher/test/test_cases/rotate_covariance_test.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_cases/rotate_covariance_test.cpp
@@ -14,10 +14,11 @@
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-#include <array>
-#include <cmath>
 
 #include <gtest/gtest.h>
+
+#include <array>
+#include <cmath>
 
 namespace autoware::ndt_scan_matcher
 {

--- a/localization/autoware_ndt_scan_matcher/test/test_cases/visualize_point_score_test.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_cases/visualize_point_score_test.cpp
@@ -1,0 +1,63 @@
+// Copyright 2026 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <autoware/localization_util/util_func.hpp>
+#include <autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp>
+
+#include <gtest/gtest.h>
+
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+namespace
+{
+using autoware::localization_util::exchange_color_crc;
+using autoware::ndt_scan_matcher::detail::colorize_point_scores;
+
+TEST(VisualizePointScoreTest, ConvertsIntensityToColor)
+{
+  pcl::PointCloud<pcl::PointXYZI> scores;
+  scores.push_back(pcl::PointXYZI{1.0F, 2.0F, 3.0F, 1.0F});
+  scores.push_back(pcl::PointXYZI{-1.0F, -2.0F, -3.0F, 2.0F});
+  scores.push_back(pcl::PointXYZI{0.5F, 0.0F, -0.5F, 3.0F});
+
+  constexpr float lower_nvs = 1.0F;
+  constexpr float upper_nvs = 3.0F;
+
+  const auto colored = colorize_point_scores(scores, lower_nvs, upper_nvs);
+
+  ASSERT_EQ(colored->size(), scores.size());
+  const float range = upper_nvs - lower_nvs;
+  for (std::size_t i = 0; i < scores.size(); ++i) {
+    EXPECT_FLOAT_EQ(colored->points[i].x, scores.points[i].x);
+    EXPECT_FLOAT_EQ(colored->points[i].y, scores.points[i].y);
+    EXPECT_FLOAT_EQ(colored->points[i].z, scores.points[i].z);
+
+    const auto expected_color = exchange_color_crc(
+      (scores.points[i].intensity - lower_nvs) / range);
+    EXPECT_EQ(colored->points[i].r, static_cast<uint8_t>(expected_color.r * 255));
+    EXPECT_EQ(colored->points[i].g, static_cast<uint8_t>(expected_color.g * 255));
+    EXPECT_EQ(colored->points[i].b, static_cast<uint8_t>(expected_color.b * 255));
+  }
+}
+
+TEST(VisualizePointScoreTest, HandlesEmptyInput)
+{
+  pcl::PointCloud<pcl::PointXYZI> empty_scores;
+
+  const auto colored = colorize_point_scores(empty_scores, 0.0F, 1.0F);
+
+  EXPECT_TRUE(colored->empty());
+}
+}  // namespace

--- a/localization/autoware_ndt_scan_matcher/test/test_cases/visualize_point_score_test.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_cases/visualize_point_score_test.cpp
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 #include <autoware/localization_util/util_func.hpp>
-#include <autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp>
+
+#include "visualize_point_score.hpp"
 
 #include <gtest/gtest.h>
+
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
@@ -43,8 +45,8 @@ TEST(VisualizePointScoreTest, ConvertsIntensityToColor)
     EXPECT_FLOAT_EQ(colored->points[i].y, scores.points[i].y);
     EXPECT_FLOAT_EQ(colored->points[i].z, scores.points[i].z);
 
-    const auto expected_color =
-      exchange_color_crc((scores.points[i].intensity - lower_nvs) / range);
+    const auto expected_color = exchange_color_crc(
+      (scores.points[i].intensity - lower_nvs) / range);
     EXPECT_EQ(colored->points[i].r, static_cast<uint8_t>(expected_color.r * 255));
     EXPECT_EQ(colored->points[i].g, static_cast<uint8_t>(expected_color.g * 255));
     EXPECT_EQ(colored->points[i].b, static_cast<uint8_t>(expected_color.b * 255));

--- a/localization/autoware_ndt_scan_matcher/test/test_cases/visualize_point_score_test.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_cases/visualize_point_score_test.cpp
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <autoware/localization_util/util_func.hpp>
-
 #include "visualize_point_score.hpp"
 
-#include <gtest/gtest.h>
+#include <autoware/localization_util/util_func.hpp>
 
+#include <gtest/gtest.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
@@ -45,8 +44,8 @@ TEST(VisualizePointScoreTest, ConvertsIntensityToColor)
     EXPECT_FLOAT_EQ(colored->points[i].y, scores.points[i].y);
     EXPECT_FLOAT_EQ(colored->points[i].z, scores.points[i].z);
 
-    const auto expected_color = exchange_color_crc(
-      (scores.points[i].intensity - lower_nvs) / range);
+    const auto expected_color =
+      exchange_color_crc((scores.points[i].intensity - lower_nvs) / range);
     EXPECT_EQ(colored->points[i].r, static_cast<uint8_t>(expected_color.r * 255));
     EXPECT_EQ(colored->points[i].g, static_cast<uint8_t>(expected_color.g * 255));
     EXPECT_EQ(colored->points[i].b, static_cast<uint8_t>(expected_color.b * 255));

--- a/localization/autoware_ndt_scan_matcher/test/test_cases/visualize_point_score_test.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_cases/visualize_point_score_test.cpp
@@ -16,7 +16,6 @@
 #include <autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp>
 
 #include <gtest/gtest.h>
-
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 
@@ -44,8 +43,8 @@ TEST(VisualizePointScoreTest, ConvertsIntensityToColor)
     EXPECT_FLOAT_EQ(colored->points[i].y, scores.points[i].y);
     EXPECT_FLOAT_EQ(colored->points[i].z, scores.points[i].z);
 
-    const auto expected_color = exchange_color_crc(
-      (scores.points[i].intensity - lower_nvs) / range);
+    const auto expected_color =
+      exchange_color_crc((scores.points[i].intensity - lower_nvs) / range);
     EXPECT_EQ(colored->points[i].r, static_cast<uint8_t>(expected_color.r * 255));
     EXPECT_EQ(colored->points[i].g, static_cast<uint8_t>(expected_color.g * 255));
     EXPECT_EQ(colored->points[i].b, static_cast<uint8_t>(expected_color.b * 255));


### PR DESCRIPTION
## Description

:warning: THIS PR IS UNDER PROGRESS. Because lots of source codes are generated by coding agent and I need to do triple check if the generated source codes are safe, though I once reviewed by myself when commit. :warning: 

- Refactored `callback_sensor_points_main` by extracting `preprocess_sensor_points`, `run_scan_matching`, and `publish_scan_matching_outputs` helpers to make the scan-matching pipeline more testable and readable.
- Added structured outputs (`PreprocessResult`, `ScanMatchingOutput`) and kept diagnostics/validation behavior intact while reducing callback complexity.
- Introduced a unit test for `preprocess_sensor_points` covering empty-cloud rejection and a valid-cloud happy path, plus friend test access for the helper.
- Registered the new gtest target in CMake.

## Related links
- (add issue/epic/meeting links)

## How was this PR tested?
- `colcon test --packages-select autoware_ndt_scan_matcher --event-handlers console_direct+ --return-code-on-test-failure`

## Notes for reviewers
- New helper is exposed to tests via a friend test helper; no public API surface changed.
- Behavior should be parity with the previous callback flow; focus review on any subtle diagnostics/publishing regressions.

## Interface changes
(None)

### Topic changes
(None)

## Effects on system behavior
- No intended runtime behavior change; structural refactor only.