### PR TITLE
feat(autoware_route_handler): smooth the centerline from `route_handler` function

### DIFF
--- a/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
+++ b/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
@@ -79,9 +79,11 @@ class RouteHandler
 {
 public:
   RouteHandler() = default;
+  explicit RouteHandler(const lanelet::LaneletMapConstPtr & lanelet_map_ptr);
   explicit RouteHandler(const LaneletMapBin & map_msg);
 
   // non-const methods
+  void setMap(const lanelet::LaneletMapConstPtr & lanelet_map_ptr);
   void setMap(const LaneletMapBin & map_msg);
   void setRoute(const LaneletRoute & route_msg);
   void setRouteLanelets(const lanelet::ConstLanelets & path_lanelets);

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -137,6 +137,8 @@ PathWithLaneId removeOverlappingPoints(const PathWithLaneId & input_path)
   PathWithLaneId filtered_path;
   filtered_path.points.reserve(input_path.points.size());
 
+  double previous_azimuth = 0;
+
   for (const auto & pt : input_path.points) {
     if (filtered_path.points.empty()) {
       filtered_path.points.push_back(pt);
@@ -144,8 +146,12 @@ PathWithLaneId removeOverlappingPoints(const PathWithLaneId & input_path)
     }
 
     constexpr double th_overlapping_dist = 0.001;
+    constexpr double th_overlapping_dist_discontinuity = 0.05;
     const double dist_between_points =
       autoware_utils_geometry::calc_distance3d(filtered_path.points.back().point, pt.point);
+
+    const double current_azimuth = autoware_utils_geometry::calc_azimuth_angle(
+      filtered_path.points.back().point.pose.position, pt.point.pose.position);
 
     if (dist_between_points < th_overlapping_dist) {
       filtered_path.points.back().lane_ids.push_back(pt.lane_ids.front());
@@ -154,7 +160,18 @@ PathWithLaneId removeOverlappingPoints(const PathWithLaneId & input_path)
       continue;
     }
 
+    if (
+      (std::fabs(autoware_utils_math::normalize_radian(previous_azimuth - current_azimuth)) >=
+       M_PI / 2) &&
+      (dist_between_points < th_overlapping_dist_discontinuity)) {
+      filtered_path.points.back().lane_ids.push_back(pt.lane_ids.front());
+      filtered_path.points.back().point.longitudinal_velocity_mps =
+        pt.point.longitudinal_velocity_mps;
+      continue;
+    }
+
     filtered_path.points.push_back(pt);
+    previous_azimuth = current_azimuth;
   }
 
   filtered_path.left_bound = input_path.left_bound;

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -240,10 +240,57 @@ std::string convertLaneletsIdToString(const lanelet::ConstLanelets & lanelets)
 }
 }  // namespace
 
