### PR TITLE
fix(autoware_trajectory): fix bugprone-unchecked-optional-access warnings

### DIFF
--- a/common/autoware_trajectory/src/utils/reference_path.cpp
+++ b/common/autoware_trajectory/src/utils/reference_path.cpp
@@ -395,7 +395,7 @@ static ReferencePoints sanitize_and_crop(
 static bool has_passed_lanelet_border(
   const ReferencePoint & prev_point, const lanelet::Id adding_point_located_lanelet_id)
 {
-  if (prev_point.is_border_point() && prev_point.next_lanelet_id.has_value()) {
+  if (prev_point.next_lanelet_id.has_value()) {
     return prev_point.next_lanelet_id.value() != adding_point_located_lanelet_id;
   }
   return prev_point.located_lanelet_id != adding_point_located_lanelet_id;


### PR DESCRIPTION
## Description
Step 2 of https://github.com/autowarefoundation/autoware_core/issues/774#issuecomment-3852976070: Remove the exception from the .clang-tidy-ci list.

## Related links

**Parent Issue:**

https://github.com/autowarefoundation/autoware_core/issues/774

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
