### PR TITLE
fix(autoware_simple_pure_pursuit): fix bugprone-narrowing-conversions warnings

### DIFF
--- a/control/autoware_simple_pure_pursuit/src/simple_pure_pursuit.cpp
+++ b/control/autoware_simple_pure_pursuit/src/simple_pure_pursuit.cpp
@@ -110,8 +110,8 @@ autoware_control_msgs::msg::Longitudinal SimplePurePursuitNode::calc_longitudina
 
   autoware_control_msgs::msg::Longitudinal longitudinal_control_command;
   longitudinal_control_command.velocity = static_cast<float>(target_longitudinal_vel);
-  longitudinal_control_command.acceleration =
-    static_cast<float>(speed_proportional_gain_ * (target_longitudinal_vel - current_longitudinal_vel));
+  longitudinal_control_command.acceleration = static_cast<float>(
+    speed_proportional_gain_ * (target_longitudinal_vel - current_longitudinal_vel));
 
   return longitudinal_control_command;
 }
@@ -148,8 +148,8 @@ autoware_control_msgs::msg::Lateral SimplePurePursuitNode::calc_lateral_control(
   autoware_control_msgs::msg::Lateral lateral_control_command;
   const double alpha = std::atan2(lookahead_point_y - rear_y, lookahead_point_x - rear_x) -
                        tf2::getYaw(odom.pose.pose.orientation);
-  lateral_control_command.steering_tire_angle =
-    static_cast<float>(std::atan2(2.0 * vehicle_info_.wheel_base_m * std::sin(alpha), lookahead_distance));
+  lateral_control_command.steering_tire_angle = static_cast<float>(
+    std::atan2(2.0 * vehicle_info_.wheel_base_m * std::sin(alpha), lookahead_distance));
 
   return lateral_control_command;
 }


### PR DESCRIPTION
## Description

Step 2 of https://github.com/autowarefoundation/autoware_core/issues/774#issuecomment-3852976070: Remove the exception from the .clang-tidy-ci list.

## Related links

**Parent Issue:**
https://github.com/autowarefoundation/autoware_core/issues/774

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

No clang-tidy error appears in CI.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
