### PR TITLE
fix(autoware_path_generator): fix bugprone-narrowing-conversions warnings

### DIFF
--- a/planning/autoware_path_generator/src/utils.cpp
+++ b/planning/autoware_path_generator/src/utils.cpp
@@ -465,7 +465,8 @@ double get_arc_length_on_path(
 
   for (auto [it, s] = std::make_tuple(lanelet_sequence.begin(), 0.); it != lanelet_sequence.end();
        ++it) {
-    const double centerline_length = static_cast<double>(lanelet::geometry::length(it->centerline2d()));
+    const double centerline_length =
+      static_cast<double>(lanelet::geometry::length(it->centerline2d()));
     if (s + centerline_length < s_centerline) {
       s += centerline_length;
       continue;
@@ -578,9 +579,12 @@ PathRange<double> get_arc_length_on_bounds(
   auto s_right = 0.;
 
   for (auto it = lanelet_sequence.begin(); it != lanelet_sequence.end(); ++it) {
-    const double centerline_length = static_cast<double>(lanelet::geometry::length(it->centerline2d()));
-    const double left_bound_length = static_cast<double>(lanelet::geometry::length(it->leftBound2d()));
-    const double right_bound_length = static_cast<double>(lanelet::geometry::length(it->rightBound2d()));
+    const double centerline_length =
+      static_cast<double>(lanelet::geometry::length(it->centerline2d()));
+    const double left_bound_length =
+      static_cast<double>(lanelet::geometry::length(it->leftBound2d()));
+    const double right_bound_length =
+      static_cast<double>(lanelet::geometry::length(it->rightBound2d()));
 
     if (s + centerline_length < s_centerline) {
       s += centerline_length;
@@ -634,8 +638,10 @@ PathRange<std::optional<double>> get_arc_length_on_centerline(
     }
 
     const double centerline_length = static_cast<double>(lanelet::geometry::length2d(*it));
-    const double left_bound_length = static_cast<double>(lanelet::geometry::length(it->leftBound2d()));
-    const double right_bound_length = static_cast<double>(lanelet::geometry::length(it->rightBound2d()));
+    const double left_bound_length =
+      static_cast<double>(lanelet::geometry::length(it->leftBound2d()));
+    const double right_bound_length =
+      static_cast<double>(lanelet::geometry::length(it->rightBound2d()));
 
     if (!is_left_done && s_left + left_bound_length > s_left_bound) {
       s_left_centerline = s + lanelet::geometry::toArcCoordinates(


### PR DESCRIPTION
## Description

Step 2 of https://github.com/autowarefoundation/autoware_core/issues/774#issuecomment-3852976070: Remove the exception from the .clang-tidy-ci list.

## Related links

**Parent Issue:**
https://github.com/autowarefoundation/autoware_core/issues/774

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

No clang-tidy error appears in CI.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
