### PR TITLE
test(autoware_trajectory): rename gtest cases to PascalCase

### DIFF
--- a/common/autoware_trajectory/test/test_add_offset.cpp
+++ b/common/autoware_trajectory/test/test_add_offset.cpp
@@ -63,7 +63,7 @@ static void expect_offset_at(
   EXPECT_NEAR(shifted.pose.position.z, original.pose.position.z + expected_offset.z(), tolerance);
 }
 
-TEST(add_offset, forward_offset_shifts_along_heading)
+TEST(AddOffset, ForwardOffsetShiftsAlongHeading)
 {
   // Straight trajectory along +x axis
   std::vector<TrajectoryPoint> points;
@@ -78,7 +78,7 @@ TEST(add_offset, forward_offset_shifts_along_heading)
   expect_offset_at(traj, traj.length(), forward_offset, 0.0);
 }
 
-TEST(add_offset, lateral_offset_shifts_to_left)
+TEST(AddOffset, LateralOffsetShiftsToLeft)
 {
   // Straight trajectory along +x axis
   std::vector<TrajectoryPoint> points;
@@ -93,7 +93,7 @@ TEST(add_offset, lateral_offset_shifts_to_left)
   expect_offset_at(traj, traj.length(), 0.0, lateral_offset);
 }
 
-TEST(add_offset, combined_offset_respects_heading_rotation)
+TEST(AddOffset, CombinedOffsetRespectsHeadingRotation)
 {
   // Trajectory with 90 degree heading (+y direction)
   std::vector<TrajectoryPoint> points;
@@ -110,7 +110,7 @@ TEST(add_offset, combined_offset_respects_heading_rotation)
   expect_offset_at(traj, traj.length(), forward_offset, lateral_offset);
 }
 
-TEST(add_offset, preserves_trajectory_length)
+TEST(AddOffset, PreservesTrajectoryLength)
 {
   std::vector<TrajectoryPoint> points;
   points.emplace_back(make_trajectory_point(0.0, 0.0));
@@ -124,7 +124,7 @@ TEST(add_offset, preserves_trajectory_length)
   EXPECT_NEAR(offset_traj.length(), traj.length(), 1e-6);
 }
 
-TEST(add_offset, zero_offset_returns_identical_trajectory)
+TEST(AddOffset, ZeroOffsetReturnsIdenticalTrajectory)
 {
   std::vector<TrajectoryPoint> points;
   points.emplace_back(make_trajectory_point(0.0, 0.0));
@@ -144,7 +144,7 @@ TEST(add_offset, zero_offset_returns_identical_trajectory)
   }
 }
 
-TEST(add_offset, negative_lateral_offset_shifts_right)
+TEST(AddOffset, NegativeLateralOffsetShiftsRight)
 {
   // Straight trajectory along +x axis
   std::vector<TrajectoryPoint> points;
@@ -159,7 +159,7 @@ TEST(add_offset, negative_lateral_offset_shifts_right)
   expect_offset_at(traj, traj.length(), 0.0, lateral_offset);
 }
 
-TEST(add_offset, single_point_combined_offset)
+TEST(AddOffset, SinglePointCombinedOffset)
 {
   // Single point trajectory at (1.0, 2.0, 0.5) with 45-degree yaw and 30-degree pitch
   const double yaw = M_PI_4;        // 45 degrees
@@ -184,7 +184,7 @@ TEST(add_offset, single_point_combined_offset)
   EXPECT_NEAR(offset_traj.length(), 0.0, 1e-9);
 }
 
-TEST(add_offset, vertical_offset_shifts_z_at_zero_pitch)
+TEST(AddOffset, VerticalOffsetShiftsZAtZeroPitch)
 {
   // Flat trajectory (zero pitch) along +x axis: offset_z should translate directly into global z
   std::vector<TrajectoryPoint> points;
@@ -199,7 +199,7 @@ TEST(add_offset, vertical_offset_shifts_z_at_zero_pitch)
   expect_offset_at(traj, traj.length(), 0.0, 0.0, offset_z);
 }
 
-TEST(add_offset, forward_offset_on_pitched_trajectory_shifts_z)
+TEST(AddOffset, ForwardOffsetOnPitchedTrajectoryShiftsZ)
 {
   // Pitched trajectory (nose-up 30 deg, heading 0): forward offset_x should lift the z
   const double pitch = M_PI / 6.0;  // 30 degrees nose-up
@@ -214,7 +214,7 @@ TEST(add_offset, forward_offset_on_pitched_trajectory_shifts_z)
   expect_offset_at(traj, 0.0, offset_x, 0.0, 0.0);
 }
 
-TEST(add_offset, explicit_zero_offset_z_matches_default_argument)
+TEST(AddOffset, ExplicitZeroOffsetZMatchesDefaultArgument)
 {
   // Verify that omitting offset_z behaves exactly the same as passing 0.0 explicitly.
   std::vector<TrajectoryPoint> points;
@@ -235,7 +235,7 @@ TEST(add_offset, explicit_zero_offset_z_matches_default_argument)
   }
 }
 
-TEST(add_offset, lateral_offset_on_rolled_trajectory_shifts_z)
+TEST(AddOffset, LateralOffsetOnRolledTrajectoryShiftsZ)
 {
   // With positive roll, a left offset should also move upward in the global frame.
   const double roll = M_PI / 6.0;  // 30 degrees

--- a/common/autoware_trajectory/test/test_build.cpp
+++ b/common/autoware_trajectory/test/test_build.cpp
@@ -78,32 +78,32 @@ autoware_planning_msgs::msg::PathPoint make_path_point(const double x, const dou
 }
 }  // namespace
 
-TEST(BuildFallback, point_single_point_succeeds)
+TEST(BuildFallback, PointSinglePointSucceeds)
 {
   expect_build_success_with_single_point(make_point(0.49, 0.59));
 }
 
-TEST(BuildFallback, pose_single_point_succeeds)
+TEST(BuildFallback, PoseSinglePointSucceeds)
 {
   expect_build_success_with_single_point(make_pose(0.49, 0.59));
 }
 
-TEST(BuildFallback, path_point_single_point_succeeds)
+TEST(BuildFallback, PathPointSinglePointSucceeds)
 {
   expect_build_success_with_single_point(make_path_point(0.49, 0.59));
 }
 
-TEST(BuildFallback, point_single_point_derivatives_are_safe)
+TEST(BuildFallback, PointSinglePointDerivativesAreSafe)
 {
   expect_single_point_derivatives_are_safe(make_point(0.49, 0.59));
 }
 
-TEST(BuildFallback, pose_single_point_derivatives_are_safe)
+TEST(BuildFallback, PoseSinglePointDerivativesAreSafe)
 {
   expect_single_point_derivatives_are_safe(make_pose(0.49, 0.59));
 }
 
-TEST(BuildFallback, path_point_single_point_derivatives_are_safe)
+TEST(BuildFallback, PathPointSinglePointDerivativesAreSafe)
 {
   expect_single_point_derivatives_are_safe(make_path_point(0.49, 0.59));
 }

--- a/common/autoware_trajectory/test/test_crossed.cpp
+++ b/common/autoware_trajectory/test/test_crossed.cpp
@@ -32,7 +32,7 @@ using autoware_utils_geometry::LineString2d;
 using autoware_utils_geometry::Point2d;
 using autoware_utils_geometry::Polygon2d;
 
-TEST(crossed, linestring)
+TEST(Crossed, Linestring)
 {
   std::vector<PathPointWithLaneId> points;
   {
@@ -77,7 +77,7 @@ TEST(crossed, linestring)
   }
 }
 
-TEST(crossed, open_polygon)
+TEST(Crossed, OpenPolygon)
 {
   std::vector<PathPointWithLaneId> points;
   {
@@ -142,7 +142,7 @@ TEST(crossed, open_polygon)
   }
 }
 
-TEST(crossed, closed_polygon)
+TEST(Crossed, ClosedPolygon)
 {
   std::vector<PathPointWithLaneId> points;
   {
@@ -207,7 +207,7 @@ TEST(crossed, closed_polygon)
   }
 }
 
