### PR TITLE
fix(autoware_agnocast_wrapper): add const to AUTOWARE_MESSAGE_CONST_SHARED_PTR macro

### DIFF
--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -245,8 +245,12 @@ public:
     subscription_ = agnocast::create_subscription<MessageT>(
       node, topic_name, qos,
       [callback = std::forward<Func>(callback)](agnocast::ipc_shared_ptr<MessageT> && msg) {
-        callback(message_ptr<const MessageT, ownership>(
-          agnocast::ipc_shared_ptr<const MessageT>(std::move(msg))));
+        if constexpr (ownership == OwnershipType::Unique) {
+          callback(message_ptr<MessageT, ownership>(std::move(msg)));
+        } else {
+          callback(message_ptr<const MessageT, ownership>(
+            agnocast::ipc_shared_ptr<const MessageT>(std::move(msg))));
+        }
       },
       options);
   }
@@ -281,8 +285,12 @@ public:
     subscription_ = node->create_subscription<MessageT>(
       topic_name, qos,
       [callback = std::forward<Func>(callback)](std::unique_ptr<MessageT> msg) {
-        callback(message_ptr<const MessageT, ownership>(
-          std::shared_ptr<const MessageT>(std::move(msg))));
+        if constexpr (ownership == OwnershipType::Unique) {
+          callback(message_ptr<MessageT, ownership>(std::move(msg)));
+        } else {
+          callback(message_ptr<const MessageT, ownership>(
+            std::shared_ptr<const MessageT>(std::move(msg))));
+        }
       },
       ros2_options);
   }

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -235,11 +235,9 @@ public:
     // CudaPointcloudPreprocessorNode which uses UNIQUE_PTR callbacks.
     static_assert(
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
-        std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_SHARED_PTR(MessageT) &&> ||
         std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>,
       "callback should be invocable with an rvalue reference to either "
-      "AUTOWARE_MESSAGE_UNIQUE_PTR, "
-      "AUTOWARE_MESSAGE_SHARED_PTR, or AUTOWARE_MESSAGE_CONST_SHARED_PTR");
+      "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR");
 
     constexpr auto ownership =
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>
@@ -274,11 +272,9 @@ public:
   {
     static_assert(
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
-        std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_SHARED_PTR(MessageT) &&> ||
         std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>,
       "callback should be invocable with an rvalue reference to either "
-      "AUTOWARE_MESSAGE_UNIQUE_PTR, "
-      "AUTOWARE_MESSAGE_SHARED_PTR, or AUTOWARE_MESSAGE_CONST_SHARED_PTR");
+      "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR");
 
     constexpr auto ownership =
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -37,7 +37,7 @@
 // For subscription (read-only message)
 #define AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) \
   autoware::agnocast_wrapper::message_ptr<          \
-    MessageT, autoware::agnocast_wrapper::OwnershipType::Shared>
+    const MessageT, autoware::agnocast_wrapper::OwnershipType::Shared>
 #define AUTOWARE_SUBSCRIPTION_PTR(MessageT) \
   typename autoware::agnocast_wrapper::Subscription<MessageT>::SharedPtr
 #define AUTOWARE_PUBLISHER_PTR(MessageT) \
@@ -245,7 +245,8 @@ public:
     subscription_ = agnocast::create_subscription<MessageT>(
       node, topic_name, qos,
       [callback = std::forward<Func>(callback)](agnocast::ipc_shared_ptr<MessageT> && msg) {
-        callback(message_ptr<MessageT, ownership>(std::move(msg)));
+        callback(message_ptr<const MessageT, ownership>(
+          agnocast::ipc_shared_ptr<const MessageT>(std::move(msg))));
       },
       options);
   }
