### PR TITLE
feat: silence clang tidy errors temporarily

### DIFF
--- a/.clang-tidy-ci
+++ b/.clang-tidy-ci
@@ -1,0 +1,18 @@
+Checks: "
+  -*,
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-exception-escape,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-narrowing-conversions,
+  -bugprone-optional-value-conversion,
+  -bugprone-reserved-identifier,
+  -bugprone-unchecked-optional-access"
+
+WarningsAsErrors: "*"
+
+ExtraArgsBefore:
+  - -Wno-unknown-warning-option
+
+ExtraArgs:
+  - -Wno-c11-extensions

--- a/.github/workflows/build-and-test-reusable.yaml
+++ b/.github/workflows/build-and-test-reusable.yaml
@@ -184,7 +184,7 @@ jobs:
           rosdistro: ${{ inputs.rosdistro }}
           cache-key-element: build-and-test-${{ inputs.cache-key-element }}${{ inputs.above && '-above' || '' }}
           target-packages: ${{ steps.get-self-packages.outputs.self-packages }}
-          clang-tidy-config-url: https://raw.githubusercontent.com/autowarefoundation/autoware/main/.clang-tidy-ci
+          clang-tidy-config-url: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/.clang-tidy-ci
           underlay-workspace: /opt/autoware
           artifact-name: clang-tidy-result-${{ inputs.rosdistro }}
 


### PR DESCRIPTION
## Description

Step 1 of https://github.com/autowarefoundation/autoware_core/issues/774#issuecomment-3852976070: Temporarily exclude all clang-tidy checks that fail.

## Related links

**Parent Issue:**
https://github.com/autowarefoundation/autoware_core/issues/774

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Tested in my own fork repo: https://github.com/NorahXiong/autoware_core/actions/runs/22656123711
No clang-tidy error in autoware_core anymore.

## Notes for reviewers
https://raw.githubusercontent.com/autowarefoundation/autoware/main/.clang-tidy-ci is copied to autoware_core repo for specialized modification in case it affects other repos.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