-TEST(crossed, post_condition_001)
+TEST(Crossed, PostCondition001)
 {
   std::vector<PathPointWithLaneId> points;
   {

--- a/common/autoware_trajectory/test/test_helpers.cpp
+++ b/common/autoware_trajectory/test/test_helpers.cpp
@@ -18,7 +18,7 @@
 
 #include <vector>
 
-TEST(TestHelpers, crop_bases)
+TEST(TestHelpers, CropBases)
 {
   using autoware::experimental::trajectory::detail::crop_bases;
 

--- a/common/autoware_trajectory/test/test_interpolator.cpp
+++ b/common/autoware_trajectory/test/test_interpolator.cpp
@@ -60,7 +60,7 @@ using Interpolators = testing::Types<
 
 TYPED_TEST_SUITE(TestInterpolator, Interpolators, );
 
-TYPED_TEST(TestInterpolator, compute)
+TYPED_TEST(TestInterpolator, Compute)
 {
   this->interpolator =
     typename TypeParam::Builder().set_bases(this->bases).set_values(this->values).build().value();
@@ -82,7 +82,7 @@ template class TestInterpolator<
  * Test LaneIds interpolator
  */
 
-TEST(TestLaneIdsInterpolator, compute)
+TEST(TestLaneIdsInterpolator, Compute)
 {
   using autoware::experimental::trajectory::interpolator::LaneIdsInterpolator;
 
@@ -135,7 +135,7 @@ geometry_msgs::msg::Quaternion create_quaternion(double w, double x, double y, d
   return q;
 }
 
-TEST(TestSphericalLinearInterpolator, compute)
+TEST(TestSphericalLinearInterpolator, Compute)
 {
   using autoware::experimental::trajectory::interpolator::SphericalLinear;
 

--- a/common/autoware_trajectory/test/test_pretty_build.cpp
+++ b/common/autoware_trajectory/test/test_pretty_build.cpp
@@ -45,7 +45,7 @@ PathPointWithLaneId make_path_point_with_lane_id(const double x, const double y,
 
 }  // namespace
 
-TEST(PrettyBuild, builds_from_two_points_with_default_interpolator)
+TEST(PrettyBuild, BuildsFromTwoPointsWithDefaultInterpolator)
 {
   const std::vector<PathPointWithLaneId> points{
     make_path_point_with_lane_id(1.0, 1.0, 0.0),
@@ -64,7 +64,7 @@ TEST(PrettyBuild, builds_from_two_points_with_default_interpolator)
   }
 }
 
-TEST(PrettyBuild, builds_from_three_points_with_default_interpolator)
+TEST(PrettyBuild, BuildsFromThreePointsWithDefaultInterpolator)
 {
   const std::vector<PathPointWithLaneId> points{
     make_path_point_with_lane_id(1.0, 1.0, 0.0), make_path_point_with_lane_id(0.7, 0.3, 0.0),
@@ -82,7 +82,7 @@ TEST(PrettyBuild, builds_from_three_points_with_default_interpolator)
   }
 }
 
-TEST(PrettyBuild, builds_from_four_points_with_akima)
+TEST(PrettyBuild, BuildsFromFourPointsWithAkima)
 {
   const std::vector<PathPointWithLaneId> points{
     make_path_point_with_lane_id(1.0, 1.0, 0.0), make_path_point_with_lane_id(1.5, 0.5, 0.0),
@@ -101,7 +101,7 @@ TEST(PrettyBuild, builds_from_four_points_with_akima)
   }
 }
 
-TEST(PrettyBuild, rejects_single_point_with_default_interpolator)
+TEST(PrettyBuild, RejectsSinglePointWithDefaultInterpolator)
 {
   const std::vector<PathPointWithLaneId> points{make_path_point_with_lane_id(1.0, 1.0, 0.0)};
 
@@ -109,7 +109,7 @@ TEST(PrettyBuild, rejects_single_point_with_default_interpolator)
   EXPECT_FALSE(trajectory_opt.has_value());
 }
 
-TEST(PrettyBuild, builds_from_single_point_with_akima_fallback)
+TEST(PrettyBuild, BuildsFromSinglePointWithAkimaFallback)
 {
   const std::vector<PathPointWithLaneId> points{make_path_point_with_lane_id(1.0, 1.0, 0.0)};
 

--- a/common/autoware_trajectory/test/test_reference_path.cpp
+++ b/common/autoware_trajectory/test/test_reference_path.cpp
@@ -87,7 +87,7 @@ void PrintTo(const Parameter_Map_Waypoint_Straight_00 & param, ::std::ostream * 
 
 using TestCase_Map_Waypoint_Straight_00 = TestCase<Parameter_Map_Waypoint_Straight_00>;  // NOLINT
 
-TEST_P(TestCase_Map_Waypoint_Straight_00, test_path_validity)
+TEST_P(TestCase_Map_Waypoint_Straight_00, TestPathValidity)
 {
   auto
     [FORWARD_LENGTH, BACKWARD_LENGTH, ids, current_id, x, y, z, quat, expect_success,
@@ -153,7 +153,7 @@ TEST_P(TestCase_Map_Waypoint_Straight_00, test_path_validity)
 }
 
 INSTANTIATE_TEST_SUITE_P(
-  test_path_validity, TestCase_Map_Waypoint_Straight_00,
+  TestPathValidity, TestCase_Map_Waypoint_Straight_00,
   ::testing::Values(  // enumerate values below
     Parameter_Map_Waypoint_Straight_00{
       200,                   // [m]
@@ -229,7 +229,7 @@ void PrintTo(const Parameter_Map_Waypoint_Curve_00 & param, ::std::ostream * os)
 
 using TestCase_Map_Waypoint_Curve_00 = TestCase<Parameter_Map_Waypoint_Curve_00>;  // NOLINT
 
-TEST_P(TestCase_Map_Waypoint_Curve_00, test_path_validity)
+TEST_P(TestCase_Map_Waypoint_Curve_00, TestPathValidity)
 {
   auto
     [FORWARD_LENGTH, BACKWARD_LENGTH, ids, current_id, x, y, z, quat, expect_success,
@@ -298,7 +298,7 @@ TEST_P(TestCase_Map_Waypoint_Curve_00, test_path_validity)
 }
 
 INSTANTIATE_TEST_SUITE_P(
-  test_path_validity, TestCase_Map_Waypoint_Curve_00,
+  TestPathValidity, TestCase_Map_Waypoint_Curve_00,
   ::testing::Values(  // enumerate values below
                       // here are the cases where current_pose is on a normal lanelet
     Parameter_Map_Waypoint_Curve_00{

--- a/common/autoware_trajectory/test/test_reference_path_vm_10_spec.cpp
+++ b/common/autoware_trajectory/test/test_reference_path_vm_10_spec.cpp
@@ -122,7 +122,7 @@ protected:
   lanelet::traffic_rules::TrafficRulesPtr traffic_rules_{nullptr};
 };
 
-TEST_P(TestWithVM_01_10_12_Map, from_P0_on_entire_lanes)  // NOLINT
+TEST_P(TestWithVM_01_10_12_Map, FromP0OnEntireLanes)  // NOLINT
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P0;
@@ -261,7 +261,7 @@ TEST_P(TestWithVM_01_10_12_Map, from_P0_on_entire_lanes)  // NOLINT
 #endif
 }
 
-TEST_P(TestWithVM_01_10_12_Map, from_P1_on_entire_lanes)
+TEST_P(TestWithVM_01_10_12_Map, FromP1OnEntireLanes)
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P1;
@@ -400,7 +400,7 @@ TEST_P(TestWithVM_01_10_12_Map, from_P1_on_entire_lanes)
 #endif
 }
 
-TEST_P(TestWithVM_01_10_12_Map, from_P2_on_entire_lanes)
+TEST_P(TestWithVM_01_10_12_Map, FromP2OnEntireLanes)
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P2;
@@ -539,7 +539,7 @@ TEST_P(TestWithVM_01_10_12_Map, from_P2_on_entire_lanes)
 #endif
 }
 
-TEST_P(TestWithVM_01_10_12_Map, from_P3_on_entire_lanes)
+TEST_P(TestWithVM_01_10_12_Map, FromP3OnEntireLanes)
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P3;
@@ -678,7 +678,7 @@ TEST_P(TestWithVM_01_10_12_Map, from_P3_on_entire_lanes)
 #endif
 }
 
-TEST_P(TestWithVM_01_10_12_Map, from_P4_on_entire_lanes)
+TEST_P(TestWithVM_01_10_12_Map, FromP4OnEntireLanes)
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P4;
@@ -817,7 +817,7 @@ TEST_P(TestWithVM_01_10_12_Map, from_P4_on_entire_lanes)
 #endif
 }
 
-TEST_P(TestWithVM_01_10_12_Map, from_P5_on_entire_lanes)
+TEST_P(TestWithVM_01_10_12_Map, FromP5OnEntireLanes)
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P5;
@@ -956,7 +956,7 @@ TEST_P(TestWithVM_01_10_12_Map, from_P5_on_entire_lanes)
 #endif
 }
 
-TEST_P(TestWithVM_01_10_12_Map, from_P6_on_entire_lanes)
+TEST_P(TestWithVM_01_10_12_Map, FromP6OnEntireLanes)
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P6;
@@ -1095,7 +1095,7 @@ TEST_P(TestWithVM_01_10_12_Map, from_P6_on_entire_lanes)
 #endif
 }
 
-TEST_P(TestWithVM_01_10_12_Map, from_P1_forward_on_entire_lanes)
+TEST_P(TestWithVM_01_10_12_Map, FromP1ForwardOnEntireLanes)
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P1;
@@ -1221,7 +1221,7 @@ TEST_P(TestWithVM_01_10_12_Map, from_P1_forward_on_entire_lanes)
 #endif
 }
 
-TEST_P(TestWithVM_01_10_12_Map, from_P2_forward_on_entire_lanes)
+TEST_P(TestWithVM_01_10_12_Map, FromP2ForwardOnEntireLanes)
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P2;
@@ -1334,7 +1334,7 @@ TEST_P(TestWithVM_01_10_12_Map, from_P2_forward_on_entire_lanes)
 #endif
 }
 
-TEST_P(TestWithVM_01_10_12_Map, from_P3_forward_on_entire_lanes)
+TEST_P(TestWithVM_01_10_12_Map, FromP3ForwardOnEntireLanes)
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P3;
@@ -1434,7 +1434,7 @@ TEST_P(TestWithVM_01_10_12_Map, from_P3_forward_on_entire_lanes)
 #endif
 }
 
-TEST_P(TestWithVM_01_10_12_Map, from_P4_forward_on_entire_lanes)
+TEST_P(TestWithVM_01_10_12_Map, FromP4ForwardOnEntireLanes)
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P4;
@@ -1521,7 +1521,7 @@ TEST_P(TestWithVM_01_10_12_Map, from_P4_forward_on_entire_lanes)
 #endif
 }
 
-TEST_P(TestWithVM_01_10_12_Map, from_P5_forward_on_entire_lanes)
+TEST_P(TestWithVM_01_10_12_Map, FromP5ForwardOnEntireLanes)
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P5;
@@ -1608,7 +1608,7 @@ TEST_P(TestWithVM_01_10_12_Map, from_P5_forward_on_entire_lanes)
 #endif
 }
 
-TEST_P(TestWithVM_01_10_12_Map, from_P6_forward_on_entire_lanes)
+TEST_P(TestWithVM_01_10_12_Map, FromP6ForwardOnEntireLanes)
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P6;
@@ -1683,7 +1683,7 @@ TEST_P(TestWithVM_01_10_12_Map, from_P6_forward_on_entire_lanes)
 }
 
 INSTANTIATE_TEST_SUITE_P(
-  ReferencePathWith_VM_01_10_Maps, TestWithVM_01_10_12_Map,
+  ReferencePathWithVm0110Maps, TestWithVM_01_10_12_Map,
   ::testing::Values(
     "test_reference_path_valid_01.yaml", "test_reference_path_valid_02.yaml",
     "test_reference_path_valid_03.yaml", "test_reference_path_valid_04.yaml",

--- a/common/autoware_trajectory/test/test_reference_path_vm_10_spec_invalid.cpp
+++ b/common/autoware_trajectory/test/test_reference_path_vm_10_spec_invalid.cpp
@@ -121,7 +121,7 @@ protected:
   lanelet::traffic_rules::TrafficRulesPtr traffic_rules_{nullptr};
 };
 
-TEST_F(TestWithVM_01_10_12_Map_Invalid, from_P0_on_entire_lanes)  // NOLINT
+TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP0OnEntireLanes)  // NOLINT
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P0;
@@ -260,7 +260,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, from_P0_on_entire_lanes)  // NOLINT
 #endif
 }
 
