### PR TITLE
ci(docker): switch CI to core/universe-dependencies images

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Autoware Core Development",
-  "image": "ghcr.io/autowarefoundation/autoware:core-devel",
+  "image": "ghcr.io/autowarefoundation/autoware:core-devel-jazzy",
   "runArgs": ["--net=host", "--privileged"],
   "workspaceMount": "source=${localWorkspaceFolder},target=/autoware/src/core/autoware_core,type=bind,consistency=cached",
   "workspaceFolder": "/autoware/src/core/autoware_core",

--- a/.github/actions/tune-dds-network/action.yaml
+++ b/.github/actions/tune-dds-network/action.yaml
@@ -9,34 +9,28 @@ runs:
   steps:
     - name: 📡 Enable multicast on loopback
       run: |
-        echo "::group::📡 Enabling multicast on lo"
         if ip link set lo multicast on; then
           echo "✅ multicast enabled on lo"
         else
           echo "::warning title=DDS tuning::could not enable multicast on lo (NET_ADMIN missing?)"
         fi
-        echo "::endgroup::"
       shell: bash
 
     - name: 🩹 Relax CycloneDDS receive buffer requirement
       # Bridge until autowarefoundation/autoware ships min="default" in cyclonedds.xml.
       run: |
-        echo "::group::🩹 Patching /home/aw/cyclonedds.xml"
         if [ -f /home/aw/cyclonedds.xml ]; then
           sed -i 's|min="10MB"|min="default"|' /home/aw/cyclonedds.xml
           echo "✅ patched: SocketReceiveBufferSize min=\"default\""
         else
           echo "::notice title=DDS tuning::/home/aw/cyclonedds.xml not present, skipping patch"
         fi
-        echo "::endgroup::"
       shell: bash
 
     - name: 🔍 Show effective DDS-relevant settings
       run: |
-        echo "::group::🔍 Effective DDS-relevant settings"
         printf '  %-22s = %s\n' "net.core.rmem_max"     "$(cat /proc/sys/net/core/rmem_max         2>/dev/null || echo unknown)"
         printf '  %-22s = %s\n' "net.ipv4.ipfrag_time"  "$(cat /proc/sys/net/ipv4/ipfrag_time      2>/dev/null || echo unknown)"
         printf '  %-22s = %s\n' "net.ipv4.ipfrag_high"  "$(cat /proc/sys/net/ipv4/ipfrag_high_thresh 2>/dev/null || echo unknown)"
         printf '  %-22s : %s\n' "lo flags"              "$(ip -o link show lo 2>/dev/null | head -1 || echo unknown)"
-        echo "::endgroup::"
       shell: bash

--- a/.github/actions/tune-dds-network/action.yaml
+++ b/.github/actions/tune-dds-network/action.yaml
@@ -1,0 +1,42 @@
+name: Tune DDS network settings
+description: |
+  Apply the DDS tweaks that docker-entrypoint.sh would have done, since
+  GitHub Actions overrides the image entrypoint with `tail -f /dev/null`.
+  The calling job's container must include `--cap-add=NET_ADMIN`.
+
+runs:
+  using: composite
+  steps:
+    - name: 📡 Enable multicast on loopback
+      run: |
+        echo "::group::📡 Enabling multicast on lo"
+        if ip link set lo multicast on; then
+          echo "✅ multicast enabled on lo"
+        else
+          echo "::warning title=DDS tuning::could not enable multicast on lo (NET_ADMIN missing?)"
+        fi
+        echo "::endgroup::"
+      shell: bash
+
+    - name: 🩹 Relax CycloneDDS receive buffer requirement
+      # Bridge until autowarefoundation/autoware ships min="default" in cyclonedds.xml.
+      run: |
+        echo "::group::🩹 Patching /home/aw/cyclonedds.xml"
+        if [ -f /home/aw/cyclonedds.xml ]; then
+          sed -i 's|min="10MB"|min="default"|' /home/aw/cyclonedds.xml
+          echo "✅ patched: SocketReceiveBufferSize min=\"default\""
+        else
+          echo "::notice title=DDS tuning::/home/aw/cyclonedds.xml not present, skipping patch"
+        fi
+        echo "::endgroup::"
+      shell: bash
+
+    - name: 🔍 Show effective DDS-relevant settings
+      run: |
+        echo "::group::🔍 Effective DDS-relevant settings"
+        printf '  %-22s = %s\n' "net.core.rmem_max"     "$(cat /proc/sys/net/core/rmem_max         2>/dev/null || echo unknown)"
+        printf '  %-22s = %s\n' "net.ipv4.ipfrag_time"  "$(cat /proc/sys/net/ipv4/ipfrag_time      2>/dev/null || echo unknown)"
+        printf '  %-22s = %s\n' "net.ipv4.ipfrag_high"  "$(cat /proc/sys/net/ipv4/ipfrag_high_thresh 2>/dev/null || echo unknown)"
+        printf '  %-22s : %s\n' "lo flags"              "$(ip -o link show lo 2>/dev/null | head -1 || echo unknown)"
+        echo "::endgroup::"
+      shell: bash

