### PR TITLE
refactor(autoware_core): add USE_SCOPED_HEADER_INSTALL_DIR to localization packages

### DIFF
--- a/localization/autoware_core_localization/CMakeLists.txt
+++ b/localization/autoware_core_localization/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   config
   launch

--- a/localization/autoware_ekf_localizer/CMakeLists.txt
+++ b/localization/autoware_ekf_localizer/CMakeLists.txt
@@ -78,6 +78,7 @@ endif()
 # endif()
 
 autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   config
   launch

--- a/localization/autoware_gyro_odometer/CMakeLists.txt
+++ b/localization/autoware_gyro_odometer/CMakeLists.txt
@@ -34,7 +34,9 @@ autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   ROS2_EXECUTOR SingleThreadedExecutor
 )
 
-autoware_ament_auto_package(INSTALL_TO_SHARE
+autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
+  INSTALL_TO_SHARE
   launch
   config
 )

--- a/localization/autoware_localization_util/CMakeLists.txt
+++ b/localization/autoware_localization_util/CMakeLists.txt
@@ -40,5 +40,6 @@ if(BUILD_TESTING)
 endif()
 
 autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
 )

--- a/localization/autoware_ndt_scan_matcher/CMakeLists.txt
+++ b/localization/autoware_ndt_scan_matcher/CMakeLists.txt
@@ -76,6 +76,7 @@ if(BUILD_TESTING)
 endif()
 
 autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   launch
   config

--- a/localization/autoware_pose_initializer/CMakeLists.txt
+++ b/localization/autoware_pose_initializer/CMakeLists.txt
@@ -36,6 +36,7 @@ if(BUILD_TESTING)
 endif()
 
 autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   launch
   config

--- a/localization/autoware_stop_filter/CMakeLists.txt
+++ b/localization/autoware_stop_filter/CMakeLists.txt
@@ -33,6 +33,7 @@ if(BUILD_TESTING)
 endif()
 
 autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   launch
   config

--- a/localization/autoware_twist2accel/CMakeLists.txt
+++ b/localization/autoware_twist2accel/CMakeLists.txt
@@ -16,6 +16,7 @@ autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
 )
 
 autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   launch
   config


### PR DESCRIPTION
## Description

This PR adds `USE_SCOPED_HEADER_INSTALL_DIR` to existing `autoware_ament_auto_package()` calls in localization packages of `autoware_core`.

Updated packages:
- `autoware_core_localization`
- `autoware_localization_util`
- `autoware_gyro_odometer`
- `autoware_stop_filter`
- `autoware_twist2accel`
- `autoware_ekf_localizer`
- `autoware_pose_initializer`
- `autoware_ndt_scan_matcher`

## How was this PR tested?

Built the target packages locally:
```bash
colcon build --base-paths ~/autoware_scoped_headers/autoware/src \
  --symlink-install \
  --cmake-args -DCMAKE_BUILD_TYPE=Release \
  --packages-select \
  autoware_core_localization \
  autoware_localization_util \
  autoware_gyro_odometer \
  autoware_stop_filter \
  autoware_twist2accel \
  autoware_ekf_localizer \
  autoware_pose_initializer \
  autoware_ndt_scan_matcher
```

Dependencies `autoware_signal_processing`, `autoware_point_types`, and `autoware_downsample_filters` were built locally as needed. All packages built successfully.

### ADDED by @sasakisasaki
When I reviewed this PR, I could not reproduce the same result. So I tested by using the following steps:

- First,
```bash
$ cd <workspace>/autoware_core
$ git remote add vish0012 https://github.com/vish0012/autoware_core.git
$ git fetch vish0012
$ git checkout refactor/add-use-scoped-header-install-dir-to-core-localization-packages

(create `core.repos` with the following contents)

$ vcs import src < core.repos
```
- `core.repos`:
```yaml
repositories:
  core/autoware_cmake:
    type: git
    url: https://github.com/autowarefoundation/autoware_cmake.git
    version: 1.2.0
  core/autoware_lanelet2_extension:
    type: git
    url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
    version: main
```
- Then,
```bash
$ rosdep install -y --from-paths ./ --ignore-src --rosdistro $ROS_DISTRO
$ sudo apt update && sudo apt upgrade -y    # fetch the latest ROS packages
$ sudo apt purge -y ros-humble-autoware-lanelet2-extension    # do not use the old lanelet2 extension as it causes build error
$ colcon build --base-paths ./ --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to \
  autoware_core_localization \
  autoware_localization_util \
  autoware_gyro_odometer \
  autoware_stop_filter \
  autoware_twist2accel \
  autoware_ekf_localizer \
  autoware_pose_initializer \
  autoware_ndt_scan_matcher
```

## Notes for reviewers

This is part of the follow-up work after adding `USE_SCOPED_HEADER_INSTALL_DIR` support to `autoware_cmake`.

## Interface changes

None.

## Effects on system behavior

No functional behavior change. This updates the package macro options for the scoped header installation migration.