-TEST_F(TestWithVM_01_10_12_Map_Invalid, from_P1_on_entire_lanes)
+TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP1OnEntireLanes)
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P1;
@@ -399,7 +399,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, from_P1_on_entire_lanes)
 #endif
 }
 
-TEST_F(TestWithVM_01_10_12_Map_Invalid, from_P2_on_entire_lanes)
+TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP2OnEntireLanes)
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P2;
@@ -538,7 +538,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, from_P2_on_entire_lanes)
 #endif
 }
 
-TEST_F(TestWithVM_01_10_12_Map_Invalid, from_P3_on_entire_lanes)
+TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP3OnEntireLanes)
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P3;
@@ -677,7 +677,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, from_P3_on_entire_lanes)
 #endif
 }
 
-TEST_F(TestWithVM_01_10_12_Map_Invalid, from_P4_on_entire_lanes)
+TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP4OnEntireLanes)
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P4;
@@ -816,7 +816,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, from_P4_on_entire_lanes)
 #endif
 }
 
-TEST_F(TestWithVM_01_10_12_Map_Invalid, from_P1_forward_on_entire_lanes)
+TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP1ForwardOnEntireLanes)
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P1;
@@ -942,7 +942,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, from_P1_forward_on_entire_lanes)
 #endif
 }
 
-TEST_F(TestWithVM_01_10_12_Map_Invalid, from_P2_forward_on_entire_lanes)
+TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP2ForwardOnEntireLanes)
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P2;
@@ -1042,7 +1042,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, from_P2_forward_on_entire_lanes)
 #endif
 }
 
-TEST_F(TestWithVM_01_10_12_Map_Invalid, from_P3_forward_on_entire_lanes)
+TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP3ForwardOnEntireLanes)
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P3;
@@ -1142,7 +1142,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, from_P3_forward_on_entire_lanes)
 #endif
 }
 
