### PR TITLE
fix: fix bugprone-exception-escape errors in autoware lanelet2 utils

### DIFF
--- a/common/autoware_lanelet2_utils/examples/example_geometry.cpp
+++ b/common/autoware_lanelet2_utils/examples/example_geometry.cpp
@@ -596,18 +596,23 @@ void check_in_lanelet()
 
 int main()
 {
-  autoware::experimental::extrapolation();
-  autoware::experimental::interpolation();
-  autoware::experimental::concatenation();
-  autoware::experimental::get_from_arc_length();
-  autoware::experimental::closest_segment();
-  autoware::experimental::lanelet_angle();
-  autoware::experimental::closest_center_pose();
-  autoware::experimental::arc_coordinates();
-  autoware::experimental::lateral_distance_related();
-  autoware::experimental::combine_lanelet();
-  autoware::experimental::expand_lanelet();
-  autoware::experimental::offset_bound();
-  autoware::experimental::check_in_lanelet();
+  try {
+    autoware::experimental::extrapolation();
+    autoware::experimental::interpolation();
+    autoware::experimental::concatenation();
+    autoware::experimental::get_from_arc_length();
+    autoware::experimental::closest_segment();
+    autoware::experimental::lanelet_angle();
+    autoware::experimental::closest_center_pose();
+    autoware::experimental::arc_coordinates();
+    autoware::experimental::lateral_distance_related();
+    autoware::experimental::combine_lanelet();
+    autoware::experimental::expand_lanelet();
+    autoware::experimental::offset_bound();
+    autoware::experimental::check_in_lanelet();
+  } catch (const std::exception & e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+    return 1;
+  }
   return 0;
 }

--- a/common/autoware_lanelet2_utils/examples/example_nn_search.cpp
+++ b/common/autoware_lanelet2_utils/examples/example_nn_search.cpp
@@ -125,6 +125,11 @@ void nn_search_main()
 
 int main()
 {
-  autoware::experimental::nn_search_main();
+  try {
+    autoware::experimental::nn_search_main();
+  } catch (const std::exception & e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+    return 1;
+  }
   return 0;
 }

--- a/common/autoware_lanelet2_utils/examples/example_route_manager.cpp
+++ b/common/autoware_lanelet2_utils/examples/example_route_manager.cpp
@@ -195,6 +195,11 @@ void route_manager_main()
 
 int main()
 {
-  autoware::experimental::route_manager_main();
+  try {
+    autoware::experimental::route_manager_main();
+  } catch (const std::exception & e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+    return 1;
+  }
   return 0;
 }

--- a/common/autoware_lanelet2_utils/examples/example_topology.cpp
+++ b/common/autoware_lanelet2_utils/examples/example_topology.cpp
@@ -260,10 +260,14 @@ void following_and_previous_lanelet_sequences()
 
 int main()
 {
-  autoware::experimental::opposite_lanelet();
-  autoware::experimental::related_lanelets();
-  autoware::experimental::neighbor_lanelet();
-  autoware::experimental::following_and_previous_lanelet_sequences();
-
+  try {
+    autoware::experimental::opposite_lanelet();
+    autoware::experimental::related_lanelets();
+    autoware::experimental::neighbor_lanelet();
+    autoware::experimental::following_and_previous_lanelet_sequences();
+  } catch (const std::exception & e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+    return 1;
+  }
   return 0;
 }


### PR DESCRIPTION
## Description

Step 2 of https://github.com/autowarefoundation/autoware_core/issues/774#issuecomment-3852976070: Remove the exception from the .clang-tidy-ci list.

## Related links

**Parent Issue:**

https://github.com/autowarefoundation/autoware_core/issues/774

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

No clang-tidy error appears in CI.

## Notes for reviewers
Depends on: https://github.com/autowarefoundation/autoware_core/pull/893
Related PR: https://github.com/autowarefoundation/autoware_core/pull/883 https://github.com/autowarefoundation/autoware_core/pull/884

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