@@ -280,11 +281,8 @@ public:
     subscription_ = node->create_subscription<MessageT>(
       topic_name, qos,
       [callback = std::forward<Func>(callback)](std::unique_ptr<MessageT> msg) {
-        if constexpr (ownership == OwnershipType::Unique) {
-          callback(message_ptr<MessageT, ownership>(std::move(msg)));
-        } else {
-          callback(message_ptr<MessageT, ownership>(std::shared_ptr<MessageT>(std::move(msg))));
-        }
+        callback(message_ptr<const MessageT, ownership>(
+          std::shared_ptr<const MessageT>(std::move(msg))));
       },
       ros2_options);
   }

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -248,8 +248,9 @@ public:
         if constexpr (ownership == OwnershipType::Unique) {
           callback(message_ptr<MessageT, ownership>(std::move(msg)));
         } else {
-          callback(message_ptr<const MessageT, ownership>(
-            agnocast::ipc_shared_ptr<const MessageT>(std::move(msg))));
+          callback(
+            message_ptr<const MessageT, ownership>(
+              agnocast::ipc_shared_ptr<const MessageT>(std::move(msg))));
         }
       },
       options);
@@ -288,8 +289,9 @@ public:
         if constexpr (ownership == OwnershipType::Unique) {
           callback(message_ptr<MessageT, ownership>(std::move(msg)));
         } else {
-          callback(message_ptr<const MessageT, ownership>(
-            std::shared_ptr<const MessageT>(std::move(msg))));
+          callback(
+            message_ptr<const MessageT, ownership>(
+              std::shared_ptr<const MessageT>(std::move(msg))));
         }
       },
       ros2_options);

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -230,27 +230,22 @@ public:
     const agnocast::SubscriptionOptions & options)
   {
     static_assert(
-      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
-        std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_SHARED_PTR(MessageT) &&> ||
+      !std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>,
+      "AUTOWARE_MESSAGE_UNIQUE_PTR is not supported for Agnocast subscriptions. "
+      "Agnocast uses shared memory, so mutable exclusive ownership is not possible. "
+      "Use AUTOWARE_MESSAGE_SHARED_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR instead.");
+
+    static_assert(
+      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_SHARED_PTR(MessageT) &&> ||
         std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>,
       "callback should be invocable with an rvalue reference to either "
-      "AUTOWARE_MESSAGE_UNIQUE_PTR, "
-      "AUTOWARE_MESSAGE_SHARED_PTR, or AUTOWARE_MESSAGE_CONST_SHARED_PTR");
-
-    constexpr auto ownership =
-      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>
-        ? OwnershipType::Unique
-        : OwnershipType::Shared;
+      "AUTOWARE_MESSAGE_SHARED_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR");
 
     subscription_ = agnocast::create_subscription<MessageT>(
       node, topic_name, qos,
       [callback = std::forward<Func>(callback)](agnocast::ipc_shared_ptr<MessageT> && msg) {
-        if constexpr (ownership == OwnershipType::Unique) {
-          callback(message_ptr<MessageT, ownership>(std::move(msg)));
-        } else {
-          callback(message_ptr<const MessageT, ownership>(
-            agnocast::ipc_shared_ptr<const MessageT>(std::move(msg))));
-        }
+        callback(message_ptr<const MessageT, OwnershipType::Shared>(
+          agnocast::ipc_shared_ptr<const MessageT>(std::move(msg))));
       },
       options);
   }

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -245,8 +245,9 @@ public:
     subscription_ = agnocast::create_subscription<MessageT>(
       node, topic_name, qos,
       [callback = std::forward<Func>(callback)](agnocast::ipc_shared_ptr<MessageT> && msg) {
-        callback(message_ptr<const MessageT, ownership>(
-          agnocast::ipc_shared_ptr<const MessageT>(std::move(msg))));
+        callback(
+          message_ptr<const MessageT, ownership>(
+            agnocast::ipc_shared_ptr<const MessageT>(std::move(msg))));
       },
       options);
   }
