### PR TITLE
fix(autoware_motion_utils): fix bugprone-unchecked-optional-access warnings

### DIFF
--- a/common/autoware_motion_utils/src/resample/resample.cpp
+++ b/common/autoware_motion_utils/src/resample/resample.cpp
@@ -401,22 +401,18 @@ autoware_internal_planning_msgs::msg::PathWithLaneId resamplePath(
     const auto distance_to_stop_point =
       autoware::motion_utils::calcDistanceToForwardStopPoint(transformed_input_path, 0);
     if (distance_to_stop_point && !resampling_arclength.empty()) {
+      const double stop_dist = *distance_to_stop_point;
       for (size_t i = 1; i < resampling_arclength.size(); ++i) {
-        if (
-          resampling_arclength.at(i - 1) <= *distance_to_stop_point &&
-          *distance_to_stop_point < resampling_arclength.at(i)) {
-          const double dist_to_prev_point =
-            std::fabs(*distance_to_stop_point - resampling_arclength.at(i - 1));
-          const double dist_to_following_point =
-            std::fabs(resampling_arclength.at(i) - *distance_to_stop_point);
+        if (resampling_arclength.at(i - 1) <= stop_dist && stop_dist < resampling_arclength.at(i)) {
+          const double dist_to_prev_point = std::fabs(stop_dist - resampling_arclength.at(i - 1));
+          const double dist_to_following_point = std::fabs(resampling_arclength.at(i) - stop_dist);
           if (dist_to_prev_point < autoware::motion_utils::overlap_threshold) {
-            resampling_arclength.at(i - 1) = *distance_to_stop_point;
+            resampling_arclength.at(i - 1) = stop_dist;
           } else if (dist_to_following_point < autoware::motion_utils::overlap_threshold) {
-            resampling_arclength.at(i) = *distance_to_stop_point;
+            resampling_arclength.at(i) = stop_dist;
           } else {
             resampling_arclength.insert(
-              resampling_arclength.begin() + static_cast<std::ptrdiff_t>(i),
-              *distance_to_stop_point);
+              resampling_arclength.begin() + static_cast<std::ptrdiff_t>(i), stop_dist);
           }
           break;
         }
@@ -546,22 +542,18 @@ autoware_planning_msgs::msg::Path resamplePath(
     const auto distance_to_stop_point =
       autoware::motion_utils::calcDistanceToForwardStopPoint(input_path.points, 0);
     if (distance_to_stop_point && !resampling_arclength.empty()) {
+      const double stop_dist = *distance_to_stop_point;
       for (size_t i = 1; i < resampling_arclength.size(); ++i) {
-        if (
-          resampling_arclength.at(i - 1) <= *distance_to_stop_point &&
-          *distance_to_stop_point < resampling_arclength.at(i)) {
-          const double dist_to_prev_point =
-            std::fabs(*distance_to_stop_point - resampling_arclength.at(i - 1));
-          const double dist_to_following_point =
-            std::fabs(resampling_arclength.at(i) - *distance_to_stop_point);
+        if (resampling_arclength.at(i - 1) <= stop_dist && stop_dist < resampling_arclength.at(i)) {
+          const double dist_to_prev_point = std::fabs(stop_dist - resampling_arclength.at(i - 1));
+          const double dist_to_following_point = std::fabs(resampling_arclength.at(i) - stop_dist);
           if (dist_to_prev_point < autoware::motion_utils::overlap_threshold) {
-            resampling_arclength.at(i - 1) = *distance_to_stop_point;
+            resampling_arclength.at(i - 1) = stop_dist;
           } else if (dist_to_following_point < autoware::motion_utils::overlap_threshold) {
-            resampling_arclength.at(i) = *distance_to_stop_point;
+            resampling_arclength.at(i) = stop_dist;
           } else {
             resampling_arclength.insert(
-              resampling_arclength.begin() + static_cast<std::ptrdiff_t>(i),
-              *distance_to_stop_point);
+              resampling_arclength.begin() + static_cast<std::ptrdiff_t>(i), stop_dist);
           }
           break;
         }
@@ -738,22 +730,18 @@ autoware_planning_msgs::msg::Trajectory resampleTrajectory(
     const auto distance_to_stop_point =
       autoware::motion_utils::calcDistanceToForwardStopPoint(input_trajectory.points, 0);
     if (distance_to_stop_point && !resampling_arclength.empty()) {
+      const double stop_dist = *distance_to_stop_point;
       for (size_t i = 1; i < resampling_arclength.size(); ++i) {
-        if (
-          resampling_arclength.at(i - 1) <= *distance_to_stop_point &&
-          *distance_to_stop_point < resampling_arclength.at(i)) {
-          const double dist_to_prev_point =
-            std::fabs(*distance_to_stop_point - resampling_arclength.at(i - 1));
-          const double dist_to_following_point =
-            std::fabs(resampling_arclength.at(i) - *distance_to_stop_point);
+        if (resampling_arclength.at(i - 1) <= stop_dist && stop_dist < resampling_arclength.at(i)) {
+          const double dist_to_prev_point = std::fabs(stop_dist - resampling_arclength.at(i - 1));
+          const double dist_to_following_point = std::fabs(resampling_arclength.at(i) - stop_dist);
           if (dist_to_prev_point < autoware::motion_utils::overlap_threshold) {
-            resampling_arclength.at(i - 1) = *distance_to_stop_point;
+            resampling_arclength.at(i - 1) = stop_dist;
           } else if (dist_to_following_point < autoware::motion_utils::overlap_threshold) {
-            resampling_arclength.at(i) = *distance_to_stop_point;
+            resampling_arclength.at(i) = stop_dist;
           } else {
             resampling_arclength.insert(
-              resampling_arclength.begin() + static_cast<std::ptrdiff_t>(i),
-              *distance_to_stop_point);
+              resampling_arclength.begin() + static_cast<std::ptrdiff_t>(i), stop_dist);
           }
           break;
         }


### PR DESCRIPTION
## Description
Step 2 of https://github.com/autowarefoundation/autoware_core/issues/774#issuecomment-3852976070: Remove the exception from the .clang-tidy-ci list.
## Related links

**Parent Issue:**
https://github.com/autowarefoundation/autoware_core/issues/774

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
