### PR TITLE
fix(autoware_motion_velocity_planner_common): avoid -Wmaybe-uninitialized warning on arm64 with ROS Jazzy

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/planner_data.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/planner_data.cpp
@@ -156,7 +156,7 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr filter_by_multi_trajectory_polygon(
 
   std::for_each(
     traj_polygons.begin(), traj_polygons.end(), [&](const Polygon2d & one_step_polygon) {
-      bg::model::box<BoostPoint2D> bbox;
+      bg::model::box<BoostPoint2D> bbox{};
       bg::envelope(one_step_polygon, bbox);
 
       std::vector<BoostValue> result_s;


### PR DESCRIPTION
## Description

This PR ensures that the bbox variable is properly initialized before being read.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/openadkit/issues/56

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