--- a/.github/workflows/build-and-test-daily.yaml
+++ b/.github/workflows/build-and-test-daily.yaml
@@ -14,10 +14,18 @@ jobs:
         above: [false, true]
         include:
           - rosdistro: humble
-            container: ghcr.io/autowarefoundation/autoware:core-common-devel
+            above: false
+            container: ghcr.io/autowarefoundation/autoware:core-dependencies-humble
+          - rosdistro: humble
+            above: true
+            container: ghcr.io/autowarefoundation/autoware:universe-dependencies-humble
 
           - rosdistro: jazzy
-            container: ghcr.io/autowarefoundation/autoware:core-common-devel-jazzy
+            above: false
+            container: ghcr.io/autowarefoundation/autoware:core-dependencies-jazzy
+          - rosdistro: jazzy
+            above: true
+            container: ghcr.io/autowarefoundation/autoware:universe-dependencies-jazzy
 
     uses: ./.github/workflows/build-and-test-reusable.yaml
 

--- a/.github/workflows/build-and-test-diff-reusable.yaml
+++ b/.github/workflows/build-and-test-diff-reusable.yaml
@@ -101,6 +101,18 @@ jobs:
           ccache --zero-stats
         shell: bash
 
+      - name: Remove self packages from underlay
+        if: ${{ inputs.above }}
+        run: |
+          for pkg_xml in $(find . -name package.xml); do
+            pkg_name=$(xmllint --xpath 'string(//package/name)' "$pkg_xml")
+            if [ -d "/opt/autoware/$pkg_name" ]; then
+              echo "Removing /opt/autoware/$pkg_name"
+              sudo rm -rf "/opt/autoware/$pkg_name"
+            fi
+          done
+        shell: bash
+
       - name: Build
         if: ${{ steps.get-modified-packages.outputs.modified-packages != '' }}
         uses: autowarefoundation/autoware-github-actions/colcon-build@v1

--- a/.github/workflows/build-and-test-diff-reusable.yaml
+++ b/.github/workflows/build-and-test-diff-reusable.yaml
@@ -41,7 +41,9 @@ jobs:
     name: build-and-test-diff
     if: ${{ inputs.run-condition }}
     runs-on: ${{ fromJson(inputs.runner) }}
-    container: ${{ inputs.container }}
+    container:
+      image: ${{ inputs.container }}
+      options: --cap-add=NET_ADMIN
     steps:
       - name: Set PR fetch depth
         run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
@@ -52,6 +54,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: ${{ env.PR_FETCH_DEPTH }}
+
+      - name: Tune DDS network settings
+        uses: ./.github/actions/tune-dds-network
 
       - name: Show disk space before the tasks
         if: ${{ always() }}

--- a/.github/workflows/build-and-test-reusable.yaml
+++ b/.github/workflows/build-and-test-reusable.yaml
@@ -65,10 +65,15 @@ jobs:
   build-and-test:
     name: build-and-test-${{ inputs.rosdistro }}${{ inputs.above && '-above' || '' }}${{ inputs.enable-agnocast && '-agnocast' || '' }}
     runs-on: ${{ fromJson(inputs.runner) }}
-    container: ${{ inputs.container }}
+    container:
+      image: ${{ inputs.container }}
+      options: --cap-add=NET_ADMIN
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+
+      - name: Tune DDS network settings
+        uses: ./.github/actions/tune-dds-network
 
       - name: Show disk space before the tasks
         if: ${{ always() }}
@@ -115,6 +120,18 @@ jobs:
         run: |
           du -sh ${CCACHE_DIR} && ccache -s
           ccache --zero-stats
+        shell: bash
+
+      - name: Remove self packages from underlay
+        if: ${{ inputs.above }}
+        run: |
+          for pkg_xml in $(find . -name package.xml); do
+            pkg_name=$(xmllint --xpath 'string(//package/name)' "$pkg_xml")
+            if [ -d "/opt/autoware/$pkg_name" ]; then
+              echo "Removing /opt/autoware/$pkg_name"
+              sudo rm -rf "/opt/autoware/$pkg_name"
+            fi
+          done
         shell: bash
 
       - name: Build

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -18,10 +18,18 @@ jobs:
             enable-agnocast: true
         include:
           - rosdistro: humble
-            container: ghcr.io/autowarefoundation/autoware:core-common-devel
+            above: false
+            container: ghcr.io/autowarefoundation/autoware:core-dependencies-humble
+          - rosdistro: humble
+            above: true
+            container: ghcr.io/autowarefoundation/autoware:universe-dependencies-humble
 
           - rosdistro: jazzy
