### PR TITLE
fix(autoware_agnocast_wrapper): use rclcpp_components_register_nodes to avoid target name collision

### DIFF
--- a/common/autoware_agnocast_wrapper/cmake/autoware_agnocast_wrapper_register_node.cmake
+++ b/common/autoware_agnocast_wrapper/cmake/autoware_agnocast_wrapper_register_node.cmake
@@ -68,7 +68,7 @@
 #   )
 #
 # NOTE: This is intentionally a macro (not a function) because it calls
-# rclcpp_components_register_node, which is also a macro and requires
+# rclcpp_components_register_node(s), which is also a macro and requires
 # access to the caller's variable scope for ament resource index registration.
 macro(autoware_agnocast_wrapper_register_node target)
   if(NOT TARGET ${target})


### PR DESCRIPTION
## Description

Replace `rclcpp_components_register_node` (singular) with `rclcpp_components_register_nodes` (plural) in the agnocast wrapper macro.

The singular form creates both a component registration and a standalone executable named `<EXECUTABLE>_component`. This `_component` executable is never referenced from any launch file but causes CMake target name collisions when a package's library target name matches the generated executable name (e.g., `autoware_raw_vehicle_cmd_converter_node_component`).

The plural form only populates the ament resource index for component container support without generating the unnecessary executable, eliminating the collision at the root cause.

## Related links

https://github.com/ros2/rclcpp/blob/b6e9b4c9b48c48eae09ab79d7b2d4ef95e6c4653/rclcpp_components/cmake/rclcpp_components_register_nodes.cmake#L27

## How was this PR tested?

- [x] Built `autoware_raw_vehicle_cmd_converter` with `ENABLE_AGNOCAST=1` (clean build) — no target name collision
- [x] Verified ament resource index is correctly populated for component container loading
- [x] Confirmed no `_component` executable is generated

## Notes for reviewers

## Interface changes

None.

## Effects on system behavior

None.