### PR TITLE
fix(autoware_motion_velocity_planner_common): fix bugprone-narrowing-conversions warnings

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/planner_data.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/planner_data.cpp
@@ -109,15 +109,17 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr crop_by_monolithic_trajectory_polygon(
     lowest_traj_height = std::min(lowest_traj_height, trajectory_point.pose.position.z);
     highest_traj_height = std::max(highest_traj_height, trajectory_point.pose.position.z);
   }
-  crop_filter.setMin(Eigen::Vector4f(
-    static_cast<float>(x_min), static_cast<float>(y_min),
-    static_cast<float>(lowest_traj_height - filter_by_trajectory_param.height_margin), 1.0f));
-  crop_filter.setMax(Eigen::Vector4f(
-    static_cast<float>(x_max), static_cast<float>(y_max),
-    static_cast<float>(
-      highest_traj_height + vehicle_info.vehicle_height_m +
-      filter_by_trajectory_param.height_margin),
-    1.0f));
+  crop_filter.setMin(
+    Eigen::Vector4f(
+      static_cast<float>(x_min), static_cast<float>(y_min),
+      static_cast<float>(lowest_traj_height - filter_by_trajectory_param.height_margin), 1.0f));
+  crop_filter.setMax(
+    Eigen::Vector4f(
+      static_cast<float>(x_max), static_cast<float>(y_max),
+      static_cast<float>(
+        highest_traj_height + vehicle_info.vehicle_height_m +
+        filter_by_trajectory_param.height_margin),
+      1.0f));
 
   auto ret_pointcloud_ptr = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
   crop_filter.filter(*ret_pointcloud_ptr);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/polygon_utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/polygon_utils.cpp
@@ -204,12 +204,14 @@ std::optional<std::pair<geometry_msgs::msg::Point, double>> get_collision_point(
   const Polygon2d & obj_polygon, const double x_offset_to_bumper)
 {
   assert(traj_points.size() == traj_polygons.size());
-  const double obj_maximum_length = static_cast<double>(boost::geometry::perimeter(obj_polygon)) * 0.5;
+  const double obj_maximum_length =
+    static_cast<double>(boost::geometry::perimeter(obj_polygon)) * 0.5;
 
   std::optional<std::pair<geometry_msgs::msg::Point, double>> nearest_collision{std::nullopt};
 
   for (size_t i = 0; i < traj_polygons.size(); ++i) {
-    const double ego_maximum_length = static_cast<double>(boost::geometry::perimeter(traj_polygons.at(i))) * 0.5;
+    const double ego_maximum_length =
+      static_cast<double>(boost::geometry::perimeter(traj_polygons.at(i))) * 0.5;
     const double center_dist =
       autoware_utils_geometry::calc_distance2d(traj_points.at(i).pose.position, obj_position);
     if (center_dist > obj_maximum_length + ego_maximum_length) {
@@ -266,8 +268,8 @@ std::vector<PointWithStamp> get_collision_points(
       break;
     }
 
-    const auto object_time =
-      rclcpp::Time(obstacle_stamp) + rclcpp::Duration(predicted_path.time_step) * static_cast<int32_t>(i);
+    const auto object_time = rclcpp::Time(obstacle_stamp) +
+                             rclcpp::Duration(predicted_path.time_step) * static_cast<int32_t>(i);
     // Ignore past position
     if ((object_time - current_time).seconds() < 0.0) {
       continue;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/utils.cpp
@@ -96,8 +96,8 @@ std::vector<TrajectoryPoint> decimate_trajectory_points_from_ego(
   const size_t traj_ego_seg_idx =
     autoware::motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
       traj_points, current_pose, ego_nearest_dist_threshold, ego_nearest_yaw_threshold);
-  const auto traj_points_from_ego =
-    std::vector<TrajectoryPoint>(traj_points.begin() + static_cast<std::ptrdiff_t>(traj_ego_seg_idx), traj_points.end());
+  const auto traj_points_from_ego = std::vector<TrajectoryPoint>(
+    traj_points.begin() + static_cast<std::ptrdiff_t>(traj_ego_seg_idx), traj_points.end());
 
   // decimate trajectory
   const auto decimated_traj_points_from_ego =


### PR DESCRIPTION
## Description

Step 2 of https://github.com/autowarefoundation/autoware_core/issues/774#issuecomment-3852976070: Remove the exception from the .clang-tidy-ci list.

## Related links

**Parent Issue:**
https://github.com/autowarefoundation/autoware_core/issues/774

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

No clang-tidy error appears in CI.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
