### PR TITLE
ci(clang-tidy): exclude test files from clang-tidy-ignore

### DIFF
--- a/.clang-tidy-ignore
+++ b/.clang-tidy-ignore
@@ -1,1 +1,2 @@
 */examples/*
+*/test/*


### PR DESCRIPTION
- **Parent Issue:** #774
- Exclude `*/test/*` in `.clang-tidy-ignore` to align differential and full clang-tidy CI behavior

## Why

The differential clang-tidy job ([`build-and-test-diff-reusable.yaml#L161`](https://github.com/autowarefoundation/autoware_core/blob/e086a2b98a8f42c7251f36795ee793c8778d363b/.github/workflows/build-and-test-diff-reusable.yaml#L161)) uses `git diff` to find changed files and passes them via `target-files`, which includes test files. The full build ([`build-and-test-reusable.yaml#L183-L192`](https://github.com/autowarefoundation/autoware_core/blob/e086a2b98a8f42c7251f36795ee793c8778d363b/.github/workflows/build-and-test-reusable.yaml#L183-L192)) does not pass `target-files`, so the clang-tidy action falls back to `find ... -name '*.cpp'` ([action.yaml#L157](https://github.com/autowarefoundation/autoware-github-actions/blob/f3e70631ee2e625f4764f87b05759e6183001950/clang-tidy/action.yaml#L157)), which naturally skips test directories. This mismatch causes PRs like #1025 to fail differential clang-tidy on test files the full build never checks.

This exclusion should be removed in the future once existing test file violations are fixed.

---

## Test plan

- [ ] Verify that PRs modifying test files (e.g. #1025) no longer fail differential clang-tidy