-            container: ghcr.io/autowarefoundation/autoware:core-common-devel-jazzy
+            above: false
+            container: ghcr.io/autowarefoundation/autoware:core-dependencies-jazzy
+          - rosdistro: jazzy
+            above: true
+            container: ghcr.io/autowarefoundation/autoware:universe-dependencies-jazzy
 
     uses: ./.github/workflows/build-and-test-reusable.yaml
 

--- a/.github/workflows/build-test-tidy-pr.yaml
+++ b/.github/workflows/build-test-tidy-pr.yaml
@@ -62,7 +62,7 @@ jobs:
     uses: ./.github/workflows/build-and-test-diff-reusable.yaml
     with:
       rosdistro: humble
-      container: ghcr.io/autowarefoundation/autoware:core-common-devel
+      container: ghcr.io/autowarefoundation/autoware:core-dependencies-humble
       above: false
       run-condition: ${{ needs.require-label.outputs.result == 'true' }}
     secrets:
@@ -76,7 +76,7 @@ jobs:
     with:
       rosdistro: humble
       runner: "['self-hosted', 'Linux', 'X64']"
-      container: ghcr.io/autowarefoundation/autoware:core-common-devel
+      container: ghcr.io/autowarefoundation/autoware:universe-dependencies-humble
       above: true
       run-condition: ${{ needs.require-label.outputs.result == 'true' }}
     secrets:
@@ -89,7 +89,7 @@ jobs:
     uses: ./.github/workflows/build-and-test-diff-reusable.yaml
     with:
       rosdistro: jazzy
-      container: ghcr.io/autowarefoundation/autoware:core-common-devel-jazzy
+      container: ghcr.io/autowarefoundation/autoware:core-dependencies-jazzy
       above: false
       run-condition: ${{ needs.require-label.outputs.result == 'true' }}
     secrets:
@@ -102,7 +102,7 @@ jobs:
     uses: ./.github/workflows/build-and-test-diff-reusable.yaml
     with:
       rosdistro: jazzy
-      container: ghcr.io/autowarefoundation/autoware:core-common-devel-jazzy
+      container: ghcr.io/autowarefoundation/autoware:core-dependencies-jazzy
       above: false
       enable-agnocast: true
       run-condition: ${{ needs.require-label.outputs.result == 'true' }}
@@ -117,7 +117,7 @@ jobs:
     with:
       rosdistro: jazzy
       runner: "['self-hosted', 'Linux', 'X64']"
-      container: ghcr.io/autowarefoundation/autoware:core-common-devel-jazzy
+      container: ghcr.io/autowarefoundation/autoware:universe-dependencies-jazzy
       above: true
       run-condition: ${{ needs.require-label.outputs.result == 'true' }}
     secrets:


### PR DESCRIPTION
- **Parent Issue:** autowarefoundation/autoware#6852
- Point [build-and-test.yaml](https://github.com/autowarefoundation/autoware_core/blob/d0600fb1a9dc3e9b331fcf3072e5ac16401189b9/.github/workflows/build-and-test.yaml) and [build-and-test-daily.yaml](https://github.com/autowarefoundation/autoware_core/blob/d0600fb1a9dc3e9b331fcf3072e5ac16401189b9/.github/workflows/build-and-test-daily.yaml) at the `core-dependencies-<distro>` and `universe-dependencies-<distro>` images published by the consolidated docker pipeline (autowarefoundation/autoware#7040), replacing the old `core-common-devel[-jazzy]` images. Under the new scheme there is one image per `(rosdistro, above)` pair, so each matrix row pins its own container instead of sharing a single base.
- In [build-and-test-reusable.yaml](https://github.com/autowarefoundation/autoware_core/blob/d0600fb1a9dc3e9b331fcf3072e5ac16401189b9/.github/workflows/build-and-test-reusable.yaml), add an "above"-only step that strips any workspace packages from `/opt/autoware` before the build so the workspace copy wins over the baked-in underlay.

## Why
The bake-based pipeline in autowarefoundation/autoware#7040 stops publishing `core-common-devel*` and replaces it with dedicated `core-dependencies-<distro>` and `universe-dependencies-<distro>` images. Without this change, CI here will 404 on image pull once that PR merges. The "above" rows now build on an image that has the universe packages pre-installed, so workspace checkouts of those packages need to shadow the underlay or the underlay's stale copy would be linked against instead.

---

- Depends on autowarefoundation/autoware#7040 for image availability.

## Test plan

- [x] [`build-and-test-daily`](https://github.com/autowarefoundation/autoware_core/actions/runs/24690716805) passes when dispatched manually via `workflow_dispatch`.
- [ ] `build-and-test` passes on this PR across all `(rosdistro, above, enable-agnocast)` rows.
- [ ] For `above: true` rows, the "Remove self packages from underlay" step logs removals of workspace-overlapping packages from `/opt/autoware`.
