### PR TITLE
feat(default_adapi): revert the relaxation of route clear condition

### DIFF
--- a/api/autoware_default_adapi/config/default_adapi.param.yaml
+++ b/api/autoware_default_adapi/config/default_adapi.param.yaml
@@ -6,7 +6,6 @@
 
 /adapi/node/routing:
   ros__parameters:
-    stop_check_duration: 1.0
     diagnostic_updater:
       period: 1.0
       use_fqn: true

--- a/api/autoware_default_adapi/src/routing.cpp
+++ b/api/autoware_default_adapi/src/routing.cpp
@@ -51,10 +51,8 @@ namespace autoware::default_adapi
 {
 
 RoutingNode::RoutingNode(const rclcpp::NodeOptions & options)
-: Node("routing", options), diagnostics_(this), vehicle_stop_checker_(this)
+: Node("routing", options), diagnostics_(this)
 {
-  stop_check_duration_ = declare_parameter<double>("stop_check_duration");
-
   diagnostics_.setHardwareID("none");
   diagnostics_.add("state", this, &RoutingNode::diagnose_state);
 
@@ -123,7 +121,6 @@ RoutingNode::RoutingNode(const rclcpp::NodeOptions & options)
       autoware::component_interface_specs::system::ChangeOperationMode::name,
       AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE(), group_cli_);
 
-  is_autoware_control_ = false;
   is_auto_mode_ = false;
   state_.state = State::Message::UNKNOWN;
 }
@@ -169,7 +166,6 @@ void RoutingNode::change_stop_mode()
 
 void RoutingNode::on_operation_mode(const OperationModeState::Message::ConstSharedPtr msg)
 {
-  is_autoware_control_ = msg->is_autoware_control_enabled;
   is_auto_mode_ = msg->mode == OperationModeState::Message::AUTONOMOUS;
 }
 
@@ -206,13 +202,11 @@ void RoutingNode::on_clear_route(
 {
   // For safety, do not clear the route while it is in use.
   // https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-architecture-v1/interfaces/ad-api/list/api/routing/clear_route/
-  if (is_auto_mode_ && is_autoware_control_) {
-    if (!vehicle_stop_checker_.isVehicleStopped(stop_check_duration_)) {
-      res->status.success = false;
-      res->status.code = ResponseStatus::UNKNOWN;
-      res->status.message = "The route cannot be cleared while it is in use.";
-      return;
-    }
+  if (is_auto_mode_) {
+    res->status.success = false;
+    res->status.code = ResponseStatus::UNKNOWN;
+    res->status.message = "The route cannot be cleared while it is in use.";
+    return;
   }
 
   if (!cli_clear_route_->service_is_ready()) {

--- a/api/autoware_default_adapi/src/routing.hpp
+++ b/api/autoware_default_adapi/src/routing.hpp
@@ -87,14 +87,9 @@ private:
     const autoware::adapi_specs::routing::SetRoute::Service::Request::SharedPtr req,
     const autoware::adapi_specs::routing::SetRoute::Service::Response::SharedPtr res);
 
-  bool is_autoware_control_;
   bool is_auto_mode_;
   State::Message state_;
   diagnostic_updater::Updater diagnostics_;
-
-  // Stop check for route clear.
-  autoware::motion_utils::VehicleStopChecker vehicle_stop_checker_;
-  double stop_check_duration_;
 };
 
 }  // namespace autoware::default_adapi


### PR DESCRIPTION
## Description

Revert the relaxation of route clear condition. This is an additional measure to prevent unintended departures regardless of the diagnostics, as the planning module holds the route even after it has been cleared.

## Related links

- https://github.com/autowarefoundation/autoware_core/pull/1004#issue-4192771021

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
