### PR TITLE
refactor(autoware_core): add USE_SCOPED_HEADER_INSTALL_DIR to common and testing packages

### DIFF
--- a/common/autoware_component_interface_specs/CMakeLists.txt
+++ b/common/autoware_component_interface_specs/CMakeLists.txt
@@ -17,4 +17,6 @@ if(BUILD_TESTING)
   )
 endif()
 
-autoware_ament_auto_package()
+autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
+)

--- a/common/autoware_geography_utils/CMakeLists.txt
+++ b/common/autoware_geography_utils/CMakeLists.txt
@@ -34,4 +34,6 @@ if(BUILD_TESTING)
   )
 endif()
 
-autoware_ament_auto_package()
+autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
+)

--- a/common/autoware_interpolation/CMakeLists.txt
+++ b/common/autoware_interpolation/CMakeLists.txt
@@ -21,4 +21,6 @@ if(BUILD_TESTING)
   )
 endif()
 
-autoware_ament_auto_package()
+autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
+)

--- a/common/autoware_kalman_filter/CMakeLists.txt
+++ b/common/autoware_kalman_filter/CMakeLists.txt
@@ -26,4 +26,6 @@ if(BUILD_TESTING)
   target_link_libraries(test_${PROJECT_NAME} ${PROJECT_NAME})
 endif()
 
-autoware_ament_auto_package()
+autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
+)

--- a/common/autoware_marker_utils/CMakeLists.txt
+++ b/common/autoware_marker_utils/CMakeLists.txt
@@ -25,4 +25,6 @@ if(BUILD_TESTING)
   endforeach()
 endif()
 
-autoware_ament_auto_package()
+autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
+)

--- a/common/autoware_motion_utils/CMakeLists.txt
+++ b/common/autoware_motion_utils/CMakeLists.txt
@@ -20,4 +20,6 @@ if(BUILD_TESTING)
   )
 endif()
 
-autoware_ament_auto_package()
+autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
+)

--- a/common/autoware_object_recognition_utils/CMakeLists.txt
+++ b/common/autoware_object_recognition_utils/CMakeLists.txt
@@ -23,4 +23,6 @@ if(BUILD_TESTING)
   )
 endif()
 
-autoware_ament_auto_package()
+autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
+)

--- a/common/autoware_vehicle_info_utils/CMakeLists.txt
+++ b/common/autoware_vehicle_info_utils/CMakeLists.txt
@@ -26,6 +26,7 @@ install(PROGRAMS
 )
 
 autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
     config
     launch

--- a/testing/autoware_planning_test_manager/CMakeLists.txt
+++ b/testing/autoware_planning_test_manager/CMakeLists.txt
@@ -14,4 +14,6 @@ if(BUILD_TESTING)
   )
 endif()
 
-autoware_ament_auto_package()
+autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
+)

--- a/testing/autoware_testing/CMakeLists.txt
+++ b/testing/autoware_testing/CMakeLists.txt
@@ -9,5 +9,6 @@ list(APPEND ${PROJECT_NAME}_CONFIG_EXTRAS
 )
 
 autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE cmake autoware_testing
 )


### PR DESCRIPTION
## Description

This PR adds `USE_SCOPED_HEADER_INSTALL_DIR` to existing `autoware_ament_auto_package()` calls in common and testing packages of `autoware_core`.

Updated packages:
- `autoware_component_interface_specs`
- `autoware_geography_utils`
- `autoware_interpolation`
- `autoware_kalman_filter`
- `autoware_marker_utils`
- `autoware_motion_utils`
- `autoware_object_recognition_utils`
- `autoware_vehicle_info_utils`
- `autoware_testing`
- `autoware_planning_test_manager`

## How was this PR tested?

Tested with:

```bash
colcon build --base-paths ~/autoware_scoped_headers/autoware/src --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to \
autoware_component_interface_specs \
autoware_geography_utils \
autoware_interpolation \
autoware_kalman_filter \
autoware_marker_utils \
autoware_motion_utils \
autoware_object_recognition_utils \
autoware_vehicle_info_utils \
autoware_testing \
autoware_planning_test_manager
```

The target packages built successfully.

### ADDED by @sasakisasaki
When I reviewed this PR, I could not reproduce the same result. So I tested by using the following steps:

- First,
```bash
$ cd <workspace>/autoware_core
$ git remote add vish0012 https://github.com/vish0012/autoware_core.git
$ git fetch vish0012
$ git checkout refactor/add-use-scoped-header-install-dir-to-core-common-testing

(create `core.repos` with the following contents)

$ vcs import src < core.repos
```
- `core.repos`:
```yaml
repositories:
  core/autoware_cmake:
    type: git
    url: https://github.com/autowarefoundation/autoware_cmake.git
    version: 1.2.0
  core/autoware_lanelet2_extension:
    type: git
    url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
    version: main
```
- Then,
```bash
$ rosdep install -y --from-paths ./ --ignore-src --rosdistro $ROS_DISTRO
$ sudo apt update && sudo apt upgrade -y    # fetch the latest ROS packages
$ sudo apt purge -y ros-humble-autoware-lanelet2-extension    # do not use the old lanelet2 extension as it causes build error
$ colcon build --base-paths ./ --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to \
  autoware_component_interface_specs \
  autoware_geography_utils \
  autoware_interpolation \
  autoware_kalman_filter \
  autoware_marker_utils \
  autoware_motion_utils \
  autoware_object_recognition_utils \
  autoware_vehicle_info_utils \
  autoware_testing \
  autoware_planning_test_manager
```

## Notes for reviewers

This is part of the follow-up work after adding `USE_SCOPED_HEADER_INSTALL_DIR` support to `autoware_cmake`.

## Effects on system behavior

No functional behavior change is intended. This updates the package macro options for the scoped header installation migration.