### PR TITLE
fix(ekf_localizer): ekf localizer diagnostics name

### DIFF
--- a/localization/autoware_ekf_localizer/package.xml
+++ b/localization/autoware_ekf_localizer/package.xml
@@ -26,7 +26,6 @@
   <depend>autoware_utils_logging</depend>
   <depend>autoware_utils_system</depend>
   <depend>diagnostic_msgs</depend>
-  <depend>diagnostic_updater</depend>
   <depend>fmt</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>

--- a/localization/autoware_ekf_localizer/schema/sub/diagnostics.sub_schema.json
+++ b/localization/autoware_ekf_localizer/schema/sub/diagnostics.sub_schema.json
@@ -4,7 +4,7 @@
   "definitions": {
     "diagnostics": {
       "type": "object",
-      "description": "Thresholds for per-check diagnostic status and the /diagnostics publish cadence. The main ekf_localizer task reflects merged status each EKF cycle; after at least one merged level change it includes KeyValue last_level_transition_timestamp (RCL ns), including while merged level is OK. An EKF node timer calls diagnostic_updater::force_update at 1/diagnostics_publish_frequency [s] (updater publishes /diagnostics; internal updater timer is disabled). The same timer also publishes a manually assembled DiagnosticArray on diagnostics_manual in parallel. Severity increase versus the previous EKF tick may trigger an extra immediate force_update and manual publish.",
+      "description": "Thresholds for per-check diagnostic status and the /diagnostics publish cadence. The main ekf_localizer task reflects merged status each EKF cycle; after at least one merged level change it includes KeyValue last_level_transition_timestamp (RCL ns), including while merged level is OK. An EKF node timer publishes a manually assembled DiagnosticArray to /diagnostics at 1/diagnostics_publish_frequency [s]. Severity increase versus the previous EKF tick may trigger an extra immediate publish in addition to this rate.",
       "properties": {
         "pose_no_update_count_threshold_warn": {
           "type": "integer",
@@ -53,7 +53,7 @@
         },
         "diagnostics_publish_frequency": {
           "type": "number",
-          "description": "Diagnostics publish frequency [Hz] (period = 1/frequency) for the EKF node timer that calls diagnostic_updater::force_update (and mirrors to diagnostics_manual). Must be strictly positive; matches config/ekf_localizer.param.yaml package default. When merged diagnostic severity increases versus the previous EKF timer tick, an extra immediate publish is triggered in addition to this rate.",
+          "description": "Diagnostics publish frequency [Hz] (period = 1/frequency) for the EKF node timer that publishes /diagnostics. Must be strictly positive; matches config/ekf_localizer.param.yaml package default. When merged diagnostic severity increases versus the previous EKF timer tick, an extra immediate publish is triggered in addition to this rate.",
           "default": 10.0,
           "exclusiveMinimum": 0
         }

--- a/localization/autoware_ekf_localizer/schema/sub/diagnostics.sub_schema.json
+++ b/localization/autoware_ekf_localizer/schema/sub/diagnostics.sub_schema.json
@@ -4,7 +4,7 @@
   "definitions": {
     "diagnostics": {
       "type": "object",
-      "description": "Thresholds for per-check diagnostic status and the diagnostic_updater publish cadence. The main ekf_localizer task reflects merged status each EKF cycle; after at least one merged level change it includes KeyValue last_level_transition_timestamp (RCL ns), including while merged level is OK. diagnostic_updater publishes /diagnostics at 1/diagnostics_publish_frequency [s], and may publish immediately when merged severity increases versus the previous EKF tick.",
+      "description": "Thresholds for per-check diagnostic status and the /diagnostics publish cadence. The main ekf_localizer task reflects merged status each EKF cycle; after at least one merged level change it includes KeyValue last_level_transition_timestamp (RCL ns), including while merged level is OK. An EKF node timer triggers diagnostic_updater::force_update at 1/diagnostics_publish_frequency [s], and severity increase versus the previous EKF tick may trigger an extra immediate publish.",
       "properties": {
         "pose_no_update_count_threshold_warn": {
           "type": "integer",
@@ -53,7 +53,7 @@
         },
         "diagnostics_publish_frequency": {
           "type": "number",
-          "description": "Diagnostics publish frequency [Hz] for diagnostic_updater::Updater (period = 1/frequency). Must be strictly positive; matches config/ekf_localizer.param.yaml package default. When merged diagnostic severity increases versus the previous EKF timer tick, an extra immediate publish is triggered in addition to this rate.",
+          "description": "Diagnostics publish frequency [Hz] (period = 1/frequency) for the EKF node timer that calls diagnostic_updater::force_update. Must be strictly positive; matches config/ekf_localizer.param.yaml package default. When merged diagnostic severity increases versus the previous EKF timer tick, an extra immediate publish is triggered in addition to this rate.",
           "default": 10.0,
           "exclusiveMinimum": 0
         }

--- a/localization/autoware_ekf_localizer/schema/sub/diagnostics.sub_schema.json
+++ b/localization/autoware_ekf_localizer/schema/sub/diagnostics.sub_schema.json
@@ -4,7 +4,7 @@
   "definitions": {
     "diagnostics": {
       "type": "object",
-      "description": "Thresholds for per-check diagnostic status and the /diagnostics publish cadence. The main ekf_localizer task reflects merged status each EKF cycle; after at least one merged level change it includes KeyValue last_level_transition_timestamp (RCL ns), including while merged level is OK. An EKF node timer triggers diagnostic_updater::force_update at 1/diagnostics_publish_frequency [s], and severity increase versus the previous EKF tick may trigger an extra immediate publish.",
+      "description": "Thresholds for per-check diagnostic status and the /diagnostics publish cadence. The main ekf_localizer task reflects merged status each EKF cycle; after at least one merged level change it includes KeyValue last_level_transition_timestamp (RCL ns), including while merged level is OK. An EKF node timer calls diagnostic_updater::force_update at 1/diagnostics_publish_frequency [s] (updater publishes /diagnostics; internal updater timer is disabled). The same timer also publishes a manually assembled DiagnosticArray on diagnostics_manual in parallel. Severity increase versus the previous EKF tick may trigger an extra immediate force_update and manual publish.",
       "properties": {
         "pose_no_update_count_threshold_warn": {
           "type": "integer",
@@ -53,7 +53,7 @@
         },
         "diagnostics_publish_frequency": {
           "type": "number",
-          "description": "Diagnostics publish frequency [Hz] (period = 1/frequency) for the EKF node timer that calls diagnostic_updater::force_update. Must be strictly positive; matches config/ekf_localizer.param.yaml package default. When merged diagnostic severity increases versus the previous EKF timer tick, an extra immediate publish is triggered in addition to this rate.",
+          "description": "Diagnostics publish frequency [Hz] (period = 1/frequency) for the EKF node timer that calls diagnostic_updater::force_update (and mirrors to diagnostics_manual). Must be strictly positive; matches config/ekf_localizer.param.yaml package default. When merged diagnostic severity increases versus the previous EKF timer tick, an extra immediate publish is triggered in addition to this rate.",
           "default": 10.0,
           "exclusiveMinimum": 0
         }

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -62,12 +62,17 @@ EKFLocalizer::EKFLocalizer(const rclcpp::NodeOptions & node_options)
   merged_diagnostic_status_.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
   merged_diagnostic_status_.message = "OK";
 
-  // Configure diagnostic updater
+  // diagnostic_updater: keep tasks/publisher; disable its internal timer (setPeriod very large).
+  // This node's diagnostics_publish_timer_ calls force_update() at diagnostics_publish_period.
   diagnostics_.setHardwareID(this->get_name());
-  diagnostics_.setPeriod(rclcpp::Duration::from_seconds(params_.diagnostics_publish_period));
-  diagnostics_.add("ekf_localizer", this, &EKFLocalizer::diagnose);
-  diagnostics_.add("callback_pose", this, &EKFLocalizer::diagnose_callback_pose);
-  diagnostics_.add("callback_twist", this, &EKFLocalizer::diagnose_callback_twist);
+  diagnostics_.setPeriod(rclcpp::Duration::from_seconds(1e9));
+  const std::string diag_base = "localization: " + std::string(this->get_name());
+  diagnostics_.add(diag_base, this, &EKFLocalizer::diagnose);
+  diagnostics_.add(diag_base + ": callback_pose", this, &EKFLocalizer::diagnose_callback_pose);
+  diagnostics_.add(diag_base + ": callback_twist", this, &EKFLocalizer::diagnose_callback_twist);
+  diagnostics_publish_timer_ = rclcpp::create_timer(
+    this, get_clock(), rclcpp::Duration::from_seconds(params_.diagnostics_publish_period),
+    [this]() { diagnostics_.force_update(); });
 
   /* initialize ros system */
   timer_control_ = rclcpp::create_timer(
@@ -451,13 +456,12 @@ void EKFLocalizer::publish_estimate_result(
 void EKFLocalizer::diagnose(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
   // merged_diagnostic_status_ is updated in update_diagnostics() each EKF tick. Publishing is
-  // driven by diagnostic_updater at diagnostics_publish_period, or force_update() on severity
-  // increase vs. the previous tick.
+  // driven by diagnostics_publish_timer_ at diagnostics_publish_period, or force_update() on
+  // severity increase vs. the previous tick.
   //
   // Thread safety: copy first for a consistent snapshot if a multi-threaded executor is used.
   const diagnostic_msgs::msg::DiagnosticStatus snapshot = merged_diagnostic_status_;
 
-  stat.name = "localization: " + std::string(this->get_name());
   stat.hardware_id = this->get_name();
   stat.summary(snapshot);
 
@@ -468,7 +472,6 @@ void EKFLocalizer::diagnose(diagnostic_updater::DiagnosticStatusWrapper & stat)
 
 void EKFLocalizer::diagnose_callback_pose(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
-  stat.name = "localization: " + std::string(this->get_name()) + ": callback_pose";
   stat.hardware_id = this->get_name();
   stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "OK");
   stat.add("topic_time_stamp", std::to_string(last_pose_callback_time_.nanoseconds()));
@@ -476,7 +479,6 @@ void EKFLocalizer::diagnose_callback_pose(diagnostic_updater::DiagnosticStatusWr
 
 void EKFLocalizer::diagnose_callback_twist(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
-  stat.name = "localization: " + std::string(this->get_name()) + ": callback_twist";
   stat.hardware_id = this->get_name();
   stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "OK");
   stat.add("topic_time_stamp", std::to_string(last_twist_callback_time_.nanoseconds()));

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -52,7 +52,6 @@ EKFLocalizer::EKFLocalizer(const rclcpp::NodeOptions & node_options)
   ekf_dt_(params_.ekf_dt),
   pose_queue_(params_.pose_smoothing_steps, params_.max_pose_queue_size),
   twist_queue_(params_.twist_smoothing_steps, params_.max_twist_queue_size),
-  diagnostics_(this),
   merged_diagnostic_last_transition_time_(0, 0, RCL_ROS_TIME),
   last_pose_callback_time_(0, 0, RCL_ROS_TIME),
   last_twist_callback_time_(0, 0, RCL_ROS_TIME)
@@ -61,14 +60,6 @@ EKFLocalizer::EKFLocalizer(const rclcpp::NodeOptions & node_options)
   is_set_initialpose_ = false;
   merged_diagnostic_status_.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
   merged_diagnostic_status_.message = "OK";
-
-  // diagnostic_updater: internal timer off; EKF diagnostics_publish_timer_ calls force_update().
-  diagnostics_.setHardwareID(this->get_name());
-  diagnostics_.setPeriod(rclcpp::Duration::from_seconds(1e9));
-  const std::string diag_base = "localization: " + std::string(this->get_name());
-  diagnostics_.add(diag_base, this, &EKFLocalizer::diagnose);
-  diagnostics_.add(diag_base + ": callback_pose", this, &EKFLocalizer::diagnose_callback_pose);
-  diagnostics_.add(diag_base + ": callback_twist", this, &EKFLocalizer::diagnose_callback_twist);
 
   /* initialize ros system */
   timer_control_ = rclcpp::create_timer(
@@ -89,14 +80,11 @@ EKFLocalizer::EKFLocalizer(const rclcpp::NodeOptions & node_options)
     "ekf_biased_pose_with_covariance", 1);
   pub_processing_time_ = create_publisher<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "debug/processing_time_ms", 1);
-  pub_diagnostics_manual_ =
-    create_publisher<diagnostic_msgs::msg::DiagnosticArray>("diagnostics_manual", 1);
+  pub_diagnostics_ =
+    create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 1);
   diagnostics_publish_timer_ = rclcpp::create_timer(
     this, get_clock(), rclcpp::Duration::from_seconds(params_.diagnostics_publish_period),
-    [this]() {
-      diagnostics_.force_update();
-      publish_diagnostics_manual();
-    });
+    [this]() { publish_diagnostics(); });
   sub_initialpose_ = create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
     "initialpose", 1, std::bind(&EKFLocalizer::callback_initial_pose, this, _1));
   sub_pose_with_cov_ = create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
@@ -299,9 +287,8 @@ void EKFLocalizer::timer_callback()
   /* publish ekf result */
   publish_estimate_result(current_ekf_pose, current_biased_ekf_pose, current_ekf_twist);
 
-  /* Latch merged diagnostics every EKF cycle; publishing is periodic via diagnostics_publish_timer_
-   * (force_update + publish_diagnostics_manual), plus the same pair inside update_diagnostics when
-   * severity increases. */
+  /* Latch merged diagnostics every EKF cycle; publishing is periodic via diagnostics_publish_timer_,
+   * plus publish_diagnostics() inside update_diagnostics when severity increases. */
   update_diagnostics(diag_status_array, current_time);
 
   /* publish processing time */
@@ -458,7 +445,7 @@ void EKFLocalizer::publish_estimate_result(
   tf_br_->sendTransform(transform_stamped);
 }
 
-void EKFLocalizer::publish_diagnostics_manual()
+void EKFLocalizer::publish_diagnostics()
 {
   const std::string node_name = this->get_name();
   const std::string main_name = "localization: " + node_name;
@@ -500,31 +487,7 @@ void EKFLocalizer::publish_diagnostics_manual()
   msg.status.push_back(main_st);
   msg.status.push_back(pose_st);
   msg.status.push_back(twist_st);
-  pub_diagnostics_manual_->publish(msg);
-}
-
-void EKFLocalizer::diagnose(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  const diagnostic_msgs::msg::DiagnosticStatus snapshot = merged_diagnostic_status_;
-  stat.hardware_id = this->get_name();
-  stat.summary(snapshot);
-  for (const auto & value : snapshot.values) {
-    stat.add(value.key, value.value);
-  }
-}
-
-void EKFLocalizer::diagnose_callback_pose(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  stat.hardware_id = this->get_name();
-  stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "OK");
-  stat.add("topic_time_stamp", std::to_string(last_pose_callback_time_.nanoseconds()));
-}
-
-void EKFLocalizer::diagnose_callback_twist(diagnostic_updater::DiagnosticStatusWrapper & stat)
-{
-  stat.hardware_id = this->get_name();
-  stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "OK");
-  stat.add("topic_time_stamp", std::to_string(last_twist_callback_time_.nanoseconds()));
+  pub_diagnostics_->publish(msg);
 }
 
 void EKFLocalizer::update_diagnostics(
@@ -564,8 +527,7 @@ void EKFLocalizer::update_diagnostics(
   }
 
   if (level_merged > level_before) {
-    diagnostics_.force_update();
-    publish_diagnostics_manual();
+    publish_diagnostics();
   }
 }
 

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -62,17 +62,13 @@ EKFLocalizer::EKFLocalizer(const rclcpp::NodeOptions & node_options)
   merged_diagnostic_status_.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
   merged_diagnostic_status_.message = "OK";
 
-  // diagnostic_updater: keep tasks/publisher; disable its internal timer (setPeriod very large).
-  // This node's diagnostics_publish_timer_ calls force_update() at diagnostics_publish_period.
+  // diagnostic_updater: internal timer off; EKF diagnostics_publish_timer_ calls force_update().
   diagnostics_.setHardwareID(this->get_name());
   diagnostics_.setPeriod(rclcpp::Duration::from_seconds(1e9));
   const std::string diag_base = "localization: " + std::string(this->get_name());
   diagnostics_.add(diag_base, this, &EKFLocalizer::diagnose);
   diagnostics_.add(diag_base + ": callback_pose", this, &EKFLocalizer::diagnose_callback_pose);
   diagnostics_.add(diag_base + ": callback_twist", this, &EKFLocalizer::diagnose_callback_twist);
-  diagnostics_publish_timer_ = rclcpp::create_timer(
-    this, get_clock(), rclcpp::Duration::from_seconds(params_.diagnostics_publish_period),
-    [this]() { diagnostics_.force_update(); });
 
   /* initialize ros system */
   timer_control_ = rclcpp::create_timer(
@@ -93,6 +89,14 @@ EKFLocalizer::EKFLocalizer(const rclcpp::NodeOptions & node_options)
     "ekf_biased_pose_with_covariance", 1);
   pub_processing_time_ = create_publisher<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "debug/processing_time_ms", 1);
+  pub_diagnostics_manual_ =
+    create_publisher<diagnostic_msgs::msg::DiagnosticArray>("diagnostics_manual", 1);
+  diagnostics_publish_timer_ = rclcpp::create_timer(
+    this, get_clock(), rclcpp::Duration::from_seconds(params_.diagnostics_publish_period),
+    [this]() {
+      diagnostics_.force_update();
+      publish_diagnostics_manual();
+    });
   sub_initialpose_ = create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
     "initialpose", 1, std::bind(&EKFLocalizer::callback_initial_pose, this, _1));
   sub_pose_with_cov_ = create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
@@ -295,8 +299,9 @@ void EKFLocalizer::timer_callback()
   /* publish ekf result */
   publish_estimate_result(current_ekf_pose, current_biased_ekf_pose, current_ekf_twist);
 
-  /* Latch merged diagnostics every EKF cycle; publishing is periodic via diagnostic_updater,
-   * plus force_update() inside update_diagnostics when severity increases. */
+  /* Latch merged diagnostics every EKF cycle; publishing is periodic via diagnostics_publish_timer_
+   * (force_update + publish_diagnostics_manual), plus the same pair inside update_diagnostics when
+   * severity increases. */
   update_diagnostics(diag_status_array, current_time);
 
   /* publish processing time */
@@ -453,18 +458,56 @@ void EKFLocalizer::publish_estimate_result(
   tf_br_->sendTransform(transform_stamped);
 }
 
+void EKFLocalizer::publish_diagnostics_manual()
+{
+  const std::string node_name = this->get_name();
+  const std::string main_name = "localization: " + node_name;
+  const std::string pose_name = main_name + ": callback_pose";
+  const std::string twist_name = main_name + ": callback_twist";
+
+  // Thread safety: snapshot merged status for a consistent array if a multi-threaded executor is
+  // used.
+  diagnostic_msgs::msg::DiagnosticStatus main_st = merged_diagnostic_status_;
+  main_st.name = main_name;
+  main_st.hardware_id = node_name;
+
+  diagnostic_msgs::msg::DiagnosticStatus pose_st;
+  pose_st.name = pose_name;
+  pose_st.hardware_id = node_name;
+  pose_st.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+  pose_st.message = "OK";
+  {
+    diagnostic_msgs::msg::KeyValue kv;
+    kv.key = "topic_time_stamp";
+    kv.value = std::to_string(last_pose_callback_time_.nanoseconds());
+    pose_st.values.push_back(kv);
+  }
+
+  diagnostic_msgs::msg::DiagnosticStatus twist_st;
+  twist_st.name = twist_name;
+  twist_st.hardware_id = node_name;
+  twist_st.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+  twist_st.message = "OK";
+  {
+    diagnostic_msgs::msg::KeyValue kv;
+    kv.key = "topic_time_stamp";
+    kv.value = std::to_string(last_twist_callback_time_.nanoseconds());
+    twist_st.values.push_back(kv);
+  }
+
+  diagnostic_msgs::msg::DiagnosticArray msg;
+  msg.header.stamp = this->now();
+  msg.status.push_back(main_st);
+  msg.status.push_back(pose_st);
+  msg.status.push_back(twist_st);
+  pub_diagnostics_manual_->publish(msg);
+}
+
 void EKFLocalizer::diagnose(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
-  // merged_diagnostic_status_ is updated in update_diagnostics() each EKF tick. Publishing is
-  // driven by diagnostics_publish_timer_ at diagnostics_publish_period, or force_update() on
-  // severity increase vs. the previous tick.
-  //
-  // Thread safety: copy first for a consistent snapshot if a multi-threaded executor is used.
   const diagnostic_msgs::msg::DiagnosticStatus snapshot = merged_diagnostic_status_;
-
   stat.hardware_id = this->get_name();
   stat.summary(snapshot);
-
   for (const auto & value : snapshot.values) {
     stat.add(value.key, value.value);
   }
@@ -499,7 +542,7 @@ void EKFLocalizer::update_diagnostics(
   // merged_diagnostic_status_ always tracks merge: ERROR→WARN when merge worst is WARN,
   // ERROR/WARN→OK when merge is all OK, same level refreshes message/values.
   merged_diagnostic_status_ = diag_merged_status;
-  // last_transition_time: any level change; force_update below: severity increase only
+  // last_transition_time: any level change; immediate publish below: severity increase only
   if (level_merged != level_before) {
     merged_diagnostic_last_transition_time_ = current_time;
   }
@@ -522,6 +565,7 @@ void EKFLocalizer::update_diagnostics(
 
   if (level_merged > level_before) {
     diagnostics_.force_update();
+    publish_diagnostics_manual();
   }
 }
 

--- a/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_localizer.cpp
@@ -80,8 +80,7 @@ EKFLocalizer::EKFLocalizer(const rclcpp::NodeOptions & node_options)
     "ekf_biased_pose_with_covariance", 1);
   pub_processing_time_ = create_publisher<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "debug/processing_time_ms", 1);
-  pub_diagnostics_ =
-    create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 1);
+  pub_diagnostics_ = create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 1);
   diagnostics_publish_timer_ = rclcpp::create_timer(
     this, get_clock(), rclcpp::Duration::from_seconds(params_.diagnostics_publish_period),
     [this]() { publish_diagnostics(); });
@@ -287,8 +286,9 @@ void EKFLocalizer::timer_callback()
   /* publish ekf result */
   publish_estimate_result(current_ekf_pose, current_biased_ekf_pose, current_ekf_twist);
 
-  /* Latch merged diagnostics every EKF cycle; publishing is periodic via diagnostics_publish_timer_,
-   * plus publish_diagnostics() inside update_diagnostics when severity increases. */
+  /* Latch merged diagnostics every EKF cycle; publishing is periodic via
+   * diagnostics_publish_timer_, plus publish_diagnostics() inside update_diagnostics when severity
+   * increases. */
   update_diagnostics(diag_status_array, current_time);
 
   /* publish processing time */

--- a/localization/autoware_ekf_localizer/src/include/ekf_localizer.hpp
+++ b/localization/autoware_ekf_localizer/src/include/ekf_localizer.hpp
@@ -83,7 +83,8 @@ private:
   //!< @brief processing_time publisher
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
     pub_processing_time_;
-  //!< @brief /diagnostics publisher (manual DiagnosticArray; same absolute topic as former diagnostic_updater)
+  //!< @brief /diagnostics publisher (manual DiagnosticArray; same absolute topic as former
+  //!< diagnostic_updater)
   rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr pub_diagnostics_;
   //!< @brief initial pose subscriber
   rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr sub_initialpose_;

--- a/localization/autoware_ekf_localizer/src/include/ekf_localizer.hpp
+++ b/localization/autoware_ekf_localizer/src/include/ekf_localizer.hpp
@@ -92,6 +92,8 @@ private:
     sub_twist_with_cov_;
   //!< @brief time for ekf calculation callback
   rclcpp::TimerBase::SharedPtr timer_control_;
+  //!< @brief calls diagnostics_.force_update() at diagnostics_publish_period (Updater internal timer off)
+  rclcpp::TimerBase::SharedPtr diagnostics_publish_timer_;
   //!< @brief last predict time
   std::shared_ptr<const rclcpp::Time> last_predict_time_;
   //!< @brief trigger_node service
@@ -186,19 +188,14 @@ private:
     const rclcpp::Time & current_time);
 
   /**
-   * @brief diagnostic function called by diagnostic_updater::Updater
-   * @param stat diagnostic status wrapper to fill
+   * @brief diagnostic function invoked via diagnostics_.force_update() (diagnostic_updater task)
    */
   void diagnose(diagnostic_updater::DiagnosticStatusWrapper & stat);
 
-  /**
-   * @brief diagnostic for callback_pose (diagnostic_updater task)
-   */
+  /** @brief callback_pose diagnostic task */
   void diagnose_callback_pose(diagnostic_updater::DiagnosticStatusWrapper & stat);
 
-  /**
-   * @brief diagnostic for callback_twist (diagnostic_updater task)
-   */
+  /** @brief callback_twist diagnostic task */
   void diagnose_callback_twist(diagnostic_updater::DiagnosticStatusWrapper & stat);
 
   /**

--- a/localization/autoware_ekf_localizer/src/include/ekf_localizer.hpp
+++ b/localization/autoware_ekf_localizer/src/include/ekf_localizer.hpp
@@ -22,7 +22,6 @@
 
 #include <autoware_utils_logging/logger_level_configure.hpp>
 #include <autoware_utils_system/stop_watch.hpp>
-#include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tf2/LinearMath/Quaternion.hpp>
 #include <tf2/utils.hpp>
@@ -84,8 +83,8 @@ private:
   //!< @brief processing_time publisher
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
     pub_processing_time_;
-  //!< @brief manual DiagnosticArray publisher (diagnostics_manual); diagnostic_updater still uses /diagnostics
-  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr pub_diagnostics_manual_;
+  //!< @brief /diagnostics publisher (manual DiagnosticArray; same absolute topic as former diagnostic_updater)
+  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr pub_diagnostics_;
   //!< @brief initial pose subscriber
   rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr sub_initialpose_;
   //!< @brief measurement pose with covariance subscriber
@@ -95,7 +94,7 @@ private:
     sub_twist_with_cov_;
   //!< @brief time for ekf calculation callback
   rclcpp::TimerBase::SharedPtr timer_control_;
-  //!< @brief calls diagnostics_.force_update() and publish_diagnostics_manual() at diagnostics_publish_period
+  //!< @brief calls publish_diagnostics() at diagnostics_publish_period
   rclcpp::TimerBase::SharedPtr diagnostics_publish_timer_;
   //!< @brief last predict time
   std::shared_ptr<const rclcpp::Time> last_predict_time_;
@@ -127,9 +126,6 @@ private:
 
   AgedObjectQueue<geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr> pose_queue_;
   AgedObjectQueue<geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr> twist_queue_;
-
-  //!< @brief diagnostic updater for /diagnostics (internal timer disabled; EKF timer calls force_update)
-  diagnostic_updater::Updater diagnostics_;
 
   //!< @brief Merged diagnostic status from the latest EKF cycle (message/values refresh every tick)
   diagnostic_msgs::msg::DiagnosticStatus merged_diagnostic_status_;
@@ -184,22 +180,15 @@ private:
 
   /**
    * @brief Overwrite merged_diagnostic_status_ from merged diagnostics each tick;
-   * force_update() and publish_diagnostics_manual() when merged severity increases vs. the previous EKF tick
+   * publish_diagnostics() when merged severity increases vs. the previous EKF tick
    * (last transition time updates on any level change).
    */
   void update_diagnostics(
     const std::vector<diagnostic_msgs::msg::DiagnosticStatus> & diag_status_array,
     const rclcpp::Time & current_time);
 
-  /**
-   * @brief Build and publish the same diagnostic content as the updater tasks to diagnostics_manual
-   * (diagnostic_updater continues to publish /diagnostics).
-   */
-  void publish_diagnostics_manual();
-
-  void diagnose(diagnostic_updater::DiagnosticStatusWrapper & stat);
-  void diagnose_callback_pose(diagnostic_updater::DiagnosticStatusWrapper & stat);
-  void diagnose_callback_twist(diagnostic_updater::DiagnosticStatusWrapper & stat);
+  /** @brief Build and publish /diagnostics (main merged + callback_pose + callback_twist) */
+  void publish_diagnostics();
 
   /**
    * @brief trigger node

--- a/localization/autoware_ekf_localizer/src/include/ekf_localizer.hpp
+++ b/localization/autoware_ekf_localizer/src/include/ekf_localizer.hpp
@@ -32,6 +32,7 @@
 
 #include <autoware_internal_debug_msgs/msg/float64_multi_array_stamped.hpp>
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <geometry_msgs/msg/pose_array.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
@@ -83,6 +84,8 @@ private:
   //!< @brief processing_time publisher
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
     pub_processing_time_;
+  //!< @brief manual DiagnosticArray publisher (diagnostics_manual); diagnostic_updater still uses /diagnostics
+  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr pub_diagnostics_manual_;
   //!< @brief initial pose subscriber
   rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr sub_initialpose_;
   //!< @brief measurement pose with covariance subscriber
@@ -92,7 +95,7 @@ private:
     sub_twist_with_cov_;
   //!< @brief time for ekf calculation callback
   rclcpp::TimerBase::SharedPtr timer_control_;
-  //!< @brief calls diagnostics_.force_update() at diagnostics_publish_period (Updater internal timer off)
+  //!< @brief calls diagnostics_.force_update() and publish_diagnostics_manual() at diagnostics_publish_period
   rclcpp::TimerBase::SharedPtr diagnostics_publish_timer_;
   //!< @brief last predict time
   std::shared_ptr<const rclcpp::Time> last_predict_time_;
@@ -125,8 +128,9 @@ private:
   AgedObjectQueue<geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr> pose_queue_;
   AgedObjectQueue<geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr> twist_queue_;
 
-  //!< @brief diagnostic updater for publishing diagnostics at configured period
+  //!< @brief diagnostic updater for /diagnostics (internal timer disabled; EKF timer calls force_update)
   diagnostic_updater::Updater diagnostics_;
+
   //!< @brief Merged diagnostic status from the latest EKF cycle (message/values refresh every tick)
   diagnostic_msgs::msg::DiagnosticStatus merged_diagnostic_status_;
   //!< @brief Wall time of the latest merged diagnostic level change vs. the previous EKF tick
@@ -180,7 +184,7 @@ private:
 
   /**
    * @brief Overwrite merged_diagnostic_status_ from merged diagnostics each tick;
-   * force_update() when merged severity increases vs. the previous EKF tick
+   * force_update() and publish_diagnostics_manual() when merged severity increases vs. the previous EKF tick
    * (last transition time updates on any level change).
    */
   void update_diagnostics(
@@ -188,14 +192,13 @@ private:
     const rclcpp::Time & current_time);
 
   /**
-   * @brief diagnostic function invoked via diagnostics_.force_update() (diagnostic_updater task)
+   * @brief Build and publish the same diagnostic content as the updater tasks to diagnostics_manual
+   * (diagnostic_updater continues to publish /diagnostics).
    */
+  void publish_diagnostics_manual();
+
   void diagnose(diagnostic_updater::DiagnosticStatusWrapper & stat);
-
-  /** @brief callback_pose diagnostic task */
   void diagnose_callback_pose(diagnostic_updater::DiagnosticStatusWrapper & stat);
-
-  /** @brief callback_twist diagnostic task */
   void diagnose_callback_twist(diagnostic_updater::DiagnosticStatusWrapper & stat);
 
   /**

--- a/localization/autoware_ekf_localizer/test/test_diagnostics.cpp
+++ b/localization/autoware_ekf_localizer/test/test_diagnostics.cpp
@@ -440,7 +440,6 @@ protected:
     ekf_localizer->publish_diagnostics();
   }
 
-
   static void call_timer_callback(autoware::ekf_localizer::EKFLocalizer * ekf_localizer)
   {
     ekf_localizer->timer_callback();
@@ -901,7 +900,8 @@ TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_at_specified_period)
 
 TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_message_names)
 {
-  // publish_diagnostics() uses names "localization: <node>" (+ ": callback_*" for the two callbacks).
+  // publish_diagnostics() uses names "localization: <node>" (+ ": callback_*" for the two
+  // callbacks).
   const double ekf_rate = 100.0;
   const double diagnostics_publish_period = 0.1;  // 10 Hz
 
@@ -1174,8 +1174,9 @@ TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_at_parameter_period)
 
 TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_immediately_on_severity_increase)
 {
-  // With a very long diagnostics period, only publish_diagnostics() on severity increase should publish /diagnostics.
-  // Slow EKF timer so executor-driven ticks do not merge to ERROR before we inject it.
+  // With a very long diagnostics period, only publish_diagnostics() on severity increase should
+  // publish /diagnostics. Slow EKF timer so executor-driven ticks do not merge to ERROR before we
+  // inject it.
   const double ekf_rate = 0.01;
   const double slow_diagnostics_frequency = 0.01;  // 100 s period
 

--- a/localization/autoware_ekf_localizer/test/test_diagnostics.cpp
+++ b/localization/autoware_ekf_localizer/test/test_diagnostics.cpp
@@ -438,7 +438,9 @@ protected:
   static void force_diagnostics_update(autoware::ekf_localizer::EKFLocalizer * ekf_localizer)
   {
     ekf_localizer->diagnostics_.force_update();
+    ekf_localizer->publish_diagnostics_manual();
   }
+
 
   static void call_timer_callback(autoware::ekf_localizer::EKFLocalizer * ekf_localizer)
   {
@@ -446,8 +448,8 @@ protected:
   }
 };
 
-// Note: Periodic /diagnostics uses an EKF node timer calling diagnostics_.force_update();
-// diagnostic_updater's internal timer is disabled (very long setPeriod).
+// Note: Periodic /diagnostics uses an EKF node timer calling diagnostics_.force_update() (updater
+// internal timer disabled). The same timer also publishes diagnostics_manual via publish_diagnostics_manual().
 
 TEST_F(EKFLocalizerDiagnosticsTest, merged_diagnostic_reflects_pose_no_update_warn_then_error)
 {
@@ -662,8 +664,8 @@ TEST_F(EKFLocalizerDiagnosticsTest, merged_diagnostic_ok_when_only_activation_an
 
 TEST_F(EKFLocalizerDiagnosticsTest, merged_diagnostic_ok_after_force_update_and_minimal_merge)
 {
-  // After force_update(), activation-only update_diagnostics sets merged status to OK (no special
-  // reset path)
+  // After force_update() (+ manual mirror), activation-only update_diagnostics sets merged status to OK
+  // (no special reset path)
   const double ekf_rate = 100.0;
   const double diagnostics_publish_period = 0.1;
 
@@ -901,8 +903,8 @@ TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_at_specified_period)
 
 TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_message_names)
 {
-  // diagnostic_updater prepends "node_name: " to each task name from add(). Task strings are
-  // "localization: " + node_name (+ ": callback_*"), matching ekf_localizer.cpp registration.
+  // /diagnostics: diagnostic_updater prepends "<node_name>: " to each add() task name.
+  // diagnostics_manual: publish_diagnostics_manual() uses names "localization: <node>" (+ ": callback_*").
   const double ekf_rate = 100.0;
   const double diagnostics_publish_period = 0.1;  // 10 Hz
 
@@ -928,8 +930,7 @@ TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_message_names)
   set_is_activated(ekf_localizer.get(), true);
   set_is_set_initialpose(ekf_localizer.get(), true);
 
-  // addedTaskCallback publishes one task at a time during construction; wait for a full update
-  // (three tasks) from the periodic diagnostics_publish_timer_ / force_update path.
+  // Wait for a full update (three tasks) from the periodic diagnostics_publish_timer_ / force_update path.
   diagnostic_msgs::msg::DiagnosticArray::SharedPtr full_diag_msg;
   auto sub = ekf_localizer->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
     "/diagnostics", 10,
@@ -994,7 +995,7 @@ TEST_F(
   EKFLocalizerDiagnosticsTest, callback_pose_and_twist_published_at_period_when_period_positive)
 {
   // When diagnostics_publish_period > 0, callback_pose and callback_twist are published at the
-  // updater period via diagnose_callback_pose and diagnose_callback_twist. This test verifies that
+  // configured period via diagnostic_updater. This test verifies that
   // after publishing pose and twist, spinning yields both callback_pose and callback_twist on
   // /diagnostics at the configured period.
   const double ekf_rate = 100.0;
@@ -1068,16 +1069,16 @@ TEST_F(
   executor.remove_node(ekf_localizer);
 
   EXPECT_TRUE(received_callback_pose_diag)
-    << "Expected at least one callback_pose diagnostic at updater period when period > 0";
+    << "Expected at least one callback_pose diagnostic at diagnostics period when period > 0";
   EXPECT_TRUE(received_callback_twist_diag)
-    << "Expected at least one callback_twist diagnostic at updater period when period > 0";
+    << "Expected at least one callback_twist diagnostic at diagnostics period when period > 0";
 }
 
 TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_at_parameter_period)
 {
   // Verify /diagnostics is emitted at roughly diagnostics_publish_period (EKF diagnostics timer).
   // Feed pose/twist occasionally so merged diagnostics stay OK: otherwise no_update_count rises,
-  // merged status returns OK after each publish, and OK->ERROR repeats every EKF tick (force_update
+  // merged status returns OK after each publish, and OK->ERROR repeats every EKF tick (publish
   // storm).
   const double ekf_rate = 50.0;
   const double diagnostics_publish_period = 0.2;  // 5 Hz
@@ -1164,7 +1165,7 @@ TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_at_parameter_period)
   for (size_t i = 2; i < receive_times.size(); ++i) {
     const double dt =
       std::chrono::duration<double>(receive_times[i] - receive_times[i - 1]).count();
-    // Ignore sub-period gaps from diagnostic_updater task registration or batched delivery.
+    // Ignore sub-period gaps from batched delivery or timer jitter.
     if (dt < diagnostics_publish_period * 0.15) {
       continue;
     }
@@ -1177,7 +1178,7 @@ TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_at_parameter_period)
 
 TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_immediately_on_severity_increase)
 {
-  // With a very long updater period, only force_update() on severity increase should publish.
+  // With a very long updater period, only force_update() on severity increase should publish /diagnostics.
   // Slow EKF timer so executor-driven ticks do not merge to ERROR before we inject it.
   const double ekf_rate = 0.01;
   const double slow_diagnostics_frequency = 0.01;  // 100 s period

--- a/localization/autoware_ekf_localizer/test/test_diagnostics.cpp
+++ b/localization/autoware_ekf_localizer/test/test_diagnostics.cpp
@@ -25,7 +25,9 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <iostream>
 #include <memory>
+#include <set>
 #include <string>
 #include <thread>
 #include <vector>
@@ -444,10 +446,8 @@ protected:
   }
 };
 
-// Note: Tests for should_publish_diagnostics() are removed because
-// diagnostic_updater::Updater now handles the period control internally.
-// The period is set via setPeriod() and the updater automatically calls
-// diagnose() at the configured interval.
+// Note: Periodic /diagnostics uses an EKF node timer calling diagnostics_.force_update();
+// diagnostic_updater's internal timer is disabled (very long setPeriod).
 
 TEST_F(EKFLocalizerDiagnosticsTest, merged_diagnostic_reflects_pose_no_update_warn_then_error)
 {
@@ -851,8 +851,8 @@ TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_updated_when_initialpose_not_set
 
 TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_at_specified_period)
 {
-  // When diagnostics_publish_period > 0, diagnostic_updater's internal timer publishes at that
-  // period
+  // When diagnostics_publish_period > 0, EKF node's diagnostics_publish_timer_ publishes at that
+  // period (via diagnostics_.force_update())
   const double ekf_rate = 100.0;
   const double diagnostics_publish_period = 0.1;  // 10 Hz
 
@@ -897,6 +897,97 @@ TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_at_specified_period)
   executor.remove_node(ekf_localizer);
 
   EXPECT_GE(diag_count, 1) << "Expected at least one /diagnostics message within 250 ms at 10 Hz";
+}
+
+TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_message_names)
+{
+  // diagnostic_updater prepends "node_name: " to each task name from add(). Task strings are
+  // "localization: " + node_name (+ ": callback_*"), matching ekf_localizer.cpp registration.
+  const double ekf_rate = 100.0;
+  const double diagnostics_publish_period = 0.1;  // 10 Hz
+
+  auto ekf_localizer = create_ekf_localizer(diagnostics_publish_period, ekf_rate);
+
+  rclcpp::Time current_time = ekf_localizer->now();
+  geometry_msgs::msg::PoseStamped current_ekf_pose;
+  current_ekf_pose.header.stamp = current_time;
+  current_ekf_pose.header.frame_id = "map";
+  current_ekf_pose.pose.position.x = 0.0;
+  current_ekf_pose.pose.position.y = 0.0;
+  current_ekf_pose.pose.position.z = 0.0;
+  current_ekf_pose.pose.orientation.w = 1.0;
+
+  geometry_msgs::msg::PoseWithCovarianceStamped initial_pose;
+  initial_pose.header.stamp = current_time;
+  initial_pose.header.frame_id = "map";
+  initial_pose.pose.pose = current_ekf_pose.pose;
+  for (size_t i = 0; i < 36; ++i) {
+    initial_pose.pose.covariance[i] = (i == 0 || i == 7 || i == 14) ? 0.01 : 0.0;
+  }
+  initialize_ekf_module(ekf_localizer.get(), initial_pose);
+  set_is_activated(ekf_localizer.get(), true);
+  set_is_set_initialpose(ekf_localizer.get(), true);
+
+  // addedTaskCallback publishes one task at a time during construction; wait for a full update
+  // (three tasks) from the periodic diagnostics_publish_timer_ / force_update path.
+  diagnostic_msgs::msg::DiagnosticArray::SharedPtr full_diag_msg;
+  auto sub = ekf_localizer->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
+    "/diagnostics", 10,
+    [&full_diag_msg](diagnostic_msgs::msg::DiagnosticArray::ConstSharedPtr msg) {
+      if (msg->status.size() == 3) {
+        full_diag_msg = std::make_shared<diagnostic_msgs::msg::DiagnosticArray>(*msg);
+      }
+    });
+
+  rclcpp::ExecutorOptions options;
+  rclcpp::executors::SingleThreadedExecutor executor(options);
+  executor.add_node(ekf_localizer);
+
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+  while (!full_diag_msg && std::chrono::steady_clock::now() < deadline && rclcpp::ok()) {
+    executor.spin_some(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+
+  executor.remove_node(ekf_localizer);
+
+  ASSERT_NE(full_diag_msg, nullptr)
+    << "Expected a /diagnostics message with three tasks (main, callback_pose, callback_twist)";
+
+  const std::string node_name = ekf_localizer->get_name();
+  const std::string task_base = "localization: " + node_name;
+  const std::string expected_main = node_name + ": " + task_base;
+  const std::string expected_pose = node_name + ": " + task_base + ": callback_pose";
+  const std::string expected_twist = node_name + ": " + task_base + ": callback_twist";
+
+  std::cout << "[diagnostics_published_message_names] node_name='" << node_name << "'\n";
+  std::cout << "[diagnostics_published_message_names] observed " << full_diag_msg->status.size()
+            << " DiagnosticStatus entries:\n";
+  for (size_t i = 0; i < full_diag_msg->status.size(); ++i) {
+    const auto & st = full_diag_msg->status[i];
+    std::cout << "[diagnostics_published_message_names]   [" << i << "] name='" << st.name << "'"
+              << " hardware_id='" << st.hardware_id << "'"
+              << " level=" << static_cast<int>(st.level) << " message='" << st.message << "'\n";
+  }
+  std::cout << "[diagnostics_published_message_names] expected names:\n"
+            << "[diagnostics_published_message_names]   main   ='" << expected_main << "'\n"
+            << "[diagnostics_published_message_names]   pose   ='" << expected_pose << "'\n"
+            << "[diagnostics_published_message_names]   twist  ='" << expected_twist << "'\n";
+  std::cout.flush();
+
+  std::set<std::string> names;
+  for (const auto & st : full_diag_msg->status) {
+    names.insert(st.name);
+    EXPECT_EQ(st.hardware_id, node_name)
+      << "hardware_id should match EKF node name for status: " << st.name;
+  }
+
+  EXPECT_EQ(full_diag_msg->status.size(), 3u)
+    << "Expected three diagnostic tasks (main, callback_pose, callback_twist)";
+  EXPECT_EQ(names.count(expected_main), 1u) << "Missing main task name: " << expected_main;
+  EXPECT_EQ(names.count(expected_pose), 1u) << "Missing callback_pose task name: " << expected_pose;
+  EXPECT_EQ(names.count(expected_twist), 1u)
+    << "Missing callback_twist task name: " << expected_twist;
 }
 
 TEST_F(
@@ -984,7 +1075,7 @@ TEST_F(
 
 TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_at_parameter_period)
 {
-  // Verify diagnostic_updater emits /diagnostics at roughly diagnostics_publish_period.
+  // Verify /diagnostics is emitted at roughly diagnostics_publish_period (EKF diagnostics timer).
   // Feed pose/twist occasionally so merged diagnostics stay OK: otherwise no_update_count rises,
   // merged status returns OK after each publish, and OK->ERROR repeats every EKF tick (force_update
   // storm).

--- a/localization/autoware_ekf_localizer/test/test_diagnostics.cpp
+++ b/localization/autoware_ekf_localizer/test/test_diagnostics.cpp
@@ -437,8 +437,7 @@ protected:
 
   static void force_diagnostics_update(autoware::ekf_localizer::EKFLocalizer * ekf_localizer)
   {
-    ekf_localizer->diagnostics_.force_update();
-    ekf_localizer->publish_diagnostics_manual();
+    ekf_localizer->publish_diagnostics();
   }
 
 
@@ -448,8 +447,7 @@ protected:
   }
 };
 
-// Note: Periodic /diagnostics uses an EKF node timer calling diagnostics_.force_update() (updater
-// internal timer disabled). The same timer also publishes diagnostics_manual via publish_diagnostics_manual().
+// Note: Periodic /diagnostics uses an EKF node timer calling publish_diagnostics().
 
 TEST_F(EKFLocalizerDiagnosticsTest, merged_diagnostic_reflects_pose_no_update_warn_then_error)
 {
@@ -664,7 +662,7 @@ TEST_F(EKFLocalizerDiagnosticsTest, merged_diagnostic_ok_when_only_activation_an
 
 TEST_F(EKFLocalizerDiagnosticsTest, merged_diagnostic_ok_after_force_update_and_minimal_merge)
 {
-  // After force_update() (+ manual mirror), activation-only update_diagnostics sets merged status to OK
+  // After publish_diagnostics(), activation-only update_diagnostics sets merged status to OK
   // (no special reset path)
   const double ekf_rate = 100.0;
   const double diagnostics_publish_period = 0.1;
@@ -854,7 +852,7 @@ TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_updated_when_initialpose_not_set
 TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_at_specified_period)
 {
   // When diagnostics_publish_period > 0, EKF node's diagnostics_publish_timer_ publishes at that
-  // period (via diagnostics_.force_update())
+  // period (via publish_diagnostics())
   const double ekf_rate = 100.0;
   const double diagnostics_publish_period = 0.1;  // 10 Hz
 
@@ -903,8 +901,7 @@ TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_at_specified_period)
 
 TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_message_names)
 {
-  // /diagnostics: diagnostic_updater prepends "<node_name>: " to each add() task name.
-  // diagnostics_manual: publish_diagnostics_manual() uses names "localization: <node>" (+ ": callback_*").
+  // publish_diagnostics() uses names "localization: <node>" (+ ": callback_*" for the two callbacks).
   const double ekf_rate = 100.0;
   const double diagnostics_publish_period = 0.1;  // 10 Hz
 
@@ -930,7 +927,7 @@ TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_message_names)
   set_is_activated(ekf_localizer.get(), true);
   set_is_set_initialpose(ekf_localizer.get(), true);
 
-  // Wait for a full update (three tasks) from the periodic diagnostics_publish_timer_ / force_update path.
+  // Wait for a full update (three tasks) from the periodic diagnostics_publish_timer_ path.
   diagnostic_msgs::msg::DiagnosticArray::SharedPtr full_diag_msg;
   auto sub = ekf_localizer->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
     "/diagnostics", 10,
@@ -956,10 +953,9 @@ TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_message_names)
     << "Expected a /diagnostics message with three tasks (main, callback_pose, callback_twist)";
 
   const std::string node_name = ekf_localizer->get_name();
-  const std::string task_base = "localization: " + node_name;
-  const std::string expected_main = node_name + ": " + task_base;
-  const std::string expected_pose = node_name + ": " + task_base + ": callback_pose";
-  const std::string expected_twist = node_name + ": " + task_base + ": callback_twist";
+  const std::string expected_main = "localization: " + node_name;
+  const std::string expected_pose = expected_main + ": callback_pose";
+  const std::string expected_twist = expected_main + ": callback_twist";
 
   std::cout << "[diagnostics_published_message_names] node_name='" << node_name << "'\n";
   std::cout << "[diagnostics_published_message_names] observed " << full_diag_msg->status.size()
@@ -995,7 +991,7 @@ TEST_F(
   EKFLocalizerDiagnosticsTest, callback_pose_and_twist_published_at_period_when_period_positive)
 {
   // When diagnostics_publish_period > 0, callback_pose and callback_twist are published at the
-  // configured period via diagnostic_updater. This test verifies that
+  // configured period via publish_diagnostics(). This test verifies that
   // after publishing pose and twist, spinning yields both callback_pose and callback_twist on
   // /diagnostics at the configured period.
   const double ekf_rate = 100.0;
@@ -1178,7 +1174,7 @@ TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_at_parameter_period)
 
 TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_immediately_on_severity_increase)
 {
-  // With a very long updater period, only force_update() on severity increase should publish /diagnostics.
+  // With a very long diagnostics period, only publish_diagnostics() on severity increase should publish /diagnostics.
   // Slow EKF timer so executor-driven ticks do not merge to ERROR before we inject it.
   const double ekf_rate = 0.01;
   const double slow_diagnostics_frequency = 0.01;  // 100 s period
@@ -1251,7 +1247,7 @@ TEST_F(EKFLocalizerDiagnosticsTest, diagnostics_published_immediately_on_severit
   executor.remove_node(ekf_localizer);
 
   EXPECT_GT(diag_count, count_before)
-    << "Severity increase should trigger an immediate /diagnostics publish (force_update) even "
+    << "Severity increase should trigger an immediate /diagnostics publish even "
        "when periodic publish is 100 s away";
   EXPECT_TRUE(saw_error_main_diag)
     << "Expected main ekf_localizer diagnostic status to report ERROR after severity increase";

--- a/localization/autoware_ekf_localizer/test/test_diagnostics_topic.cpp
+++ b/localization/autoware_ekf_localizer/test/test_diagnostics_topic.cpp
@@ -1,0 +1,108 @@
+// Copyright 2023 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/ekf_localizer/ekf_localizer.hpp"
+
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+
+namespace autoware::ekf_localizer
+{
+
+static rclcpp::NodeOptions make_minimal_ekf_options()
+{
+  rclcpp::NodeOptions options;
+  options.parameter_overrides({
+    {"node.show_debug_info", false},
+    {"node.enable_yaw_bias_estimation", true},
+    {"node.predict_frequency", 100.0},
+    {"node.tf_rate", 50.0},
+    {"node.extend_state_step", 50},
+    {"misc.pose_frame_id", std::string("map")},
+    {"pose_measurement.pose_additional_delay", 0.0},
+    {"pose_measurement.pose_gate_dist", 49.5},
+    {"pose_measurement.pose_smoothing_steps", 5},
+    {"pose_measurement.max_pose_queue_size", 5},
+    {"twist_measurement.twist_additional_delay", 0.0},
+    {"twist_measurement.twist_gate_dist", 46.1},
+    {"twist_measurement.twist_smoothing_steps", 2},
+    {"twist_measurement.max_twist_queue_size", 2},
+    {"process_noise.proc_stddev_vx_c", 10.0},
+    {"process_noise.proc_stddev_wz_c", 5.0},
+    {"process_noise.proc_stddev_yaw_c", 0.005},
+    {"simple_1d_filter_parameters.z_filter_proc_dev", 5.0},
+    {"simple_1d_filter_parameters.roll_filter_proc_dev", 0.1},
+    {"simple_1d_filter_parameters.pitch_filter_proc_dev", 0.1},
+    {"diagnostics.pose_no_update_count_threshold_warn", 50},
+    {"diagnostics.pose_no_update_count_threshold_error", 100},
+    {"diagnostics.twist_no_update_count_threshold_warn", 50},
+    {"diagnostics.twist_no_update_count_threshold_error", 100},
+    {"diagnostics.ellipse_scale", 3.0},
+    {"diagnostics.error_ellipse_size", 1.5},
+    {"diagnostics.warn_ellipse_size", 1.2},
+    {"diagnostics.error_ellipse_size_lateral_direction", 0.3},
+    {"diagnostics.warn_ellipse_size_lateral_direction", 0.25},
+    {"misc.threshold_observable_velocity_mps", 0.0},
+  });
+  return options;
+}
+
+TEST(DiagnosticsTopicTest, logs_published_diagnostic_status_names)
+{
+  if (!rclcpp::ok()) {
+    rclcpp::init(0, nullptr);
+  }
+
+  auto ekf = std::make_shared<EKFLocalizer>(make_minimal_ekf_options());
+
+  size_t message_count = 0;
+  auto sub = ekf->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
+    "/diagnostics", 10,
+    [&message_count](diagnostic_msgs::msg::DiagnosticArray::ConstSharedPtr msg) {
+      ++message_count;
+      std::cout << "[DiagnosticsTopicTest] /diagnostics message #" << message_count << " — "
+                << msg->status.size() << " status(es)\n";
+      for (size_t i = 0; i < msg->status.size(); ++i) {
+        const auto & st = msg->status[i];
+        std::cout << "[DiagnosticsTopicTest]   [" << i << "] name='" << st.name << "'"
+                  << " hardware_id='" << st.hardware_id << "'"
+                  << " level=" << static_cast<int>(st.level) << " message='" << st.message << "'\n";
+      }
+      std::cout.flush();
+    });
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(ekf);
+
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+  while (message_count == 0 && std::chrono::steady_clock::now() < deadline && rclcpp::ok()) {
+    executor.spin_some(std::chrono::milliseconds(20));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  }
+
+  executor.remove_node(ekf);
+
+  EXPECT_GE(message_count, 1u)
+    << "Expected at least one /diagnostics message (timer publishes when not activated)";
+}
+
+}  // namespace autoware::ekf_localizer

--- a/localization/autoware_ekf_localizer/test/test_diagnostics_topic.cpp
+++ b/localization/autoware_ekf_localizer/test/test_diagnostics_topic.cpp
@@ -14,8 +14,9 @@
 
 #include "include/ekf_localizer.hpp"
 
-#include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <rclcpp/rclcpp.hpp>
+
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
 
 #include <gtest/gtest.h>
 

--- a/localization/autoware_ekf_localizer/test/test_diagnostics_topic.cpp
+++ b/localization/autoware_ekf_localizer/test/test_diagnostics_topic.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "autoware/ekf_localizer/ekf_localizer.hpp"
+#include "include/ekf_localizer.hpp"
 
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -61,6 +61,7 @@ static rclcpp::NodeOptions make_minimal_ekf_options()
     {"diagnostics.warn_ellipse_size", 1.2},
     {"diagnostics.error_ellipse_size_lateral_direction", 0.3},
     {"diagnostics.warn_ellipse_size_lateral_direction", 0.25},
+    {"diagnostics.diagnostics_publish_frequency", 10.0},
     {"misc.threshold_observable_velocity_mps", 0.0},
   });
   return options;


### PR DESCRIPTION
## Description

This PR fixes incorrect **diagnostic status names** published by `autoware_ekf_localizer` and replaces `diagnostic_updater` with a **manual** `diagnostic_msgs/msg/DiagnosticArray` publisher on `/diagnostics`.

### Problem

- With `diagnostic_updater`, each task name was registered as `localization: <node_name>`, but the updater **prepends** `<node_name>: ` to every task. The resulting names looked like `ekf_localizer: localization: ekf_localizer`, which was redundant and inconsistent with the intended `localization: ekf_localizer` style used elsewhere (e.g. tooling and documentation).

### Solution

- **Remove** the `diagnostic_updater` dependency and `Updater` usage.
- **Publish** a single `DiagnosticArray` to the absolute topic `/diagnostics` (QoS depth 1), matching the former updater behavior for topic placement.
- **Name** the three `DiagnosticStatus` entries explicitly:
  - Main merged task: `localization: <node_name>`
  - Pose callback task: `localization: <node_name>: callback_pose`
  - Twist callback task: `localization: <node_name>: callback_twist`
- **Cadence**: an EKF node timer calls `publish_diagnostics()` at `1 / diagnostics_publish_frequency` (same parameter as before). When merged diagnostic **severity increases** compared to the previous EKF timer tick, an **extra** immediate publish is issued (same policy as before, without relying on `force_update()`).

### Tests and schema

- Extended and updated unit tests for merged diagnostics, periodic `/diagnostics` output, message names, and severity-triggered publishes.
- Added a small diagnostics topic test with optional logging of observed names.
- Updated `schema/sub/diagnostics.sub_schema.json` to describe the manual publisher and timer behavior.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- The following replay test was done.

1. Clone Autoware and do `vcs import`.
2. Cherry-pick the changes of this pull-request and the related one above in each src repo (`src/core/autoware_core`, `src/launcher/autoware_launch`). For example, `git cherry-pick <base>..HEAD` on your feature branch.
3. Build Autoware.
4. Run unit tests `colcon test --packages-select autoware_ekf_localizer` and confirm the result `colcon test-result --all --verbose --test-result-base build/autoware_ekf_localizer`
5. Set `diagnostics_publish_frequency` as needed in launch/package YAML (must be **positive** for a well-defined period; package default is **10.0 Hz** in `config/ekf_localizer.param.yaml`).
6. Launch and replay the sample rosbag and map.
7. Confirm the diagnostics publishing frequency of EKF localizer matches the configured value (e.g. 10.0 Hz when set to 10.0). (Please verify using a script like [this](https://github.com/user-attachments/files/26233755/check_ekf_diagnostics_stamp_delta.py).)
8. Check the diagnostics names and content by `ros2 topic echo /diagnostics`.

## Notes for reviewers

- `hardware_id` remains the node name (e.g. `ekf_localizer`).
- No change to the **semantic** content of merged diagnostics (merge logic, `last_level_transition_timestamp`, thresholds, etc.) beyond naming and the publishing mechanism.

## Interface changes

| Item | Change |
|------|--------|
| ROS dependency | `diagnostic_updater` removed from `autoware_ekf_localizer` |
| Topic `/diagnostics` | Still used; message type unchanged (`DiagnosticArray`) |
| `DiagnosticStatus.name` | **Fixed** — see Description |
| Parameters | Unchanged (`diagnostics.diagnostics_publish_frequency`, thresholds, etc.) |


<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
