### PR TITLE
fix(autoware_lanelet2_utils): fix bugprone-unchecked-optional-access warnings

### DIFF
--- a/common/autoware_lanelet2_utils/examples/example_conversion.cpp
+++ b/common/autoware_lanelet2_utils/examples/example_conversion.cpp
@@ -137,6 +137,10 @@ void create_safe_object()
     auto p3 = lanelet::BasicPoint3d(3.0, 3.0, 3.0);
     std::vector<lanelet::BasicPoint3d> vector_points = {p1, p2, p3};
     auto opt = autoware::experimental::lanelet2_utils::create_safe_linestring(vector_points);
+    if (!opt.has_value()) {
+      std::cerr << "Failed to create safe linestring from BasicPoint3d" << std::endl;
+      return;
+    }
     auto basic_linestring = *opt;
   }
 
@@ -147,6 +151,10 @@ void create_safe_object()
     auto p3 = lanelet::ConstPoint3d(lanelet::Point3d(lanelet::InvalId, 3.0, 3.0, 3.0));
     std::vector<lanelet::ConstPoint3d> vector_points = {p1, p2, p3};
     auto opt = autoware::experimental::lanelet2_utils::create_safe_linestring(vector_points);
+    if (!opt.has_value()) {
+      std::cerr << "Failed to create safe linestring from ConstPoint3d" << std::endl;
+      return;
+    }
     auto const_linestring = *opt;
     std::cout << "Construct ConstLinestring3d from ConstPoints3d." << std::endl;
   }
@@ -162,6 +170,10 @@ void create_safe_object()
 
     const auto opt =
       autoware::experimental::lanelet2_utils::create_safe_lanelet(left_points, right_points);
+    if (!opt.has_value()) {
+      std::cerr << "Failed to create safe lanelet from BasicPoints3d" << std::endl;
+      return;
+    }
     auto lanelet = *opt;
     std::cout << "Construct ConstLanelet from BasicPoints3d." << std::endl;
   }
@@ -177,6 +189,10 @@ void create_safe_object()
     std::vector<lanelet::BasicPoint3d> right_points = {p3, p4};
     const auto opt =
       autoware::experimental::lanelet2_utils::create_safe_lanelet(left_points, right_points);
+    if (!opt.has_value()) {
+      std::cerr << "Failed to create safe lanelet from ConstPoints3d" << std::endl;
+      return;
+    }
     auto lanelet = *opt;
     std::cout << "Construct ConstLanelet from ConstPoints3d." << std::endl;
   }

--- a/common/autoware_lanelet2_utils/examples/example_geometry.cpp
+++ b/common/autoware_lanelet2_utils/examples/example_geometry.cpp
@@ -71,6 +71,10 @@ void interpolation()
     double half_of_segment_length = std::hypot(4.0 - 1.0, 5.0 - 2.0, 6.0 - 3.0) / 2;
 
     auto opt = lanelet2_utils::interpolate_point(p1, p2, half_of_segment_length);
+    if (!opt.has_value()) {
+      std::cerr << "Failed to interpolate point" << std::endl;
+      return;
+    }
     auto interpolated_pt = *opt;
     std::cout << "Interpolated Point (Half length)" << std::endl;
     std::cout << "x: " << interpolated_pt.x() << std::endl;
@@ -81,6 +85,10 @@ void interpolation()
   {
     const auto ll = lanelet_map_ptr_->laneletLayer.get(2287);
     auto opt_pt = lanelet2_utils::interpolate_lanelet(ll, 3.0);
+    if (!opt_pt.has_value()) {
+      std::cerr << "Failed to interpolate lanelet" << std::endl;
+      return;
+    }
     auto interpolated_pt = *opt_pt;
     std::cout << "Interpolated Point (From Lanelet)" << std::endl;
     std::cout << "x: " << interpolated_pt.x() << std::endl;
@@ -95,6 +103,10 @@ void interpolation()
       lanelets.push_back(lanelet_map_ptr_->laneletLayer.get(id));
     }
     auto opt_pt = lanelet2_utils::interpolate_lanelet_sequence(lanelets, 3.0);
