### PR TITLE
fix(autoware_kalman_filter): fix bugprone-implicit-widening-of-multiplication-result warnings

### DIFF
--- a/common/autoware_kalman_filter/src/time_delay_kalman_filter.cpp
+++ b/common/autoware_kalman_filter/src/time_delay_kalman_filter.cpp
@@ -30,8 +30,9 @@ void TimeDelayKalmanFilter::init(
   P_ = Eigen::MatrixXd::Zero(dim_x_ex_, dim_x_ex_);
 
   for (int i = 0; i < max_delay_step_; ++i) {
-    x_.block(i * dim_x_, 0, dim_x_, 1) = x;
-    P_.block(i * dim_x_, i * dim_x_, dim_x_, dim_x_) = P0;
+    const Eigen::Index offset = static_cast<Eigen::Index>(i) * dim_x_;
+    x_.block(offset, 0, dim_x_, 1) = x;
+    P_.block(offset, offset, dim_x_, dim_x_) = P0;
   }
 }
 
@@ -94,7 +95,7 @@ bool TimeDelayKalmanFilter::updateWithDelay(
 
   /* set measurement matrix */
   Eigen::MatrixXd C_ex = Eigen::MatrixXd::Zero(dim_y, dim_x_ex_);
-  C_ex.block(0, dim_x_ * delay_step, dim_y, dim_x_) = C;
+  C_ex.block(0, static_cast<Eigen::Index>(dim_x_) * delay_step, dim_y, dim_x_) = C;
 
   return update(y, C_ex, R);
 }


### PR DESCRIPTION
## Description
Step 2 of https://github.com/autowarefoundation/autoware_core/issues/774#issuecomment-3852976070: Remove the exception from the .clang-tidy-ci list.
## Related links

**Parent Issue:**
https://github.com/autowarefoundation/autoware_core/issues/774

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
No clang-tidy error appears in CI.
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
