### PR TITLE
fix(ci): exclude deleted files from clang-tidy target list

### DIFF
--- a/.github/workflows/build-and-test-diff-reusable.yaml
+++ b/.github/workflows/build-and-test-diff-reusable.yaml
@@ -160,7 +160,7 @@ jobs:
       - name: Get changed files (existing files only)
         id: get-changed-files
         run: |
-          echo "changed-files=$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD | grep -E '\.(cpp|hpp)$' | while read -r file; do [ -e "$file" ] && echo -n "$file "; done)" >> $GITHUB_OUTPUT
+          echo "changed-files=$(git diff --diff-filter=d --name-only "origin/${{ github.base_ref }}"...HEAD | grep -E '\.(cpp|hpp)$' | while read -r file; do [ -e "$file" ] && echo -n "$file "; done)" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Run clang-tidy


### PR DESCRIPTION
## Description

Add `--diff-filter=d` to `git diff` in the clang-tidy-diff job to exclude deleted files from the changed file list.

When a PR deletes a `.cpp`/`.hpp` file, `git diff --name-only` still includes it in the output. Since the file does not exist on disk, `[ -e "$file" ]` returns exit code 1. With `pipefail` enabled, this causes the entire pipeline to fail with exit code 1.

`--diff-filter=d` (lowercase `d`) excludes deleted files from the diff output, preventing this issue at the source.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware_core/actions/runs/23043685642/job/66931554311?pr=885

## How was this PR tested?

Confirmed that `git diff --diff-filter=d --name-only origin/main...HEAD` correctly excludes deleted files from its output.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.