+    if (!opt_pt.has_value()) {
+      std::cerr << "Failed to interpolate lanelet sequence" << std::endl;
+      return;
+    }
     auto interpolated_pt = *opt_pt;
     std::cout << "Interpolated Point (From LaneletSequence)" << std::endl;
     std::cout << "x: " << interpolated_pt.x() << std::endl;
@@ -114,6 +126,10 @@ void concatenation()
   }
 
   auto opt_ls = lanelet2_utils::concatenate_center_line(lanelets);
+  if (!opt_ls.has_value()) {
+    std::cerr << "Failed to concatenate center line" << std::endl;
+    return;
+  }
 
   const auto & ls = *opt_ls;
 
@@ -147,6 +163,10 @@ void get_from_arc_length()
     lanelet::ConstLineString3d line{lanelet::InvalId, pts};
     auto opt =
       autoware::experimental::lanelet2_utils::get_linestring_from_arc_length(line, 0.5, 1.5);
+    if (!opt.has_value()) {
+      std::cerr << "Failed to get linestring from arc length" << std::endl;
+      return;
+    }
     const auto & out = *opt;
 
     std::cout << "Get linestring from 0.5 to 1.5" << std::endl;
@@ -165,6 +185,10 @@ void get_from_arc_length()
     }
     auto opt_pose =
       autoware::experimental::lanelet2_utils::get_pose_from_2d_arc_length(lanelets, 3.0);
+    if (!opt_pose.has_value()) {
+      std::cerr << "Failed to get pose from 2D arc length" << std::endl;
+      return;
+    }
     const auto & p = *opt_pose;
     std::cout << "Pose from arc-length" << std::endl;
     std::cout << "x: " << p.position.x << std::endl;
@@ -188,6 +212,10 @@ void get_from_arc_length()
     std::vector<lanelet::BasicPoint3d> right_points1 = {p3, p4};
 
     auto ll1 = create_safe_lanelet(left_points1, right_points1);
+    if (!ll1.has_value()) {
+      std::cerr << "Failed to create safe lanelet for polygon (ll1)" << std::endl;
+      return;
+    }
 
     auto p5 = lanelet::BasicPoint3d(3.0, 2.0, 0.0);
     auto p6 = lanelet::BasicPoint3d(6.0, 2.0, 0.0);
@@ -198,6 +226,10 @@ void get_from_arc_length()
     std::vector<lanelet::BasicPoint3d> right_points2 = {p7, p8};
 
     auto ll2 = create_safe_lanelet(left_points2, right_points2);
+    if (!ll2.has_value()) {
+      std::cerr << "Failed to create safe lanelet for polygon (ll2)" << std::endl;
+      return;
+    }
 
     const auto lanelet_sequence = lanelet::ConstLanelets{*ll1, *ll2};
     const auto opt_polygon =
@@ -255,6 +287,10 @@ void closest_center_pose()
   std::vector<lanelet::BasicPoint3d> left_points = {p1, p2};
   std::vector<lanelet::BasicPoint3d> right_points = {p3, p4};
   auto ll = create_safe_lanelet(left_points, right_points);
+  if (!ll.has_value()) {
+    std::cerr << "Failed to create safe lanelet for closest center pose" << std::endl;
+    return;
+  }
 
   auto search_pt = lanelet::BasicPoint3d(1.2, 1.0, 0.0);
   auto p = autoware::experimental::lanelet2_utils::get_closest_center_pose(*ll, search_pt);
@@ -279,7 +315,12 @@ void arc_coordinates()
   std::vector<lanelet::BasicPoint3d> left_points1 = {p1, p2};
   std::vector<lanelet::BasicPoint3d> right_points1 = {p3, p4};
 
-  auto ll1 = *create_safe_lanelet(left_points1, right_points1);
+  auto ll1_opt = create_safe_lanelet(left_points1, right_points1);
+  if (!ll1_opt.has_value()) {
+    std::cerr << "Failed to create safe lanelet for arc coordinates (ll1)" << std::endl;
+    return;
+  }
+  auto ll1 = *ll1_opt;
 
   auto p5 = lanelet::BasicPoint3d(3.0, 2.0, 0.0);
   auto p6 = lanelet::BasicPoint3d(6.0, 2.0, 0.0);
