### PR TITLE
fix(autoware_crop_box_filter): fix bugprone-narrowing-conversions warnings

### DIFF
--- a/sensing/autoware_crop_box_filter/src/crop_box_filter.cpp
+++ b/sensing/autoware_crop_box_filter/src/crop_box_filter.cpp
@@ -83,9 +83,9 @@ geometry_msgs::msg::PolygonStamped generate_crop_box_polygon(
 {
   auto generate_point = [](double x, double y, double z) {
     geometry_msgs::msg::Point32 point;
-    point.x = x;
-    point.y = y;
-    point.z = z;
+    point.x = static_cast<float>(x);
+    point.y = static_cast<float>(y);
+    point.z = static_cast<float>(z);
     return point;
   };
 

--- a/sensing/autoware_crop_box_filter/src/crop_box_filter_node.cpp
+++ b/sensing/autoware_crop_box_filter/src/crop_box_filter_node.cpp
@@ -80,12 +80,12 @@ CropBoxFilter::CropBoxFilter(const rclcpp::NodeOptions & node_options)
   // get polygon parameters
   {
     auto & p = config_.param;
-    p.min_x = declare_parameter<double>("min_x");
-    p.min_y = declare_parameter<double>("min_y");
-    p.min_z = declare_parameter<double>("min_z");
-    p.max_x = declare_parameter<double>("max_x");
-    p.max_y = declare_parameter<double>("max_y");
-    p.max_z = declare_parameter<double>("max_z");
+    p.min_x = static_cast<float>(declare_parameter<double>("min_x"));
+    p.min_y = static_cast<float>(declare_parameter<double>("min_y"));
+    p.min_z = static_cast<float>(declare_parameter<double>("min_z"));
+    p.max_x = static_cast<float>(declare_parameter<double>("max_x"));
+    p.max_y = static_cast<float>(declare_parameter<double>("max_y"));
+    p.max_z = static_cast<float>(declare_parameter<double>("max_z"));
     config_.keep_outside_box = declare_parameter<bool>("negative");
     if (tf_input_frame_.empty()) {
       throw std::invalid_argument("Crop box requires non-empty input_frame");


### PR DESCRIPTION
## Description

Step 2 of https://github.com/autowarefoundation/autoware_core/issues/774#issuecomment-3852976070: Remove the exception from the .clang-tidy-ci list.

## Related links

**Parent Issue:**
https://github.com/autowarefoundation/autoware_core/issues/774

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

No clang-tidy error appears in CI.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
