### PR TITLE
refactor(autoware_core): add USE_SCOPED_HEADER_INSTALL_DIR to sensing packages

### DIFF
--- a/sensing/autoware_core_sensing/CMakeLists.txt
+++ b/sensing/autoware_core_sensing/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   launch
 )

--- a/sensing/autoware_crop_box_filter/CMakeLists.txt
+++ b/sensing/autoware_crop_box_filter/CMakeLists.txt
@@ -33,7 +33,9 @@ if(BUILD_TESTING)
   target_include_directories(test_crop_box_filter_integration PRIVATE src)
 endif()
 
-autoware_ament_auto_package(INSTALL_TO_SHARE
+autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
+  INSTALL_TO_SHARE
   launch
   config
   test

--- a/sensing/autoware_downsample_filters/CMakeLists.txt
+++ b/sensing/autoware_downsample_filters/CMakeLists.txt
@@ -24,7 +24,9 @@ rclcpp_components_register_node(${PROJECT_NAME}
   PLUGIN "autoware::downsample_filters::VoxelGridDownsampleFilter"
   EXECUTABLE ${VOXEL_GRID}_node)
 
-autoware_ament_auto_package(INSTALL_TO_SHARE
+autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
+  INSTALL_TO_SHARE
   launch
   config
 )

--- a/sensing/autoware_gnss_poser/CMakeLists.txt
+++ b/sensing/autoware_gnss_poser/CMakeLists.txt
@@ -31,7 +31,9 @@ if(BUILD_TESTING)
   target_include_directories(test_${PROJECT_NAME} PRIVATE src)
 endif()
 
-autoware_ament_auto_package(INSTALL_TO_SHARE
+autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
+  INSTALL_TO_SHARE
   config
   launch
 )

--- a/sensing/autoware_vehicle_velocity_converter/CMakeLists.txt
+++ b/sensing/autoware_vehicle_velocity_converter/CMakeLists.txt
@@ -29,6 +29,7 @@ if(BUILD_TESTING)
 endif()
 
 autoware_ament_auto_package(
+  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   launch
   config


### PR DESCRIPTION
## Description

This PR adds `USE_SCOPED_HEADER_INSTALL_DIR` to existing `autoware_ament_auto_package()` calls in sensing packages of `autoware_core`.

Updated packages:
- `autoware_core_sensing`
- `autoware_crop_box_filter`
- `autoware_downsample_filters`
- `autoware_gnss_poser`
- `autoware_vehicle_velocity_converter`

## How was this PR tested?

Built the target packages locally:
```bash
colcon build --base-paths ~/autoware_scoped_headers/autoware/src \
  --symlink-install \
  --cmake-args -DCMAKE_BUILD_TYPE=Release \
  --packages-select \
  autoware_core_sensing \
  autoware_crop_box_filter \
  autoware_downsample_filters \
  autoware_gnss_poser \
  autoware_vehicle_velocity_converter
```

Dependency `autoware_sensing_msgs` was built locally as needed. All packages built successfully.

### ADDED by @sasakisasaki (Sorry for editing multiple times due to my mistake :pray: )
When I reviewed this PR, I could not reproduce the same result. So I tested by using the following steps:

- First,
```bash
$ cd <workspace>/autoware_core
$ git remote add vish0012 https://github.com/vish0012/autoware_core.git
$ git fetch vish0012
$ git checkout refactor/add-use-scoped-header-install-dir-to-core-sensing-packages

(create `core.repos` with the following contents)

$ vcs import src < core.repos
```
- `core.repos`:
```yaml
repositories:
  core/autoware_cmake:
    type: git
    url: https://github.com/autowarefoundation/autoware_cmake.git
    version: 1.2.0
  core/autoware_lanelet2_extension:
    type: git
    url: https://github.com/autowarefoundation/autoware_lanelet2_extension.git
    version: main
```
- Then,
```bash
$ rosdep install -y --from-paths ./ --ignore-src --rosdistro $ROS_DISTRO
$ sudo apt update && sudo apt upgrade -y    # fetch the latest ROS packages
$ sudo apt purge -y ros-humble-autoware-lanelet2-extension    # do not use the old lanelet2 extension as it causes build error
$ colcon build --base-paths ./ --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to \
  autoware_core_sensing \
  autoware_crop_box_filter \
  autoware_downsample_filters \
  autoware_gnss_poser \
  autoware_vehicle_velocity_converter
```

## Notes for reviewers

This is part of the follow-up work after adding `USE_SCOPED_HEADER_INSTALL_DIR` support to `autoware_cmake`.

## Interface changes

None.

## Effects on system behavior

No functional behavior change. This updates the package macro options for the scoped header installation migration.