### PR TITLE
feat: add support for area for route planning

### DIFF
--- a/common/autoware_lanelet2_utils/src/map_handler.cpp
+++ b/common/autoware_lanelet2_utils/src/map_handler.cpp
@@ -16,6 +16,7 @@
 #include <autoware/lanelet2_utils/kind.hpp>
 #include <autoware/lanelet2_utils/map_handler.hpp>
 #include <autoware/lanelet2_utils/topology.hpp>
+#include <autoware_lanelet2_extension/traffic_rules/autoware_traffic_rules.hpp>
 #include <rclcpp/logging.hpp>
 
 #include <lanelet2_core/geometry/Lanelet.h>
@@ -133,7 +134,7 @@ std::optional<MapHandler> MapHandler::create(const autoware_map_msgs::msg::Lanel
     return std::nullopt;
   }
   const auto [routing_graph, traffic_rules] =
-    instantiate_routing_graph_and_traffic_rules(lanelet_map);
+    instantiate_routing_graph_and_traffic_rules(lanelet_map, lanelet::autoware::DefaultLocation);
 
   return MapHandler(lanelet_map, routing_graph, traffic_rules);
 }

--- a/common/autoware_lanelet2_utils/src/route_manager.cpp
+++ b/common/autoware_lanelet2_utils/src/route_manager.cpp
@@ -15,6 +15,7 @@
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware/lanelet2_utils/nn_search.hpp>
 #include <autoware/lanelet2_utils/route_manager.hpp>
+#include <autoware_lanelet2_extension/traffic_rules/autoware_traffic_rules.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/Lanelet.h>
@@ -40,7 +41,7 @@ std::optional<RouteManager> RouteManager::create(
     return std::nullopt;
   }
   const auto [routing_graph, traffic_rules] =
-    instantiate_routing_graph_and_traffic_rules(lanelet_map);
+    instantiate_routing_graph_and_traffic_rules(lanelet_map, lanelet::autoware::DefaultLocation);
 
   lanelet::ConstLanelets all_route_lanelets;
   lanelet::ConstLanelets preferred_lanelets;

--- a/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization_node.cpp
+++ b/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization_node.cpp
@@ -138,6 +138,12 @@ void Lanelet2MapVisualizationNode::on_map_bin(
   lanelet::ConstPolygons3d obstacle_removal_areas =
     lanelet::utils::query::getAllPolygonsByType(viz_lanelet_map, "obstacle_removal_area");
 
+  std::vector<lanelet::ConstArea> lanelet_areas;
+  lanelet_areas.reserve(viz_lanelet_map->areaLayer.size());
+  for (const auto & area : viz_lanelet_map->areaLayer) {
+    lanelet_areas.push_back(area);
+  }
+
   std_msgs::msg::ColorRGBA cl_road;
   std_msgs::msg::ColorRGBA cl_shoulder;
   std_msgs::msg::ColorRGBA cl_cross;
@@ -167,6 +173,8 @@ void Lanelet2MapVisualizationNode::on_map_bin(
   std_msgs::msg::ColorRGBA cl_bicycle_lane;
   std_msgs::msg::ColorRGBA cl_waypoints;
   std_msgs::msg::ColorRGBA cl_obstacle_removal_area;
+  std_msgs::msg::ColorRGBA cl_lanelet_routing_area;
+  std_msgs::msg::ColorRGBA cl_lanelet_routing_area_outline;
   set_color(&cl_road, 0.27, 0.27, 0.27, 0.999);
   set_color(&cl_shoulder, 0.15, 0.15, 0.15, 0.999);
   set_color(&cl_cross, 0.27, 0.3, 0.27, 0.5);
@@ -196,6 +204,9 @@ void Lanelet2MapVisualizationNode::on_map_bin(
   set_color(&cl_bicycle_lane, 0.0, 0.3843, 0.6274, 0.5);
   set_color(&cl_waypoints, 0.6, 0.4, 0.3, 0.999);
   set_color(&cl_obstacle_removal_area, 0.2, 0.2, 0.5, 0.5);
+  // Static map fill for areaLayer namespace lanelet_routing_area; darker edge in lanelet_routing_area_outline
+  set_color(&cl_lanelet_routing_area, 0.8, 0.53, 0.25, 0.35);
+  set_color(&cl_lanelet_routing_area_outline, 0.45, 0.28, 0.12, 0.95);
 
   visualization_msgs::msg::MarkerArray map_marker_array;
 
@@ -330,6 +341,10 @@ void Lanelet2MapVisualizationNode::on_map_bin(
   insert_marker_array(
     &map_marker_array, lanelet::visualization::obstacleRemovalAreaAsMarkerArray(
                          obstacle_removal_areas, cl_obstacle_removal_area));
+
+  insert_marker_array(
+    &map_marker_array, lanelet::visualization::laneletAreasAsMarkerArray(
+                         lanelet_areas, cl_lanelet_routing_area, cl_lanelet_routing_area_outline));
 
   pub_marker_->publish(map_marker_array);
 }

--- a/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization_node.cpp
+++ b/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization_node.cpp
@@ -204,7 +204,8 @@ void Lanelet2MapVisualizationNode::on_map_bin(
   set_color(&cl_bicycle_lane, 0.0, 0.3843, 0.6274, 0.5);
   set_color(&cl_waypoints, 0.6, 0.4, 0.3, 0.999);
   set_color(&cl_obstacle_removal_area, 0.2, 0.2, 0.5, 0.5);
-  // Static map fill for areaLayer namespace lanelet_routing_area; darker edge in lanelet_routing_area_outline
+  // Static map fill for areaLayer namespace lanelet_routing_area; darker edge in
+  // lanelet_routing_area_outline
   set_color(&cl_lanelet_routing_area, 0.8, 0.53, 0.25, 0.35);
   set_color(&cl_lanelet_routing_area_outline, 0.45, 0.28, 0.12, 0.95);
 

--- a/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization_node.cpp
+++ b/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization_node.cpp
@@ -138,12 +138,6 @@ void Lanelet2MapVisualizationNode::on_map_bin(
   lanelet::ConstPolygons3d obstacle_removal_areas =
     lanelet::utils::query::getAllPolygonsByType(viz_lanelet_map, "obstacle_removal_area");
 
-  std::vector<lanelet::ConstArea> lanelet_areas;
-  lanelet_areas.reserve(viz_lanelet_map->areaLayer.size());
-  for (const auto & area : viz_lanelet_map->areaLayer) {
-    lanelet_areas.push_back(area);
-  }
-
   std_msgs::msg::ColorRGBA cl_road;
   std_msgs::msg::ColorRGBA cl_shoulder;
   std_msgs::msg::ColorRGBA cl_cross;
@@ -173,8 +167,6 @@ void Lanelet2MapVisualizationNode::on_map_bin(
   std_msgs::msg::ColorRGBA cl_bicycle_lane;
   std_msgs::msg::ColorRGBA cl_waypoints;
   std_msgs::msg::ColorRGBA cl_obstacle_removal_area;
-  std_msgs::msg::ColorRGBA cl_lanelet_routing_area;
-  std_msgs::msg::ColorRGBA cl_lanelet_routing_area_outline;
   set_color(&cl_road, 0.27, 0.27, 0.27, 0.999);
   set_color(&cl_shoulder, 0.15, 0.15, 0.15, 0.999);
   set_color(&cl_cross, 0.27, 0.3, 0.27, 0.5);
@@ -204,10 +196,6 @@ void Lanelet2MapVisualizationNode::on_map_bin(
   set_color(&cl_bicycle_lane, 0.0, 0.3843, 0.6274, 0.5);
   set_color(&cl_waypoints, 0.6, 0.4, 0.3, 0.999);
   set_color(&cl_obstacle_removal_area, 0.2, 0.2, 0.5, 0.5);
-  // Static map fill for areaLayer namespace lanelet_routing_area; darker edge in
-  // lanelet_routing_area_outline
-  set_color(&cl_lanelet_routing_area, 0.8, 0.53, 0.25, 0.35);
-  set_color(&cl_lanelet_routing_area_outline, 0.45, 0.28, 0.12, 0.95);
 
   visualization_msgs::msg::MarkerArray map_marker_array;
 
@@ -342,10 +330,6 @@ void Lanelet2MapVisualizationNode::on_map_bin(
   insert_marker_array(
     &map_marker_array, lanelet::visualization::obstacleRemovalAreaAsMarkerArray(
                          obstacle_removal_areas, cl_obstacle_removal_area));
-
-  insert_marker_array(
-    &map_marker_array, lanelet::visualization::laneletAreasAsMarkerArray(
-                         lanelet_areas, cl_lanelet_routing_area, cl_lanelet_routing_area_outline));
 
   pub_marker_->publish(map_marker_array);
 }

--- a/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
+++ b/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
@@ -32,8 +32,8 @@
 #include <lanelet2_core/geometry/BoundingBox.h>
 #include <lanelet2_core/primitives/BoundingBox.h>
 #include <lanelet2_core/primitives/Lanelet.h>
-#include <lanelet2_core/primitives/Polygon.h>
 #include <lanelet2_core/primitives/LaneletOrArea.h>
+#include <lanelet2_core/primitives/Polygon.h>
 #include <lanelet2_routing/Forward.h>
 #include <lanelet2_routing/LaneletPath.h>
 #include <lanelet2_routing/RoutingCost.h>

--- a/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
+++ b/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
@@ -30,8 +30,8 @@
 #include <lanelet2_core/Forward.h>
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/BoundingBox.h>
-#include <lanelet2_core/primitives/BoundingBox.h>
 #include <lanelet2_core/primitives/Area.h>
+#include <lanelet2_core/primitives/BoundingBox.h>
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <lanelet2_core/primitives/LaneletOrArea.h>
 #include <lanelet2_core/primitives/Polygon.h>

--- a/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
+++ b/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
@@ -438,6 +438,19 @@ private:
     const lanelet::ConstLanelet & start_lanelet, const lanelet::ConstLanelet & goal_lanelet) const;
   std::optional<lanelet::routing::LaneletOrAreaPath> findDrivableLanePathIncludingAreas(
     const lanelet::ConstLanelet & start_lanelet, const lanelet::ConstLanelet & goal_lanelet) const;
+
+  lanelet::ConstLanelets getStartRoadLaneletsForCheckpoint(const Pose & start_checkpoint) const;
+  std::optional<lanelet::ConstLanelet> getGoalRoadLaneletForCheckpoint(
+    const Pose & goal_checkpoint) const;
+  bool planLaneletPathBetweenResolvedEndpoints(
+    const Pose & start_checkpoint, const Pose & goal_checkpoint,
+    const lanelet::ConstLanelets & start_lanelets, const lanelet::ConstLanelet & goal_lanelet,
+    const bool consider_no_drivable_lanes, lanelet::ConstLanelets * path_lanelets) const;
+  bool planLaneletOrAreaPathBetweenResolvedEndpoints(
+    const Pose & start_checkpoint, const Pose & goal_checkpoint,
+    const lanelet::ConstLanelets & start_lanelets, const lanelet::ConstLanelet & goal_lanelet,
+    const bool consider_no_drivable_lanes, lanelet::ConstLaneletOrAreas * path_lanelets_or_areas)
+    const;
 };
 
 /// @brief custom routing cost with infinity cost for no drivable lanes

--- a/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
+++ b/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
@@ -33,7 +33,9 @@
 #include <lanelet2_core/primitives/BoundingBox.h>
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <lanelet2_core/primitives/Polygon.h>
+#include <lanelet2_core/primitives/LaneletOrArea.h>
 #include <lanelet2_routing/Forward.h>
+#include <lanelet2_routing/LaneletPath.h>
 #include <lanelet2_routing/RoutingCost.h>
 #include <lanelet2_traffic_rules/TrafficRules.h>
 
@@ -110,6 +112,10 @@ public:
   bool planPathLaneletsBetweenCheckpoints(
     const Pose & start_checkpoint, const Pose & goal_checkpoint,
     lanelet::ConstLanelets * path_lanelets, const bool consider_no_drivable_lanes = false) const;
+  bool planPathLaneletsBetweenCheckpoints(
+    const Pose & start_checkpoint, const Pose & goal_checkpoint,
+    lanelet::ConstLaneletOrAreas * path_lanelets_or_areas,
+    const bool consider_no_drivable_lanes = false) const;
   std::vector<LaneletSegment> createMapSegments(const lanelet::ConstLanelets & path_lanelets) const;
   static bool isRouteLooped(const RouteSections & route_sections);
 
@@ -410,6 +416,7 @@ private:
    * include any.
    */
   bool hasNoDrivableLaneInPath(const lanelet::routing::LaneletPath & path) const;
+  bool hasNoDrivableLaneInPath(const lanelet::routing::LaneletOrAreaPath & path) const;
   /**
    * @brief Searches for the shortest path between start and goal lanelets that does not include any
    * no_drivable_lane.
@@ -418,6 +425,8 @@ private:
    * @return the lanelet path (if found)
    */
   std::optional<lanelet::routing::LaneletPath> findDrivableLanePath(
+    const lanelet::ConstLanelet & start_lanelet, const lanelet::ConstLanelet & goal_lanelet) const;
+  std::optional<lanelet::routing::LaneletOrAreaPath> findDrivableLanePathIncludingAreas(
     const lanelet::ConstLanelet & start_lanelet, const lanelet::ConstLanelet & goal_lanelet) const;
 };
 

--- a/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
+++ b/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
@@ -449,8 +449,8 @@ private:
   bool planLaneletOrAreaPathBetweenResolvedEndpoints(
     const Pose & start_checkpoint, const Pose & goal_checkpoint,
     const lanelet::ConstLanelets & start_lanelets, const lanelet::ConstLanelet & goal_lanelet,
-    const bool consider_no_drivable_lanes, lanelet::ConstLaneletOrAreas * path_lanelets_or_areas)
-    const;
+    const bool consider_no_drivable_lanes,
+    lanelet::ConstLaneletOrAreas * path_lanelets_or_areas) const;
 };
 
 /// @brief custom routing cost with infinity cost for no drivable lanes

--- a/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
+++ b/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
@@ -31,6 +31,7 @@
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/BoundingBox.h>
 #include <lanelet2_core/primitives/BoundingBox.h>
+#include <lanelet2_core/primitives/Area.h>
 #include <lanelet2_core/primitives/Lanelet.h>
 #include <lanelet2_core/primitives/LaneletOrArea.h>
 #include <lanelet2_core/primitives/Polygon.h>
@@ -117,6 +118,12 @@ public:
     lanelet::ConstLaneletOrAreas * path_lanelets_or_areas,
     const bool consider_no_drivable_lanes = false) const;
   std::vector<LaneletSegment> createMapSegments(const lanelet::ConstLanelets & path_lanelets) const;
+  /**
+   * @brief Build route segments from a planned path that may include drivable Areas.
+   * @note When the path contains no Areas, behavior matches createMapSegments(lane-only path).
+   */
+  std::vector<LaneletSegment> createMapSegmentsFromLaneletOrAreaPath(
+    const lanelet::ConstLaneletOrAreas & path) const;
   static bool isRouteLooped(const RouteSections & route_sections);
 
   // for goal
@@ -287,6 +294,7 @@ public:
     const double yaw_threshold) const;
 
   lanelet::ConstLanelet getLaneletsFromId(const lanelet::Id id) const;
