### PR TITLE
feat(autoware_pyplot): support horizon and vertical line

### DIFF
--- a/testing/autoware_pyplot/include/autoware/pyplot/axes.hpp
+++ b/testing/autoware_pyplot/include/autoware/pyplot/axes.hpp
@@ -35,6 +35,14 @@ public:
     const pybind11::tuple & args = pybind11::tuple(),
     const pybind11::dict & kwargs = pybind11::dict()) const;
 
+  PyObjectWrapper axhline(
+    const pybind11::tuple & args = pybind11::tuple(),
+    const pybind11::dict & kwargs = pybind11::dict()) const;
+
+  PyObjectWrapper axvline(
+    const pybind11::tuple & args = pybind11::tuple(),
+    const pybind11::dict & kwargs = pybind11::dict()) const;
+
   PyObjectWrapper bar_label(
     const pybind11::tuple & args = pybind11::tuple(),
     const pybind11::dict & kwargs = pybind11::dict()) const;
@@ -131,6 +139,8 @@ private:
   void load_attrs();
 
   pybind11::object add_patch_attr;
+  pybind11::object axhline_attr;
+  pybind11::object axvline_attr;
   pybind11::object cla_attr;
   pybind11::object contour_attr;
   pybind11::object contourf_attr;

--- a/testing/autoware_pyplot/include/autoware/pyplot/pyplot.hpp
+++ b/testing/autoware_pyplot/include/autoware/pyplot/pyplot.hpp
@@ -32,7 +32,15 @@ public:
 
   axes::Axes axes(const pybind11::dict & kwargs = pybind11::dict());
 
+  PyObjectWrapper axhline(
+    const pybind11::tuple & args = pybind11::tuple(),
+    const pybind11::dict & kwargs = pybind11::dict());
+
   PyObjectWrapper axis(
+    const pybind11::tuple & args = pybind11::tuple(),
+    const pybind11::dict & kwargs = pybind11::dict());
+
+  PyObjectWrapper axvline(
     const pybind11::tuple & args = pybind11::tuple(),
     const pybind11::dict & kwargs = pybind11::dict());
 
@@ -128,6 +136,8 @@ private:
   pybind11::module mod;
   pybind11::object axis_attr;
   pybind11::object axes_attr;
+  pybind11::object axhline_attr;
+  pybind11::object axvline_attr;
   pybind11::object cla_attr;
   pybind11::object clf_attr;
   pybind11::object figure_attr;

--- a/testing/autoware_pyplot/src/axes.cpp
+++ b/testing/autoware_pyplot/src/axes.cpp
@@ -35,6 +35,16 @@ PyObjectWrapper Axes::add_patch(const pybind11::tuple & args, const pybind11::di
   return PyObjectWrapper{add_patch_attr(*args, **kwargs)};
 }
 
+PyObjectWrapper Axes::axhline(const pybind11::tuple & args, const pybind11::dict & kwargs) const
+{
+  return PyObjectWrapper{axhline_attr(*args, **kwargs)};
+}
+
+PyObjectWrapper Axes::axvline(const pybind11::tuple & args, const pybind11::dict & kwargs) const
+{
+  return PyObjectWrapper{axvline_attr(*args, **kwargs)};
+}
+
 PyObjectWrapper Axes::cla(const pybind11::tuple & args, const pybind11::dict & kwargs) const
 {
   return PyObjectWrapper{cla_attr(*args, **kwargs)};
@@ -155,6 +165,8 @@ void Axes::view_init(const pybind11::tuple & args, const pybind11::dict & kwargs
 void Axes::load_attrs()
 {
   LOAD_FUNC_ATTR(add_patch, self_);
+  LOAD_FUNC_ATTR(axhline, self_);
+  LOAD_FUNC_ATTR(axvline, self_);
   LOAD_FUNC_ATTR(cla, self_);
   LOAD_FUNC_ATTR(contour, self_);
   LOAD_FUNC_ATTR(contourf, self_);

--- a/testing/autoware_pyplot/src/pyplot.cpp
+++ b/testing/autoware_pyplot/src/pyplot.cpp
@@ -29,6 +29,8 @@ void PyPlot::load_attrs()
 {
   LOAD_FUNC_ATTR(axis, mod);
   LOAD_FUNC_ATTR(axes, mod);
+  LOAD_FUNC_ATTR(axhline, mod);
+  LOAD_FUNC_ATTR(axvline, mod);
   LOAD_FUNC_ATTR(cla, mod);
   LOAD_FUNC_ATTR(clf, mod);
   LOAD_FUNC_ATTR(figure, mod);
@@ -61,6 +63,16 @@ PyObjectWrapper PyPlot::axis(const pybind11::tuple & args, const pybind11::dict 
 axes::Axes PyPlot::axes(const pybind11::dict & kwargs)
 {
   return axes::Axes{axes_attr(**kwargs)};
+}
+
+PyObjectWrapper PyPlot::axhline(const pybind11::tuple & args, const pybind11::dict & kwargs)
+{
+  return PyObjectWrapper{axhline_attr(*args, **kwargs)};
+}
+
+PyObjectWrapper PyPlot::axvline(const pybind11::tuple & args, const pybind11::dict & kwargs)
+{
+  return PyObjectWrapper{axvline_attr(*args, **kwargs)};
 }
 
 PyObjectWrapper PyPlot::cla(const pybind11::tuple & args, const pybind11::dict & kwargs)


### PR DESCRIPTION
## Description

Add support for `axvline` and `axhline`.

<img width="960" height="720" alt="test_all_branches_normal_critical_priority" src="https://github.com/user-attachments/assets/6b8cdb00-a271-4a2b-a0c7-d60195967a45" />

### Example 

```c++
    plt.axhline(
      Args(th_critical), Kwargs("color"_a = "red", "linestyle"_a = "--", "label"_a = "Critical Thresh"));
    plt.axhline(
      Args(th_near), Kwargs("color"_a = "orange", "linestyle"_a = "--", "label"_a = "Near Thresh"));

    plt.axvline(
      Args(braking_dist_min), Kwargs("color"_a = "gray", "linestyle"_a = ":", "label"_a = "Min Braking"));
    plt.axvline(
      Args(braking_dist_max), Kwargs("color"_a = "black", "linestyle"_a = ":", "label"_a = "Max Braking"));
```

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
