### PR TITLE
fix(crop_box_filter): maybe-uninitialized build error

### DIFF
--- a/sensing/autoware_crop_box_filter/test/test_crop_box_filter.cpp
+++ b/sensing/autoware_crop_box_filter/test/test_crop_box_filter.cpp
@@ -263,7 +263,7 @@ TEST(CropBoxFilterTest, FilterExcludePointsOutsideBoxWhenKeepInsideBox)
 TEST(GenerateCropBoxPolygonTest, SetsFrameIdStampAndPointCount)
 {
   // Arrange
-  autoware::crop_box_filter::CropBoxParam param;
+  autoware::crop_box_filter::CropBoxParam param = {-5.0f, 5.0f, -5.0f, 5.0f, -5.0f, 5.0f};
   const std::string frame_id = "base_link";
   builtin_interfaces::msg::Time stamp;
   stamp.sec = 123;


### PR DESCRIPTION
## Description

Fix a build error in `autoware_crop_box_filter` test caused by potentially uninitialized `float` fields in `CropBoxParam`.
`--cmake-args -DCMAKE_BUILD_TYPE=Release` seemed to be a trigger for the build error.

## Related links

None

## How was this PR tested?

```bash
PACKAGE_NAME=autoware_crop_box_filter && colcon build --packages-select $PACKAGE_NAME --cmake-args -DCMAKE_BUILD_TYPE=Release && colcon test --packages-select $PACKAGE_NAME --event-handlers console_cohesion+
```

All existing tests pass and the `-Werror=maybe-uninitialized` build error is resolved.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
