### PR TITLE
fix(autoware_behavior_velocity_planner): fix bugprone-narrowing-conversions warnings

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/experimental/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/experimental/node.cpp
@@ -403,7 +403,7 @@ void BehaviorVelocityPlannerNode::publishDebugMarker(const autoware_planning_msg
   for (size_t i = 0; i < path.points.size(); ++i) {
     visualization_msgs::msg::Marker marker;
     marker.header = path.header;
-    marker.id = i;
+    marker.id = static_cast<int>(i);
     marker.type = visualization_msgs::msg::Marker::ARROW;
     marker.pose = path.points.at(i).pose;
     marker.scale.y = marker.scale.z = 0.05;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -404,7 +404,7 @@ void BehaviorVelocityPlannerNode::publishDebugMarker(const autoware_planning_msg
   for (size_t i = 0; i < path.points.size(); ++i) {
     visualization_msgs::msg::Marker marker;
     marker.header = path.header;
-    marker.id = i;
+    marker.id = static_cast<int>(i);
     marker.type = visualization_msgs::msg::Marker::ARROW;
     marker.pose = path.points.at(i).pose;
     marker.scale.y = marker.scale.z = 0.05;


### PR DESCRIPTION
## Description

Step 2 of https://github.com/autowarefoundation/autoware_core/issues/774#issuecomment-3852976070: Remove the exception from the .clang-tidy-ci list.

## Related links

**Parent Issue:**
https://github.com/autowarefoundation/autoware_core/issues/774

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

No clang-tidy error appears in CI.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
