### PR TITLE
fix(autoware_agnocast_wrapper): separate to `CONST_SHARED_PTR` and mutable `SHARED_PTR`

### DIFF
--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -36,7 +36,7 @@
     MessageT, autoware::agnocast_wrapper::OwnershipType::Shared>
 // For subscription (read-only message)
 #define AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) \
-  autoware::agnocast_wrapper::message_ptr<           \
+  autoware::agnocast_wrapper::message_ptr<          \
     MessageT, autoware::agnocast_wrapper::OwnershipType::Shared>
 #define AUTOWARE_SUBSCRIPTION_PTR(MessageT) \
   typename autoware::agnocast_wrapper::Subscription<MessageT>::SharedPtr
@@ -233,7 +233,8 @@ public:
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
         std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_SHARED_PTR(MessageT) &&> ||
         std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>,
-      "callback should be invocable with an rvalue reference to either AUTOWARE_MESSAGE_UNIQUE_PTR, "
+      "callback should be invocable with an rvalue reference to either "
+      "AUTOWARE_MESSAGE_UNIQUE_PTR, "
       "AUTOWARE_MESSAGE_SHARED_PTR, or AUTOWARE_MESSAGE_CONST_SHARED_PTR");
 
     constexpr auto ownership =
@@ -265,7 +266,8 @@ public:
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
         std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_SHARED_PTR(MessageT) &&> ||
         std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>,
-      "callback should be invocable with an rvalue reference to either AUTOWARE_MESSAGE_UNIQUE_PTR, "
+      "callback should be invocable with an rvalue reference to either "
+      "AUTOWARE_MESSAGE_UNIQUE_PTR, "
       "AUTOWARE_MESSAGE_SHARED_PTR, or AUTOWARE_MESSAGE_CONST_SHARED_PTR");
 
     constexpr auto ownership =


### PR DESCRIPTION
## Description
Add `AUTOWARE_MESSAGE_CONST_SHARED_PTR` macro to resolve a type mismatch that causes compilation failure in the non-agnocast (standard ROS2) build path.                                                                                                                                                                                                                                                                               
                  
## Problem                                                                                                                                                                                                                                                                                                                                                                                                                             
`AUTOWARE_MESSAGE_SHARED_PTR(MessageT)` is used for both subscription (read-only) and publisher (write) use cases. In the agnocast path, this works fine because `message_ptr<MessageT, Shared>` is a single wrapper type that serves both purposes.

In the non-agnocast path, the macro expands to `std::shared_ptr<MessageT>`. However, rclcpp's `create_subscription` expects `std::shared_ptr<const MessageT>` in callbacks. Since `std::shared_ptr<T>` and `std::shared_ptr<const T>` are distinct types, one macro cannot serve both subscription and publisher use cases.

  A natural workaround would be for users to write `AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)`, but this breaks the agnocast path: the wrapper's `create_subscription<MessageT>` uses non-const `MessageT` internally, so `message_ptr<const MessageT, Shared>` and `message_ptr<MessageT, Shared>` become mismatched types, failing the static\_assert.

## Solution
Introduce a separate macro for subscription (const) use:

  | Macro | Purpose | agnocast path | non-agnocast path |
  |---|---|---|---|
  | `AUTOWARE_MESSAGE_SHARED_PTR` | Publisher (mutable) | `message_ptr<T, Shared>` | `std::shared_ptr<T>` |
  | `AUTOWARE_MESSAGE_CONST_SHARED_PTR` | Subscription (read-only) | `message_ptr<T, Shared>` | `std::shared_ptr<const T>` |

In the agnocast path, both macros expand to the same type. In the non-agnocast path, the const variant satisfies rclcpp's callback type requirements.

## Changes
- Add `AUTOWARE_MESSAGE_CONST_SHARED_PTR` macro definition in both build paths



## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