@@ -289,7 +330,12 @@ void arc_coordinates()
   std::vector<lanelet::BasicPoint3d> left_points2 = {p5, p6};
   std::vector<lanelet::BasicPoint3d> right_points2 = {p7, p8};
 
-  auto ll2 = *create_safe_lanelet(left_points2, right_points2);
+  auto ll2_opt = create_safe_lanelet(left_points2, right_points2);
+  if (!ll2_opt.has_value()) {
+    std::cerr << "Failed to create safe lanelet for arc coordinates (ll2)" << std::endl;
+    return;
+  }
+  auto ll2 = *ll2_opt;
 
   auto lanelet_sequence = lanelet::ConstLanelets{ll1, ll2};
 
@@ -329,7 +375,12 @@ void lateral_distance_related()
   std::vector<lanelet::BasicPoint3d> left_points1 = {p1, p2};
   std::vector<lanelet::BasicPoint3d> right_points1 = {p3, p4};
 
-  auto ll1 = *create_safe_lanelet(left_points1, right_points1);
+  auto ll1_opt = create_safe_lanelet(left_points1, right_points1);
+  if (!ll1_opt.has_value()) {
+    std::cerr << "Failed to create safe lanelet for lateral distance (ll1)" << std::endl;
+    return;
+  }
+  auto ll1 = *ll1_opt;
 
   auto p5 = lanelet::BasicPoint3d(3.0, 2.0, 0.0);
   auto p6 = lanelet::BasicPoint3d(6.0, 2.0, 0.0);
@@ -339,7 +390,12 @@ void lateral_distance_related()
   std::vector<lanelet::BasicPoint3d> left_points2 = {p5, p6};
   std::vector<lanelet::BasicPoint3d> right_points2 = {p7, p8};
 
-  auto ll2 = *create_safe_lanelet(left_points2, right_points2);
+  auto ll2_opt = create_safe_lanelet(left_points2, right_points2);
+  if (!ll2_opt.has_value()) {
+    std::cerr << "Failed to create safe lanelet for lateral distance (ll2)" << std::endl;
+    return;
+  }
+  auto ll2 = *ll2_opt;
 
   auto lanelet_sequence = lanelet::ConstLanelets{ll1, ll2};
 
@@ -377,7 +433,12 @@ void combine_lanelet()
   std::vector<lanelet::BasicPoint3d> left_points1 = {p1, p2};
   std::vector<lanelet::BasicPoint3d> right_points1 = {p3, p4};
 
-  auto ll1 = *create_safe_lanelet(left_points1, right_points1);
+  auto ll1_opt = create_safe_lanelet(left_points1, right_points1);
+  if (!ll1_opt.has_value()) {
+    std::cerr << "Failed to create safe lanelet for combine (ll1)" << std::endl;
+    return;
+  }
+  auto ll1 = *ll1_opt;
 
   auto p5 = lanelet::BasicPoint3d(3.0, 2.0, 0.0);
   auto p6 = lanelet::BasicPoint3d(6.0, 2.0, 0.0);
@@ -387,7 +448,12 @@ void combine_lanelet()
   std::vector<lanelet::BasicPoint3d> left_points2 = {p5, p6};
   std::vector<lanelet::BasicPoint3d> right_points2 = {p7, p8};
 
-  auto ll2 = *create_safe_lanelet(left_points2, right_points2);
+  auto ll2_opt = create_safe_lanelet(left_points2, right_points2);
+  if (!ll2_opt.has_value()) {
+    std::cerr << "Failed to create safe lanelet for combine (ll2)" << std::endl;
+    return;
+  }
+  auto ll2 = *ll2_opt;
 
   const auto one_lanelet_opt =
     autoware::experimental::lanelet2_utils::combine_lanelets_shape({ll1, ll2});
@@ -413,7 +479,12 @@ void expand_lanelet()
 
   std::vector<lanelet::BasicPoint3d> left_points1 = {p1, p2};
   std::vector<lanelet::BasicPoint3d> right_points1 = {p3, p4};
