### PR TITLE
fix(ci): handle PRs with no C++ file changes in clang-tidy step

### DIFF
--- a/.github/workflows/build-and-test-diff-reusable.yaml
+++ b/.github/workflows/build-and-test-diff-reusable.yaml
@@ -160,7 +160,7 @@ jobs:
       - name: Get changed files (existing files only, excluding header-only packages)
         id: get-changed-files
         run: |
-          changed_files=$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD | grep -E '\.(cpp|hpp)$' | while read -r file; do [ -e "$file" ] && echo -n "$file "; done)
+          changed_files=$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD | { grep -E '\.(cpp|hpp)$' || true; } | while read -r file; do [ -e "$file" ] && echo -n "$file "; done)
 
           # Exclude files belonging to header-only packages (no .cpp in src/).
           # These packages don't generate compile_commands.json, which causes clang-tidy to fail.

--- a/.github/workflows/build-and-test-diff-reusable.yaml
+++ b/.github/workflows/build-and-test-diff-reusable.yaml
@@ -160,7 +160,7 @@ jobs:
       - name: Get changed files (existing files only)
         id: get-changed-files
         run: |
-          echo "changed-files=$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD | grep -E '\.(cpp|hpp)$' | while read -r file; do [ -e "$file" ] && echo -n "$file "; done)" >> $GITHUB_OUTPUT
+          echo "changed-files=$(git diff --diff-filter=d --name-only "origin/${{ github.base_ref }}"...HEAD | grep -E '\.(cpp|hpp)$' | while read -r file; do [ -e "$file" ] && echo -n "$file "; done)" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Run clang-tidy


### PR DESCRIPTION
## Description
Fix build-and-test-diff-reusable workflow failing when a PR contains no .cpp/.hpp file changes (e.g., documentation-only or launch file changes).

  - `grep -E '\.(cpp|hpp)$'` returns exit code 1 when there are no matches, which causes the step to fail due to set -e. Wrapped the `grep` in `{ ... || true; }` so that an empty match produces an empty string instead of a pipeline failure.
  - Added `--diff-filter=d` to git diff to exclude deleted files, since they cannot be checked by clang-tidy.

Observed in: https://github.com/autowarefoundation/autoware_core/pull/944

## Related links
github workflows was recently modified by https://github.com/autowarefoundation/autoware_core/pull/905.
This bug was latent in the original code but became more visible after #905 refactored the step to store the grep result in a variable.

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Checked that the error doesn't occur in https://github.com/autowarefoundation/autoware_core/pull/944.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