+  lanelet::ConstArea getAreaFromId(const lanelet::Id id) const;
   lanelet::ConstLanelets getLaneletsFromIds(const lanelet::Ids & ids) const;
   lanelet::ConstLanelets getLaneletSequence(
     const lanelet::ConstLanelet & lanelet, const Pose & current_pose,
@@ -363,6 +371,7 @@ private:
   std::shared_ptr<const lanelet::routing::RoutingGraphContainer> overall_graphs_ptr_;
   lanelet::LaneletMapPtr lanelet_map_ptr_;
   lanelet::ConstLanelets route_lanelets_;
+  std::vector<lanelet::ConstArea> route_areas_;
   RouteRtree route_lanelets_rtree_;
   lanelet::ConstLanelets preferred_lanelets_;
   lanelet::ConstLanelets start_lanelets_;
@@ -383,6 +392,7 @@ private:
 
   // const methods
   // for routing
+  LaneletSegment makeLaneSegmentFromMainLanelet(const lanelet::ConstLanelet & main_llt) const;
   lanelet::ConstLanelets getMainLanelets(const lanelet::ConstLanelets & path_lanelets) const;
 
   // for lanelet

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -586,7 +586,7 @@ void RouteHandler::setLaneletsFromRouteMsg()
       start_lanelets_.push_back(llt);
     }
   }
-  
+
   is_handler_ready_ = true;
 }
 
@@ -2288,8 +2288,9 @@ std::optional<lanelet::ConstLanelet> RouteHandler::getGoalRoadLaneletForCheckpoi
   if (auto closest_lanelet = findGoalClosestPreferredLanelet()) {
     return closest_lanelet.value();
   }