-  auto ll1 = *create_safe_lanelet(left_points1, right_points1);
+  auto ll1_opt = create_safe_lanelet(left_points1, right_points1);
+  if (!ll1_opt.has_value()) {
+    std::cerr << "Failed to create safe lanelet for expand (ll1)" << std::endl;
+    return;
+  }
+  auto ll1 = *ll1_opt;
 
   auto p5 = lanelet::BasicPoint3d(3.0, 2.0, 1.0);
   auto p6 = lanelet::BasicPoint3d(6.0, 2.0, 1.0);
@@ -423,7 +494,12 @@ void expand_lanelet()
   std::vector<lanelet::BasicPoint3d> left_points2 = {p5, p6};
   std::vector<lanelet::BasicPoint3d> right_points2 = {p7, p8};
 
-  auto ll2 = *create_safe_lanelet(left_points2, right_points2);
+  auto ll2_opt = create_safe_lanelet(left_points2, right_points2);
+  if (!ll2_opt.has_value()) {
+    std::cerr << "Failed to create safe lanelet for expand (ll2)" << std::endl;
+    return;
+  }
+  auto ll2 = *ll2_opt;
 
   auto lls = lanelet::ConstLanelets{ll1, ll2};
 
@@ -498,7 +574,12 @@ void offset_bound()
 
   std::vector<lanelet::BasicPoint3d> left_points = {p1, p2};
   std::vector<lanelet::BasicPoint3d> right_points = {p3, p4};
