### PR TITLE
fix(autoware_kalman_filter): fix bugprone-narrowing-conversions warnings

### DIFF
--- a/common/autoware_kalman_filter/src/time_delay_kalman_filter.cpp
+++ b/common/autoware_kalman_filter/src/time_delay_kalman_filter.cpp
@@ -23,7 +23,7 @@ void TimeDelayKalmanFilter::init(
   const Eigen::MatrixXd & x, const Eigen::MatrixXd & P0, const int max_delay_step)
 {
   max_delay_step_ = max_delay_step;
-  dim_x_ = x.rows();
+  dim_x_ = static_cast<int>(x.rows());
   dim_x_ex_ = dim_x_ * max_delay_step;
 
   x_ = Eigen::MatrixXd::Zero(dim_x_ex_, 1);
@@ -90,7 +90,7 @@ bool TimeDelayKalmanFilter::updateWithDelay(
     return false;
   }
 
-  const int dim_y = y.rows();
+  const int dim_y = static_cast<int>(y.rows());
 
   /* set measurement matrix */
   Eigen::MatrixXd C_ex = Eigen::MatrixXd::Zero(dim_y, dim_x_ex_);


### PR DESCRIPTION
## Description

Step 2 of https://github.com/autowarefoundation/autoware_core/issues/774#issuecomment-3852976070: Remove the exception from the .clang-tidy-ci list.

## Related links

**Parent Issue:**
https://github.com/autowarefoundation/autoware_core/issues/774

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

No clang-tidy error appears in CI.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