-  if (const auto closest_lanelet =
-        experimental::lanelet2_utils::get_closest_lanelet(candidates, goal_checkpoint)) {
+  if (
+    const auto closest_lanelet =
+      experimental::lanelet2_utils::get_closest_lanelet(candidates, goal_checkpoint)) {
     return closest_lanelet.value();
   }
   return std::nullopt;
@@ -2382,8 +2383,8 @@ bool RouteHandler::planLaneletPathBetweenResolvedEndpoints(
 bool RouteHandler::planLaneletOrAreaPathBetweenResolvedEndpoints(
   const Pose & start_checkpoint, const Pose & goal_checkpoint,
   const lanelet::ConstLanelets & start_lanelets, const lanelet::ConstLanelet & goal_lanelet,
-  const bool consider_no_drivable_lanes, lanelet::ConstLaneletOrAreas * path_lanelets_or_areas)
-  const
+  const bool consider_no_drivable_lanes,
+  lanelet::ConstLaneletOrAreas * path_lanelets_or_areas) const
 {
   lanelet::Optional<lanelet::routing::LaneletOrAreaPath> optional_path;
   lanelet::routing::LaneletOrAreaPath shortest_path;

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -32,6 +32,7 @@
 
 #include <autoware_internal_planning_msgs/msg/path_point_with_lane_id.hpp>
 #include <autoware_planning_msgs/msg/lanelet_primitive.hpp>
+#include <autoware_planning_msgs/msg/lanelet_segment.hpp>
 #include <autoware_planning_msgs/msg/path.hpp>
 
 #include <boost/geometry/algorithms/detail/comparable_distance/interface.hpp>
@@ -71,6 +72,7 @@ using autoware::experimental::lanelet2_utils::is_bicycle_lane;
 using autoware_internal_planning_msgs::msg::PathPointWithLaneId;
 using autoware_internal_planning_msgs::msg::PathWithLaneId;
 using autoware_planning_msgs::msg::LaneletPrimitive;
+using autoware_planning_msgs::msg::LaneletSegment;
 using autoware_planning_msgs::msg::Path;
 using autoware_utils_geometry::create_point;
 using autoware_utils_geometry::create_quaternion_from_yaw;
@@ -95,6 +97,18 @@ bool exists(const lanelet::ConstLanelets & vectors, const lanelet::ConstLanelet 
     }
   }
   return false;
+}
+
+LaneletSegment make_area_segment(const lanelet::ConstArea & area)
+{
+  LaneletSegment seg;
+  seg.preferred_primitive.id = area.id();
+  seg.preferred_primitive.primitive_type = "area";
+  LaneletPrimitive p;
+  p.id = area.id();
+  p.primitive_type = "area";
+  seg.primitives.push_back(p);
+  return seg;
 }
 
 std::optional<geometry_msgs::msg::Point> getGeometryPointFrom2DArcLength(
@@ -491,6 +505,7 @@ void RouteHandler::setRouteLanelets(const lanelet::ConstLanelets & path_lanelets
 void RouteHandler::clearRoute()
 {
   route_lanelets_.clear();
+  route_areas_.clear();
   route_lanelets_rtree_.clear();
   preferred_lanelets_.clear();
   start_lanelets_.clear();
@@ -505,6 +520,7 @@ void RouteHandler::setLaneletsFromRouteMsg()
     return;
   }
   route_lanelets_.clear();
+  route_areas_.clear();
   route_lanelets_rtree_.clear();
   preferred_lanelets_.clear();
   const bool is_route_valid = lanelet::utils::route::isRouteValid(*route_ptr_, lanelet_map_ptr_);
@@ -512,46 +528,88 @@ void RouteHandler::setLaneletsFromRouteMsg()
     return;
   }
 
-  size_t primitive_size{0};
+  size_t lane_primitive_size = 0;
   for (const auto & route_section : route_ptr_->segments) {
-    primitive_size += route_section.primitives.size();
+    for (const auto & primitive : route_section.primitives) {
+      if (primitive.primitive_type != "area") {
+        ++lane_primitive_size;
+      }
+    }
   }
-  route_lanelets_.reserve(primitive_size);
+  route_lanelets_.reserve(lane_primitive_size);
   std::vector<RouteRtreeNode> rtree_nodes;
-  rtree_nodes.reserve(primitive_size);
+  rtree_nodes.reserve(lane_primitive_size);
   size_t i = 0;
+
+  const auto append_lane_primitive = [&](
+                                       const LaneletPrimitive & primitive,
+                                       const LaneletSegment & route_section) {
+    const auto id = primitive.id;
+    const auto & llt = lanelet_map_ptr_->laneletLayer.get(id);
+    route_lanelets_.push_back(llt);
+    rtree_nodes.emplace_back(
+      boost::geometry::return_envelope<autoware_utils_geometry::Box2d>(
+        llt.polygon2d().basicPolygon()),
+      i++);
+    if (id == route_section.preferred_primitive.id && primitive.primitive_type != "area") {
+      preferred_lanelets_.push_back(llt);
+    }
+  };
+
+  const auto append_area_primitive = [&](const LaneletPrimitive & primitive) {
+    const auto & ar = lanelet_map_ptr_->areaLayer.get(primitive.id);
+    route_areas_.push_back(ar);
+  };
 
   for (const auto & route_section : route_ptr_->segments) {
     for (const auto & primitive : route_section.primitives) {
-      const auto id = primitive.id;
-      const auto & llt = lanelet_map_ptr_->laneletLayer.get(id);
-      route_lanelets_.push_back(llt);
-      rtree_nodes.emplace_back(
-        boost::geometry::return_envelope<autoware_utils_geometry::Box2d>(
-          llt.polygon2d().basicPolygon()),
-        i++);
-      if (id == route_section.preferred_primitive.id) {
-        preferred_lanelets_.push_back(llt);
+      if (primitive.primitive_type == "area") {
+        append_area_primitive(primitive);
+      } else {
+        append_lane_primitive(primitive, route_section);
       }
     }
   }
   route_lanelets_rtree_ = RouteRtree(rtree_nodes);
+
+  const auto collect_lane_lanelets_from_segment =
+    [&](const autoware_planning_msgs::msg::LaneletSegment & seg, lanelet::ConstLanelets * out) {
+      for (const auto & primitive : seg.primitives) {
+        if (primitive.primitive_type == "area") {
+          continue;
+        }
+        out->push_back(lanelet_map_ptr_->laneletLayer.get(primitive.id));
+      }
+    };
+
   goal_lanelets_.clear();
   start_lanelets_.clear();
   if (!route_ptr_->segments.empty()) {
-    goal_lanelets_.reserve(route_ptr_->segments.back().primitives.size());
-    for (const auto & primitive : route_ptr_->segments.back().primitives) {
-      const auto id = primitive.id;
-      const auto & llt = lanelet_map_ptr_->laneletLayer.get(id);
-      goal_lanelets_.push_back(llt);
+    collect_lane_lanelets_from_segment(route_ptr_->segments.back(), &goal_lanelets_);
+    if (goal_lanelets_.empty()) {
+      for (auto it = route_ptr_->segments.rbegin(); it != route_ptr_->segments.rend(); ++it) {
+        collect_lane_lanelets_from_segment(*it, &goal_lanelets_);
+        if (!goal_lanelets_.empty()) {
+          break;
+        }
+      }
     }
-    start_lanelets_.reserve(route_ptr_->segments.front().primitives.size());
-    for (const auto & primitive : route_ptr_->segments.front().primitives) {
-      const auto id = primitive.id;
-      const auto & llt = lanelet_map_ptr_->laneletLayer.get(id);
-      start_lanelets_.push_back(llt);
+    collect_lane_lanelets_from_segment(route_ptr_->segments.front(), &start_lanelets_);
+    if (start_lanelets_.empty()) {
+      for (const auto & seg : route_ptr_->segments) {
+        collect_lane_lanelets_from_segment(seg, &start_lanelets_);
+        if (!start_lanelets_.empty()) {
+          break;
+        }
+      }
     }
   }
+
+  RCLCPP_DEBUG(
+    logger_,
+    "[Route Handler] setLaneletsFromRouteMsg: lane primitives=%zu, areas=%zu, segments=%zu",
+    route_lanelets_.size(), route_areas_.size(), route_ptr_->segments.size());
+
   is_handler_ready_ = true;
 }
 
@@ -689,6 +747,11 @@ lanelet::ConstLanelets RouteHandler::getLaneletsFromIds(const lanelet::Ids & ids
 lanelet::ConstLanelet RouteHandler::getLaneletsFromId(const lanelet::Id id) const
 {
   return lanelet_map_ptr_->laneletLayer.get(id);
+}
+
+lanelet::ConstArea RouteHandler::getAreaFromId(const lanelet::Id id) const
+{
+  return lanelet_map_ptr_->areaLayer.get(id);
 }
 
 bool RouteHandler::isDeadEndLanelet(const lanelet::ConstLanelet & lanelet) const
@@ -2343,6 +2406,23 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
   return is_route_found;
 }
 
+LaneletSegment RouteHandler::makeLaneSegmentFromMainLanelet(
+  const lanelet::ConstLanelet & main_llt) const
+{
+  LaneletSegment route_section_msg;
+  route_section_msg.preferred_primitive.id = main_llt.id();
+  route_section_msg.preferred_primitive.primitive_type = "lane";
+  const lanelet::ConstLanelets route_section_lanelets = getNeighborsWithinRoute(main_llt);
+  route_section_msg.primitives.reserve(route_section_lanelets.size());
+  for (const auto & section_llt : route_section_lanelets) {
+    LaneletPrimitive p;
+    p.id = section_llt.id();
+    p.primitive_type = "lane";
+    route_section_msg.primitives.push_back(p);
+  }
+  return route_section_msg;
+}
+
 std::vector<LaneletSegment> RouteHandler::createMapSegments(
   const lanelet::ConstLanelets & path_lanelets) const
 {
@@ -2356,19 +2436,85 @@ std::vector<LaneletSegment> RouteHandler::createMapSegments(
 
   route_sections.reserve(main_path.size());
   for (const auto & main_llt : main_path) {
-    LaneletSegment route_section_msg;
-    const lanelet::ConstLanelets route_section_lanelets = getNeighborsWithinRoute(main_llt);
-    route_section_msg.preferred_primitive.id = main_llt.id();
-    route_section_msg.primitives.reserve(route_section_lanelets.size());
-    for (const auto & section_llt : route_section_lanelets) {
-      LaneletPrimitive p;
-      p.id = section_llt.id();
-      p.primitive_type = "lane";
-      route_section_msg.primitives.push_back(p);
-    }
-    route_sections.push_back(route_section_msg);
+    route_sections.push_back(makeLaneSegmentFromMainLanelet(main_llt));
   }
   return route_sections;
+}
+
+std::vector<LaneletSegment> RouteHandler::createMapSegmentsFromLaneletOrAreaPath(
+  const lanelet::ConstLaneletOrAreas & path) const
+{
+  lanelet::ConstLanelets lane_only;
+  lane_only.reserve(path.size());
+  bool has_area = false;
+  for (const auto & elem : path) {
+    if (elem.isLanelet()) {
+      lane_only.push_back(static_cast<const lanelet::ConstLanelet &>(elem));
+    } else if (elem.isArea()) {
+      has_area = true;
+    }
+  }
+
+  if (!has_area) {
+    return createMapSegments(lane_only);
+  }
+
+  if (lane_only.empty()) {
+    std::vector<LaneletSegment> out;
+    out.reserve(path.size());
+    for (const auto & elem : path) {
+      if (elem.isArea()) {
+        out.push_back(
+          make_area_segment(static_cast<const lanelet::ConstArea &>(elem)));
+      }
+    }
+    RCLCPP_DEBUG(
+      logger_, "[Route Handler] createMapSegmentsFromLaneletOrAreaPath: area-only path, "
+               "segments=%zu",
+      out.size());
+    return out;
+  }
+
+  const auto main_path = getMainLanelets(lane_only);
+  std::vector<LaneletSegment> lane_segments;
+  lane_segments.reserve(main_path.size());
+  for (const auto & main_llt : main_path) {
+    lane_segments.push_back(makeLaneSegmentFromMainLanelet(main_llt));
+  }
+
+  std::vector<LaneletSegment> out;
+  out.reserve(path.size());
+  size_t main_idx = 0;
+
+  for (const auto & elem : path) {
+    if (elem.isArea()) {
+      out.push_back(make_area_segment(static_cast<const lanelet::ConstArea &>(elem)));
+      RCLCPP_DEBUG(
+        logger_, "[Route Handler] createMapSegmentsFromLaneletOrAreaPath: area id=%ld",
+        elem.id());
+      continue;
+    }
+    const auto & ll = static_cast<const lanelet::ConstLanelet &>(elem);
+    if (main_idx < main_path.size() && ll.id() == main_path[main_idx].id()) {
+      out.push_back(lane_segments[main_idx]);
+      ++main_idx;
+      RCLCPP_DEBUG(
+        logger_, "[Route Handler] createMapSegmentsFromLaneletOrAreaPath: main lane id=%ld",
+        ll.id());
+    } else {
+      out.push_back(makeLaneSegmentFromMainLanelet(ll));
+      RCLCPP_DEBUG(
+        logger_, "[Route Handler] createMapSegmentsFromLaneletOrAreaPath: non-main lane id=%ld",
+        ll.id());
+    }
+  }
+
+  RCLCPP_DEBUG(
+    logger_,
+    "[Route Handler] createMapSegmentsFromLaneletOrAreaPath: segments=%zu (lane_only main=%zu)",
+    out.size(), main_path.size());
+
+  return out;
 }
 
 lanelet::ConstLanelets RouteHandler::getMainLanelets(

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -570,45 +570,23 @@ void RouteHandler::setLaneletsFromRouteMsg()
     }
   }
   route_lanelets_rtree_ = RouteRtree(rtree_nodes);
-
-  const auto collect_lane_lanelets_from_segment =
-    [&](const autoware_planning_msgs::msg::LaneletSegment & seg, lanelet::ConstLanelets * out) {
-      for (const auto & primitive : seg.primitives) {
-        if (primitive.primitive_type == "area") {
-          continue;
-        }
-        out->push_back(lanelet_map_ptr_->laneletLayer.get(primitive.id));
-      }
-    };
-
   goal_lanelets_.clear();
   start_lanelets_.clear();
   if (!route_ptr_->segments.empty()) {
-    collect_lane_lanelets_from_segment(route_ptr_->segments.back(), &goal_lanelets_);
-    if (goal_lanelets_.empty()) {
-      for (auto it = route_ptr_->segments.rbegin(); it != route_ptr_->segments.rend(); ++it) {
-        collect_lane_lanelets_from_segment(*it, &goal_lanelets_);
-        if (!goal_lanelets_.empty()) {
-          break;
-        }
-      }
+    goal_lanelets_.reserve(route_ptr_->segments.back().primitives.size());
+    for (const auto & primitive : route_ptr_->segments.back().primitives) {
+      const auto id = primitive.id;
+      const auto & llt = lanelet_map_ptr_->laneletLayer.get(id);
+      goal_lanelets_.push_back(llt);
     }
-    collect_lane_lanelets_from_segment(route_ptr_->segments.front(), &start_lanelets_);
-    if (start_lanelets_.empty()) {
-      for (const auto & seg : route_ptr_->segments) {
-        collect_lane_lanelets_from_segment(seg, &start_lanelets_);
-        if (!start_lanelets_.empty()) {
-          break;
-        }
-      }
+    start_lanelets_.reserve(route_ptr_->segments.front().primitives.size());
+    for (const auto & primitive : route_ptr_->segments.front().primitives) {
+      const auto id = primitive.id;
+      const auto & llt = lanelet_map_ptr_->laneletLayer.get(id);
+      start_lanelets_.push_back(llt);
     }
   }
-
-  RCLCPP_DEBUG(
-    logger_,
-    "[Route Handler] setLaneletsFromRouteMsg: lane primitives=%zu, areas=%zu, segments=%zu",
-    route_lanelets_.size(), route_areas_.size(), route_ptr_->segments.size());
-
+  
   is_handler_ready_ = true;
 }
 
@@ -2310,9 +2288,8 @@ std::optional<lanelet::ConstLanelet> RouteHandler::getGoalRoadLaneletForCheckpoi
   if (auto closest_lanelet = findGoalClosestPreferredLanelet()) {
     return closest_lanelet.value();
   }
-  if (
-    const auto closest_lanelet =
-      experimental::lanelet2_utils::get_closest_lanelet(candidates, goal_checkpoint)) {
+  if (const auto closest_lanelet =
+        experimental::lanelet2_utils::get_closest_lanelet(candidates, goal_checkpoint)) {
     return closest_lanelet.value();
   }
   return std::nullopt;
@@ -2405,8 +2382,8 @@ bool RouteHandler::planLaneletPathBetweenResolvedEndpoints(
 bool RouteHandler::planLaneletOrAreaPathBetweenResolvedEndpoints(
   const Pose & start_checkpoint, const Pose & goal_checkpoint,
   const lanelet::ConstLanelets & start_lanelets, const lanelet::ConstLanelet & goal_lanelet,
-  const bool consider_no_drivable_lanes,
-  lanelet::ConstLaneletOrAreas * path_lanelets_or_areas) const
+  const bool consider_no_drivable_lanes, lanelet::ConstLaneletOrAreas * path_lanelets_or_areas)
+  const
 {
   lanelet::Optional<lanelet::routing::LaneletOrAreaPath> optional_path;
   lanelet::routing::LaneletOrAreaPath shortest_path;

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -541,20 +541,19 @@ void RouteHandler::setLaneletsFromRouteMsg()
   rtree_nodes.reserve(lane_primitive_size);
   size_t i = 0;
 
-  const auto append_lane_primitive = [&](
-                                       const LaneletPrimitive & primitive,
-                                       const LaneletSegment & route_section) {
-    const auto id = primitive.id;
-    const auto & llt = lanelet_map_ptr_->laneletLayer.get(id);
-    route_lanelets_.push_back(llt);
-    rtree_nodes.emplace_back(
-      boost::geometry::return_envelope<autoware_utils_geometry::Box2d>(
-        llt.polygon2d().basicPolygon()),
-      i++);
-    if (id == route_section.preferred_primitive.id && primitive.primitive_type != "area") {
-      preferred_lanelets_.push_back(llt);
-    }
-  };
+  const auto append_lane_primitive =
+    [&](const LaneletPrimitive & primitive, const LaneletSegment & route_section) {
+      const auto id = primitive.id;
+      const auto & llt = lanelet_map_ptr_->laneletLayer.get(id);
+      route_lanelets_.push_back(llt);
+      rtree_nodes.emplace_back(
+        boost::geometry::return_envelope<autoware_utils_geometry::Box2d>(
+          llt.polygon2d().basicPolygon()),
+        i++);
+      if (id == route_section.preferred_primitive.id && primitive.primitive_type != "area") {
+        preferred_lanelets_.push_back(llt);
+      }
+    };
 
   const auto append_area_primitive = [&](const LaneletPrimitive & primitive) {
     const auto & ar = lanelet_map_ptr_->areaLayer.get(primitive.id);
@@ -2464,13 +2463,13 @@ std::vector<LaneletSegment> RouteHandler::createMapSegmentsFromLaneletOrAreaPath
     out.reserve(path.size());
     for (const auto & elem : path) {
       if (elem.isArea()) {
-        out.push_back(
-          make_area_segment(static_cast<const lanelet::ConstArea &>(elem)));
+        out.push_back(make_area_segment(static_cast<const lanelet::ConstArea &>(elem)));
       }
     }
     RCLCPP_DEBUG(
-      logger_, "[Route Handler] createMapSegmentsFromLaneletOrAreaPath: area-only path, "
-               "segments=%zu",
+      logger_,
+      "[Route Handler] createMapSegmentsFromLaneletOrAreaPath: area-only path, "
+      "segments=%zu",
       out.size());
     return out;
   }
@@ -2490,8 +2489,7 @@ std::vector<LaneletSegment> RouteHandler::createMapSegmentsFromLaneletOrAreaPath
     if (elem.isArea()) {
       out.push_back(make_area_segment(static_cast<const lanelet::ConstArea &>(elem)));
       RCLCPP_DEBUG(
-        logger_, "[Route Handler] createMapSegmentsFromLaneletOrAreaPath: area id=%ld",
-        elem.id());
+        logger_, "[Route Handler] createMapSegmentsFromLaneletOrAreaPath: area id=%ld", elem.id());
       continue;
     }
     const auto & ll = static_cast<const lanelet::ConstLanelet &>(elem);

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -2286,12 +2286,12 @@ std::optional<lanelet::ConstLanelet> RouteHandler::getGoalRoadLaneletForCheckpoi
     return std::nullopt;
   };
   if (auto closest_lanelet = findGoalClosestPreferredLanelet()) {
-    return closest_lanelet.value();
+    return closest_lanelet;
   }
   if (
     const auto closest_lanelet =
       experimental::lanelet2_utils::get_closest_lanelet(candidates, goal_checkpoint)) {
-    return closest_lanelet.value();
+    return closest_lanelet;
   }
   return std::nullopt;
 }

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -2230,9 +2230,8 @@ lanelet::ConstLanelets RouteHandler::getNeighborsWithinRoute(
   return neighbors_within_route;
 }
 
-bool RouteHandler::planPathLaneletsBetweenCheckpoints(
-  const Pose & start_checkpoint, const Pose & goal_checkpoint,
-  lanelet::ConstLanelets * path_lanelets, const bool consider_no_drivable_lanes) const
+lanelet::ConstLanelets RouteHandler::getStartRoadLaneletsForCheckpoint(
+  const Pose & start_checkpoint) const
 {
   // Find lanelets for start point. First, find all lanelets containing the start point to
   // calculate all possible route later. It fails when the point is not located on any road
@@ -2260,17 +2259,13 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
       start_lanelets = {start_lanelet};
     }
   }
-  if (start_lanelets.empty()) {
-    RCLCPP_WARN_STREAM(
-      logger_, "Failed to find current lanelet."
-                 << std::endl
-                 << " - start checkpoint: " << toString(start_checkpoint) << std::endl
-                 << " - goal checkpoint: " << toString(goal_checkpoint) << std::endl);
-    return false;
-  }
+  return start_lanelets;
+}
 
-  // Find lanelets for goal point.
-  lanelet::ConstLanelet goal_lanelet;
+std::optional<lanelet::ConstLanelet> RouteHandler::getGoalRoadLaneletForCheckpoint(
+  const Pose & goal_checkpoint) const
+{
+  constexpr auto max_search_range = 20.0;
   const lanelet::BasicPoint2d p(goal_checkpoint.position.x, goal_checkpoint.position.y);
   const lanelet::BoundingBox2d bbox(
     lanelet::BasicPoint2d(p.x() - max_search_range, p.y() - max_search_range),
@@ -2313,21 +2308,20 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
     return std::nullopt;
   };
   if (auto closest_lanelet = findGoalClosestPreferredLanelet()) {
-    goal_lanelet = closest_lanelet.value();
-  } else {
-    closest_lanelet =
-      experimental::lanelet2_utils::get_closest_lanelet(candidates, goal_checkpoint);
-    if (!closest_lanelet) {
-      RCLCPP_WARN_STREAM(
-        logger_, "Failed to find closest lanelet."
-                   << std::endl
-                   << " - start checkpoint: " << toString(start_checkpoint) << std::endl
-                   << " - goal checkpoint: " << toString(goal_checkpoint) << std::endl);
-      return false;
-    }
-    goal_lanelet = closest_lanelet.value();
+    return closest_lanelet.value();
   }
+  if (const auto closest_lanelet =
+        experimental::lanelet2_utils::get_closest_lanelet(candidates, goal_checkpoint)) {
+    return closest_lanelet.value();
+  }
+  return std::nullopt;
+}
 
+bool RouteHandler::planLaneletPathBetweenResolvedEndpoints(
+  const Pose & start_checkpoint, const Pose & goal_checkpoint,
+  const lanelet::ConstLanelets & start_lanelets, const lanelet::ConstLanelet & goal_lanelet,
+  const bool consider_no_drivable_lanes, lanelet::ConstLanelets * path_lanelets) const
+{
   lanelet::Optional<lanelet::routing::Route> optional_route;
   lanelet::routing::LaneletPath shortest_path;
   bool is_route_found = false;
@@ -2335,6 +2329,8 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
   double min_route_cost = std::numeric_limits<double>::max();
   constexpr double yaw_threshold = M_PI / 2.0;
   constexpr double angle_diff_weight = 1000.0;
+
+  lanelet::ConstLanelet start_lanelet;
 
   for (const auto & st_llt : start_lanelets) {
     // check if the angle difference between start_checkpoint and start lanelet center line
@@ -2403,6 +2399,127 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
   }
 
   return is_route_found;
+}
+
+bool RouteHandler::planLaneletOrAreaPathBetweenResolvedEndpoints(
+  const Pose & start_checkpoint, const Pose & goal_checkpoint,
+  const lanelet::ConstLanelets & start_lanelets, const lanelet::ConstLanelet & goal_lanelet,
+  const bool consider_no_drivable_lanes, lanelet::ConstLaneletOrAreas * path_lanelets_or_areas)
+  const
+{
+  lanelet::Optional<lanelet::routing::LaneletOrAreaPath> optional_path;
+  lanelet::routing::LaneletOrAreaPath shortest_path;
+  bool is_route_found = false;
+
+  double min_route_cost = std::numeric_limits<double>::max();
+  constexpr double yaw_threshold = M_PI / 2.0;
+  constexpr double angle_diff_weight = 1000.0;
+
+  lanelet::ConstLanelet start_lanelet;
+
+  for (const auto & st_llt : start_lanelets) {
+    double lanelet_angle = autoware::experimental::lanelet2_utils::get_lanelet_angle(
+      st_llt,
+      autoware::experimental::lanelet2_utils::from_ros(start_checkpoint.position).basicPoint());
+    double pose_yaw = tf2::getYaw(start_checkpoint.orientation);
+    double angle_diff = std::abs(autoware_utils_math::normalize_radian(lanelet_angle - pose_yaw));
+
+    bool is_proper_angle = angle_diff <= std::abs(yaw_threshold);
+
+    optional_path = routing_graph_ptr_->shortestPathIncludingAreas(st_llt, goal_lanelet, 0);
+    if (!optional_path || !is_proper_angle) {
+      RCLCPP_DEBUG_STREAM(
+        logger_, "Failed to find a proper route!"
+                   << std::endl
+                   << " - start checkpoint: " << toString(start_checkpoint) << std::endl
+                   << " - goal checkpoint: " << toString(goal_checkpoint) << std::endl
+                   << " - start lane id: " << st_llt.id() << std::endl
+                   << " - goal lane id: " << goal_lanelet.id() << std::endl);
+      continue;
+    }
+    is_route_found = true;
+    if (const auto preferred_lane = getClosestPreferredLaneletWithinRoute(start_checkpoint)) {
+      if (st_llt.id() == preferred_lane.value().id()) {
+        shortest_path = *optional_path;
+        start_lanelet = st_llt;
+        break;
+      }
+    }
+    // compute path length
+    double optional_path_length = 0.0;
+    for (const auto & elem : *optional_path) {
+      if (elem.isLanelet()) {
+        optional_path_length +=
+          lanelet::geometry::length2d(static_cast<const lanelet::ConstLanelet &>(elem));
+      }
+      // Areas do not have a centerline length; skip them in length calculation.
+    }
+    const double optional_route_cost = optional_path_length + angle_diff_weight * angle_diff;
+    RCLCPP_DEBUG(
+      logger_, "Lanelet ID %ld: Route length = %.1f, Angle Diff = %.4f rad, Route cost = %.2f",
+      st_llt.id(), optional_path_length, angle_diff, optional_route_cost);
+    if (optional_route_cost < min_route_cost) {
+      min_route_cost = optional_route_cost;
+      shortest_path = *optional_path;
+      start_lanelet = st_llt;
+    }
+  }
+
+  if (is_route_found) {
+    lanelet::routing::LaneletOrAreaPath path;
+    path = [&]() -> lanelet::routing::LaneletOrAreaPath {
+      if (consider_no_drivable_lanes && hasNoDrivableLaneInPath(shortest_path)) {
+        const auto drivable_lane_path =
+          findDrivableLanePathIncludingAreas(start_lanelet, goal_lanelet);
+        if (drivable_lane_path) return *drivable_lane_path;
+      }
+      return shortest_path;
+    }();
+
+    path_lanelets_or_areas->reserve(path.size());
+    for (const auto & elem : path) {
+      path_lanelets_or_areas->push_back(elem);
+    }
+  } else {
+    RCLCPP_ERROR_STREAM(
+      logger_, "Failed to find a proper route!"
+                 << std::endl
+                 << " - start checkpoint: " << toString(start_checkpoint) << std::endl
+                 << " - goal checkpoint: " << toString(goal_checkpoint) << std::endl
+                 << " - start lane ids: " << convertLaneletsIdToString(start_lanelets) << std::endl
+                 << " - goal lane id: " << goal_lanelet.id() << std::endl);
+  }
+
+  return is_route_found;
+}
+
+bool RouteHandler::planPathLaneletsBetweenCheckpoints(
+  const Pose & start_checkpoint, const Pose & goal_checkpoint,
+  lanelet::ConstLanelets * path_lanelets, const bool consider_no_drivable_lanes) const
+{
+  const auto start_lanelets = getStartRoadLaneletsForCheckpoint(start_checkpoint);
+  if (start_lanelets.empty()) {
+    RCLCPP_WARN_STREAM(
+      logger_, "Failed to find current lanelet."
+                 << std::endl
+                 << " - start checkpoint: " << toString(start_checkpoint) << std::endl
+                 << " - goal checkpoint: " << toString(goal_checkpoint) << std::endl);
+    return false;
+  }
+
+  const auto goal_lanelet = getGoalRoadLaneletForCheckpoint(goal_checkpoint);
+  if (!goal_lanelet) {
+    RCLCPP_WARN_STREAM(
+      logger_, "Failed to find closest lanelet."
+                 << std::endl
+                 << " - start checkpoint: " << toString(start_checkpoint) << std::endl
+                 << " - goal checkpoint: " << toString(goal_checkpoint) << std::endl);
+    return false;
+  }
+
+  return planLaneletPathBetweenResolvedEndpoints(
+    start_checkpoint, goal_checkpoint, start_lanelets, goal_lanelet.value(),
+    consider_no_drivable_lanes, path_lanelets);
 }
 
 LaneletSegment RouteHandler::makeLaneSegmentFromMainLanelet(
@@ -2582,32 +2699,7 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
   lanelet::ConstLaneletOrAreas * path_lanelets_or_areas,
   const bool consider_no_drivable_lanes) const
 {
-  // Find lanelets for start point. First, find all lanelets containing the start point to
-  // calculate all possible route later. It fails when the point is not located on any road
-  // lanelet (e.g. the start point is located out of any lanelets or road_shoulder lanelet which
-  // is not contained in road lanelet). In that case, find the closest lanelet instead (within
-  // some maximum range).
-  constexpr auto max_search_range = 20.0;
-  auto start_lanelets = getRoadLaneletsAtPose(start_checkpoint);
-  lanelet::ConstLanelet start_lanelet;
-  if (start_lanelets.empty()) {
-    const lanelet::BasicPoint2d p(start_checkpoint.position.x, start_checkpoint.position.y);
-    const lanelet::BoundingBox2d bbox(
-      lanelet::BasicPoint2d(p.x() - max_search_range, p.y() - max_search_range),
-      lanelet::BasicPoint2d(p.x() + max_search_range, p.y() + max_search_range));
-    // std::as_const(*ptr) to use the const version of the search function
-    auto candidates = std::as_const(*lanelet_map_ptr_).laneletLayer.search(bbox);
-    candidates.erase(
-      std::remove_if(
-        candidates.begin(), candidates.end(), [&](const auto & l) { return !isRoadLanelet(l); }),
-      candidates.end());
-    if (const auto closest_lanelet =
-          experimental::lanelet2_utils::get_closest_lanelet(candidates, start_checkpoint);
-        closest_lanelet) {
-      start_lanelet = closest_lanelet.value();
-      start_lanelets = {start_lanelet};
-    }
-  }
+  const auto start_lanelets = getStartRoadLaneletsForCheckpoint(start_checkpoint);
   if (start_lanelets.empty()) {
     RCLCPP_WARN_STREAM(
       logger_, "Failed to find current lanelet."
@@ -2617,144 +2709,19 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
     return false;
   }
 
-  // Find lanelets for goal point.
-  lanelet::ConstLanelet goal_lanelet;
-  const lanelet::BasicPoint2d p(goal_checkpoint.position.x, goal_checkpoint.position.y);
-  const lanelet::BoundingBox2d bbox(
-    lanelet::BasicPoint2d(p.x() - max_search_range, p.y() - max_search_range),
-    lanelet::BasicPoint2d(p.x() + max_search_range, p.y() + max_search_range));
-  auto candidates = std::as_const(*lanelet_map_ptr_).laneletLayer.search(bbox);
-  candidates.erase(
-    std::remove_if(
-      candidates.begin(), candidates.end(), [&](const auto & l) { return !isRoadLanelet(l); }),
-    candidates.end());
-  const auto findGoalClosestPreferredLanelet = [&]() -> std::optional<lanelet::ConstLanelet> {
-    if (const auto closest_lanelet = getClosestPreferredLaneletWithinRoute(goal_checkpoint)) {
-      if (std::find(candidates.begin(), candidates.end(), closest_lanelet) != candidates.end()) {
-        if (autoware::experimental::lanelet2_utils::is_in_lanelet(
-              goal_checkpoint, closest_lanelet.value())) {
-          return closest_lanelet;
-        }
-      }
-    }
-    lanelet::ConstLanelet closest_lanelet;
-    if (getClosestLaneletWithinRoute(goal_checkpoint, &closest_lanelet)) {
-      if (std::find(candidates.begin(), candidates.end(), closest_lanelet) != candidates.end()) {
-        if (autoware::experimental::lanelet2_utils::is_in_lanelet(
-              goal_checkpoint, closest_lanelet)) {
-          std::stringstream preferred_lanelets_str;
-          for (const auto & preferred_lanelet : preferred_lanelets_) {
-            preferred_lanelets_str << preferred_lanelet.id() << ", ";
-          }
-          RCLCPP_WARN(
-            logger_,
-            "Failed to find reroute on previous preferred lanelets %s, but on previous route "
-            "segment %ld still",
-            preferred_lanelets_str.str().c_str(), closest_lanelet.id());
-          return closest_lanelet;
-        }
-      }
-    }
-    return std::nullopt;
-  };
-  if (auto closest_lanelet = findGoalClosestPreferredLanelet()) {
-    goal_lanelet = closest_lanelet.value();
-  } else {
-    closest_lanelet =
-      experimental::lanelet2_utils::get_closest_lanelet(candidates, goal_checkpoint);
-    if (!closest_lanelet) {
-      RCLCPP_WARN_STREAM(
-        logger_, "Failed to find closest lanelet."
-                   << std::endl
-                   << " - start checkpoint: " << toString(start_checkpoint) << std::endl
-                   << " - goal checkpoint: " << toString(goal_checkpoint) << std::endl);
-      return false;
-    }
-    goal_lanelet = closest_lanelet.value();
-  }
-
-  lanelet::Optional<lanelet::routing::LaneletOrAreaPath> optional_path;
-  lanelet::routing::LaneletOrAreaPath shortest_path;
-  bool is_route_found = false;
-
-  double min_route_cost = std::numeric_limits<double>::max();
-  constexpr double yaw_threshold = M_PI / 2.0;
-  constexpr double angle_diff_weight = 1000.0;
-
-  for (const auto & st_llt : start_lanelets) {
-    double lanelet_angle = autoware::experimental::lanelet2_utils::get_lanelet_angle(
-      st_llt,
-      autoware::experimental::lanelet2_utils::from_ros(start_checkpoint.position).basicPoint());
-    double pose_yaw = tf2::getYaw(start_checkpoint.orientation);
-    double angle_diff = std::abs(autoware_utils_math::normalize_radian(lanelet_angle - pose_yaw));
-
-    bool is_proper_angle = angle_diff <= std::abs(yaw_threshold);
-
-    optional_path = routing_graph_ptr_->shortestPathIncludingAreas(st_llt, goal_lanelet, 0);
-    if (!optional_path || !is_proper_angle) {
-      RCLCPP_DEBUG_STREAM(
-        logger_, "Failed to find a proper route!"
-                   << std::endl
-                   << " - start checkpoint: " << toString(start_checkpoint) << std::endl
-                   << " - goal checkpoint: " << toString(goal_checkpoint) << std::endl
-                   << " - start lane id: " << st_llt.id() << std::endl
-                   << " - goal lane id: " << goal_lanelet.id() << std::endl);
-      continue;
-    }
-    is_route_found = true;
-    if (const auto preferred_lane = getClosestPreferredLaneletWithinRoute(start_checkpoint)) {
-      if (st_llt.id() == preferred_lane.value().id()) {
-        shortest_path = *optional_path;
-        start_lanelet = st_llt;
-        break;
-      }
-    }
-    // compute path length
-    double optional_path_length = 0.0;
-    for (const auto & elem : *optional_path) {
-      if (elem.isLanelet()) {
-        optional_path_length +=
-          lanelet::geometry::length2d(static_cast<const lanelet::ConstLanelet &>(elem));
-      }
-      // Areas do not have a centerline length; skip them in length calculation.
-    }
-    const double optional_route_cost = optional_path_length + angle_diff_weight * angle_diff;
-    RCLCPP_DEBUG(
-      logger_, "Lanelet ID %ld: Route length = %.1f, Angle Diff = %.4f rad, Route cost = %.2f",
-      st_llt.id(), optional_path_length, angle_diff, optional_route_cost);
-    if (optional_route_cost < min_route_cost) {
-      min_route_cost = optional_route_cost;
-      shortest_path = *optional_path;
-      start_lanelet = st_llt;
-    }
-  }
-
-  if (is_route_found) {
-    lanelet::routing::LaneletOrAreaPath path;
-    path = [&]() -> lanelet::routing::LaneletOrAreaPath {
-      if (consider_no_drivable_lanes && hasNoDrivableLaneInPath(shortest_path)) {
-        const auto drivable_lane_path =
-          findDrivableLanePathIncludingAreas(start_lanelet, goal_lanelet);
-        if (drivable_lane_path) return *drivable_lane_path;
-      }
-      return shortest_path;
-    }();
-
-    path_lanelets_or_areas->reserve(path.size());
-    for (const auto & elem : path) {
-      path_lanelets_or_areas->push_back(elem);
-    }
-  } else {
-    RCLCPP_ERROR_STREAM(
-      logger_, "Failed to find a proper route!"
+  const auto goal_lanelet = getGoalRoadLaneletForCheckpoint(goal_checkpoint);
+  if (!goal_lanelet) {
+    RCLCPP_WARN_STREAM(
+      logger_, "Failed to find closest lanelet."
                  << std::endl
                  << " - start checkpoint: " << toString(start_checkpoint) << std::endl
-                 << " - goal checkpoint: " << toString(goal_checkpoint) << std::endl
-                 << " - start lane ids: " << convertLaneletsIdToString(start_lanelets) << std::endl
-                 << " - goal lane id: " << goal_lanelet.id() << std::endl);
+                 << " - goal checkpoint: " << toString(goal_checkpoint) << std::endl);
+    return false;
   }
 
-  return is_route_found;
+  return planLaneletOrAreaPathBetweenResolvedEndpoints(
+    start_checkpoint, goal_checkpoint, start_lanelets, goal_lanelet.value(),
+    consider_no_drivable_lanes, path_lanelets_or_areas);
 }
 
 Pose RouteHandler::get_pose_from_2d_arc_length(

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -2310,8 +2310,9 @@ std::optional<lanelet::ConstLanelet> RouteHandler::getGoalRoadLaneletForCheckpoi
   if (auto closest_lanelet = findGoalClosestPreferredLanelet()) {
     return closest_lanelet.value();
   }
-  if (const auto closest_lanelet =
-        experimental::lanelet2_utils::get_closest_lanelet(candidates, goal_checkpoint)) {
+  if (
+    const auto closest_lanelet =
+      experimental::lanelet2_utils::get_closest_lanelet(candidates, goal_checkpoint)) {
     return closest_lanelet.value();
   }
   return std::nullopt;
@@ -2404,8 +2405,8 @@ bool RouteHandler::planLaneletPathBetweenResolvedEndpoints(
 bool RouteHandler::planLaneletOrAreaPathBetweenResolvedEndpoints(
   const Pose & start_checkpoint, const Pose & goal_checkpoint,
   const lanelet::ConstLanelets & start_lanelets, const lanelet::ConstLanelet & goal_lanelet,
-  const bool consider_no_drivable_lanes, lanelet::ConstLaneletOrAreas * path_lanelets_or_areas)
-  const
+  const bool consider_no_drivable_lanes,
+  lanelet::ConstLaneletOrAreas * path_lanelets_or_areas) const
 {
   lanelet::Optional<lanelet::routing::LaneletOrAreaPath> optional_path;
   lanelet::routing::LaneletOrAreaPath shortest_path;

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -22,6 +22,8 @@
 #include <autoware_lanelet2_extension/io/autoware_osm_parser.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/route_checker.hpp>
+#include <autoware_lanelet2_extension/utility/utilities.hpp>
+#include <autoware_lanelet2_extension/traffic_rules/autoware_traffic_rules.hpp>
 #include <autoware_utils_geometry/boost_geometry.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_utils_math/normalization.hpp>
@@ -42,6 +44,8 @@
 #include <lanelet2_core/primitives/BoundingBox.h>
 #include <lanelet2_core/primitives/LaneletSequence.h>
 #include <lanelet2_core/primitives/Point.h>
+#include <lanelet2_core/geometry/Area.h>
+#include <lanelet2_routing/LaneletPath.h>
 #include <lanelet2_routing/Route.h>
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_routing/RoutingGraphContainer.h>
@@ -303,7 +307,7 @@ void RouteHandler::setMap(const LaneletMapBin & map_msg)
     autoware::experimental::lanelet2_utils::from_autoware_map_msgs(map_msg));
   auto routing_graph_and_traffic_rules =
     autoware::experimental::lanelet2_utils::instantiate_routing_graph_and_traffic_rules(
-      lanelet_map_ptr_);
+      lanelet_map_ptr_, lanelet::autoware::DefaultLocation);
   routing_graph_ptr_ =
     autoware::experimental::lanelet2_utils::remove_const(routing_graph_and_traffic_rules.first);
   traffic_rules_ptr_ = routing_graph_and_traffic_rules.second;
@@ -2405,6 +2409,210 @@ std::optional<lanelet::routing::LaneletPath> RouteHandler::findDrivableLanePath(
   const auto route = drivable_routing_graph_ptr->getRoute(start_lanelet, goal_lanelet, 0);
   if (route) return route->shortestPath();
   return {};
+}
+
+std::optional<lanelet::routing::LaneletOrAreaPath>
+RouteHandler::findDrivableLanePathIncludingAreas(
+  const lanelet::ConstLanelet & start_lanelet, const lanelet::ConstLanelet & goal_lanelet) const
+{
+  const auto drivable_routing_graph_ptr = lanelet::routing::RoutingGraph::build(
+    *lanelet_map_ptr_, *traffic_rules_ptr_,
+    lanelet::routing::RoutingCostPtrs{std::make_shared<RoutingCostDrivable>()});
+  const auto result =
+    drivable_routing_graph_ptr->shortestPathIncludingAreas(start_lanelet, goal_lanelet, 0);
+  if (result) return *result;
+  return {};
+}
+
+bool RouteHandler::hasNoDrivableLaneInPath(const lanelet::routing::LaneletOrAreaPath & path) const
+{
+  for (const auto & llt_or_area : path) {
+    if (llt_or_area.isLanelet()) {
+      if (isNoDrivableLane(static_cast<const lanelet::ConstLanelet &>(llt_or_area))) return true;
+    }
+  }
+  return false;
+}
+
+bool RouteHandler::planPathLaneletsBetweenCheckpoints(
+  const Pose & start_checkpoint, const Pose & goal_checkpoint,
+  lanelet::ConstLaneletOrAreas * path_lanelets_or_areas,
+  const bool consider_no_drivable_lanes) const
+{
+  // Find lanelets for start point. First, find all lanelets containing the start point to
+  // calculate all possible route later. It fails when the point is not located on any road
+  // lanelet (e.g. the start point is located out of any lanelets or road_shoulder lanelet which
+  // is not contained in road lanelet). In that case, find the closest lanelet instead (within
+  // some maximum range).
+  constexpr auto max_search_range = 20.0;
+  auto start_lanelets = getRoadLaneletsAtPose(start_checkpoint);
+  lanelet::ConstLanelet start_lanelet;
+  if (start_lanelets.empty()) {
+    const lanelet::BasicPoint2d p(start_checkpoint.position.x, start_checkpoint.position.y);
+    const lanelet::BoundingBox2d bbox(
+      lanelet::BasicPoint2d(p.x() - max_search_range, p.y() - max_search_range),
+      lanelet::BasicPoint2d(p.x() + max_search_range, p.y() + max_search_range));
+    // std::as_const(*ptr) to use the const version of the search function
+    auto candidates = std::as_const(*lanelet_map_ptr_).laneletLayer.search(bbox);
+    candidates.erase(
+      std::remove_if(
+        candidates.begin(), candidates.end(), [&](const auto & l) { return !isRoadLanelet(l); }),
+      candidates.end());
+    if (const auto closest_lanelet =
+          experimental::lanelet2_utils::get_closest_lanelet(candidates, start_checkpoint);
+        closest_lanelet) {
+      start_lanelet = closest_lanelet.value();
+      start_lanelets = {start_lanelet};
+    }
+  }
+  if (start_lanelets.empty()) {
+    RCLCPP_WARN_STREAM(
+      logger_, "Failed to find current lanelet."
+                 << std::endl
+                 << " - start checkpoint: " << toString(start_checkpoint) << std::endl
+                 << " - goal checkpoint: " << toString(goal_checkpoint) << std::endl);
+    return false;
+  }
+
+  // Find lanelets for goal point.
+  lanelet::ConstLanelet goal_lanelet;
+  const lanelet::BasicPoint2d p(goal_checkpoint.position.x, goal_checkpoint.position.y);
+  const lanelet::BoundingBox2d bbox(
+    lanelet::BasicPoint2d(p.x() - max_search_range, p.y() - max_search_range),
+    lanelet::BasicPoint2d(p.x() + max_search_range, p.y() + max_search_range));
+  auto candidates = std::as_const(*lanelet_map_ptr_).laneletLayer.search(bbox);
+  candidates.erase(
+    std::remove_if(
+      candidates.begin(), candidates.end(), [&](const auto & l) { return !isRoadLanelet(l); }),
+    candidates.end());
+  const auto findGoalClosestPreferredLanelet = [&]() -> std::optional<lanelet::ConstLanelet> {
+    if (const auto closest_lanelet = getClosestPreferredLaneletWithinRoute(goal_checkpoint)) {
+      if (std::find(candidates.begin(), candidates.end(), closest_lanelet) != candidates.end()) {
+        if (autoware::experimental::lanelet2_utils::is_in_lanelet(
+              goal_checkpoint, closest_lanelet.value())) {
+          return closest_lanelet;
+        }
+      }
+    }
+    lanelet::ConstLanelet closest_lanelet;
+    if (getClosestLaneletWithinRoute(goal_checkpoint, &closest_lanelet)) {
+      if (std::find(candidates.begin(), candidates.end(), closest_lanelet) != candidates.end()) {
+        if (autoware::experimental::lanelet2_utils::is_in_lanelet(
+              goal_checkpoint, closest_lanelet)) {
+          std::stringstream preferred_lanelets_str;
+          for (const auto & preferred_lanelet : preferred_lanelets_) {
+            preferred_lanelets_str << preferred_lanelet.id() << ", ";
+          }
+          RCLCPP_WARN(
+            logger_,
+            "Failed to find reroute on previous preferred lanelets %s, but on previous route "
+            "segment %ld still",
+            preferred_lanelets_str.str().c_str(), closest_lanelet.id());
+          return closest_lanelet;
+        }
+      }
+    }
+    return std::nullopt;
+  };
+  if (auto closest_lanelet = findGoalClosestPreferredLanelet()) {
+    goal_lanelet = closest_lanelet.value();
+  } else {
+    closest_lanelet =
+      experimental::lanelet2_utils::get_closest_lanelet(candidates, goal_checkpoint);
+    if (!closest_lanelet) {
+      RCLCPP_WARN_STREAM(
+        logger_, "Failed to find closest lanelet."
+                   << std::endl
+                   << " - start checkpoint: " << toString(start_checkpoint) << std::endl
+                   << " - goal checkpoint: " << toString(goal_checkpoint) << std::endl);
+      return false;
+    }
+    goal_lanelet = closest_lanelet.value();
+  }
+
+  lanelet::Optional<lanelet::routing::LaneletOrAreaPath> optional_path;
+  lanelet::routing::LaneletOrAreaPath shortest_path;
+  bool is_route_found = false;
+
+  double min_route_cost = std::numeric_limits<double>::max();
+  constexpr double yaw_threshold = M_PI / 2.0;
+  constexpr double angle_diff_weight = 1000.0;
+
+  for (const auto & st_llt : start_lanelets) {
+    double lanelet_angle = autoware::experimental::lanelet2_utils::get_lanelet_angle(
+      st_llt,
+      autoware::experimental::lanelet2_utils::from_ros(start_checkpoint.position).basicPoint());
+    double pose_yaw = tf2::getYaw(start_checkpoint.orientation);
+    double angle_diff = std::abs(autoware_utils_math::normalize_radian(lanelet_angle - pose_yaw));
+
+    bool is_proper_angle = angle_diff <= std::abs(yaw_threshold);
+
+    optional_path =
+      routing_graph_ptr_->shortestPathIncludingAreas(st_llt, goal_lanelet, 0);
+    if (!optional_path || !is_proper_angle) {
+      RCLCPP_DEBUG_STREAM(
+        logger_, "Failed to find a proper route!"
+                   << std::endl
+                   << " - start checkpoint: " << toString(start_checkpoint) << std::endl
+                   << " - goal checkpoint: " << toString(goal_checkpoint) << std::endl
+                   << " - start lane id: " << st_llt.id() << std::endl
+                   << " - goal lane id: " << goal_lanelet.id() << std::endl);
+      continue;
+    }
+    is_route_found = true;
+    if (const auto preferred_lane = getClosestPreferredLaneletWithinRoute(start_checkpoint)) {
+      if (st_llt.id() == preferred_lane.value().id()) {
+        shortest_path = *optional_path;
+        start_lanelet = st_llt;
+        break;
+      }
+    }
+    // compute path length
+    double optional_path_length = 0.0;
+    for (const auto & elem : *optional_path) {
+      if (elem.isLanelet()) {
+        optional_path_length +=
+          lanelet::geometry::length2d(static_cast<const lanelet::ConstLanelet &>(elem));
+      }
+      // Areas do not have a centerline length; skip them in length calculation.
+    }
+    const double optional_route_cost = optional_path_length + angle_diff_weight * angle_diff;
+    RCLCPP_DEBUG(
+      logger_, "Lanelet ID %ld: Route length = %.1f, Angle Diff = %.4f rad, Route cost = %.2f",
+      st_llt.id(), optional_path_length, angle_diff, optional_route_cost);
+    if (optional_route_cost < min_route_cost) {
+      min_route_cost = optional_route_cost;
+      shortest_path = *optional_path;
+      start_lanelet = st_llt;
+    }
+  }
+
+  if (is_route_found) {
+    lanelet::routing::LaneletOrAreaPath path;
+    path = [&]() -> lanelet::routing::LaneletOrAreaPath {
+      if (consider_no_drivable_lanes && hasNoDrivableLaneInPath(shortest_path)) {
+        const auto drivable_lane_path =
+          findDrivableLanePathIncludingAreas(start_lanelet, goal_lanelet);
+        if (drivable_lane_path) return *drivable_lane_path;
+      }
+      return shortest_path;
+    }();
+
+    path_lanelets_or_areas->reserve(path.size());
+    for (const auto & elem : path) {
+      path_lanelets_or_areas->push_back(elem);
+    }
+  } else {
+    RCLCPP_ERROR_STREAM(
+      logger_, "Failed to find a proper route!"
+                 << std::endl
+                 << " - start checkpoint: " << toString(start_checkpoint) << std::endl
+                 << " - goal checkpoint: " << toString(goal_checkpoint) << std::endl
+                 << " - start lane ids: " << convertLaneletsIdToString(start_lanelets) << std::endl
+                 << " - goal lane id: " << goal_lanelet.id() << std::endl);
+  }
+
+  return is_route_found;
 }
 
 Pose RouteHandler::get_pose_from_2d_arc_length(

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -20,10 +20,10 @@
 #include <autoware/lanelet2_utils/nn_search.hpp>
 #include <autoware/lanelet2_utils/topology.hpp>
 #include <autoware_lanelet2_extension/io/autoware_osm_parser.hpp>
+#include <autoware_lanelet2_extension/traffic_rules/autoware_traffic_rules.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 #include <autoware_lanelet2_extension/utility/route_checker.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
-#include <autoware_lanelet2_extension/traffic_rules/autoware_traffic_rules.hpp>
 #include <autoware_utils_geometry/boost_geometry.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_utils_math/normalization.hpp>
@@ -39,12 +39,12 @@
 #include <boost/geometry/index/distance_predicates.hpp>
 #include <boost/geometry/index/predicates.hpp>
 
+#include <lanelet2_core/geometry/Area.h>
 #include <lanelet2_core/geometry/BoundingBox.h>
 #include <lanelet2_core/geometry/Lanelet.h>
 #include <lanelet2_core/primitives/BoundingBox.h>
 #include <lanelet2_core/primitives/LaneletSequence.h>
 #include <lanelet2_core/primitives/Point.h>
-#include <lanelet2_core/geometry/Area.h>
 #include <lanelet2_routing/LaneletPath.h>
 #include <lanelet2_routing/Route.h>
 #include <lanelet2_routing/RoutingGraph.h>
@@ -2411,8 +2411,7 @@ std::optional<lanelet::routing::LaneletPath> RouteHandler::findDrivableLanePath(
   return {};
 }
 
-std::optional<lanelet::routing::LaneletOrAreaPath>
-RouteHandler::findDrivableLanePathIncludingAreas(
+std::optional<lanelet::routing::LaneletOrAreaPath> RouteHandler::findDrivableLanePathIncludingAreas(
   const lanelet::ConstLanelet & start_lanelet, const lanelet::ConstLanelet & goal_lanelet) const
 {
   const auto drivable_routing_graph_ptr = lanelet::routing::RoutingGraph::build(
@@ -2547,8 +2546,7 @@ bool RouteHandler::planPathLaneletsBetweenCheckpoints(
 
     bool is_proper_angle = angle_diff <= std::abs(yaw_threshold);
 
-    optional_path =
-      routing_graph_ptr_->shortestPathIncludingAreas(st_llt, goal_lanelet, 0);
+    optional_path = routing_graph_ptr_->shortestPathIncludingAreas(st_llt, goal_lanelet, 0);
     if (!optional_path || !is_proper_angle) {
       RCLCPP_DEBUG_STREAM(
         logger_, "Failed to find a proper route!"


### PR DESCRIPTION
## Description

Enable **global routing through Lanelet2 Areas** by registering **`AutowareVehicle`** traffic rules (Areas passable per **GenericTrafficRules** / participant tags) and extending **`RouteHandler`** to plan with `shortestPathIncludingAreas`, build `LaneletSegment`s with `primitive_type == "area"`, and support drivable-lane fallbacks where needed. **Areas are connectors in the routing graph only**—no centerline or path inside the Area; lane legs stay lanelet-based.

## Related Links

**Related PRs**
- [autoware_core PR](https://github.com/autowarefoundation/autoware_core/pull/993)
- [autoware_lanelet2_extension PR](https://github.com/autowarefoundation/autoware_lanelet2_extension/pull/104/changes)
- [autoware_universe PR](https://github.com/autowarefoundation/autoware_universe/pull/12381)

**Issues**
TierIV Internal [Issue Link](https://tier4.atlassian.net/browse/T4DEV-51269)

**Design Documents**
Tier IV Internal [Design Document: Area Visualization](https://tier4.atlassian.net/wiki/spaces/SI/pages/5070815408/Detailed+Design+Document+Lanelet2+Routing+Area+Visualization+in+RViz)
Tier IV Internal [Design Document: Route Serach through Areas](https://tier4.atlassian.net/wiki/spaces/SI/pages/5077074153/Detailed+Design+Document+Lanelet2+Area+Support+for+Route+Finding)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- **Colcon** build of touched packages (`autoware_lanelet2_extension`, `autoware_route_handler`, and dependents as needed).  
- **Route handler / mission** tests or a minimal **L–A–L** map in sim, if available in-tree.
- Evaluator Results [link1](https://evaluation.tier4.jp/evaluation/reports/cc0b9e8e-52a2-53b9-b800-2398e8949fc3?project_id=prd_jt), [link2](https://evaluation.tier4.jp/evaluation/reports/27a7c480-59dc-581e-9f3b-a26f9a660a62?project_id=prd_jt), [link3](https://evaluation.tier4.jp/evaluation/reports/563bc244-631a-5ed6-a0c9-2ea5d4519af7?project_id=autoware_dev).

## Notes for reviewers

None.

## Interface changes

No new ROS topics or parameters in core. C++ RouteHandler (and related headers) gain overloads and helpers for area-inclusive paths and segment construction. Downstream LaneletRoute.segments may include primitive_type == "area" once the mission planner uses this pipeline (that wiring may be a separate PR).

## Effects on system behavior

Routes can traverse Areas as graph links, so some maps become plannable that were not before. 
Lane-only routes and maps without area-inclusive paths should match prior behavior. 