-  auto ll = *create_safe_lanelet(left_points, right_points);
+  auto ll_opt = create_safe_lanelet(left_points, right_points);
+  if (!ll_opt.has_value()) {
+    std::cerr << "Failed to create safe lanelet for offset bound" << std::endl;
+    return;
+  }
+  auto ll = *ll_opt;
 
   // fine centerline
   {
@@ -557,7 +638,12 @@ void check_in_lanelet()
 
   std::vector<lanelet::BasicPoint3d> left_points = {p1, p2};
   std::vector<lanelet::BasicPoint3d> right_points = {p3, p4};
-  auto ll = *create_safe_lanelet(left_points, right_points);
+  auto ll_opt = create_safe_lanelet(left_points, right_points);
+  if (!ll_opt.has_value()) {
+    std::cerr << "Failed to create safe lanelet for in-lanelet check" << std::endl;
+    return;
+  }
+  auto ll = *ll_opt;
 
   // inside
   {

--- a/common/autoware_lanelet2_utils/examples/example_lane_sequence.cpp
+++ b/common/autoware_lanelet2_utils/examples/example_lane_sequence.cpp
@@ -74,6 +74,10 @@ void lane_sequence_main()
   }
   {
     const auto opt = lanelet2_utils::LaneSequence::create({lane1, lane2}, routing_graph_ptr_);
+    if (!opt.has_value()) {
+      std::cerr << "Failed to create lane sequence from lane1 and lane2" << std::endl;
+      return;
+    }
     const auto seq = *opt;
     std::cout << "Created LaneSequence size is: " << seq.as_lanelets().size() << std::endl;
   }

--- a/common/autoware_lanelet2_utils/examples/example_map_handler.cpp
+++ b/common/autoware_lanelet2_utils/examples/example_map_handler.cpp
@@ -45,14 +45,23 @@ std::optional<lanelet2_utils::MapHandler> load_map_handler(
   // convert to laneletMapBin
   auto map_msg_ = lanelet2_utils::to_autoware_map_msgs(lanelet_map_ptr_);
 
-  std::optional<lanelet2_utils::MapHandler> map_handler_opt_;
-  map_handler_opt_.emplace(lanelet2_utils::MapHandler::create(map_msg_).value());
+  std::optional<lanelet2_utils::MapHandler> map_handler_opt_ =
+    lanelet2_utils::MapHandler::create(map_msg_);
+  if (!map_handler_opt_.has_value()) {
+    std::cerr << "Failed to create map handler" << std::endl;
+    return std::nullopt;
+  }
   return map_handler_opt_;
 }
 
 void map_handler_main()
 {
-  auto map_handler = load_map_handler().value();
+  auto map_handler_opt = load_map_handler();
+  if (!map_handler_opt.has_value()) {
+    std::cerr << "Failed to load map handler" << std::endl;
+    return;
+  }
+  auto map_handler = std::move(map_handler_opt).value();
   auto lanelet_map_ptr = map_handler.lanelet_map_ptr();
 
   // for left_lanelet
@@ -67,6 +76,10 @@ void map_handler_main()
   {
     const auto lane = map_handler.left_lanelet(
       lanelet_map_ptr->laneletLayer.get(2257), false, lanelet2_utils::ExtraVRU::Shoulder);
+    if (!lane.has_value()) {
+      std::cerr << "Failed to get left lanelet with Shoulder" << std::endl;
+      return;
+    }
     std::cout << "Shoulder lane id is " << (*lane).id() << std::endl;
   }
 
@@ -85,6 +98,10 @@ void map_handler_main()
     std::cout << (opt.has_value() ? "There is left lane that is Shoulder and Bicycle Lane"
                                   : "There is no left lane that is Shoulder and Bicycle Lane")
               << std::endl;
+    if (!opt.has_value()) {
+      std::cerr << "Failed to get left lanelet with ShoulderAndBicycleLane" << std::endl;
+      return;
+    }
     auto lane = *opt;
     std::cout << "Shoulder and Bicycle lane id is " << lane.id() << std::endl;
   }
@@ -93,6 +110,10 @@ void map_handler_main()
   {
     const auto opt = map_handler.right_lanelet(
       lanelet_map_ptr->laneletLayer.get(2245), false, lanelet2_utils::ExtraVRU::RoadOnly);
+    if (!opt.has_value()) {
+      std::cerr << "Failed to get right lanelet with RoadOnly" << std::endl;
+      return;
+    }
     auto lane = *opt;
     std::cout << "Right Road only lane id is " << lane.id() << std::endl;
   }
@@ -101,6 +122,10 @@ void map_handler_main()
   {
     const auto opt = map_handler.leftmost_lanelet(
       lanelet_map_ptr->laneletLayer.get(2288), false, lanelet2_utils::ExtraVRU::RoadOnly);
+    if (!opt.has_value()) {
+      std::cerr << "Failed to get leftmost lanelet with RoadOnly" << std::endl;
+      return;
+    }
     auto lane = *opt;
     std::cout << "Leftmost Road only lane id is " << lane.id() << std::endl;
   }
@@ -109,6 +134,10 @@ void map_handler_main()
   {
     const auto opt = map_handler.rightmost_lanelet(
       lanelet_map_ptr->laneletLayer.get(2286), false, lanelet2_utils::ExtraVRU::RoadOnly);
+    if (!opt.has_value()) {
+      std::cerr << "Failed to get rightmost lanelet with RoadOnly" << std::endl;
+      return;
+    }
     auto lane = *opt;
     std::cout << "Rightmost Road only lane id is " << lane.id() << std::endl;
   }
@@ -135,7 +164,12 @@ void map_handler_main()
 
   // for get_shoulder_lanelet_sequence
   {
-    auto map_handler002 = load_map_handler("vm_01_15-16/highway/lanelet2_map.osm").value();
+    auto map_handler002_opt = load_map_handler("vm_01_15-16/highway/lanelet2_map.osm");
+    if (!map_handler002_opt.has_value()) {
+      std::cerr << "Failed to load map handler for highway map" << std::endl;
+      return;
+    }
+    auto map_handler002 = std::move(map_handler002_opt).value();
     auto lanelet_map_ptr002 = map_handler002.lanelet_map_ptr();
     const auto seq =
       map_handler002.get_shoulder_lanelet_sequence(lanelet_map_ptr002->laneletLayer.get(48));

--- a/common/autoware_lanelet2_utils/examples/example_nn_search.cpp
+++ b/common/autoware_lanelet2_utils/examples/example_nn_search.cpp
@@ -72,12 +72,24 @@ void nn_search_main()
   // get_closest_lanelet (without rtree)
   {
     auto opt = lanelet2_utils::get_closest_lanelet(all_lanelets_, P0);
+    if (!opt.has_value()) {
+      std::cerr << "Failed to get closest lanelet (without rtree)" << std::endl;
+      return;
+    }
     auto closest = *opt;
     std::cout << "Closest Lanelet id is: " << closest.id() << std::endl;
   }
   // get_closest_lanelet (using rtree)
   {
+    if (!rtree_.has_value()) {
+      std::cerr << "Failed to get rtree value" << std::endl;
+      return;
+    }
     auto opt = rtree_->get_closest_lanelet(P0);
+    if (!opt.has_value()) {
+      std::cerr << "Failed to get closest lanelet (using rtree)" << std::endl;
+      return;
+    }
     auto closest = *opt;
     std::cout << "Closest Lanelet id is: " << closest.id() << std::endl;
   }
@@ -89,13 +101,25 @@ void nn_search_main()
   {
     auto opt = lanelet2_utils::get_closest_lanelet_within_constraint(
       all_lanelets_, P0, ego_nearest_dist_threshold, ego_nearest_yaw_threshold);
+    if (!opt.has_value()) {
+      std::cerr << "Failed to get closest lanelet within constraint (without rtree)" << std::endl;
+      return;
+    }
     auto closest = *opt;
     std::cout << "Closest Lanelet id is: " << closest.id() << std::endl;
   }
   // get_closest_lanelet_within_constraint (using rtree)
   {
+    if (!rtree_.has_value()) {
+      std::cerr << "Failed to get rtree value for constraint search" << std::endl;
+      return;
+    }
     auto opt = rtree_->get_closest_lanelet_within_constraint(
       P0, ego_nearest_dist_threshold, ego_nearest_yaw_threshold);
+    if (!opt.has_value()) {
+      std::cerr << "Failed to get closest lanelet within constraint (using rtree)" << std::endl;
+      return;
+    }
     auto closest = *opt;
     std::cout << "Closest Lanelet id is: " << closest.id() << std::endl;
   }

--- a/common/autoware_lanelet2_utils/examples/example_route_manager.cpp
+++ b/common/autoware_lanelet2_utils/examples/example_route_manager.cpp
@@ -95,6 +95,10 @@ void route_manager_main()
               << std::endl;
 
     // get current_lanelet
+    if (!route_manager_opt.has_value()) {
+      std::cerr << "Failed to create route manager" << std::endl;
+      return;
+    }
     const auto & route_manager = route_manager_opt.value();
     const auto initial_lanelet = route_manager.current_lanelet();
     std::cout << "Current lanelet (initial) id is " << initial_lanelet.id() << std::endl;
@@ -121,10 +125,18 @@ void route_manager_main()
     static constexpr double ego_nearest_dist_threshold = 3.0;
     static constexpr double ego_nearest_yaw_threshold = 1.046;
     {
+      if (!route_manager_opt.has_value()) {
+        std::cerr << "Failed to create route manager for update" << std::endl;
+        return;
+      }
       route_manager_opt =
         std::move(route_manager_opt.value())
           .update_current_pose(P1, ego_nearest_dist_threshold, ego_nearest_yaw_threshold);
 
+      if (!route_manager_opt.has_value()) {
+        std::cerr << "Failed to update current pose" << std::endl;
+        return;
+      }
       const auto & route_manager = route_manager_opt.value();
       const auto & current_lanelet = route_manager.current_lanelet();
       std::cout << "Current lanelet (moved) id is " << current_lanelet.id() << std::endl;
@@ -141,7 +153,15 @@ void route_manager_main()
     P5.orientation.z = -0.6826331781647528;
 
     {
+      if (!route_manager_opt.has_value()) {
+        std::cerr << "Failed to get route manager for lane change" << std::endl;
+        return;
+      }
       route_manager_opt = std::move(route_manager_opt.value()).commit_lane_change_success(P5);
+      if (!route_manager_opt.has_value()) {
+        std::cerr << "Failed to commit lane change" << std::endl;
+        return;
+      }
       const auto & route_manager = route_manager_opt.value();
       const auto & lane_changed_lanelet = route_manager.current_lanelet();
       std::cout << "Current lanelet (lane changed) id is " << lane_changed_lanelet.id()
@@ -152,6 +172,10 @@ void route_manager_main()
   // reset route_manager_opt
   const auto route_manager_opt =
     lanelet2_utils::RouteManager::create(map_msg_, route_msg_, initial_pose_);
+  if (!route_manager_opt.has_value()) {
+    std::cerr << "Failed to create route manager for lanelet sequence queries" << std::endl;
+    return;
+  }
   const auto & route_manager = route_manager_opt.value();
 
   // get lanelet_sequence
@@ -177,6 +201,10 @@ void route_manager_main()
   {
     {
       const auto lane_opt = route_manager.get_closest_preferred_route_lanelet(initial_pose_);
+      if (!lane_opt.has_value()) {
+        std::cerr << "Failed to get closest preferred route lanelet" << std::endl;
+        return;
+      }
       auto lane = *lane_opt;
       std::cout << "Closest preferred route lanelet id is " << lane.id() << std::endl;
     }
@@ -186,6 +214,10 @@ void route_manager_main()
       static constexpr double ego_nearest_yaw_threshold = 1.046;
       const auto lane_opt = route_manager.get_closest_route_lanelet_within_constraints(
         initial_pose_, ego_nearest_dist_threshold, ego_nearest_yaw_threshold);
+      if (!lane_opt.has_value()) {
+        std::cerr << "Failed to get closest route lanelet within constraints" << std::endl;
+        return;
+      }
       auto lane = *lane_opt;
       std::cout << "Closest route lanelet (with constraint) id is " << lane.id() << std::endl;
     }

--- a/common/autoware_lanelet2_utils/examples/example_topology.cpp
+++ b/common/autoware_lanelet2_utils/examples/example_topology.cpp
@@ -59,6 +59,10 @@ void opposite_lanelet()
     std::tie(lanelet_map_ptr_, routing_graph_ptr_) = set_up_lanelet_map_ptr(false);
     const auto opt = lanelet2_utils::left_opposite_lanelet(
       lanelet_map_ptr_->laneletLayer.get(2311), lanelet_map_ptr_);
+    if (!opt.has_value()) {
+      std::cerr << "Failed to get left opposite lanelet" << std::endl;
+      return;
+    }
     const auto lane = *opt;
     std::cout << "The left opposite lanelet id is : " << lane.id() << std::endl;
   }
@@ -70,6 +74,10 @@ void opposite_lanelet()
     std::tie(lanelet_map_ptr_, routing_graph_ptr_) = set_up_lanelet_map_ptr();
     const auto opt = lanelet2_utils::right_opposite_lanelet(
       lanelet_map_ptr_->laneletLayer.get(2288), lanelet_map_ptr_);
+    if (!opt.has_value()) {
+      std::cerr << "Failed to get right opposite lanelet" << std::endl;
+      return;
+    }
     const auto lane = *opt;
     std::cout << "The right opposite lanelet id is : " << lane.id() << std::endl;
   }

--- a/common/autoware_lanelet2_utils/src/geometry.cpp
+++ b/common/autoware_lanelet2_utils/src/geometry.cpp
@@ -441,8 +441,14 @@ lanelet::ArcCoordinates get_arc_coordinates_on_ego_centerline(
     }
   }
 
-  const auto full_centerline = *create_safe_linestring(concatenated_points);
-  const auto full_centerline_2d = lanelet::utils::to2D(full_centerline);
+  const auto full_centerline_opt = create_safe_linestring(concatenated_points);
+  if (!full_centerline_opt.has_value()) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("autoware_lanelet2_utility"),
+      "Failed to create safe linestring. Returning default ArcCoordinates.");
+    return lanelet::ArcCoordinates();
+  }
+  const auto full_centerline_2d = lanelet::utils::to2D(*full_centerline_opt);
 
   const auto lanelet_point = from_ros(pose);
 
