### PR TITLE
fix(autoware_motion_utils): fix bugprone-narrowing-conversions warnings

### DIFF
--- a/common/autoware_motion_utils/src/resample/resample.cpp
+++ b/common/autoware_motion_utils/src/resample/resample.cpp
@@ -215,7 +215,8 @@ autoware_internal_planning_msgs::msg::PathWithLaneId resamplePath(
           resampling_arclength.at(j) = distance_to_resampling_point;
         } else {
           resampling_arclength.insert(
-            resampling_arclength.begin() + static_cast<std::ptrdiff_t>(j), distance_to_resampling_point);
+            resampling_arclength.begin() + static_cast<std::ptrdiff_t>(j),
+            distance_to_resampling_point);
         }
         break;
       }
@@ -413,7 +414,9 @@ autoware_internal_planning_msgs::msg::PathWithLaneId resamplePath(
           } else if (dist_to_following_point < autoware::motion_utils::overlap_threshold) {
             resampling_arclength.at(i) = *distance_to_stop_point;
           } else {
-            resampling_arclength.insert(resampling_arclength.begin() + static_cast<std::ptrdiff_t>(i), *distance_to_stop_point);
+            resampling_arclength.insert(
+              resampling_arclength.begin() + static_cast<std::ptrdiff_t>(i),
+              *distance_to_stop_point);
           }
           break;
         }
@@ -556,7 +559,9 @@ autoware_planning_msgs::msg::Path resamplePath(
           } else if (dist_to_following_point < autoware::motion_utils::overlap_threshold) {
             resampling_arclength.at(i) = *distance_to_stop_point;
           } else {
-            resampling_arclength.insert(resampling_arclength.begin() + static_cast<std::ptrdiff_t>(i), *distance_to_stop_point);
+            resampling_arclength.insert(
+              resampling_arclength.begin() + static_cast<std::ptrdiff_t>(i),
+              *distance_to_stop_point);
           }
           break;
         }
@@ -746,7 +751,9 @@ autoware_planning_msgs::msg::Trajectory resampleTrajectory(
           } else if (dist_to_following_point < autoware::motion_utils::overlap_threshold) {
             resampling_arclength.at(i) = *distance_to_stop_point;
           } else {
-            resampling_arclength.insert(resampling_arclength.begin() + static_cast<std::ptrdiff_t>(i), *distance_to_stop_point);
+            resampling_arclength.insert(
+              resampling_arclength.begin() + static_cast<std::ptrdiff_t>(i),
+              *distance_to_stop_point);
           }
           break;
         }

--- a/common/autoware_motion_utils/src/trajectory/interpolation.cpp
+++ b/common/autoware_motion_utils/src/trajectory/interpolation.cpp
@@ -66,15 +66,12 @@ TrajectoryPoint calcInterpolatedPoint(
     interpolated_point.lateral_velocity_mps = curr_pt.lateral_velocity_mps;
     interpolated_point.acceleration_mps2 = curr_pt.acceleration_mps2;
   } else {
-    interpolated_point.longitudinal_velocity_mps = static_cast<float>(
-      autoware::interpolation::lerp(
-        curr_pt.longitudinal_velocity_mps, next_pt.longitudinal_velocity_mps, clamped_ratio));
-    interpolated_point.lateral_velocity_mps = static_cast<float>(
-      autoware::interpolation::lerp(
-        curr_pt.lateral_velocity_mps, next_pt.lateral_velocity_mps, clamped_ratio));
-    interpolated_point.acceleration_mps2 = static_cast<float>(
-      autoware::interpolation::lerp(
-        curr_pt.acceleration_mps2, next_pt.acceleration_mps2, clamped_ratio));
+    interpolated_point.longitudinal_velocity_mps = static_cast<float>(autoware::interpolation::lerp(
+      curr_pt.longitudinal_velocity_mps, next_pt.longitudinal_velocity_mps, clamped_ratio));
+    interpolated_point.lateral_velocity_mps = static_cast<float>(autoware::interpolation::lerp(
+      curr_pt.lateral_velocity_mps, next_pt.lateral_velocity_mps, clamped_ratio));
+    interpolated_point.acceleration_mps2 = static_cast<float>(autoware::interpolation::lerp(
+      curr_pt.acceleration_mps2, next_pt.acceleration_mps2, clamped_ratio));
   }
 
   // heading rate interpolation
@@ -137,12 +134,12 @@ PathPointWithLaneId calcInterpolatedPoint(
     interpolated_point.point.longitudinal_velocity_mps = curr_pt.point.longitudinal_velocity_mps;
     interpolated_point.point.lateral_velocity_mps = curr_pt.point.lateral_velocity_mps;
   } else {
-    interpolated_point.point.longitudinal_velocity_mps = static_cast<float>(
-      autoware::interpolation::lerp(
+    interpolated_point.point.longitudinal_velocity_mps =
+      static_cast<float>(autoware::interpolation::lerp(
         curr_pt.point.longitudinal_velocity_mps, next_pt.point.longitudinal_velocity_mps,
         clamped_ratio));
-    interpolated_point.point.lateral_velocity_mps = static_cast<float>(
-      autoware::interpolation::lerp(
+    interpolated_point.point.lateral_velocity_mps =
+      static_cast<float>(autoware::interpolation::lerp(
         curr_pt.point.lateral_velocity_mps, next_pt.point.lateral_velocity_mps, clamped_ratio));
   }
 

--- a/common/autoware_motion_utils/src/trajectory/path_with_lane_id.cpp
+++ b/common/autoware_motion_utils/src/trajectory/path_with_lane_id.cpp
@@ -67,7 +67,8 @@ size_t findNearestIndexFromLaneId(
     validateNonEmpty(path.points);
 
     const auto sub_points = std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId>{
-      path.points.begin() + static_cast<std::ptrdiff_t>(start_idx), path.points.begin() + static_cast<std::ptrdiff_t>(end_idx + 1)};
+      path.points.begin() + static_cast<std::ptrdiff_t>(start_idx),
+      path.points.begin() + static_cast<std::ptrdiff_t>(end_idx + 1)};
     validateNonEmpty(sub_points);
 
     return start_idx + findNearestIndex(sub_points, pos);


### PR DESCRIPTION
## Description

Step 2 of https://github.com/autowarefoundation/autoware_core/issues/774#issuecomment-3852976070: Remove the exception from the .clang-tidy-ci list.

## Related links

**Parent Issue:**
https://github.com/autowarefoundation/autoware_core/issues/774

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

No clang-tidy error appears in CI.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
