### PR TITLE
ci(build-and-test): set CCACHE_DIR in job env

### DIFF
--- a/.github/workflows/build-and-test-diff-reusable.yaml
+++ b/.github/workflows/build-and-test-diff-reusable.yaml
@@ -35,6 +35,7 @@ on:
 env:
   CC: /usr/lib/ccache/gcc
   CXX: /usr/lib/ccache/g++
+  CCACHE_DIR: /root/.ccache
 
 jobs:
   build-and-test-differential:

--- a/.github/workflows/build-and-test-reusable.yaml
+++ b/.github/workflows/build-and-test-reusable.yaml
@@ -60,6 +60,7 @@ concurrency:
 env:
   CC: /usr/lib/ccache/gcc
   CXX: /usr/lib/ccache/g++
+  CCACHE_DIR: /root/.ccache
 
 jobs:
   build-and-test:
@@ -91,11 +92,6 @@ jobs:
 
       - name: Create ccache directory
         run: |
-          if [ -z "${CCACHE_DIR}" ]; then
-            apt-get update
-            apt-get install -y ccache
-            export CCACHE_DIR=/root/.ccache
-          fi
           mkdir -p ${CCACHE_DIR}
           du -sh ${CCACHE_DIR} && ccache -s
         shell: bash


### PR DESCRIPTION
- Follow-up to #1035.
- Set `CCACHE_DIR: /root/.ccache` in the job-level `env:` block of both [build-and-test-reusable.yaml](https://github.com/autowarefoundation/autoware_core/blob/1f48dfe525b49403cb5dc54a43a88067dc0530c4/.github/workflows/build-and-test-reusable.yaml) and [build-and-test-diff-reusable.yaml](https://github.com/autowarefoundation/autoware_core/blob/1f48dfe525b49403cb5dc54a43a88067dc0530c4/.github/workflows/build-and-test-diff-reusable.yaml).
- Drop the now-dead fallback in `build-and-test-reusable.yaml` that `apt-get install`ed ccache and `export`ed `CCACHE_DIR` inside a single shell step (the export never escaped that step anyway).

## Why
Both workflows reference \`${CCACHE_DIR}\` in several steps (create dir, limit size, stats, post-build stats), but only \`CC\` and \`CXX\` were set at the job \`env:\` level. \`CCACHE_DIR\` was either unset (diff-reusable) or set only inside one shell step via \`export\` (reusable), which doesn't persist across steps. That left the cache-size limit and stats steps operating on an empty path, and the \`actions/cache/restore\` path hard-coded to \`/root/.ccache\` could drift from whatever the build step actually used. Pinning \`CCACHE_DIR\` at the job level keeps every step, plus the ccache compiler wrappers, pointed at the same directory the cache action restores to.

---

## Test plan

- [ ] \`build-and-test-differential\` on this PR is green across all rows.
- [ ] In the ccache stats steps, \`ccache -s\` shows \`Cache directory: /root/.ccache\` and a warm cache reports non-zero hits on reruns.