@@ -281,8 +282,8 @@ public:
     subscription_ = node->create_subscription<MessageT>(
       topic_name, qos,
       [callback = std::forward<Func>(callback)](std::unique_ptr<MessageT> msg) {
-        callback(message_ptr<const MessageT, ownership>(
-          std::shared_ptr<const MessageT>(std::move(msg))));
+        callback(
+          message_ptr<const MessageT, ownership>(std::shared_ptr<const MessageT>(std::move(msg))));
       },
       ros2_options);
   }

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -229,23 +229,32 @@ public:
     NodeT * node, const std::string & topic_name, const rclcpp::QoS & qos, Func && callback,
     const agnocast::SubscriptionOptions & options)
   {
+    // TODO(Koichi98): AUTOWARE_MESSAGE_UNIQUE_PTR should be disallowed for Agnocast subscriptions.
+    // Agnocast uses shared memory, so mutable exclusive ownership is semantically incorrect and
+    // risks corrupting data read by other subscribers. Currently kept for compatibility with
+    // CudaPointcloudPreprocessorNode which uses UNIQUE_PTR callbacks.
     static_assert(
-      !std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>,
-      "AUTOWARE_MESSAGE_UNIQUE_PTR is not supported for Agnocast subscriptions. "
-      "Agnocast uses shared memory, so mutable exclusive ownership is not possible. "
-      "Use AUTOWARE_MESSAGE_SHARED_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR instead.");
-
-    static_assert(
-      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_SHARED_PTR(MessageT) &&> ||
+      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
+        std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_SHARED_PTR(MessageT) &&> ||
         std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>,
       "callback should be invocable with an rvalue reference to either "
-      "AUTOWARE_MESSAGE_SHARED_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR");
+      "AUTOWARE_MESSAGE_UNIQUE_PTR, "
+      "AUTOWARE_MESSAGE_SHARED_PTR, or AUTOWARE_MESSAGE_CONST_SHARED_PTR");
+
+    constexpr auto ownership =
+      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>
+        ? OwnershipType::Unique
+        : OwnershipType::Shared;
 
     subscription_ = agnocast::create_subscription<MessageT>(
       node, topic_name, qos,
       [callback = std::forward<Func>(callback)](agnocast::ipc_shared_ptr<MessageT> && msg) {
-        callback(message_ptr<const MessageT, OwnershipType::Shared>(
-          agnocast::ipc_shared_ptr<const MessageT>(std::move(msg))));
+        if constexpr (ownership == OwnershipType::Unique) {
+          callback(message_ptr<MessageT, ownership>(std::move(msg)));
+        } else {
+          callback(message_ptr<const MessageT, ownership>(
+            agnocast::ipc_shared_ptr<const MessageT>(std::move(msg))));
+        }
       },
       options);
   }


### PR DESCRIPTION
##  Description
  - Fix `AUTOWARE_MESSAGE_CONST_SHARED_PTR(M)` to expand to `message_ptr<const M, Shared>` instead of `message_ptr<M, Shared>`
  - Update `AgnocastSubscription` and `ROS2Subscription` adapters to produce `message_ptr<const MessageT, Shared>` for shared-ownership callbacks, while keeping `message_ptr<MessageT, Unique>` for unique-ownership callbacks

  ## Background
  PR #953 introduced `AUTOWARE_MESSAGE_CONST_SHARED_PTR` but set the agnocast path to `message_ptr<T, Shared>` (without `const`) to match what the subscription adapter was producing. This worked around the immediate compilation issue but left the macro semantically inconsistent — `CONST_SHARED_PTR` was not actually const in the agnocast path.

  This PR fixes the root cause by making the subscription adapters produce `message_ptr<const MessageT, Shared>`, then correcting the macro to include `const`. This makes `AUTOWARE_MESSAGE_CONST_SHARED_PTR(M)` and `AUTOWARE_MESSAGE_SHARED_PTR(const M)` resolve to the same type, and enforces read-only access for subscription callbacks at compile time.


### Known issue: `UNIQUE_PTR` in Agnocast subscriptions
  Agnocast subscriptions receive messages via `ipc_shared_ptr`. Allowing `AUTOWARE_MESSAGE_UNIQUE_PTR` callbacks gives mutable access to shared memory. Ideally, AgnocastSubscription should reject `UNIQUE_PTR` callbacks via `static_assert` and require users to copy the message if mutation is needed. However,   `CudaPointcloudPreprocessorNode` currently uses `UNIQUE_PTR` callbacks, so this restriction is deferred to a follow-up PR.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