@@ -464,9 +470,15 @@ double get_lateral_distance_to_centerline(
 double get_lateral_distance_to_centerline(
   const lanelet::ConstLanelets & lanelet_sequence, const geometry_msgs::msg::Pose & pose)
 {
-  lanelet::ConstLanelet closest_lanelet = *get_closest_lanelet(lanelet_sequence, pose);
+  const auto closest_lanelet_opt = get_closest_lanelet(lanelet_sequence, pose);
+  if (!closest_lanelet_opt.has_value()) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("autoware_lanelet2_utility"),
+      "Failed to find closest lanelet. Returning 0.0 lateral distance.");
+    return 0.0;
+  }
 
-  return get_lateral_distance_to_centerline(closest_lanelet, pose);
+  return get_lateral_distance_to_centerline(*closest_lanelet_opt, pose);
 }
 
 std::optional<lanelet::ConstLanelet> combine_lanelets_shape(const lanelet::ConstLanelets & lanelets)
@@ -632,7 +644,12 @@ lanelet::ConstLineString3d get_fine_centerline(
   }
 
   const auto centerline_opt = create_safe_linestring(center_points);
-  assert(centerline_opt.has_value() && "center_points has less than two points.");
+  if (!centerline_opt.has_value()) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("autoware_lanelet2_utility"),
+      "center_points has less than two points. Returning empty linestring.");
+    return lanelet::ConstLineString3d();
+  }
 
   return *centerline_opt;
 }
