### PR TITLE
fix(autoware_object_recognition_utils): fix bugprone-narrowing-convertions warnings

### DIFF
--- a/common/autoware_object_recognition_utils/src/predicted_path_utils.cpp
+++ b/common/autoware_object_recognition_utils/src/predicted_path_utils.cpp
@@ -36,8 +36,8 @@ boost::optional<geometry_msgs::msg::Pose> calcInterpolatedPose(
   for (size_t path_idx = 1; path_idx < path.path.size(); ++path_idx) {
     const auto & pt = path.path.at(path_idx);
     const auto & prev_pt = path.path.at(path_idx - 1);
-    if (relative_time - epsilon < time_step * path_idx) {
-      const double offset = relative_time - time_step * (path_idx - 1);
+    if (relative_time - epsilon < time_step * static_cast<double>(path_idx)) {
+      const double offset = relative_time - time_step * static_cast<double>(path_idx - 1);
       const double ratio = std::clamp(offset / time_step, 0.0, 1.0);
       return autoware_utils_geometry::calc_interpolated_pose(prev_pt, pt, ratio, false);
     }
@@ -62,7 +62,7 @@ autoware_perception_msgs::msg::PredictedPath resamplePredictedPath(
   std::vector<double> z(path.path.size());
   std::vector<geometry_msgs::msg::Quaternion> quat(path.path.size());
   for (size_t i = 0; i < path.path.size(); ++i) {
-    input_time.at(i) = time_step * i;
+    input_time.at(i) = time_step * static_cast<double>(i);
     x.at(i) = path.path.at(i).position.x;
     y.at(i) = path.path.at(i).position.y;
     z.at(i) = path.path.at(i).position.z;


### PR DESCRIPTION
## Description

Step 2 of https://github.com/autowarefoundation/autoware_core/issues/774#issuecomment-3852976070: Remove the exception from the .clang-tidy-ci list.

## Related links

**Parent Issue:**
https://github.com/autowarefoundation/autoware_core/issues/774

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

No clang-tidy error appears in CI.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
