### PR TITLE
fix(autoware_motion_velocity_obstacle_stop_module): fix bugprone-narrowing-conversions warnings

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/obstacle_stop_module.cpp
@@ -359,7 +359,8 @@ std::optional<CollisionPointWithDist> ObstacleStopModule::get_nearest_collision_
   const auto & height_margin = pointcloud_segmentation_param_.height_margin;
   std::vector<geometry_msgs::msg::Point> collision_geom_points{};
   for (size_t traj_index = 0; traj_index < traj_points.size(); ++traj_index) {
-    const double rough_dist_th = static_cast<double>(boost::geometry::perimeter(traj_polygons.at(traj_index))) * 0.5;
+    const double rough_dist_th =
+      static_cast<double>(boost::geometry::perimeter(traj_polygons.at(traj_index))) * 0.5;
     const double traj_height = traj_points.at(traj_index).pose.position.z;
 
     for (const auto & cluster : clusters) {
@@ -524,7 +525,8 @@ void ObstacleStopModule::upsert_pointcloud_stop_candidates(
         vel_vec.push_back(clamped_vel);
         if (vel_vec.size() >= vel_params.required_velocity_count) {
           stop_candidate->vel_lpf.reset(
-            std::accumulate(vel_vec.begin(), vel_vec.end(), 0.0) / static_cast<double>(vel_vec.size()));
+            std::accumulate(vel_vec.begin(), vel_vec.end(), 0.0) /
+            static_cast<double>(vel_vec.size()));
         }
       } else {
         stop_candidate->vel_lpf.filter(clamped_vel);
@@ -588,8 +590,9 @@ std::vector<StopObstacle> ObstacleStopModule::filter_stop_obstacle_for_point_clo
     point_cloud, x_offset_to_bumper, vehicle_info);
 
   // update pointcloud_stop_candidates
-  const auto latest_point_cloud_time =
-    rclcpp::Time(static_cast<int64_t>(point_cloud.pointcloud.header.stamp * static_cast<uint32_t>(1e3)), RCL_ROS_TIME);
+  const auto latest_point_cloud_time = rclcpp::Time(
+    static_cast<int64_t>(point_cloud.pointcloud.header.stamp * static_cast<uint32_t>(1e3)),
+    RCL_ROS_TIME);
   if (nearest_collision_point) {
     upsert_pointcloud_stop_candidates(
       nearest_collision_point.value(), traj_points, latest_point_cloud_time);


### PR DESCRIPTION
## Description

Step 2 of https://github.com/autowarefoundation/autoware_core/issues/774#issuecomment-3852976070: Remove the exception from the .clang-tidy-ci list.

## Related links

**Parent Issue:**
https://github.com/autowarefoundation/autoware_core/issues/774

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

No clang-tidy error appears in CI.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
