### PR TITLE
fix(autoware_agnocast_wrapper): delete `deprecated` mark from `publish(const MessageT&)` API

### DIFF
--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -413,15 +413,10 @@ public:
   virtual void publish(AUTOWARE_MESSAGE_SHARED_PTR(MessageT) && message) = 0;
 
   /// Publish by const reference (internally copies into allocated message).
-  /// Not truly deprecated — [[deprecated]] is used solely to emit a compile-time warning, as
-  /// __attribute__((warning)) does not work on virtual methods (vtable dispatch).
+  /// This method is discouraged because it performs an implicit copy.
   /// Prefer ALLOCATE_OUTPUT_MESSAGE_{UNIQUE,SHARED}(publisher) + the corresponding publish()
-  /// overload. This method exists to work around a circular dependency: autoware_utils_debug
-  /// cannot depend on autoware_agnocast_wrapper through autoware_utils.
-  [[deprecated(
-    "publish(const MessageT &) performs an implicit copy. Prefer "
-    "ALLOCATE_OUTPUT_MESSAGE_{UNIQUE,SHARED}(publisher) + the corresponding publish() overload, "
-    "unless avoiding a circular dependency.")]]
+  /// overload. May be marked [[deprecated]] in the future once autoware_cmake supports
+  /// suppressing deprecation warnings for test targets.
   virtual void publish(const MessageT & data) = 0;
 
   virtual uint32_t get_subscription_count() const = 0;


### PR DESCRIPTION
## Description
Remove `[[deprecated]]` attribute from `Publisher::publish(const MessageT &)`.                                                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                                                                         
The `[[deprecated]]` attribute was used to emit a compile-time warning discouraging implicit-copy publishes. However, `autoware_cmake` enables` -Werror` (or `CMAKE_COMPILE_WARNING_AS_ERROR`), which turns this warning into a build error — making the method effectively unusable rather than merely discouraged.

Once all production code has migrated to the allocate-then-publish pattern and only test code calls this method, I plan to re-introduce a compile-time diagnostic that fires only in Release builds (e.g., via a conditional compile definition in `autoware_cmake`). For now, simply remove the attribute to unblock usage.

## Related links

## How was this PR tested?
Build verification — confirmed the removal compiles without errors under -Werror.

## Notes for reviewers

## Interface changes
None. The method signature is unchanged; only the [[deprecated]] attribute is removed.

## Effects on system behavior
None. Runtime behavior is identical. Callers of publish(const MessageT &) will no longer see a compile-time warning.


<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
