### PR TITLE
fix(ground_filter): remove unused `grid_id`

### DIFF
--- a/perception/autoware_ground_filter/src/ground_filter.hpp
+++ b/perception/autoware_ground_filter/src/ground_filter.hpp
@@ -46,10 +46,7 @@ struct PointsCentroid
   std::vector<float> radius_list;
   std::vector<bool> is_ground_list;
 
-  PointsCentroid()
-  : radius_avg(0.0f), height_avg(0.0f), height_max(-10.0f), height_min(10.0f)
-  {
-  }
+  PointsCentroid() : radius_avg(0.0f), height_avg(0.0f), height_max(-10.0f), height_min(10.0f) {}
 
   void initialize()
   {

--- a/perception/autoware_ground_filter/src/ground_filter.hpp
+++ b/perception/autoware_ground_filter/src/ground_filter.hpp
@@ -41,14 +41,13 @@ struct PointsCentroid
   float height_avg;
   float height_max;
   float height_min;
-  uint16_t grid_id;
   std::vector<size_t> pcl_indices;
   std::vector<float> height_list;
   std::vector<float> radius_list;
   std::vector<bool> is_ground_list;
 
   PointsCentroid()
-  : radius_avg(0.0f), height_avg(0.0f), height_max(-10.0f), height_min(10.0f), grid_id(0)
+  : radius_avg(0.0f), height_avg(0.0f), height_max(-10.0f), height_min(10.0f)
   {
   }
 
@@ -58,7 +57,6 @@ struct PointsCentroid
     height_avg = 0.0f;
     height_max = -10.0f;
     height_min = 10.0f;
-    grid_id = 0;
     pcl_indices.clear();
     height_list.clear();
     radius_list.clear();

--- a/perception/autoware_ground_filter/src/node.cpp
+++ b/perception/autoware_ground_filter/src/node.cpp
@@ -430,7 +430,7 @@ void GroundFilterComponent::convertPointcloud(
 
       // store the point in the corresponding radial division
       out_radial_ordered_points[radial_div].emplace_back(
-        PointData{radius, PointLabel::INIT, 0U, data_index});
+        PointData{radius, PointLabel::INIT, data_index});
     }
   }
 

--- a/perception/autoware_ground_filter/src/node.hpp
+++ b/perception/autoware_ground_filter/src/node.hpp
@@ -105,7 +105,6 @@ private:
   {
     float radius;  // cylindrical coords on XY Plane
     PointLabel point_state{PointLabel::INIT};
-    uint16_t grid_id;   // id of grid in vertical
     size_t data_index;  // index of this point data in the source pointcloud
   };
   using PointCloudVector = std::vector<PointData>;
@@ -119,7 +118,6 @@ private:
     float height_max;
     float height_min;
     uint32_t point_num;
-    uint16_t grid_id;
     std::vector<size_t> pcl_indices;
     std::vector<float> height_list;
     std::vector<float> radius_list;
@@ -131,8 +129,7 @@ private:
       height_avg(0.0f),
       height_max(-10.0f),
       height_min(10.0f),
-      point_num(0),
-      grid_id(0)
+      point_num(0)
     {
     }
 
@@ -145,7 +142,6 @@ private:
       height_max = -10.0f;
       height_min = 10.0f;
       point_num = 0;
-      grid_id = 0;
       pcl_indices.clear();
       height_list.clear();
     }

--- a/perception/autoware_ground_filter/test/test_ground_filter.cpp
+++ b/perception/autoware_ground_filter/test/test_ground_filter.cpp
@@ -146,7 +146,6 @@ TEST_F(GroundFilterTest, TestPointsCentroidFunctionality)
   EXPECT_FLOAT_EQ(centroid.height_avg, 0.0f);
   EXPECT_FLOAT_EQ(centroid.height_max, -10.0f);
   EXPECT_FLOAT_EQ(centroid.height_min, 10.0f);
-  EXPECT_EQ(centroid.grid_id, 0);
 
   // Test addPoint functionality
   centroid.addPoint(1.0f, 0.5f, 0);


### PR DESCRIPTION
## Description

Removed unused `grid_id` form `PointsCentroid` and `PointData`

## Related links

@xmfcx 's comment
https://github.com/autowarefoundation/autoware_core/pull/956#pullrequestreview-4085498733

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Passed unit tests.

```
$ colcon test --packages-select autoware_ground_filter
Starting >>> autoware_ground_filter
Finished <<< autoware_ground_filter [11.5s]            

Summary: 1 package finished [12.4s]
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