+RouteHandler::RouteHandler(const lanelet::LaneletMapConstPtr & lanelet_map_ptr)
+{
+  setMap(lanelet_map_ptr);
+  route_ptr_ = nullptr;
+}
+
 RouteHandler::RouteHandler(const LaneletMapBin & map_msg)
 {
   setMap(map_msg);
   route_ptr_ = nullptr;
+}
+
+void RouteHandler::setMap(const lanelet::LaneletMapConstPtr & lanelet_map_ptr)
+{
+  lanelet_map_ptr_ = autoware::experimental::lanelet2_utils::remove_const(lanelet_map_ptr);
+  const auto & map_msg =
+    autoware::experimental::lanelet2_utils::to_autoware_map_msgs(lanelet_map_ptr_);
+  auto routing_graph_and_traffic_rules =
+    autoware::experimental::lanelet2_utils::instantiate_routing_graph_and_traffic_rules(
+      lanelet_map_ptr_);
+  routing_graph_ptr_ =
+    autoware::experimental::lanelet2_utils::remove_const(routing_graph_and_traffic_rules.first);
+  traffic_rules_ptr_ = routing_graph_and_traffic_rules.second;
+  const auto map_major_version_opt =
+    lanelet::io_handlers::parseMajorVersion(map_msg.version_map_format);
+  if (!map_major_version_opt) {
+    RCLCPP_WARN(
+      logger_, "setMap() for invalid version map: %s", map_msg.version_map_format.c_str());
+  } else if (map_major_version_opt.value() > static_cast<uint64_t>(lanelet::autoware::version)) {
+    RCLCPP_WARN(
+      logger_, "setMap() for a map(version %s) newer than lanelet2_extension support version(%d)",
+      map_msg.version_map_format.c_str(), static_cast<int>(lanelet::autoware::version));
+  }
+
+  const auto traffic_rules = lanelet::traffic_rules::TrafficRulesFactory::create(
+    lanelet::Locations::Germany, lanelet::Participants::Vehicle);
+  const auto pedestrian_rules = lanelet::traffic_rules::TrafficRulesFactory::create(
+    lanelet::Locations::Germany, lanelet::Participants::Pedestrian);
+  const lanelet::routing::RoutingGraphConstPtr vehicle_graph =
+    lanelet::routing::RoutingGraph::build(*lanelet_map_ptr_, *traffic_rules);
+  const lanelet::routing::RoutingGraphConstPtr pedestrian_graph =
+    lanelet::routing::RoutingGraph::build(*lanelet_map_ptr_, *pedestrian_rules);
+  const lanelet::routing::RoutingGraphContainer overall_graphs({vehicle_graph, pedestrian_graph});
+  overall_graphs_ptr_ =
+    std::make_shared<const lanelet::routing::RoutingGraphContainer>(overall_graphs);
+  lanelet::ConstLanelets all_lanelets = lanelet::utils::query::laneletLayer(lanelet_map_ptr_);
+
+  is_map_msg_ready_ = true;
+  is_handler_ready_ = false;
+
+  setLaneletsFromRouteMsg();
 }
 
 void RouteHandler::setMap(const LaneletMapBin & map_msg)

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -1959,7 +1959,7 @@ void RouteHandler::removeOverlappedCenterlineWithWaypoints(
   const size_t piecewise_waypoints_lanelet_sequence_index,
   const bool is_removing_direction_forward) const
 {
-  const double waypoints_interpolation_arc_margin_ratio = 10.0;
+  const double waypoints_interpolation_arc_margin_ratio = 1.0;
 
   // calculate arc length threshold
   const double front_arc_length_threshold = [&]() {

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -1745,6 +1745,10 @@ PathWithLaneId RouteHandler::getCenterLinePath(
   const lanelet::ConstLanelets & lanelet_sequence, const double s_start, const double s_end,
   bool use_exact) const
 {
+  using autoware::experimental::lanelet2_utils::create_safe_linestring;
+  using autoware::experimental::lanelet2_utils::from_ros;
+  using autoware::experimental::lanelet2_utils::interpolate_point;
+  using autoware::experimental::lanelet2_utils::to_ros;
   using lanelet::utils::to2D;
 
   // 1. calculate reference points by lanelets' centerline
@@ -1849,6 +1853,8 @@ PathWithLaneId RouteHandler::getCenterLinePath(
       const auto & ref_point = piecewise_ref_points.at(ref_point_idx);
       const auto & next_ref_point = (ref_point_idx + 1 < piecewise_ref_points.size())
                                       ? piecewise_ref_points.at(ref_point_idx + 1)
+                                    : (lanelet_idx + 1 < lanelet_sequence.size())
+                                      ? piecewise_ref_points_vec.at(lanelet_idx + 1).at(0)
                                       : piecewise_ref_points.at(ref_point_idx);
 
       const double distance =
@@ -1857,7 +1863,23 @@ PathWithLaneId RouteHandler::getCenterLinePath(
       if (s < s_start && s + distance > s_start) {
         const auto p_opt = getGeometryPointFrom2DArcLength(lanelet_sequence, s_start);
         if (p_opt.has_value()) {
-          const auto p = use_exact ? p_opt.value() : ref_point.point;
+          // convert geometry_msgs to ros_msg
+          const auto ref_pt = from_ros(ref_point.point);
+          const auto next_pt = from_ros(next_ref_point.point);
+          const auto on_centerline_pt = to2D(from_ros(p_opt.value())).basicPoint();
+
+          lanelet::ConstPoints3d segment{ref_pt, next_pt};
+          const auto ls_opt = create_safe_linestring(segment);
+          geometry_msgs::msg::Point p = ref_point.point;
+          // find interpolated point on "waypoint" if there is.
+          if (ls_opt.has_value()) {
+            const auto ls = to2D(*ls_opt);
+
+            const auto arc_coord = lanelet::geometry::toArcCoordinates(ls, on_centerline_pt);
+            const auto interpolated_pt_opt = interpolate_point(ref_pt, next_pt, arc_coord.length);
+            p = (use_exact && interpolated_pt_opt.has_value()) ? to_ros(interpolated_pt_opt.value())
+                                                               : ref_point.point;
+          }
           add_path_point(p, lanelet, speed_limit);
         } else {
           add_path_point(ref_point.point, lanelet, speed_limit);

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -160,6 +160,10 @@ PathWithLaneId removeOverlappingPoints(const PathWithLaneId & input_path)
       continue;
     }
 
+    // If the direction changes sharply (not smooth) but the points are very close,
+    // treat it as an overlap.
+    // This can occur at joints between a waypoint and an auto-generated centerline.
+    // It's not considered overlap in ordinary case, thus, this case relax the condition.
     if (
       (std::fabs(autoware_utils_math::normalize_radian(previous_azimuth - current_azimuth)) >=
        M_PI / 2) &&

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -1872,13 +1872,13 @@ PathWithLaneId RouteHandler::getCenterLinePath(
           const auto ls_opt = create_safe_linestring(segment);
           geometry_msgs::msg::Point p = ref_point.point;
           // find interpolated point on "waypoint" if there is.
-          if (ls_opt.has_value()) {
+          if (use_exact && ls_opt.has_value()) {
             const auto ls = to2D(*ls_opt);
 
             const auto arc_coord = lanelet::geometry::toArcCoordinates(ls, on_centerline_pt);
             const auto interpolated_pt_opt = interpolate_point(ref_pt, next_pt, arc_coord.length);
-            p = (use_exact && interpolated_pt_opt.has_value()) ? to_ros(interpolated_pt_opt.value())
-                                                               : ref_point.point;
+            p = interpolated_pt_opt.has_value() ? to_ros(interpolated_pt_opt.value())
+                                                : ref_point.point;
           }
           add_path_point(p, lanelet, speed_limit);
         } else {


### PR DESCRIPTION
## Description
PR #986 added the tests to validate the usage of `getCenterLinePath` from `route_handler`.
But most of the test samples failed due to the discontinuity. 
This PR fixes these logic to obtain the expected `centerline` which is close to what obtained from `build_reference_path` ([link](https://github.com/autowarefoundation/autoware_core/blob/2d0e7325d9e0c6ea5f8b0968ccfe87aee7e7b884/common/autoware_trajectory/src/utils/reference_path.cpp#L788-L789)) from `autoware_trajectory`.

List of the fix.

- Fix border's discontinuity - [311cb06](https://github.com/autowarefoundation/autoware_core/pull/986/commits/311cb06991bbec6e60ac0c3ec0226942daa8e7d8)
- Bypass route_handler constructor- [cc30493](https://github.com/autowarefoundation/autoware_core/pull/986/commits/cc30493090f57336cd77b6692bee56ccf26940a4)
- Change removeOverlappedCenterlineWithWaypoints trim margin - [f06625d](https://github.com/autowarefoundation/autoware_core/pull/986/commits/f06625d569594bcebec33c0a77e144a03cdb8c91)
- Change interpolation method at s_start - [8096d62](https://github.com/autowarefoundation/autoware_core/pull/986/commits/8096d62b8d40247a954004e5e79931185953f83c)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Pass CI and Evaluator (https://evaluation.tier4.jp/evaluation/reports/3bd94d94-3bb9-5819-a989-0882bd63109c?project_id=autoware_dev) :white_check_mark: 

## Notes for reviewers

Please merge this PR before #986.
## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
