### PR TITLE
feat(autoware_trajectory): control test plotting via ENABLE_TEST_PLOT env var

### DIFF
--- a/common/autoware_trajectory/test/test_plot.hpp
+++ b/common/autoware_trajectory/test/test_plot.hpp
@@ -12,36 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
-#include <pybind11/embed.h>
+#ifndef TEST_PLOT_HPP_
+#define TEST_PLOT_HPP_
 
-#include <cstdlib>
-#include <string>
-
-#ifdef PLOT
-#include "test_plot.hpp"
-
-#include <optional>
-#endif
 namespace autoware::test_utils
 {
 
-bool plot_enabled()
-{
-  const char * env = std::getenv("ENABLE_TEST_PLOT");
-  return env && std::string(env) == "1";
-}
+bool plot_enabled();
 
 }  // namespace autoware::test_utils
 
-int main(int argc, char ** argv)
-{
-#ifdef PLOT
-  std::optional<pybind11::scoped_interpreter> guard;
-  if (autoware::test_utils::plot_enabled()) {
-    guard.emplace();
-  }
-#endif
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+#endif  // TEST_PLOT_HPP_

--- a/common/autoware_trajectory/test/test_reference_path_vm_10_spec.cpp
+++ b/common/autoware_trajectory/test/test_reference_path_vm_10_spec.cpp
@@ -16,6 +16,7 @@
 #include "autoware/trajectory/threshold.hpp"
 #include "autoware/trajectory/utils/reference_path.hpp"
 #include "test_case.hpp"
+#include "test_plot.hpp"
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <autoware/lanelet2_utils/conversion.hpp>
@@ -251,7 +252,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP0OnEntireLanes)  // NOLINT
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -390,7 +391,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP1OnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -529,7 +530,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP2OnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -668,7 +669,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP3OnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -807,7 +808,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP4OnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -946,7 +947,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP5OnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -1085,7 +1086,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP6OnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -1211,7 +1212,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP1ForwardOnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -1324,7 +1325,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP2ForwardOnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -1424,7 +1425,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP3ForwardOnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -1511,7 +1512,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP4ForwardOnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -1598,7 +1599,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP5ForwardOnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -1672,7 +1673,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP6ForwardOnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";

--- a/common/autoware_trajectory/test/test_reference_path_vm_10_spec_invalid.cpp
+++ b/common/autoware_trajectory/test/test_reference_path_vm_10_spec_invalid.cpp
@@ -16,6 +16,7 @@
 #include "autoware/trajectory/threshold.hpp"
 #include "autoware/trajectory/utils/reference_path.hpp"
 #include "test_case.hpp"
+#include "test_plot.hpp"
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <autoware/lanelet2_utils/conversion.hpp>
@@ -250,7 +251,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP0OnEntireLanes)  // NOLINT
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +
       "test_reference_path_invalid_01.svg";
@@ -389,7 +390,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP1OnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +
       "test_reference_path_invalid_01.svg";
@@ -528,7 +529,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP2OnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +
       "test_reference_path_invalid_01.svg";
@@ -667,7 +668,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP3OnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +
       "test_reference_path_invalid_01.svg";
@@ -806,7 +807,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP4OnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +
       "test_reference_path_invalid_01.svg";
@@ -932,7 +933,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP1ForwardOnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +
       "test_reference_path_invalid_01.svg";
@@ -1032,7 +1033,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP2ForwardOnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +
       "test_reference_path_invalid_01.svg";
@@ -1132,7 +1133,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP3ForwardOnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +
       "test_reference_path_invalid_01.svg";
@@ -1219,7 +1220,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP4ForwardOnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +
       "test_reference_path_invalid_01.svg";


### PR DESCRIPTION
## Description
<!-- Briefly describe the state/problem before this PR -->
Before this PR, test plotting in `autoware_trajectory` was controlled by compile-time `#ifdef PLOT` flags. This meant plots were either always generated or always skipped based on the build configuration, with no runtime flexibility.

<!-- Describe the changes made (select/add as appropriate) -->
This PR introduces runtime control of test plotting via the `ENABLE_TEST_PLOT` environment variable.
- Add `plot_enabled()` utility that checks `ENABLE_TEST_PLOT == "1"`
- Extract plot declaration into `test_plot.hpp`
- Guard all plotting calls in test files with `if (plot_enabled())`
- Remove compile-time `#ifdef PLOT` blocks in favor of runtime checks

## Related links
- None.

## Notes for reviewers
None.

## Effects on system behavior
None.
