### PR TITLE
fix(ndt_scan_matcher): add mutex lock when passing latest_ekf_position to map_update_module

### DIFF
--- a/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -231,7 +231,16 @@ void NDTScanMatcher::callback_timer()
 
   diagnostics_map_update_->add_key_value("timer_callback_time_stamp", ros_time_now.nanoseconds());
 
-  map_update_module_->callback_timer(is_activated_, latest_ekf_position_, diagnostics_map_update_);
+  // Avoid data race when reading and writing latest_ekf_position 
+  // from multiple threads
+  std::unique_lock<std::mutex> lock(latest_ekf_position_mtx_);
+
+  auto tmp_latest_ekf_position = latest_ekf_position_;
+
+  lock.unlock();
+
+  // Pass the copy of latest_ekf_position instead of the real one
+  map_update_module_->callback_timer(is_activated_, tmp_latest_ekf_position, diagnostics_map_update_);
 
   diagnostics_map_update_->publish(ros_time_now);
 }

--- a/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -231,7 +231,7 @@ void NDTScanMatcher::callback_timer()
 
   diagnostics_map_update_->add_key_value("timer_callback_time_stamp", ros_time_now.nanoseconds());
 
-  // Avoid data race when reading and writing latest_ekf_position 
+  // Avoid data race when reading and writing latest_ekf_position
   // from multiple threads
   std::unique_lock<std::mutex> lock(latest_ekf_position_mtx_);
 
@@ -240,7 +240,8 @@ void NDTScanMatcher::callback_timer()
   lock.unlock();
 
   // Pass the copy of latest_ekf_position instead of the real one
-  map_update_module_->callback_timer(is_activated_, tmp_latest_ekf_position, diagnostics_map_update_);
+  map_update_module_->callback_timer(
+    is_activated_, tmp_latest_ekf_position, diagnostics_map_update_);
 
   diagnostics_map_update_->publish(ros_time_now);
 }

--- a/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -233,11 +233,12 @@ void NDTScanMatcher::callback_timer()
 
   // Avoid data race when reading and writing latest_ekf_position
   // from multiple threads
-  std::unique_lock<std::mutex> lock(latest_ekf_position_mtx_);
-
-  auto tmp_latest_ekf_position = latest_ekf_position_;
-
-  lock.unlock();
+  // Copy latest_ekf_position under lock to avoid data race with callback_initial_pose
+  std::optional<geometry_msgs::msg::Point> tmp_latest_ekf_position;
+  {
+    std::lock_guard<std::mutex> lock(latest_ekf_position_mtx_);
+    tmp_latest_ekf_position = latest_ekf_position_;
+  }
 
   // Pass the copy of latest_ekf_position instead of the real one
   map_update_module_->callback_timer(


### PR DESCRIPTION
## Description
- This PR aims to fix a read/write data race on the variable latest_ekf_position_ of autoware_ndt_scan_matcher
- When the latest_ekf_position_ is passed to map_update_module (to update the surrounding point cloud map), its mutex is not locked. As a result, data race may occur if another thread tries to modify the variable.
- To avoid the data race, I added a lock guard, create a temporal copy of latest_ekf_position_, unlock the mutex, and pass the copy to map_update_module. 

## How was this PR tested?
- Tested on Autoware [rosbag replay simulation demo](https://autowarefoundation.github.io/autoware-documentation/main/demos/rosbag-replay-simulation/)  

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
