### PR TITLE
fix(autoware_marker_utils): fix bugprone-narrowing-conversions warnings

### DIFF
--- a/common/autoware_marker_utils/src/marker_conversion.cpp
+++ b/common/autoware_marker_utils/src/marker_conversion.cpp
@@ -148,7 +148,8 @@ visualization_msgs::msg::MarkerArray create_geometry_msgs_marker_array(
   const std_msgs::msg::ColorRGBA & color)
 {
   visualization_msgs::msg::MarkerArray marker_array;
-  auto marker = create_default_marker("map", stamp, ns, id, static_cast<int32_t>(marker_type), scale, color);
+  auto marker =
+    create_default_marker("map", stamp, ns, id, static_cast<int32_t>(marker_type), scale, color);
 
   const auto & points = polygon.points;
   const size_t N = points.size();
@@ -198,7 +199,8 @@ visualization_msgs::msg::MarkerArray create_geometry_msgs_marker_array(
   const std_msgs::msg::ColorRGBA & color)
 {
   visualization_msgs::msg::MarkerArray marker_array;
-  auto marker = create_default_marker("map", stamp, ns, id, static_cast<int32_t>(marker_type), scale, color);
+  auto marker =
+    create_default_marker("map", stamp, ns, id, static_cast<int32_t>(marker_type), scale, color);
 
   marker.pose.position = point;
   marker.pose.position.z += 2.0;
@@ -216,7 +218,8 @@ visualization_msgs::msg::MarkerArray create_geometry_msgs_marker_array(
   visualization_msgs::msg::MarkerArray marker_array;
 
   visualization_msgs::msg::Marker marker_line = create_default_marker(
-    "map", stamp, ns + "_line", static_cast<int32_t>(id), visualization_msgs::msg::Marker::LINE_STRIP, scale, color);
+    "map", stamp, ns + "_line", static_cast<int32_t>(id),
+    visualization_msgs::msg::Marker::LINE_STRIP, scale, color);
 
   constexpr double a = 3.0;
   geometry_msgs::msg::Point p0 =
@@ -251,14 +254,16 @@ visualization_msgs::msg::MarkerArray create_geometry_msgs_marker_array(
         rclcpp::get_logger("autoware_marker_utils").get_child("marker_conversion"),
         "ARROW type Marker requires exactly 2 points. Too many points, use the first two points.");
     }
-    auto marker = create_default_marker("map", stamp, ns + "_line", id, static_cast<int32_t>(marker_type), scale, color);
+    auto marker = create_default_marker(
+      "map", stamp, ns + "_line", id, static_cast<int32_t>(marker_type), scale, color);
 
     marker.points.push_back(points.at(0));
     marker.points.push_back(points.at(1));
 
     marker_array.markers.push_back(marker);
   } else if (marker_type == visualization_msgs::msg::Marker::SPHERE) {
-    auto marker = create_default_marker("map", stamp, ns, id, static_cast<int32_t>(marker_type), scale, color);
+    auto marker =
+      create_default_marker("map", stamp, ns, id, static_cast<int32_t>(marker_type), scale, color);
 
     // Put each point to each marker
     for (size_t i = 0; i < points.size(); ++i) {
@@ -268,7 +273,8 @@ visualization_msgs::msg::MarkerArray create_geometry_msgs_marker_array(
     }
   } else if (marker_type == visualization_msgs::msg::Marker::LINE_STRIP) {
     // Put all points in one marker
-    auto marker = create_default_marker("map", stamp, ns, id, static_cast<int32_t>(marker_type), scale, color);
+    auto marker =
+      create_default_marker("map", stamp, ns, id, static_cast<int32_t>(marker_type), scale, color);
     for (const auto & point : points) {
       marker.points.push_back(point);
     }
@@ -303,7 +309,8 @@ visualization_msgs::msg::MarkerArray create_autoware_geometry_marker_array(
   const geometry_msgs::msg::Vector3 & scale, const std_msgs::msg::ColorRGBA & color)
 {
   visualization_msgs::msg::MarkerArray marker_array;
-  auto marker = create_default_marker("map", stamp, ns, id, static_cast<int32_t>(marker_type), scale, color);
+  auto marker =
+    create_default_marker("map", stamp, ns, id, static_cast<int32_t>(marker_type), scale, color);
 
   for (size_t i = 0; i < ring.size(); ++i) {
     geometry_msgs::msg::Point pt;
@@ -438,7 +445,8 @@ visualization_msgs::msg::MarkerArray create_lanelet_polygon_marker_array(
   const std_msgs::msg::ColorRGBA & color, double z)
 {
   visualization_msgs::msg::MarkerArray marker_array;
-  auto marker = create_default_marker("map", stamp, ns, id, static_cast<int32_t>(marker_type), scale, color);
+  auto marker =
+    create_default_marker("map", stamp, ns, id, static_cast<int32_t>(marker_type), scale, color);
 
   if (polygons.empty()) return visualization_msgs::msg::MarkerArray{};
 


### PR DESCRIPTION
## Description

Step 2 of https://github.com/autowarefoundation/autoware_core/issues/774#issuecomment-3852976070: Remove the exception from the .clang-tidy-ci list.

## Related links

**Parent Issue:**
https://github.com/autowarefoundation/autoware_core/issues/774

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

No clang-tidy error appears in CI.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
