### PR TITLE
refactor(autoware_core): add USE_SCOPED_HEADER_INSTALL_DIR to map packages

### DIFF
--- a/map/autoware_core_map/CMakeLists.txt
+++ b/map/autoware_core_map/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   config
   launch

--- a/map/autoware_map_height_fitter/CMakeLists.txt
+++ b/map/autoware_map_height_fitter/CMakeLists.txt
@@ -18,6 +18,7 @@ rclcpp_components_register_node(${PROJECT_NAME}
 )
 
 autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   launch
   config

--- a/map/autoware_map_loader/CMakeLists.txt
+++ b/map/autoware_map_loader/CMakeLists.txt
@@ -71,7 +71,9 @@ install(PROGRAMS
   DESTINATION lib/${PROJECT_NAME}
 )
 
-autoware_ament_auto_package(INSTALL_TO_SHARE
+autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
+  INSTALL_TO_SHARE
   launch
   config
 )

--- a/map/autoware_map_projection_loader/CMakeLists.txt
+++ b/map/autoware_map_projection_loader/CMakeLists.txt
@@ -57,6 +57,7 @@ if(BUILD_TESTING)
 endif()
 
 autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   launch
   config


### PR DESCRIPTION
## Description

This PR adds `USE_SCOPED_HEADER_INSTALL_DIR` to existing `autoware_ament_auto_package()` calls in map packages of `autoware_core`.

Updated packages:
- `autoware_core_map`
- `autoware_map_height_fitter`
- `autoware_map_loader`
- `autoware_map_projection_loader`

## How was this PR tested?

Tested with:

```bash
colcon build --base-paths ~/autoware_scoped_headers/autoware/src \
  --symlink-install \
  --cmake-args -DCMAKE_BUILD_TYPE=Release \
  --packages-select \
  autoware_map_height_fitter \
  autoware_map_projection_loader \
  autoware_map_loader \
  autoware_core_map
```

The target packages built successfully.

### ADDED by @sasakisasaki
When I reviewed this PR, I could not reproduce the same result. So I tested by using the following steps:

- First,
```bash
$ cd <workspace>/autoware_core
$ git remote add vish0012 https://github.com/vish0012/autoware_core.git
$ git fetch vish0012
$ git checkout refactor/add-use-scoped-header-install-dir-to-core-map-packages

(create `core.repos` with the following contents)

$ vcs import src < core.repos
```
- `core.repos`:
```yaml
repositories:
  core/autoware_cmake:
    type: git
    url: https://github.com/autowarefoundation/autoware_cmake.git
    version: 1.2.0
  core/autoware_lanelet2_extension:
    type: git
    url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
    version: main
```
- Then,
```bash
$ rosdep install -y --from-paths ./ --ignore-src --rosdistro $ROS_DISTRO
$ sudo apt update && sudo apt upgrade -y    # fetch the latest ROS packages
$ sudo apt purge -y ros-humble-autoware-lanelet2-extension    # do not use the old lanelet2 extension as it causes build error
$ colcon build --base-paths ./ --symlink-install \
  --cmake-args -DCMAKE_BUILD_TYPE=Release \
  --packages-up-to \
  autoware_map_height_fitter \
  autoware_map_projection_loader \
  autoware_map_loader \
  autoware_core_map
```

## Notes for reviewers

`autoware_lanelet2_map_visualizer` was checked as part of the map group, but it currently fails local build due to an unrelated source/API issue (`obstacleRemovalAreaAsMarkerArray` is not a member of `lanelet::visualization`).

It was excluded from this PR to keep the migration change isolated and reviewable.

This is part of the follow-up work after adding `USE_SCOPED_HEADER_INSTALL_DIR` support to `autoware_cmake`.

## Effects on system behavior

No functional behavior change is intended. This updates the package macro options for the scoped header installation migration.