### PR TITLE
fix(`workflows`): exclude all test folders in the `build-and-test-diff-reusable.yaml`

### DIFF
--- a/.github/workflows/build-and-test-diff-reusable.yaml
+++ b/.github/workflows/build-and-test-diff-reusable.yaml
@@ -158,7 +158,7 @@ jobs:
       - name: Get changed files (existing files only, excluding header-only packages)
         id: get-changed-files
         run: |
-          changed_files=$(git diff --diff-filter=d --name-only "origin/${{ github.base_ref }}"...HEAD | { grep -E '\.(cpp|hpp)$' || true; } | { grep -Ev '(^|/)(test|tests)/' || true; } | while read -r file; do [ -e "$file" ] && echo -n "$file "; done)
+          changed_files=$(git diff --diff-filter=d --name-only "origin/${{ github.base_ref }}"...HEAD | { grep -E '\.(cpp|hpp)$' || true; } | { grep -Ev '(^|/)test/' || true; } | while read -r file; do [ -e "$file" ] && echo -n "$file "; done)
 
           # Exclude files belonging to header-only packages (no .cpp in src/).
           # These packages don't generate compile_commands.json, which causes clang-tidy to fail.

--- a/.github/workflows/build-and-test-diff-reusable.yaml
+++ b/.github/workflows/build-and-test-diff-reusable.yaml
@@ -158,7 +158,7 @@ jobs:
       - name: Get changed files (existing files only, excluding header-only packages)
         id: get-changed-files
         run: |
-          changed_files=$(git diff --diff-filter=d --name-only "origin/${{ github.base_ref }}"...HEAD | { grep -E '\.(cpp|hpp)$' || true; } | while read -r file; do [ -e "$file" ] && echo -n "$file "; done)
+          changed_files=$(git diff --diff-filter=d --name-only "origin/${{ github.base_ref }}"...HEAD | { grep -E '\.(cpp|hpp)$' || true; } | { grep -Ev '(^|/)(test|tests)/' || true; } | while read -r file; do [ -e "$file" ] && echo -n "$file "; done)
 
           # Exclude files belonging to header-only packages (no .cpp in src/).
           # These packages don't generate compile_commands.json, which causes clang-tidy to fail.


### PR DESCRIPTION
## Description
- Exclude files under test directories from clang-tidy differential target files.
- Keep the existing header-only package filter intact.

## Related links
- https://github.com/autowarefoundation/autoware_core/pull/942

## How was this PR tested?
- We see if the required CIs pass. The result will be added after the CI succeeded.

Also, I tested the change on my local machine by running following command with intentional dummy change and commit (due to `echo -n`, the output is a little bit hard-to-see). The test source file is excluded by this PR fix.
```bash
junyasasaki@dpc2403002:~/autoware_core$ git diff --diff-filter=d --name-only "origin/main"...HEAD
.github/workflows/build-and-test-diff-reusable.yaml
planning/autoware_path_generator/src/utils.hpp
planning/autoware_path_generator/test/test_path_cut.cpp
junyasasaki@dpc2403002:~/autoware_core$ git diff --diff-filter=d --name-only "origin/main"...HEAD | { grep -E '\.(cpp|hpp)$' || true; } | while read -r file; do [ -e "$file" ] && echo -n "$file "; done
planning/autoware_path_generator/src/utils.hpp planning/autoware_path_generator/test/test_path_cut.cpp junyasasaki@dpc2403002:~/autoware_core$ 
junyasasaki@dpc2403002:~/autoware_core$ 
junyasasaki@dpc2403002:~/autoware_core$ git diff --diff-filter=d --name-only "origin/main"...HEAD | { grep -E '\.(cpp|hpp)$' || true; } | { grep -Ev '(^|/)test/' || true; } | while read -r file; do [ -e "$file" ] && echo -n "$file "; done
planning/autoware_path_generator/src/utils.hpp junyasasaki@dpc2403002:~/autoware_core$
```

## Notes for reviewers
- The change only affects the clang-tidy target file list; build and test steps are unchanged.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior
- No runtime behavior changes; CI clang-tidy skips files in test directories.
