### PR TITLE
feat(autoware_mission_planner): remove glog component

### DIFF
--- a/planning/autoware_mission_planner/launch/mission_planner.launch.xml
+++ b/planning/autoware_mission_planner/launch/mission_planner.launch.xml
@@ -11,6 +11,5 @@
       <remap from="~/input/operation_mode_state" to="/system/operation_mode/state"/>
       <remap from="~/debug/route_marker" to="$(var visualization_topic_name)"/>
     </composable_node>
-    <composable_node pkg="autoware_glog_component" plugin="autoware::glog_component::GlogComponent" name="glog_component" namespace=""/>
   </node_container>
 </launch>


### PR DESCRIPTION
## Description

Read https://github.com/autowarefoundation/autoware_universe/issues/12176.

Actually, the glog version mismatch mentioned in the issue does not occur even without this change. However, I would like to take this opportunity to remove all unnecessary dependencies on tier4/glog alongside the fix for the issue.

If backtraces are required in AWF, you may reject this PR. 

## Related links

**Private Links:**

- [TIER IV internal link](https://star4.slack.com/archives/CTEJP8L4T/p1772013277319279?thread_ts=1771925914.587189&cid=CTEJP8L4T)

## How was this PR tested?

Confirmed the following:

The node launches successfully without any errors.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

Backtraces will no longer be obtainable when this node is launched as part of AWF's Autoware.