-TEST_F(TestWithVM_01_10_12_Map_Invalid, from_P4_forward_on_entire_lanes)
+TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP4ForwardOnEntireLanes)
 {
   const std::vector<lanelet::Id> ids = {60, 57, 56, 58, 59, 55};
   const auto ego_pose = P4;

--- a/common/autoware_trajectory/test/test_shift.cpp
+++ b/common/autoware_trajectory/test/test_shift.cpp
@@ -31,7 +31,7 @@ geometry_msgs::msg::Point point(double x, double y)
 namespace autoware::experimental::trajectory
 {
 
-TEST(ShiftInvalid, error_shift_start_is_less_than_end)
+TEST(ShiftInvalid, ErrorShiftStartIsLessThanEnd)
 {
   std::vector<geometry_msgs::msg::Point> points = {point(0.0, 0.0),  point(3.0, 0.0),
                                                    point(6.0, 0.0),  point(9.0, 0.0),
@@ -58,7 +58,7 @@ TEST(ShiftInvalid, error_shift_start_is_less_than_end)
   EXPECT_NEAR(end_point.y, -lateral_shift, 1e-3);
 }
 
-TEST(ShiftInvalid, error_shift_end_is_less_than_end)
+TEST(ShiftInvalid, ErrorShiftEndIsLessThanEnd)
 {
   std::vector<geometry_msgs::msg::Point> points = {point(0.0, 0.0),  point(3.0, 0.0),
                                                    point(6.0, 0.0),  point(9.0, 0.0),
@@ -85,7 +85,7 @@ TEST(ShiftInvalid, error_shift_end_is_less_than_end)
   EXPECT_GT(end_point.y, -lateral_shift);
 }
 
-TEST(ShiftInvalid, error_interval_is_backward)
+TEST(ShiftInvalid, ErrorIntervalIsBackward)
 {
   std::vector<geometry_msgs::msg::Point> points = {point(0.0, 0.0),  point(3.0, 0.0),
                                                    point(6.0, 0.0),  point(9.0, 0.0),
@@ -106,7 +106,7 @@ TEST(ShiftInvalid, error_interval_is_backward)
   ASSERT_TRUE(!shifted_trajectory);
 }
 
-TEST(ShiftInvalid, error_longitudinal_velocity_is_negative)
+TEST(ShiftInvalid, ErrorLongitudinalVelocityIsNegative)
 {
   std::vector<geometry_msgs::msg::Point> points = {point(0.0, 0.0),  point(3.0, 0.0),
                                                    point(6.0, 0.0),  point(9.0, 0.0),
@@ -127,7 +127,7 @@ TEST(ShiftInvalid, error_longitudinal_velocity_is_negative)
   ASSERT_TRUE(!shifted_trajectory_info);
 }
 
-TEST(ShiftSuccess, shift_end_meets_given_lateral_longitudinal_distance_4points)
+TEST(ShiftSuccess, ShiftEndMeetsGivenLateralLongitudinalDistance4Points)
 {
   std::vector<geometry_msgs::msg::Point> points = {point(0.0, 0.0),  point(3.0, 0.0),
                                                    point(6.0, 0.0),  point(9.0, 0.0),
@@ -157,7 +157,7 @@ TEST(ShiftSuccess, shift_end_meets_given_lateral_longitudinal_distance_4points)
   EXPECT_FLOAT_EQ(shifted_trajectory.compute(shifted_trajectory.length()).y, -lateral_shift);
 }
 
-TEST(ShiftSuccess, shift_end_meets_given_lateral_longitudinal_distance_6points)
+TEST(ShiftSuccess, ShiftEndMeetsGivenLateralLongitudinalDistance6Points)
 {
   std::vector<geometry_msgs::msg::Point> points = {point(0.0, 0.0),  point(3.0, 0.0),
                                                    point(6.0, 0.0),  point(9.0, 0.0),
@@ -182,7 +182,7 @@ TEST(ShiftSuccess, shift_end_meets_given_lateral_longitudinal_distance_6points)
   ASSERT_TRUE(shifted_trajectory_info);
 }
 
-TEST(ShiftInvalid, multiple_shift)
+TEST(ShiftInvalid, MultipleShift)
 {
   std::vector<geometry_msgs::msg::Point> points = {point(0.0, 0.0),  point(3.0, 0.0),
                                                    point(6.0, 0.0),  point(9.0, 0.0),

--- a/common/autoware_trajectory/test/test_trajectory_container.cpp
+++ b/common/autoware_trajectory/test/test_trajectory_container.cpp
@@ -263,6 +263,8 @@ public:
 
 TEST_F(TrajectoryTest, Compute)
 {
+  ASSERT_TRUE(trajectory);
+
   double length = trajectory->length();
 
   trajectory->longitudinal_velocity_mps()
@@ -281,6 +283,7 @@ TEST_F(TrajectoryTest, Compute)
 
 TEST_F(TrajectoryTest, ManipulateLongitudinalVelocity)
 {
+  ASSERT_TRUE(trajectory);
   trajectory->longitudinal_velocity_mps() = 10.0;
   trajectory->longitudinal_velocity_mps()
     .range(trajectory->length() / 3, 2.0 * trajectory->length() / 3)
@@ -296,6 +299,7 @@ TEST_F(TrajectoryTest, ManipulateLongitudinalVelocity)
 
 TEST_F(TrajectoryTest, ManipulateLateralVelocity)
 {
+  ASSERT_TRUE(trajectory);
   trajectory->lateral_velocity_mps()
     .range(trajectory->length() / 3, 2.0 * trajectory->length() / 3)
     .set(5.0);
@@ -315,6 +319,7 @@ TEST_F(TrajectoryTest, ManipulateLateralVelocity)
 
 TEST_F(TrajectoryTest, ClampLongitudinalVelocity)
 {
+  ASSERT_TRUE(trajectory);
   trajectory->longitudinal_velocity_mps() = 10.0;
   trajectory->longitudinal_velocity_mps()
     .range(trajectory->length() / 3, 2 * trajectory->length() / 3)
@@ -337,6 +342,7 @@ TEST_F(TrajectoryTest, ClampLongitudinalVelocity)
 
 TEST_F(TrajectoryTest, ManipulateVelocities)
 {
+  ASSERT_TRUE(trajectory);
   // longitudinal velocity = 1.0 [0.3, 0.7]
   trajectory->longitudinal_velocity_mps()
     .range(trajectory->length() * 0.3, trajectory->length() * 0.7)
@@ -399,6 +405,7 @@ TEST_F(TrajectoryTest, ManipulateVelocities)
 
 TEST_F(TrajectoryTest, ManipulateVelocitiesWithCopyCtor)
 {
+  ASSERT_TRUE(trajectory);
   Trajectory trajectory2(*trajectory);
   // longitudinal velocity = 1.0 [0.3, 0.7]
   trajectory2.longitudinal_velocity_mps()
@@ -651,6 +658,7 @@ TEST_F(TrajectoryTest, ManipulateVelocitiesWithMoveAssignment)
 
 TEST_F(TrajectoryTest, Direction)
 {
+  ASSERT_TRUE(trajectory);
   double dir = trajectory->azimuth(0.0);
   EXPECT_LT(0, dir);
   EXPECT_LT(dir, M_PI / 2);
@@ -658,6 +666,7 @@ TEST_F(TrajectoryTest, Direction)
 
 TEST_F(TrajectoryTest, Curvature)
 {
+  ASSERT_TRUE(trajectory);
   double curvature_val = trajectory->curvature(0.0);
   EXPECT_LT(-1.0, curvature_val);
   EXPECT_LT(curvature_val, 1.0);
@@ -665,6 +674,7 @@ TEST_F(TrajectoryTest, Curvature)
 
 TEST_F(TrajectoryTest, Restore)
 {
+  ASSERT_TRUE(trajectory);
   using autoware::experimental::trajectory::Trajectory;
   trajectory->longitudinal_velocity_mps().range(4.0, trajectory->length()).set(5.0);
   auto points = trajectory->restore();
@@ -673,6 +683,7 @@ TEST_F(TrajectoryTest, Restore)
 
 TEST_F(TrajectoryTest, Crossed)
 {
+  ASSERT_TRUE(trajectory);
   lanelet::LineString2d line_string;
   line_string.push_back(lanelet::Point3d(lanelet::InvalId, 0.0, 10.0, 0.0));
   line_string.push_back(lanelet::Point3d(lanelet::InvalId, 10.0, 0.0, 0.0));
@@ -686,6 +697,7 @@ TEST_F(TrajectoryTest, Crossed)
 
 TEST_F(TrajectoryTest, Closest)
 {
+  ASSERT_TRUE(trajectory);
   geometry_msgs::msg::Pose pose;
   pose.position.x = 5.0;
   pose.position.y = 5.0;
@@ -702,6 +714,7 @@ TEST_F(TrajectoryTest, Closest)
 
 TEST_F(TrajectoryTest, Crop)
 {
+  ASSERT_TRUE(trajectory);
   double length = trajectory->length();
 
   auto start_point_expect = trajectory->compute(length / 3.0);
@@ -727,6 +740,7 @@ TEST_F(TrajectoryTest, Crop)
 
 TEST_F(TrajectoryTest, FindIf)
 {
+  ASSERT_TRUE(trajectory);
   geometry_msgs::msg::Point base_point;
   base_point.x = 5.0;
   base_point.y = 5.0;
@@ -785,6 +799,7 @@ TEST_F(TrajectoryTest, FindIf)
 
 TEST_F(TrajectoryTest, FindInterval)
 {
+  ASSERT_TRUE(trajectory);
   auto intervals = autoware::experimental::trajectory::find_intervals(
     *trajectory, [](const autoware_internal_planning_msgs::msg::PathPointWithLaneId & point) {
       return point.lane_ids[0] == 1;
@@ -797,6 +812,7 @@ TEST_F(TrajectoryTest, FindInterval)
 
 TEST_F(TrajectoryTest, FindIntervalWithBinarySearch)
 {
+  ASSERT_TRUE(trajectory);
   geometry_msgs::msg::Point base_point;
   base_point.x = 6.0;
   base_point.y = 2.0;
@@ -838,12 +854,14 @@ TEST_F(TrajectoryTest, FindIntervalWithBinarySearch)
 
 TEST_F(TrajectoryTest, MaxCurvature)
 {
+  ASSERT_TRUE(trajectory);
   double max_curvature = autoware::experimental::trajectory::max_curvature(*trajectory);
   EXPECT_LT(0, max_curvature);
 }
 
 TEST_F(TrajectoryTest, GetContainedLaneIds)
 {
+  ASSERT_TRUE(trajectory);
   auto contained_lane_ids = trajectory->get_contained_lane_ids();
   EXPECT_EQ(2, contained_lane_ids.size());
   EXPECT_EQ(0, contained_lane_ids[0]);
@@ -852,6 +870,7 @@ TEST_F(TrajectoryTest, GetContainedLaneIds)
 
 TEST_F(TrajectoryTest, CopyCtor)
 {
+  ASSERT_TRUE(trajectory);
   const auto trajectory2(*trajectory);
 
   check_if_equals(*trajectory, trajectory2);
@@ -859,6 +878,7 @@ TEST_F(TrajectoryTest, CopyCtor)
 
 TEST_F(TrajectoryTest, CopyAssignment)
 {
+  ASSERT_TRUE(trajectory);
   const auto trajectory2 = Trajectory::Builder{}.build(
     {path_point_with_lane_id(0.00, 0.00, 1), path_point_with_lane_id(1.68, 0.81, 1),
      path_point_with_lane_id(2.98, 1.65, 1), path_point_with_lane_id(4.01, 3.30, 0)});
@@ -870,6 +890,7 @@ TEST_F(TrajectoryTest, CopyAssignment)
 
 TEST_F(TrajectoryTest, MoveCtor)
 {
+  ASSERT_TRUE(trajectory);
   const auto trajectory1(*trajectory);
   const auto trajectory2(std::move(*trajectory));
 
@@ -878,6 +899,7 @@ TEST_F(TrajectoryTest, MoveCtor)
 
 TEST_F(TrajectoryTest, MoveAssignment)
 {
+  ASSERT_TRUE(trajectory);
   auto trajectory1 = Trajectory::Builder{}.build(
     {path_point_with_lane_id(0.00, 0.00, 1), path_point_with_lane_id(1.68, 0.81, 1),
      path_point_with_lane_id(2.98, 1.65, 1), path_point_with_lane_id(4.01, 3.30, 0)});

--- a/common/autoware_trajectory/test/test_trajectory_container.cpp
+++ b/common/autoware_trajectory/test/test_trajectory_container.cpp
@@ -81,7 +81,7 @@ void check_if_equals(const Trajectory & trajectory1, const Trajectory & trajecto
   EXPECT_EQ(trajectory1.lane_ids().end(), trajectory2.lane_ids().end());
 }
 }  // namespace
-TEST(TrajectoryCreatorTest, constructor)
+TEST(TrajectoryCreatorTest, Constructor)
 {
   std::vector<geometry_msgs::msg::Point> points{
     point(0.00, 0.00), point(0.81, 1.68), point(1.65, 2.98), point(3.30, 4.01)};
@@ -92,7 +92,7 @@ TEST(TrajectoryCreatorTest, constructor)
   autoware::experimental::trajectory::Trajectory<geometry_msgs::msg::Pose> trj_pose(*trajectory);
 }
 
-TEST(TrajectoryCreatorTest, create_from_single_point)
+TEST(TrajectoryCreatorTest, CreateFromSinglePoint)
 {
   std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> points{
     path_point_with_lane_id(0.00, 0.00, 0)};
@@ -100,7 +100,7 @@ TEST(TrajectoryCreatorTest, create_from_single_point)
   ASSERT_TRUE(trajectory);
 }
 
-TEST(TrajectoryCreatorTest, restore_single_point_trajectory)
+TEST(TrajectoryCreatorTest, RestoreSinglePointTrajectory)
 {
   const std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> points{
     path_point_with_lane_id(0.00, 0.00, 7)};
@@ -115,7 +115,7 @@ TEST(TrajectoryCreatorTest, restore_single_point_trajectory)
   EXPECT_EQ(restored.front().lane_ids.front(), 7);
 }
 
-TEST(TrajectoryCreatorTest, restore_complete_duplicate_points_trajectory_preserves_duplicates)
+TEST(TrajectoryCreatorTest, RestoreCompleteDuplicatePointsTrajectoryPreservesDuplicates)
 {
   const std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> points{
     path_point_with_lane_id(1.0, 2.0, 7), path_point_with_lane_id(1.0, 2.0, 7),
@@ -133,7 +133,7 @@ TEST(TrajectoryCreatorTest, restore_complete_duplicate_points_trajectory_preserv
   }
 }
 
-TEST(TrajectoryCreatorTest, restore_crop_to_zero_length_trajectory_preserves_boundaries)
+TEST(TrajectoryCreatorTest, RestoreCropToZeroLengthTrajectoryPreservesBoundaries)
 {
   const std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> points{
     path_point_with_lane_id(0.0, 0.0, 0), path_point_with_lane_id(1.0, 1.0, 1),
@@ -154,7 +154,7 @@ TEST(TrajectoryCreatorTest, restore_crop_to_zero_length_trajectory_preserves_bou
   }
 }
 
-TEST(TrajectoryCreatorTest, restore_tiny_cropped_trajectory_preserves_boundaries)
+TEST(TrajectoryCreatorTest, RestoreTinyCroppedTrajectoryPreservesBoundaries)
 {
   const std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> points{
     path_point_with_lane_id(0.0, 0.0, 0), path_point_with_lane_id(1.0, 1.0, 1),
@@ -188,7 +188,7 @@ TEST(TrajectoryCreatorTest, restore_tiny_cropped_trajectory_preserves_boundaries
     autoware::experimental::trajectory::k_points_minimum_dist_threshold);
 }
 
-TEST(TrajectoryCreatorTest, create_from_multiple_points)
+TEST(TrajectoryCreatorTest, CreateFromMultiplePoints)
 {
   std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> points{
     path_point_with_lane_id(0.00, 0.00, 0), path_point_with_lane_id(0.81, 1.68, 0),
@@ -197,7 +197,7 @@ TEST(TrajectoryCreatorTest, create_from_multiple_points)
   ASSERT_TRUE(trajectory);
 }
 
-TEST(TrajectoryCreatorTest, almost_same_points_are_given)
+TEST(TrajectoryCreatorTest, AlmostSamePointsAreGiven)
 {
   const double nano_meter = 1e-9;
   std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> points{
@@ -213,7 +213,7 @@ TEST(TrajectoryCreatorTest, almost_same_points_are_given)
   }
 }
 
-TEST(TrajectoryCreatorTest, create_from_complete_duplicate_points_with_increasing_bases)
+TEST(TrajectoryCreatorTest, CreateFromCompleteDuplicatePointsWithIncreasingBases)
 {
   std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> points{
     path_point_with_lane_id(1.0, 2.0, 0), path_point_with_lane_id(1.0, 2.0, 0),
@@ -227,7 +227,7 @@ TEST(TrajectoryCreatorTest, create_from_complete_duplicate_points_with_increasin
   expect_strictly_increasing(bases);
 }
 
-TEST(TrajectoryCreatorTest, create_from_partially_duplicate_points_with_increasing_bases)
+TEST(TrajectoryCreatorTest, CreateFromPartiallyDuplicatePointsWithIncreasingBases)
 {
   std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> points{
     path_point_with_lane_id(0.0, 0.0, 0), path_point_with_lane_id(1.0, 1.0, 0),
@@ -261,7 +261,7 @@ public:
   }
 };
 
-TEST_F(TrajectoryTest, compute)
+TEST_F(TrajectoryTest, Compute)
 {
   double length = trajectory->length();
 
@@ -279,7 +279,7 @@ TEST_F(TrajectoryTest, compute)
   EXPECT_EQ(1, point.lane_ids[0]);
 }
 
-TEST_F(TrajectoryTest, manipulate_longitudinal_velocity)
+TEST_F(TrajectoryTest, ManipulateLongitudinalVelocity)
 {
   trajectory->longitudinal_velocity_mps() = 10.0;
   trajectory->longitudinal_velocity_mps()
@@ -294,7 +294,7 @@ TEST_F(TrajectoryTest, manipulate_longitudinal_velocity)
   EXPECT_FLOAT_EQ(10.0, point3.point.longitudinal_velocity_mps);
 }
 
-TEST_F(TrajectoryTest, manipulate_lateral_velocity)
+TEST_F(TrajectoryTest, ManipulateLateralVelocity)
 {
   trajectory->lateral_velocity_mps()
     .range(trajectory->length() / 3, 2.0 * trajectory->length() / 3)
@@ -313,7 +313,7 @@ TEST_F(TrajectoryTest, manipulate_lateral_velocity)
   EXPECT_FLOAT_EQ(0.0, point4.point.lateral_velocity_mps);
 }
 
-TEST_F(TrajectoryTest, clamp_longitudinal_velocity)
+TEST_F(TrajectoryTest, ClampLongitudinalVelocity)
 {
   trajectory->longitudinal_velocity_mps() = 10.0;
   trajectory->longitudinal_velocity_mps()
@@ -335,7 +335,7 @@ TEST_F(TrajectoryTest, clamp_longitudinal_velocity)
   EXPECT_FLOAT_EQ(10.0, point5.point.longitudinal_velocity_mps);
 }
 
-TEST_F(TrajectoryTest, manipulate_velocities)
+TEST_F(TrajectoryTest, ManipulateVelocities)
 {
   // longitudinal velocity = 1.0 [0.3, 0.7]
   trajectory->longitudinal_velocity_mps()
@@ -397,7 +397,7 @@ TEST_F(TrajectoryTest, manipulate_velocities)
   }
 }
 
-TEST_F(TrajectoryTest, manipulate_velocities_with_copy_ctor)
+TEST_F(TrajectoryTest, ManipulateVelocitiesWithCopyCtor)
 {
   Trajectory trajectory2(*trajectory);
   // longitudinal velocity = 1.0 [0.3, 0.7]
@@ -460,7 +460,7 @@ TEST_F(TrajectoryTest, manipulate_velocities_with_copy_ctor)
   }
 }
 
-TEST_F(TrajectoryTest, manipulate_velocities_with_copy_assignment)
+TEST_F(TrajectoryTest, ManipulateVelocitiesWithCopyAssignment)
 {
   auto trajectory2 = *trajectory;
   // longitudinal velocity = 1.0 [0.3, 0.7]
@@ -523,7 +523,7 @@ TEST_F(TrajectoryTest, manipulate_velocities_with_copy_assignment)
   }
 }
 
-TEST_F(TrajectoryTest, manipulate_velocities_with_move_ctor)
+TEST_F(TrajectoryTest, ManipulateVelocitiesWithMoveCtor)
 {
   auto trajectory2(std::move(*trajectory));
   // longitudinal velocity = 1.0 [0.3, 0.7]
@@ -586,7 +586,7 @@ TEST_F(TrajectoryTest, manipulate_velocities_with_move_ctor)
   }
 }
 
-TEST_F(TrajectoryTest, manipulate_velocities_with_move_assignment)
+TEST_F(TrajectoryTest, ManipulateVelocitiesWithMoveAssignment)
 {
   auto trajectory2 = std::move(*trajectory);
   // longitudinal velocity = 1.0 [0.3, 0.7]
@@ -649,21 +649,21 @@ TEST_F(TrajectoryTest, manipulate_velocities_with_move_assignment)
   }
 }
 
-TEST_F(TrajectoryTest, direction)
+TEST_F(TrajectoryTest, Direction)
 {
   double dir = trajectory->azimuth(0.0);
   EXPECT_LT(0, dir);
   EXPECT_LT(dir, M_PI / 2);
 }
 
-TEST_F(TrajectoryTest, curvature)
+TEST_F(TrajectoryTest, Curvature)
 {
   double curvature_val = trajectory->curvature(0.0);
   EXPECT_LT(-1.0, curvature_val);
   EXPECT_LT(curvature_val, 1.0);
 }
 
-TEST_F(TrajectoryTest, restore)
+TEST_F(TrajectoryTest, Restore)
 {
   using autoware::experimental::trajectory::Trajectory;
   trajectory->longitudinal_velocity_mps().range(4.0, trajectory->length()).set(5.0);
@@ -671,7 +671,7 @@ TEST_F(TrajectoryTest, restore)
   EXPECT_EQ(11, points.size());
 }
 
-TEST_F(TrajectoryTest, crossed)
+TEST_F(TrajectoryTest, Crossed)
 {
   lanelet::LineString2d line_string;
   line_string.push_back(lanelet::Point3d(lanelet::InvalId, 0.0, 10.0, 0.0));
@@ -684,7 +684,7 @@ TEST_F(TrajectoryTest, crossed)
   EXPECT_LT(crossed_point.at(0), trajectory->length());
 }
 
-TEST_F(TrajectoryTest, closest)
+TEST_F(TrajectoryTest, Closest)
 {
   geometry_msgs::msg::Pose pose;
   pose.position.x = 5.0;
@@ -700,7 +700,7 @@ TEST_F(TrajectoryTest, closest)
   EXPECT_LT(distance, 3.0);
 }
 
-TEST_F(TrajectoryTest, crop)
+TEST_F(TrajectoryTest, Crop)
 {
   double length = trajectory->length();
 
@@ -725,7 +725,7 @@ TEST_F(TrajectoryTest, crop)
   EXPECT_EQ(end_point_expect.lane_ids[0], end_point_actual.lane_ids[0]);
 }
 
-TEST_F(TrajectoryTest, find_if)
+TEST_F(TrajectoryTest, FindIf)
 {
   geometry_msgs::msg::Point base_point;
   base_point.x = 5.0;
@@ -783,7 +783,7 @@ TEST_F(TrajectoryTest, find_if)
   }
 }
 
-TEST_F(TrajectoryTest, find_interval)
+TEST_F(TrajectoryTest, FindInterval)
 {
   auto intervals = autoware::experimental::trajectory::find_intervals(
     *trajectory, [](const autoware_internal_planning_msgs::msg::PathPointWithLaneId & point) {
@@ -795,7 +795,7 @@ TEST_F(TrajectoryTest, find_interval)
   EXPECT_NEAR(intervals[0].end, trajectory->length(), 0.1);
 }
 
-TEST_F(TrajectoryTest, find_interval_with_binary_search)
+TEST_F(TrajectoryTest, FindIntervalWithBinarySearch)
 {
   geometry_msgs::msg::Point base_point;
   base_point.x = 6.0;
@@ -836,13 +836,13 @@ TEST_F(TrajectoryTest, find_interval_with_binary_search)
   EXPECT_GT(interval_0_end_error_decrease, 0);
 }
 
-TEST_F(TrajectoryTest, max_curvature)
+TEST_F(TrajectoryTest, MaxCurvature)
 {
   double max_curvature = autoware::experimental::trajectory::max_curvature(*trajectory);
   EXPECT_LT(0, max_curvature);
 }
 
-TEST_F(TrajectoryTest, get_contained_lane_ids)
+TEST_F(TrajectoryTest, GetContainedLaneIds)
 {
   auto contained_lane_ids = trajectory->get_contained_lane_ids();
   EXPECT_EQ(2, contained_lane_ids.size());
@@ -850,14 +850,14 @@ TEST_F(TrajectoryTest, get_contained_lane_ids)
   EXPECT_EQ(1, contained_lane_ids[1]);
 }
 
-TEST_F(TrajectoryTest, copy_ctor)
+TEST_F(TrajectoryTest, CopyCtor)
 {
   const auto trajectory2(*trajectory);
 
   check_if_equals(*trajectory, trajectory2);
 }
 
-TEST_F(TrajectoryTest, copy_assignment)
+TEST_F(TrajectoryTest, CopyAssignment)
 {
   const auto trajectory2 = Trajectory::Builder{}.build(
     {path_point_with_lane_id(0.00, 0.00, 1), path_point_with_lane_id(1.68, 0.81, 1),
@@ -868,7 +868,7 @@ TEST_F(TrajectoryTest, copy_assignment)
   check_if_equals(*trajectory, *trajectory2);
 }
 
-TEST_F(TrajectoryTest, move_ctor)
+TEST_F(TrajectoryTest, MoveCtor)
 {
   const auto trajectory1(*trajectory);
   const auto trajectory2(std::move(*trajectory));
@@ -876,7 +876,7 @@ TEST_F(TrajectoryTest, move_ctor)
   check_if_equals(trajectory1, trajectory2);
 }
 
-TEST_F(TrajectoryTest, move_assignment)
+TEST_F(TrajectoryTest, MoveAssignment)
 {
   auto trajectory1 = Trajectory::Builder{}.build(
     {path_point_with_lane_id(0.00, 0.00, 1), path_point_with_lane_id(1.68, 0.81, 1),

--- a/common/autoware_trajectory/test/test_trajectory_container_trajectory_point.cpp
+++ b/common/autoware_trajectory/test/test_trajectory_container_trajectory_point.cpp
@@ -183,6 +183,7 @@ public:
 
 TEST_F(TrajectoryTestForTrajectoryPoint, Compute)
 {
+  ASSERT_TRUE(trajectory);
   double length = trajectory->length();
 
   trajectory->longitudinal_velocity_mps()
@@ -199,6 +200,7 @@ TEST_F(TrajectoryTestForTrajectoryPoint, Compute)
 
 TEST_F(TrajectoryTestForTrajectoryPoint, ManipulateVelocity)
 {
+  ASSERT_TRUE(trajectory);
   trajectory->longitudinal_velocity_mps() = 10.0;
   trajectory->longitudinal_velocity_mps()
     .range(trajectory->length() / 3, 2.0 * trajectory->length() / 3)
@@ -214,6 +216,7 @@ TEST_F(TrajectoryTestForTrajectoryPoint, ManipulateVelocity)
 
 TEST_F(TrajectoryTestForTrajectoryPoint, Direction)
 {
+  ASSERT_TRUE(trajectory);
   double dir = trajectory->azimuth(0.0);
   EXPECT_LT(0, dir);
   EXPECT_LT(dir, M_PI / 2);
@@ -221,6 +224,7 @@ TEST_F(TrajectoryTestForTrajectoryPoint, Direction)
 
 TEST_F(TrajectoryTestForTrajectoryPoint, Curvature)
 {
+  ASSERT_TRUE(trajectory);
   double curvature_val = trajectory->curvature(0.0);
   EXPECT_LT(-1.0, curvature_val);
   EXPECT_LT(curvature_val, 1.0);
@@ -228,6 +232,7 @@ TEST_F(TrajectoryTestForTrajectoryPoint, Curvature)
 
 TEST_F(TrajectoryTestForTrajectoryPoint, Restore)
 {
+  ASSERT_TRUE(trajectory);
   using autoware::experimental::trajectory::Trajectory;
   trajectory->longitudinal_velocity_mps().range(4.0, trajectory->length()).set(5.0);
   auto points = trajectory->restore();
@@ -236,6 +241,7 @@ TEST_F(TrajectoryTestForTrajectoryPoint, Restore)
 
 TEST_F(TrajectoryTestForTrajectoryPoint, Crossed)
 {
+  ASSERT_TRUE(trajectory);
   lanelet::LineString2d line_string;
   line_string.push_back(lanelet::Point3d(lanelet::InvalId, 0.0, 10.0, 0.0));
   line_string.push_back(lanelet::Point3d(lanelet::InvalId, 10.0, 0.0, 0.0));
@@ -249,6 +255,7 @@ TEST_F(TrajectoryTestForTrajectoryPoint, Crossed)
 
 TEST_F(TrajectoryTestForTrajectoryPoint, Closest)
 {
+  ASSERT_TRUE(trajectory);
   geometry_msgs::msg::Pose pose;
   pose.position.x = 5.0;
   pose.position.y = 5.0;
@@ -264,6 +271,7 @@ TEST_F(TrajectoryTestForTrajectoryPoint, Closest)
 
 TEST_F(TrajectoryTestForTrajectoryPoint, Crop)
 {
+  ASSERT_TRUE(trajectory);
   double length = trajectory->length();
 
   auto start_point_expect = trajectory->compute(length / 3.0);
@@ -285,12 +293,14 @@ TEST_F(TrajectoryTestForTrajectoryPoint, Crop)
 
 TEST_F(TrajectoryTestForTrajectoryPoint, MaxCurvature)
 {
+  ASSERT_TRUE(trajectory);
   double max_curvature = autoware::experimental::trajectory::max_curvature(*trajectory);
   EXPECT_LT(0, max_curvature);
 }
 
 TEST_F(TrajectoryTestForTrajectoryPoint, BuildFromTwoPoints)
 {
+  ASSERT_TRUE(trajectory);
   using autoware_utils_geometry::get_rpy;
 
   std::vector<autoware_planning_msgs::msg::TrajectoryPoint> points{

--- a/common/autoware_trajectory/test/test_trajectory_container_trajectory_point.cpp
+++ b/common/autoware_trajectory/test/test_trajectory_container_trajectory_point.cpp
@@ -42,14 +42,14 @@ void expect_strictly_increasing(const std::vector<double> & bases)
   }
 }
 
-TEST(TrajectoryCreatorTestForTrajectoryPoint, create_from_single_point)
+TEST(TrajectoryCreatorTestForTrajectoryPoint, CreateFromSinglePoint)
 {
   std::vector<autoware_planning_msgs::msg::TrajectoryPoint> points{trajectory_point(0.00, 0.00)};
   auto trajectory = Trajectory::Builder{}.build(points);
   ASSERT_TRUE(trajectory);
 }
 
-TEST(TrajectoryCreatorTestForTrajectoryPoint, restore_single_point_trajectory)
+TEST(TrajectoryCreatorTestForTrajectoryPoint, RestoreSinglePointTrajectory)
 {
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> points{
     trajectory_point(0.0, 0.0)};
@@ -64,7 +64,7 @@ TEST(TrajectoryCreatorTestForTrajectoryPoint, restore_single_point_trajectory)
 
 TEST(
   TrajectoryCreatorTestForTrajectoryPoint,
-  restore_complete_duplicate_points_trajectory_preserves_duplicates)
+  RestoreCompleteDuplicatePointsTrajectoryPreservesDuplicates)
 {
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> points{
     trajectory_point(1.0, 2.0), trajectory_point(1.0, 2.0), trajectory_point(1.0, 2.0)};
@@ -79,9 +79,7 @@ TEST(
   }
 }
 
-TEST(
-  TrajectoryCreatorTestForTrajectoryPoint,
-  restore_crop_to_zero_length_trajectory_preserves_boundaries)
+TEST(TrajectoryCreatorTestForTrajectoryPoint, RestoreCropToZeroLengthTrajectoryPreservesBoundaries)
 {
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> points{
     trajectory_point(0.0, 0.0), trajectory_point(1.0, 1.0), trajectory_point(2.0, 2.0),
@@ -100,7 +98,7 @@ TEST(
   }
 }
 
-TEST(TrajectoryCreatorTestForTrajectoryPoint, restore_tiny_cropped_trajectory_preserves_boundaries)
+TEST(TrajectoryCreatorTestForTrajectoryPoint, RestoreTinyCroppedTrajectoryPreservesBoundaries)
 {
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> points{
     trajectory_point(0.0, 0.0), trajectory_point(1.0, 1.0), trajectory_point(2.0, 2.0),
@@ -128,7 +126,7 @@ TEST(TrajectoryCreatorTestForTrajectoryPoint, restore_tiny_cropped_trajectory_pr
     autoware::experimental::trajectory::k_points_minimum_dist_threshold);
 }
 
-TEST(TrajectoryCreatorTestForTrajectoryPoint, create_from_multiple_points)
+TEST(TrajectoryCreatorTestForTrajectoryPoint, CreateFromMultiplePoints)
 {
   std::vector<autoware_planning_msgs::msg::TrajectoryPoint> points{
     trajectory_point(0.00, 0.00), trajectory_point(0.81, 1.68), trajectory_point(1.65, 2.98),
@@ -137,9 +135,7 @@ TEST(TrajectoryCreatorTestForTrajectoryPoint, create_from_multiple_points)
   ASSERT_TRUE(trajectory);
 }
 
-TEST(
-  TrajectoryCreatorTestForTrajectoryPoint,
-  create_from_complete_duplicate_points_with_increasing_bases)
+TEST(TrajectoryCreatorTestForTrajectoryPoint, CreateFromCompleteDuplicatePointsWithIncreasingBases)
 {
   std::vector<autoware_planning_msgs::msg::TrajectoryPoint> points{
     trajectory_point(1.0, 2.0), trajectory_point(1.0, 2.0), trajectory_point(1.0, 2.0)};
@@ -152,9 +148,7 @@ TEST(
   expect_strictly_increasing(bases);
 }
 
-TEST(
-  TrajectoryCreatorTestForTrajectoryPoint,
-  create_from_partially_duplicate_points_with_increasing_bases)
+TEST(TrajectoryCreatorTestForTrajectoryPoint, CreateFromPartiallyDuplicatePointsWithIncreasingBases)
 {
   std::vector<autoware_planning_msgs::msg::TrajectoryPoint> points{
     trajectory_point(0.0, 0.0), trajectory_point(1.0, 1.0), trajectory_point(1.0, 1.0),
@@ -187,7 +181,7 @@ public:
   }
 };
 
-TEST_F(TrajectoryTestForTrajectoryPoint, compute)
+TEST_F(TrajectoryTestForTrajectoryPoint, Compute)
 {
   double length = trajectory->length();
 
@@ -203,7 +197,7 @@ TEST_F(TrajectoryTestForTrajectoryPoint, compute)
   EXPECT_LT(point.pose.position.y, 10);
 }
 
-TEST_F(TrajectoryTestForTrajectoryPoint, manipulate_velocity)
+TEST_F(TrajectoryTestForTrajectoryPoint, ManipulateVelocity)
 {
   trajectory->longitudinal_velocity_mps() = 10.0;
   trajectory->longitudinal_velocity_mps()
@@ -218,21 +212,21 @@ TEST_F(TrajectoryTestForTrajectoryPoint, manipulate_velocity)
   EXPECT_EQ(10.0, point3.longitudinal_velocity_mps);
 }
 
-TEST_F(TrajectoryTestForTrajectoryPoint, direction)
+TEST_F(TrajectoryTestForTrajectoryPoint, Direction)
 {
   double dir = trajectory->azimuth(0.0);
   EXPECT_LT(0, dir);
   EXPECT_LT(dir, M_PI / 2);
 }
 
-TEST_F(TrajectoryTestForTrajectoryPoint, curvature)
+TEST_F(TrajectoryTestForTrajectoryPoint, Curvature)
 {
   double curvature_val = trajectory->curvature(0.0);
   EXPECT_LT(-1.0, curvature_val);
   EXPECT_LT(curvature_val, 1.0);
 }
 
-TEST_F(TrajectoryTestForTrajectoryPoint, restore)
+TEST_F(TrajectoryTestForTrajectoryPoint, Restore)
 {
   using autoware::experimental::trajectory::Trajectory;
   trajectory->longitudinal_velocity_mps().range(4.0, trajectory->length()).set(5.0);
@@ -240,7 +234,7 @@ TEST_F(TrajectoryTestForTrajectoryPoint, restore)
   EXPECT_EQ(11, points.size());
 }
 
-TEST_F(TrajectoryTestForTrajectoryPoint, crossed)
+TEST_F(TrajectoryTestForTrajectoryPoint, Crossed)
 {
   lanelet::LineString2d line_string;
   line_string.push_back(lanelet::Point3d(lanelet::InvalId, 0.0, 10.0, 0.0));
@@ -253,7 +247,7 @@ TEST_F(TrajectoryTestForTrajectoryPoint, crossed)
   EXPECT_LT(crossed_point.at(0), trajectory->length());
 }
 
-TEST_F(TrajectoryTestForTrajectoryPoint, closest)
+TEST_F(TrajectoryTestForTrajectoryPoint, Closest)
 {
   geometry_msgs::msg::Pose pose;
   pose.position.x = 5.0;
@@ -268,7 +262,7 @@ TEST_F(TrajectoryTestForTrajectoryPoint, closest)
   EXPECT_LT(distance, 3.0);
 }
 
-TEST_F(TrajectoryTestForTrajectoryPoint, crop)
+TEST_F(TrajectoryTestForTrajectoryPoint, Crop)
 {
   double length = trajectory->length();
 
@@ -289,13 +283,13 @@ TEST_F(TrajectoryTestForTrajectoryPoint, crop)
   EXPECT_EQ(end_point_expect.pose.position.y, end_point_actual.pose.position.y);
 }
 
-TEST_F(TrajectoryTestForTrajectoryPoint, max_curvature)
+TEST_F(TrajectoryTestForTrajectoryPoint, MaxCurvature)
 {
   double max_curvature = autoware::experimental::trajectory::max_curvature(*trajectory);
   EXPECT_LT(0, max_curvature);
 }
 
-TEST_F(TrajectoryTestForTrajectoryPoint, build_from_two_points)
+TEST_F(TrajectoryTestForTrajectoryPoint, BuildFromTwoPoints)
 {
   using autoware_utils_geometry::get_rpy;
 

--- a/common/autoware_trajectory/test/test_utils_find_nearest.cpp
+++ b/common/autoware_trajectory/test/test_utils_find_nearest.cpp
@@ -229,7 +229,7 @@ Trajectory<geometry_msgs::msg::Pose> build_lollipop_trajectory(
 // ======================================== TEST ============================================//
 
 // Test 1: Point-based queries find_nearest_index on a curved trajectory (no threshold)
-TEST(trajectory, find_nearest_index_Point_CurvedTrajectory)
+TEST(Trajectory, FindNearestIndexPointCurvedTrajectory)
 {
   auto traj = build_curved_trajectory(10, 1.0, 0.1);
   {
@@ -264,7 +264,7 @@ TEST(trajectory, find_nearest_index_Point_CurvedTrajectory)
 }
 
 // Test 2: find_first_nearest_index on a curved trajectory (no thresholds)
-TEST(trajectory, find_first_nearest_index_CurvedTrajectory)
+TEST(Trajectory, FindFirstNearestIndexCurvedTrajectory)
 {
   auto traj = build_curved_trajectory(10, 1.0, 0.1);
 
@@ -304,7 +304,7 @@ TEST(trajectory, find_first_nearest_index_CurvedTrajectory)
 }
 
 // Test 3: Pose-based queries on curved trajectory with no threshold
-TEST(trajectory, find_first_nearest_index_Pose_NoThreshold)
+TEST(Trajectory, FindFirstNearestIndexPoseNoThreshold)
 {
   auto traj = build_curved_trajectory(10, 1.0, 0.1);
 
@@ -364,7 +364,7 @@ TEST(trajectory, find_first_nearest_index_Pose_NoThreshold)
 }
 
 // Test 4: Pose-based queries on curved trajectory with distance threshold
-TEST(trajectory, find_first_nearest_index_Pose_DistThreshold)
+TEST(Trajectory, FindFirstNearestIndexPoseDistThreshold)
 {
   auto traj = build_curved_trajectory(10, 1.0, 0.1);
 
@@ -386,7 +386,7 @@ TEST(trajectory, find_first_nearest_index_Pose_DistThreshold)
 }
 
 // Pose-based queries on curved trajectory with yaw threshold
-TEST(trajectory, find_first_nearest_index_Pose_YawThreshold)
+TEST(Trajectory, FindFirstNearestIndexPoseYawThreshold)
 {
   auto traj = build_curved_trajectory(10, 1.0, 0.1);
   const double max_d = std::numeric_limits<double>::max();
@@ -409,7 +409,7 @@ TEST(trajectory, find_first_nearest_index_Pose_YawThreshold)
 }
 
 // Test 5: Pose-based queries on curved trajectory with both distance & yaw thresholds
-TEST(trajectory, find_first_nearest_index_Pose_DistAndYawThreshold)
+TEST(Trajectory, FindFirstNearestIndexPoseDistAndYawThreshold)
 {
   auto traj = build_curved_trajectory(10, 1.0, 0.1);
 
@@ -431,7 +431,7 @@ TEST(trajectory, find_first_nearest_index_Pose_DistAndYawThreshold)
 }
 
 // Test 6: Pose-based queries on curved trajectory with both distance & yaw thresholds
-TEST(trajectory, find_first_nearest_index_Pose_TwoMinimaDistAndYawThreshold)
+TEST(Trajectory, FindFirstNearestIndexPoseTwoMinimaDistAndYawThreshold)
 {
   auto traj = build_curved_trajectory(10, 1.0, 0.1);
 
@@ -453,7 +453,7 @@ TEST(trajectory, find_first_nearest_index_Pose_TwoMinimaDistAndYawThreshold)
 }
 
 // Test 7: Two equal distance nearest points on a parabolic trajectory
-TEST(trajectory, find_first_nearest_index_ParabolicTrajectory_AboveMinima)
+TEST(Trajectory, FindFirstNearestIndexParabolicTrajectoryAboveMinima)
 {
   auto traj = build_parabolic_trajectory(11, 1.0);
   {
@@ -468,7 +468,7 @@ TEST(trajectory, find_first_nearest_index_ParabolicTrajectory_AboveMinima)
 }
 
 // Test 8: Two equal distance nearest points at the self-intersecting trajectory (less bases)
-TEST(trajectory, find_first_nearest_index_BowTrajectoryLessBases)
+TEST(Trajectory, FindFirstNearestIndexBowTrajectoryLessBases)
 {
   // ALL FAILED WITH SMALL INACCURATE
   auto traj = build_bow_trajectory(10, 3, 1.5 * M_PI);
@@ -504,7 +504,7 @@ TEST(trajectory, find_first_nearest_index_BowTrajectoryLessBases)
 }
 
 // Test 9: Two equal distance nearest points at the self-intersecting trajectory (many bases)
-TEST(trajectory, find_first_nearest_index_BowTrajectoryManyBases)
+TEST(Trajectory, FindFirstNearestIndexBowTrajectoryManyBases)
 {
   auto traj = build_bow_trajectory(1000, 3, 1.5 * M_PI);
   {
@@ -539,7 +539,7 @@ TEST(trajectory, find_first_nearest_index_BowTrajectoryManyBases)
 }
 
 // Test 10: find_first_nearest_index on vertical loop trajectory
-TEST(trajectory, find_first_nearest_index_VerticalLoop)
+TEST(Trajectory, FindFirstNearestIndexVerticalLoop)
 {
   {
     auto traj = build_vertical_loop_trajectory(10, 3, 3, 0);
@@ -616,7 +616,7 @@ TEST(trajectory, find_first_nearest_index_VerticalLoop)
 }
 
 // TEST 11: Test Lollipop trajectory find_first_nearest_index
-TEST(trajectory, find_first_nearest_index_LollipopTrajectory)
+TEST(Trajectory, FindFirstNearestIndexLollipopTrajectory)
 {
   auto traj = build_lollipop_trajectory(1000, 3);
   {

--- a/common/autoware_trajectory/test/test_utils_find_nearest.cpp
+++ b/common/autoware_trajectory/test/test_utils_find_nearest.cpp
@@ -78,7 +78,7 @@ Trajectory<geometry_msgs::msg::Pose> build_curved_trajectory(
   raw_poses.reserve(num_points);
 
   for (size_t i = 0; i < num_points; ++i) {
-    double theta = i * delta_theta;
+    double theta = static_cast<double>(i) * delta_theta;
     double x = static_cast<double>(i) * interval * std::cos(theta);
     double y = static_cast<double>(i) * interval * std::sin(theta);
     geometry_msgs::msg::Pose p;
@@ -118,10 +118,10 @@ Trajectory<geometry_msgs::msg::Pose> build_bow_trajectory(
   std::vector<geometry_msgs::msg::Pose> raw_poses;
   raw_poses.reserve(num_points);
 
-  auto delta_theta = total_angle / num_points;
+  auto delta_theta = total_angle / static_cast<double>(num_points);
 
   for (size_t i = 0; i < num_points; ++i) {
-    double theta = M_PI / 4 + i * delta_theta;
+    double theta = M_PI / 4 + static_cast<double>(i) * delta_theta;
 
     double x = size * cos(theta);
     double y = size * sin(theta) * cos(theta);
@@ -154,28 +154,28 @@ Trajectory<geometry_msgs::msg::Pose> build_vertical_loop_trajectory(
   size_t second_part = static_cast<size_t>(num_points - first_part - last_part);
 
   // First part: going in (from right to left)
-  double rate = (start_x) / (first_part);
+  double rate = (start_x) / static_cast<double>(first_part);
   for (size_t i = 0u; i < first_part; ++i) {
-    double x = start_x - rate * i;
+    double x = start_x - rate * static_cast<double>(i);
     double y = offset;
     raw_poses.push_back(make_pose(x, y, M_PI));
   }
 
   // Second part: go in the loop
   double start_theta = M_PI * 3 / 2;
-  double loop_rate = 2 * M_PI / (second_part - 1);
+  double loop_rate = 2 * M_PI / static_cast<double>(second_part - 1);
   for (size_t i = 0u; i < second_part; ++i) {
     // from 3/2 pi to -1/2pi
-    double theta = start_theta - i * loop_rate;
+    double theta = start_theta - static_cast<double>(i) * loop_rate;
     double x = radius * cos(theta);
     double y = (offset + radius) + radius * sin(theta);
     raw_poses.push_back(make_pose(x, y, theta - M_PI / 2));
   }
 
   // Last part: go out to the left
-  double out_rate = (start_x) / (first_part);
+  double out_rate = (start_x) / static_cast<double>(first_part);
   for (size_t i = 1u; i <= last_part; ++i) {
-    double x = 0 - out_rate * i;
+    double x = 0 - out_rate * static_cast<double>(i);
     double y = offset;
     raw_poses.push_back(make_pose(x, y, M_PI));
   }
@@ -196,9 +196,9 @@ Trajectory<geometry_msgs::msg::Pose> build_lollipop_trajectory(
   size_t second_part = static_cast<size_t>(num_points - first_part - last_part);
 
   // First part: go into bottom
-  double rate = (start_x) / (first_part);
+  double rate = (start_x) / static_cast<double>(first_part);
   for (size_t i = 0u; i < first_part; ++i) {
-    double x = start_x - rate * i;
+    double x = start_x - rate * static_cast<double>(i);
     double y = offset - radius * sin(phase_dif / 2);
     raw_poses.push_back(make_pose(x, y, M_PI));
   }
@@ -206,19 +206,19 @@ Trajectory<geometry_msgs::msg::Pose> build_lollipop_trajectory(
   // Second part: go in the loop
   double start_theta = 2 * M_PI - phase_dif / 2;
   double end_theta = phase_dif / 2;
-  double loop_rate = (end_theta - start_theta) / (second_part - 1);
+  double loop_rate = (end_theta - start_theta) / static_cast<double>(second_part - 1);
   for (size_t i = 0u; i < second_part; ++i) {
     // from -phase_dif/2 to +phase_dif/2
-    double theta = start_theta + i * loop_rate;
+    double theta = start_theta + static_cast<double>(i) * loop_rate;
     double x = -radius * cos(phase_dif / 2) + radius * cos(theta);
     double y = offset + radius * sin(theta);
     raw_poses.push_back(make_pose(x, y, theta - M_PI / 2));
   }
 
   // Last part: go out from top
-  double out_rate = (start_x) / (last_part);
+  double out_rate = (start_x) / static_cast<double>(last_part);
   for (size_t i = 1u; i <= last_part; ++i) {
-    double x = 0 + out_rate * i;
+    double x = 0 + out_rate * static_cast<double>(i);
     double y = offset + radius * sin(phase_dif / 2);
     raw_poses.push_back(make_pose(x, y, 0));
   }

--- a/common/autoware_trajectory/test/test_utils_footprint.cpp
+++ b/common/autoware_trajectory/test/test_utils_footprint.cpp
@@ -55,7 +55,7 @@ Trajectory<geometry_msgs::msg::Pose> build_parabolic_trajectory(
 }
 
 // Test 1: check type of long path polygon from build_path_polygon
-TEST(trajectoryFootprint, LongPolygon)
+TEST(TrajectoryFootprint, LongPolygon)
 {
   auto traj = build_parabolic_trajectory(11, 0.5);
   const auto polygon = autoware::experimental::trajectory::build_path_polygon(
@@ -66,7 +66,7 @@ TEST(trajectoryFootprint, LongPolygon)
 }
 
 // Test 2: count numbers of footprint trace with default interval
-TEST(trajectoryFootprint, FootprintTraceDefault)
+TEST(TrajectoryFootprint, FootprintTraceDefault)
 {
   autoware_utils_geometry::Point2d left_front{-0.5, 0.25};
   autoware_utils_geometry::Point2d right_front{0.5, 0.25};
@@ -104,7 +104,7 @@ TEST(trajectoryFootprint, FootprintTraceDefault)
 }
 
 // Test 3: count numbers of footprint trace with designated interval
-TEST(trajectoryFootprint, FootprintTraceAdjustInterval)
+TEST(TrajectoryFootprint, FootprintTraceAdjustInterval)
 {
   autoware_utils_geometry::Point2d left_front{-0.5, 0.25};
   autoware_utils_geometry::Point2d right_front{0.5, 0.25};

--- a/common/autoware_trajectory/test/test_utils_lateral_metrics.cpp
+++ b/common/autoware_trajectory/test/test_utils_lateral_metrics.cpp
@@ -77,7 +77,7 @@ Trajectory<geometry_msgs::msg::Pose> build_parabolic_trajectory(
 }
 
 // Test 1: Simple test on horizontal line
-TEST(lateral_metrics, horizontalLine)
+TEST(LateralMetrics, HorizontalLine)
 {
   auto traj = build_horizontal_line(10, 1.0);
   geometry_msgs::msg::Point target_point;
@@ -96,7 +96,7 @@ TEST(lateral_metrics, horizontalLine)
 }
 
 // Test 2: Parabolic Trajectory (not at nearest index)
-TEST(lateral_metrics, parabolicTrajectoryNotNearest)
+TEST(LateralMetrics, ParabolicTrajectoryNotNearest)
 {
   auto traj = build_parabolic_trajectory(11, 0.5);
   geometry_msgs::msg::Point target_point;

--- a/common/autoware_trajectory/test/test_utils_velocity.cpp
+++ b/common/autoware_trajectory/test/test_utils_velocity.cpp
@@ -42,7 +42,7 @@ static TrajectoryPoint make_trajectory_point(double x, double y, double vx, doub
 namespace autoware::experimental::trajectory
 {
 
-TEST(search_zero_velocity_position, found_at_exact_base_point)
+TEST(SearchZeroVelocityPosition, FoundAtExactBasePoint)
 {
   std::vector<TrajectoryPoint> points;
   points.push_back(make_trajectory_point(0.0, 0.0, 10.0));
@@ -57,7 +57,7 @@ TEST(search_zero_velocity_position, found_at_exact_base_point)
   EXPECT_NEAR(result.value(), traj.length() * 2.0 / 3.0, k_zero_velocity_threshold);
 }
 
-TEST(search_zero_velocity_position, found_at_zero_crossing)
+TEST(SearchZeroVelocityPosition, FoundAtZeroCrossing)
 {
   std::vector<TrajectoryPoint> points;
   points.push_back(make_trajectory_point(0.0, 0.0, 10.0));
@@ -73,7 +73,7 @@ TEST(search_zero_velocity_position, found_at_zero_crossing)
   EXPECT_LT(result.value(), traj.length());
 }
 
-TEST(search_zero_velocity_position, not_found_monotonic_positive)
+TEST(SearchZeroVelocityPosition, NotFoundMonotonicPositive)
 {
   std::vector<TrajectoryPoint> points;
   points.push_back(make_trajectory_point(0.0, 0.0, 10.0));
@@ -87,7 +87,7 @@ TEST(search_zero_velocity_position, not_found_monotonic_positive)
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(search_zero_velocity_position, not_found_monotonic_negative)
+TEST(SearchZeroVelocityPosition, NotFoundMonotonicNegative)
 {
   std::vector<TrajectoryPoint> points;
   points.push_back(make_trajectory_point(0.0, 0.0, -10.0));
@@ -101,7 +101,7 @@ TEST(search_zero_velocity_position, not_found_monotonic_negative)
   EXPECT_FALSE(result.has_value());
 }
 
-TEST(search_zero_velocity_position, found_at_first_point)
+TEST(SearchZeroVelocityPosition, FoundAtFirstPoint)
 {
   std::vector<TrajectoryPoint> points;
   points.push_back(make_trajectory_point(0.0, 0.0, 0.0));
@@ -116,7 +116,7 @@ TEST(search_zero_velocity_position, found_at_first_point)
   EXPECT_NEAR(result.value(), 0.0, k_zero_velocity_threshold);
 }
 
-TEST(search_zero_velocity_position, found_at_last_point)
+TEST(SearchZeroVelocityPosition, FoundAtLastPoint)
 {
   std::vector<TrajectoryPoint> points;
   points.push_back(make_trajectory_point(0.0, 0.0, 2.0));
@@ -131,7 +131,7 @@ TEST(search_zero_velocity_position, found_at_last_point)
   EXPECT_NEAR(result.value(), traj.length(), k_zero_velocity_threshold);
 }
 
-TEST(search_zero_velocity_position, found_with_interval)
+TEST(SearchZeroVelocityPosition, FoundWithInterval)
 {
   std::vector<TrajectoryPoint> points;
   points.push_back(make_trajectory_point(0.0, 0.0, 10.0));

--- a/common/autoware_trajectory/test/test_utils_velocity.cpp
+++ b/common/autoware_trajectory/test/test_utils_velocity.cpp
@@ -33,7 +33,7 @@ static TrajectoryPoint make_trajectory_point(double x, double y, double vx, doub
   point.pose = build<Pose>()
                  .position(build<Point>().x(x).y(y).z(0.0))
                  .orientation(create_quaternion_from_yaw(yaw));
-  point.longitudinal_velocity_mps = vx;
+  point.longitudinal_velocity_mps = static_cast<float>(vx);
   point.lateral_velocity_mps = 0.0;
   point.heading_rate_rps = 0.0;
   return point;


### PR DESCRIPTION
## Description

Rename the test files by following [this guidline](https://autowarefoundation.github.io/autoware-documentation/main/contributing/testing-guidelines/unit-testing/).

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

(ADDED by @sasakisasaki ) We will check if the CI build and tests succeed.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
