### PR TITLE
fix(autoware_ground_filter): fix bugprone-narrowing-conversions warnings

### DIFF
--- a/perception/autoware_ground_filter/src/ground_filter.cpp
+++ b/perception/autoware_ground_filter/src/ground_filter.cpp
@@ -389,7 +389,9 @@ void GroundFilter::classify(pcl::PointIndices & out_no_ground_indices)
         grid_ptr_->getCell(grid_idcs.back()).radial_idx_ + static_cast<int>(grid_idcs.size());
       const float radial_diff_between_cells = cell.center_radius_ - prev_cell.center_radius_;
 
-      if (radial_diff_between_cells < static_cast<float>(param_.ground_grid_continual_thresh) * cell.radial_size_) {
+      if (
+        radial_diff_between_cells <
+        static_cast<float>(param_.ground_grid_continual_thresh) * cell.radial_size_) {
         if (cell.radial_idx_ - front_radial_id < param_.ground_grid_continual_thresh) {
           mode = SegmentationMode::CONTINUOUS;
         } else {

--- a/perception/autoware_ground_filter/src/node.cpp
+++ b/perception/autoware_ground_filter/src/node.cpp
@@ -126,7 +126,8 @@ GroundFilterComponent::GroundFilterComponent(const rclcpp::NodeOptions & options
       param.grid_size_m = grid_size_m_;
       param.grid_mode_switch_radius = grid_mode_switch_radius_;
       param.ground_grid_buffer_size = ground_grid_buffer_size_;
-      param.virtual_lidar_x = static_cast<float>(vehicle_info_.wheel_base_m) / 2.0f + center_pcl_shift_;
+      param.virtual_lidar_x =
+        static_cast<float>(vehicle_info_.wheel_base_m) / 2.0f + center_pcl_shift_;
       param.virtual_lidar_y = 0.0f;
       param.virtual_lidar_z = virtual_lidar_z_;
 


### PR DESCRIPTION
## Description

Step 2 of https://github.com/autowarefoundation/autoware_core/issues/774#issuecomment-3852976070: Remove the exception from the .clang-tidy-ci list.

## Related links

**Parent Issue:**
https://github.com/autowarefoundation/autoware_core/issues/774

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

No clang-tidy error appears in CI.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
