### PR TITLE
fix(autoware_path_generator): remove getArcCoordinates

### DIFF
--- a/planning/autoware_path_generator/src/node.cpp
+++ b/planning/autoware_path_generator/src/node.cpp
@@ -225,7 +225,9 @@ std::optional<PathWithLaneId> PathGenerator::generate_path(
                     .as_lanelets();
 
   const auto & current_lanelet = route_manager_->current_lanelet();
-  auto s_ego = lanelet::utils::getArcCoordinates({current_lanelet}, current_pose).length;
+  auto s_ego =
+    autoware::experimental::lanelet2_utils::get_arc_coordinates({current_lanelet}, current_pose)
+      .length;
   auto s_start = s_ego - params.path_length.backward;
   auto s_end = s_ego + params.path_length.forward;
 

--- a/planning/autoware_path_generator/test/test_goal_connection.cpp
+++ b/planning/autoware_path_generator/test/test_goal_connection.cpp
@@ -33,7 +33,9 @@ TEST_F(UtilsTest, connectPathToGoalInsideLaneletSequence)
   auto s_goal = 0.;
   for (const auto & lanelet : route_manager_->preferred_lanelets()) {
     if (route_manager_->goal_lanelet().id() == lanelet.id()) {
-      s_goal += lanelet::utils::getArcCoordinates({lanelet}, route_->goal_pose).length;
+      s_goal +=
+        autoware::experimental::lanelet2_utils::get_arc_coordinates({lanelet}, route_->goal_pose)
+          .length;
       break;
     }
     s_goal += lanelet::geometry::length2d(lanelet);
@@ -82,7 +84,9 @@ TEST_F(UtilsTest, connectPathToGoal)
   auto s_goal = 0.;
   for (const auto & lanelet : route_manager_->preferred_lanelets()) {
     if (route_manager_->goal_lanelet().id() == lanelet.id()) {
-      s_goal += lanelet::utils::getArcCoordinates({lanelet}, route_->goal_pose).length;
+      s_goal +=
+        autoware::experimental::lanelet2_utils::get_arc_coordinates({lanelet}, route_->goal_pose)
+          .length;
       break;
     }
     s_goal += lanelet::geometry::length2d(lanelet);


### PR DESCRIPTION
## Description
`getArcCoordinates` is ported to `autoware_lanelet2_utils` (`get_arc_coordinates`) in #842, and was deprecated in `autoware_lanelet2_extension` [#95](https://github.com/autowarefoundation/autoware_lanelet2_extension/pull/95).

These usages are added after the deprecation process, so this PR replaces them. 

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Pass CI.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