@@ -663,7 +680,13 @@ lanelet::ConstLineString3d get_centerline_with_offset(
   }
 
   const auto centerline_opt = create_safe_linestring(center_points);
-  assert(centerline_opt.has_value() && "center_points has less than two points.");
+  if (!centerline_opt.has_value()) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("autoware_lanelet2_utility"),
+      "center_points has less than two points in get_centerline_with_offset. "
+      "Returning empty linestring.");
+    return lanelet::ConstLineString3d();
+  }
 
   return *centerline_opt;
 }
@@ -691,7 +714,12 @@ lanelet::ConstLineString3d get_right_bound_with_offset(
     right_bound_points.push_back(right_bound_point);
   }
   const auto right_bound_opt = create_safe_linestring(right_bound_points);
-  assert(right_bound_opt.has_value() && "right_bound_points has less than two points.");
+  if (!right_bound_opt.has_value()) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("autoware_lanelet2_utility"),
+      "right_bound_points has less than two points. Returning empty linestring.");
+    return lanelet::ConstLineString3d();
+  }
 
   return *right_bound_opt;
 }
@@ -720,7 +748,12 @@ lanelet::ConstLineString3d get_left_bound_with_offset(
   }
 
   const auto left_bound_opt = create_safe_linestring(left_bound_points);
-  assert(left_bound_opt.has_value() && "left_bound_points has less than two points.");
+  if (!left_bound_opt.has_value()) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("autoware_lanelet2_utility"),
+      "left_bound_points has less than two points. Returning empty linestring.");
+    return lanelet::ConstLineString3d();
+  }
 
   return *left_bound_opt;
 }

--- a/common/autoware_lanelet2_utils/src/route_manager.cpp
+++ b/common/autoware_lanelet2_utils/src/route_manager.cpp
@@ -69,6 +69,7 @@ std::optional<RouteManager> RouteManager::create(
   if (!closest_lanelet_opt) {
     return std::nullopt;
   }
+  const auto & closest_lanelet = *closest_lanelet_opt;
 
   std::unordered_map<lanelet::Id, double> all_route_length_cache;
   for (const auto & route_lanelet : all_route_lanelets) {
@@ -86,7 +87,7 @@ std::optional<RouteManager> RouteManager::create(
   return RouteManager(
     lanelet_map, routing_graph, traffic_rules, std::move(all_route_lanelets),
     std::move(all_route_length_cache), std::move(preferred_lanelets), start_lanelet, goal_lanelet,
-    initial_pose, closest_lanelet_opt.value(), route_submap_ptr, std::move(route_subgraph_ptr));
+    initial_pose, closest_lanelet, route_submap_ptr, std::move(route_subgraph_ptr));
 }
 
 std::optional<RouteManager> RouteManager::update_current_pose(


### PR DESCRIPTION
## Description
Step 2 of https://github.com/autowarefoundation/autoware_core/issues/774#issuecomment-3852976070: Remove the exception from the .clang-tidy-ci list.

## Related links

**Parent Issue:**

https://github.com/autowarefoundation/autoware_core/issues/774

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
