### PR TITLE
refactor(autoware_trajectory): introduce granular epsilon constants and parameterize interpolators

### DIFF
--- a/common/autoware_trajectory/include/autoware/trajectory/detail/helpers.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/detail/helpers.hpp
@@ -102,6 +102,34 @@ inline bool has_strictly_increasing_bases(
 }
 
 /**
+ * @brief Remove consecutive duplicate points whose base differences are too small.
+ * @param[in] bases Interpolation bases.
+ * @param[in] values Interpolation values corresponding to bases.
+ * @return Pair of cleaned bases and cleaned values.
+ */
+template <typename T>
+inline std::pair<std::vector<double>, std::vector<T>> remove_duplicate_points(
+  const std::vector<double> & bases, const std::vector<T> & values, const double epsilon)
+{
+  std::vector<double> out_bases;
+  std::vector<T> out_values;
+  if (bases.empty()) {
+    return {out_bases, out_values};
+  }
+  out_bases.reserve(bases.size());
+  out_values.reserve(values.size());
+  out_bases.push_back(bases.front());
+  out_values.push_back(values.front());
+  for (size_t i = 1; i < bases.size(); ++i) {
+    if (bases[i] - out_bases.back() > epsilon) {
+      out_bases.push_back(bases[i]);
+      out_values.push_back(values[i]);
+    }
+  }
+  return {std::move(out_bases), std::move(out_values)};
+}
+
+/**
  * @brief Crop bases to the closed interval `[start, end]`, inserting boundaries if needed.
  * @param[in] x Input bases.
  * @param[in] start Crop start.

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/akima_spline.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/akima_spline.hpp
@@ -19,6 +19,7 @@
 
 #include <Eigen/Dense>
 
+#include <limits>
 #include <vector>
 
 namespace autoware::experimental::trajectory::interpolator
@@ -32,6 +33,7 @@ namespace autoware::experimental::trajectory::interpolator
 class AkimaSpline : public detail::InterpolatorMixin<AkimaSpline, double>
 {
 private:
+  double epsilon_{};               ///< Duplicate-base tolerance.
   Eigen::VectorXd a_, b_, c_, d_;  ///< Coefficients for the Akima spline.
 
   /**
@@ -89,7 +91,10 @@ private:
   double compute_second_derivative_impl(const double s) const override;
 
 public:
-  AkimaSpline() = default;
+  explicit AkimaSpline(const double epsilon = std::numeric_limits<double>::epsilon())
+  : epsilon_(epsilon)
+  {
+  }
 
   /**
    * @brief Get the minimum number of required points for the interpolator.

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/cubic_spline.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/cubic_spline.hpp
@@ -19,6 +19,7 @@
 
 #include <Eigen/Dense>
 
+#include <limits>
 #include <vector>
 
 namespace autoware::experimental::trajectory::interpolator
@@ -32,6 +33,7 @@ namespace autoware::experimental::trajectory::interpolator
 class CubicSpline : public detail::InterpolatorMixin<CubicSpline, double>
 {
 private:
+  double epsilon_{};               ///< Duplicate-base tolerance.
   Eigen::VectorXd a_, b_, c_, d_;  ///< Coefficients for the cubic spline.
   Eigen::VectorXd h_;              ///< Interval sizes between bases points.
 
@@ -92,7 +94,10 @@ private:
   double compute_second_derivative_impl(const double s) const override;
 
 public:
-  CubicSpline() = default;
+  explicit CubicSpline(const double epsilon = std::numeric_limits<double>::epsilon())
+  : epsilon_(epsilon)
+  {
+  }
 
   /**
    * @brief Get the minimum number of required points for the interpolator.

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/linear.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/linear.hpp
@@ -19,6 +19,7 @@
 
 #include <Eigen/Dense>
 
+#include <limits>
 #include <vector>
 
 namespace autoware::experimental::trajectory::interpolator
@@ -32,6 +33,7 @@ namespace autoware::experimental::trajectory::interpolator
 class Linear : public detail::InterpolatorMixin<Linear, double>
 {
 private:
+  double epsilon_{};        ///< Duplicate-base tolerance.
   Eigen::VectorXd values_;  ///< Interpolation values.
 
   /**
@@ -82,7 +84,9 @@ public:
   /**
    * @brief Default constructor.
    */
-  Linear() = default;
+  explicit Linear(const double epsilon = std::numeric_limits<double>::epsilon()) : epsilon_(epsilon)
+  {
+  }
 
   /**
    * @brief Get the minimum number of required points for the interpolator.

--- a/common/autoware_trajectory/include/autoware/trajectory/interpolator/spherical_linear.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/interpolator/spherical_linear.hpp
@@ -19,8 +19,8 @@
 
 #include <geometry_msgs/msg/quaternion.hpp>
 
+#include <limits>
 #include <vector>
-
 namespace autoware::experimental::trajectory::interpolator
 {
 
@@ -33,6 +33,7 @@ class SphericalLinear
 : public detail::InterpolatorMixin<SphericalLinear, geometry_msgs::msg::Quaternion>
 {
 private:
+  double epsilon_{};  ///< Duplicate-base tolerance.
   std::vector<geometry_msgs::msg::Quaternion> quaternions_;
 
   /**
@@ -69,7 +70,10 @@ public:
   /**
    * @brief Default constructor.
    */
-  SphericalLinear() = default;
+  explicit SphericalLinear(const double epsilon = std::numeric_limits<double>::epsilon())
+  : epsilon_(epsilon)
+  {
+  }
 
   /**
    * @brief Get the minimum number of required points for the interpolator.

--- a/common/autoware_trajectory/include/autoware/trajectory/threshold.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/threshold.hpp
@@ -19,6 +19,7 @@
 #include <autoware_planning_msgs/msg/path_point.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
 #include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/quaternion.hpp>
 
 #include <lanelet2_core/Forward.h>
 
@@ -26,10 +27,12 @@ namespace autoware::experimental::trajectory
 {
 
 // TODO(soblin): this should be defined as one of Autoware's interface/limitations
-static constexpr double k_points_minimum_dist_threshold = 0.005;
+static constexpr double k_epsilon_time = 1e-6;       // second
+static constexpr double k_epsilon_distance = 0.005;  // meter
+static constexpr double k_epsilon_velocity = 1e-6;   // m/s
+static constexpr double k_epsilon_angle = 1e-6;      // rad
 
-// zero velocity threshold [m/s]
-static constexpr double k_zero_velocity_threshold = 1e-6;
+static constexpr double k_points_minimum_dist_threshold = k_epsilon_distance;  // deprecated
 
 /**
  * @brief check if two base values are almost-same
@@ -40,6 +43,12 @@ bool is_almost_same(const double s1, const double s2);
  * @brief check if two points are almost-same
  */
 bool is_almost_same(const geometry_msgs::msg::Point & p1, const geometry_msgs::msg::Point & p2);
+
+/**
+ * @brief check if two quaternions represent almost the same rotation
+ */
+bool is_almost_same(
+  const geometry_msgs::msg::Quaternion & q1, const geometry_msgs::msg::Quaternion & q2);
 
 /**
  * @brief check if two points are almost-same

--- a/common/autoware_trajectory/include/autoware/trajectory/utils/find_nearest.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/utils/find_nearest.hpp
@@ -57,7 +57,7 @@ template <class TrajectoryPointType>
   double min_dist = std::numeric_limits<double>::infinity();
   double min_s = (search_start + search_end) * 0.5;
 
-  while (search_end - search_start > k_points_minimum_dist_threshold) {
+  while (search_end - search_start > k_epsilon_distance) {
     const double mid1 = search_start + (search_end - search_start) / 3.0;
     const double mid2 = search_end - (search_end - search_start) / 3.0;
 
@@ -115,7 +115,7 @@ std::optional<double> find_precise_index(
   double min_dist = std::numeric_limits<double>::infinity();
   double min_s = (search_start + search_end) * 0.5;
 
-  while (search_end - search_start > k_points_minimum_dist_threshold) {
+  while (search_end - search_start > k_epsilon_distance) {
     const double mid1 = search_start + (search_end - search_start) / 3.0;
     const double mid2 = search_end - (search_end - search_start) / 3.0;
 

--- a/common/autoware_trajectory/include/autoware/trajectory/utils/pretty_build.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/utils/pretty_build.hpp
@@ -38,7 +38,7 @@ namespace autoware::experimental::trajectory
  * @return Built trajectory, or `std::nullopt` when the build fails.
  * @details
  * When `use_akima` is false, this delegates to `Trajectory<PointType>::Builder{}.build(points)`
- * and rejects trajectories shorter than `k_points_minimum_dist_threshold`.
+ * and rejects trajectories shorter than `k_epsilon_distance`.
  * When `use_akima` is true, this delegates to a builder configured with
  * `interpolator::AkimaSpline` for XY interpolation and returns the build result as-is.
  */
@@ -61,7 +61,7 @@ std::optional<Trajectory<PointType>> pretty_build(
   if (!try_trajectory) {
     return std::nullopt;
   }
-  if (try_trajectory->length() < k_points_minimum_dist_threshold) {
+  if (try_trajectory->length() < k_epsilon_distance) {
     return std::nullopt;
   }
   return try_trajectory.value();

--- a/common/autoware_trajectory/include/autoware/trajectory/utils/velocity.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/utils/velocity.hpp
@@ -59,7 +59,7 @@ template <class PointT>
       break;
     }
 
-    if (std::abs(curr_vel) < k_zero_velocity_threshold) {
+    if (std::abs(curr_vel) < k_epsilon_velocity) {
       return curr_distance;
     }
 
@@ -85,7 +85,7 @@ template <class PointT>
   const double last_vel = velocities.back();
   if (
     last_distance >= start_distance && last_distance <= end_distance &&
-    std::abs(last_vel) < k_zero_velocity_threshold) {
+    std::abs(last_vel) < k_epsilon_velocity) {
     return last_distance;
   }
 

--- a/common/autoware_trajectory/src/interpolator/akima_spline.cpp
+++ b/common/autoware_trajectory/src/interpolator/akima_spline.cpp
@@ -64,25 +64,41 @@ void AkimaSpline::compute_parameters(
 
 bool AkimaSpline::build_impl(const std::vector<double> & bases, const std::vector<double> & values)
 {
-  if (!::autoware::experimental::trajectory::detail::has_strictly_increasing_bases(bases)) {
+  auto [cleaned_bases, cleaned_values] =
+    ::autoware::experimental::trajectory::detail::remove_duplicate_points(bases, values, epsilon_);
+  if (cleaned_bases.size() < minimum_required_points()) {
     return false;
   }
-  this->bases_ = bases;
+  if (!::autoware::experimental::trajectory::detail::has_strictly_increasing_bases(
+        cleaned_bases, epsilon_)) {
+    return false;
+  }
+  this->bases_ = std::move(cleaned_bases);
   compute_parameters(
-    Eigen::Map<const Eigen::VectorXd>(bases.data(), static_cast<Eigen::Index>(bases.size())),
-    Eigen::Map<const Eigen::VectorXd>(values.data(), static_cast<Eigen::Index>(values.size())));
+    Eigen::Map<const Eigen::VectorXd>(
+      this->bases_.data(), static_cast<Eigen::Index>(this->bases_.size())),
+    Eigen::Map<const Eigen::VectorXd>(
+      cleaned_values.data(), static_cast<Eigen::Index>(cleaned_values.size())));
   return true;
 }
 
 bool AkimaSpline::build_impl(const std::vector<double> & bases, std::vector<double> && values)
 {
-  if (!::autoware::experimental::trajectory::detail::has_strictly_increasing_bases(bases)) {
+  auto [cleaned_bases, cleaned_values] =
+    ::autoware::experimental::trajectory::detail::remove_duplicate_points(bases, values, epsilon_);
+  if (cleaned_bases.size() < minimum_required_points()) {
     return false;
   }
-  this->bases_ = bases;
+  if (!::autoware::experimental::trajectory::detail::has_strictly_increasing_bases(
+        cleaned_bases, epsilon_)) {
+    return false;
+  }
+  this->bases_ = std::move(cleaned_bases);
   compute_parameters(
-    Eigen::Map<const Eigen::VectorXd>(bases.data(), static_cast<Eigen::Index>(bases.size())),
-    Eigen::Map<const Eigen::VectorXd>(values.data(), static_cast<Eigen::Index>(values.size())));
+    Eigen::Map<const Eigen::VectorXd>(
+      this->bases_.data(), static_cast<Eigen::Index>(this->bases_.size())),
+    Eigen::Map<const Eigen::VectorXd>(
+      cleaned_values.data(), static_cast<Eigen::Index>(cleaned_values.size())));
   return true;
 }
 

--- a/common/autoware_trajectory/src/interpolator/cubic_spline.cpp
+++ b/common/autoware_trajectory/src/interpolator/cubic_spline.cpp
@@ -65,26 +65,41 @@ void CubicSpline::compute_parameters(
 
 bool CubicSpline::build_impl(const std::vector<double> & bases, const std::vector<double> & values)
 {
-  if (!::autoware::experimental::trajectory::detail::has_strictly_increasing_bases(bases)) {
+  auto [cleaned_bases, cleaned_values] =
+    ::autoware::experimental::trajectory::detail::remove_duplicate_points(bases, values, epsilon_);
+  if (cleaned_bases.size() < minimum_required_points()) {
     return false;
   }
-  this->bases_ = bases;
+  if (!::autoware::experimental::trajectory::detail::has_strictly_increasing_bases(
+        cleaned_bases, epsilon_)) {
+    return false;
+  }
+  this->bases_ = std::move(cleaned_bases);
   compute_parameters(
-    Eigen::Map<const Eigen::VectorXd>(bases.data(), static_cast<Eigen::Index>(bases.size())),
-    Eigen::Map<const Eigen::VectorXd>(values.data(), static_cast<Eigen::Index>(values.size())));
+    Eigen::Map<const Eigen::VectorXd>(
+      this->bases_.data(), static_cast<Eigen::Index>(this->bases_.size())),
+    Eigen::Map<const Eigen::VectorXd>(
+      cleaned_values.data(), static_cast<Eigen::Index>(cleaned_values.size())));
   return true;
 }
 
 bool CubicSpline::build_impl(const std::vector<double> & bases, std::vector<double> && values)
 {
-  if (!::autoware::experimental::trajectory::detail::has_strictly_increasing_bases(bases)) {
+  auto [cleaned_bases, cleaned_values] =
+    ::autoware::experimental::trajectory::detail::remove_duplicate_points(bases, values, epsilon_);
+  if (cleaned_bases.size() < minimum_required_points()) {
     return false;
   }
-  this->bases_ = bases;
+  if (!::autoware::experimental::trajectory::detail::has_strictly_increasing_bases(
+        cleaned_bases, epsilon_)) {
+    return false;
+  }
+  this->bases_ = std::move(cleaned_bases);
   compute_parameters(
     Eigen::Map<const Eigen::VectorXd>(
       this->bases_.data(), static_cast<Eigen::Index>(this->bases_.size())),
-    Eigen::Map<const Eigen::VectorXd>(values.data(), static_cast<Eigen::Index>(values.size())));
+    Eigen::Map<const Eigen::VectorXd>(
+      cleaned_values.data(), static_cast<Eigen::Index>(cleaned_values.size())));
   return true;
 }
 

--- a/common/autoware_trajectory/src/interpolator/linear.cpp
+++ b/common/autoware_trajectory/src/interpolator/linear.cpp
@@ -26,23 +26,35 @@ namespace autoware::experimental::trajectory::interpolator
 
 bool Linear::build_impl(const std::vector<double> & bases, const std::vector<double> & values)
 {
-  if (!::autoware::experimental::trajectory::detail::has_strictly_increasing_bases(bases)) {
+  auto [cleaned_bases, cleaned_values] =
+    ::autoware::experimental::trajectory::detail::remove_duplicate_points(bases, values, epsilon_);
+  if (cleaned_bases.size() < minimum_required_points()) {
     return false;
   }
-  this->bases_ = bases;
-  this->values_ =
-    Eigen::Map<const Eigen::VectorXd>(values.data(), static_cast<Eigen::Index>(values.size()));
+  if (!::autoware::experimental::trajectory::detail::has_strictly_increasing_bases(
+        cleaned_bases, epsilon_)) {
+    return false;
+  }
+  this->bases_ = std::move(cleaned_bases);
+  this->values_ = Eigen::Map<const Eigen::VectorXd>(
+    cleaned_values.data(), static_cast<Eigen::Index>(cleaned_values.size()));
   return true;
 }
 
 bool Linear::build_impl(const std::vector<double> & bases, std::vector<double> && values)
 {
-  if (!::autoware::experimental::trajectory::detail::has_strictly_increasing_bases(bases)) {
+  auto [cleaned_bases, cleaned_values] =
+    ::autoware::experimental::trajectory::detail::remove_duplicate_points(bases, values, epsilon_);
+  if (cleaned_bases.size() < minimum_required_points()) {
     return false;
   }
-  this->bases_ = bases;
-  this->values_ =
-    Eigen::Map<const Eigen::VectorXd>(values.data(), static_cast<Eigen::Index>(values.size()));
+  if (!::autoware::experimental::trajectory::detail::has_strictly_increasing_bases(
+        cleaned_bases, epsilon_)) {
+    return false;
+  }
+  this->bases_ = std::move(cleaned_bases);
+  this->values_ = Eigen::Map<const Eigen::VectorXd>(
+    cleaned_values.data(), static_cast<Eigen::Index>(cleaned_values.size()));
   return true;
 }
 

--- a/common/autoware_trajectory/src/interpolator/spherical_linear.cpp
+++ b/common/autoware_trajectory/src/interpolator/spherical_linear.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/trajectory/interpolator/spherical_linear.hpp"
 
+#include "autoware/trajectory/detail/helpers.hpp"
+
 #include <Eigen/Geometry>
 
 #include <utility>
@@ -26,16 +28,36 @@ bool SphericalLinear::build_impl(
   const std::vector<double> & bases,
   const std::vector<geometry_msgs::msg::Quaternion> & quaternions)
 {
-  this->bases_ = bases;
-  this->quaternions_ = quaternions;
+  auto [cleaned_bases, cleaned_quaternions] =
+    ::autoware::experimental::trajectory::detail::remove_duplicate_points(
+      bases, quaternions, epsilon_);
+  if (cleaned_bases.size() < minimum_required_points()) {
+    return false;
+  }
+  if (!::autoware::experimental::trajectory::detail::has_strictly_increasing_bases(
+        cleaned_bases, epsilon_)) {
+    return false;
+  }
+  this->bases_ = std::move(cleaned_bases);
+  this->quaternions_ = std::move(cleaned_quaternions);
   return true;
 }
 
 bool SphericalLinear::build_impl(
   const std::vector<double> & bases, std::vector<geometry_msgs::msg::Quaternion> && quaternions)
 {
-  this->bases_ = bases;
-  this->quaternions_ = std::move(quaternions);
+  auto [cleaned_bases, cleaned_quaternions] =
+    ::autoware::experimental::trajectory::detail::remove_duplicate_points(
+      bases, quaternions, epsilon_);
+  if (cleaned_bases.size() < minimum_required_points()) {
+    return false;
+  }
+  if (!::autoware::experimental::trajectory::detail::has_strictly_increasing_bases(
+        cleaned_bases, epsilon_)) {
+    return false;
+  }
+  this->bases_ = std::move(cleaned_bases);
+  this->quaternions_ = std::move(cleaned_quaternions);
   return true;
 }
 

--- a/common/autoware_trajectory/src/point.cpp
+++ b/common/autoware_trajectory/src/point.cpp
@@ -87,15 +87,12 @@ interpolator::InterpolationResult Trajectory<PointType>::build(
 
   for (size_t i = 1; i < points.size(); ++i) {
     /**
-       NOTE:
-       this sanitization is essential for avoiding zero division and NaN in later interpolation.
-
-       if there are 100 points with the interval of 1nm, then they are treated as 100 points with
-       the interval of k_points_minimum_dist_threshold and interpolation is continued.
+       NOTE: This sanitisation is essential for avoiding the same base. The process of avoiding zero
+       division is handled by each interpolator.
     */
     const auto dist = std::max<double>(
       autoware_utils_geometry::calc_distance3d(points.at(i), points.at(i - 1)),
-      k_points_minimum_dist_threshold);
+      std::numeric_limits<double>::epsilon());
     bases_.emplace_back(bases_.back() + dist);
     xs.emplace_back(points.at(i).x);
     ys.emplace_back(points.at(i).y);
@@ -160,10 +157,12 @@ void Trajectory<PointType>::update_bases(const double s)
     // NOTE(soblin): the extension of base(or extrapolation) will be supported by other API.
     return;
   }
-  if (std::fabs(*it - s) < k_points_minimum_dist_threshold) {
+  if (std::fabs(*it - s) < std::numeric_limits<double>::epsilon()) {
     return;
   }
-  if (it != bases_.begin() && std::fabs(*std::prev(it) - s) < k_points_minimum_dist_threshold) {
+  if (
+    it != bases_.begin() &&
+    std::fabs(*std::prev(it) - s) < std::numeric_limits<double>::epsilon()) {
     return;
   }
   bases_.insert(it, s);
@@ -267,9 +266,9 @@ Trajectory<PointType>::Builder::Builder() : trajectory_(std::make_unique<Traject
 
 void Trajectory<PointType>::Builder::defaults(Trajectory<PointType> * trajectory)
 {
-  trajectory->x_interpolator_ = std::make_shared<interpolator::CubicSpline>();
-  trajectory->y_interpolator_ = std::make_shared<interpolator::CubicSpline>();
-  trajectory->z_interpolator_ = std::make_shared<interpolator::Linear>();
+  trajectory->x_interpolator_ = std::make_shared<interpolator::CubicSpline>(k_epsilon_distance);
+  trajectory->y_interpolator_ = std::make_shared<interpolator::CubicSpline>(k_epsilon_distance);
+  trajectory->z_interpolator_ = std::make_shared<interpolator::Linear>(k_epsilon_distance);
 }
 
 tl::expected<Trajectory<PointType>, interpolator::InterpolationFailure>

--- a/common/autoware_trajectory/src/pose.cpp
+++ b/common/autoware_trajectory/src/pose.cpp
@@ -18,6 +18,7 @@
 #include "autoware/trajectory/forward.hpp"
 #include "autoware/trajectory/interpolator/nearest_neighbor.hpp"
 #include "autoware/trajectory/interpolator/spherical_linear.hpp"
+#include "autoware/trajectory/threshold.hpp"
 
 #include <tf2/LinearMath/Quaternion.hpp>
 #include <tf2/LinearMath/Vector3.hpp>
@@ -219,7 +220,8 @@ Trajectory<PointType>::Builder::Builder() : trajectory_(std::make_unique<Traject
 void Trajectory<PointType>::Builder::defaults(Trajectory<PointType> * trajectory)
 {
   BaseClass::Builder::defaults(trajectory);
-  trajectory->orientation_interpolator_ = std::make_shared<interpolator::SphericalLinear>();
+  trajectory->orientation_interpolator_ =
+    std::make_shared<interpolator::SphericalLinear>(k_epsilon_distance);
 }
 
 tl::expected<Trajectory<PointType>, interpolator::InterpolationFailure>

--- a/common/autoware_trajectory/src/threshold.cpp
+++ b/common/autoware_trajectory/src/threshold.cpp
@@ -16,7 +16,13 @@
 
 #include "autoware_utils_geometry/geometry.hpp"
 
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/LinearMath/Scalar.hpp>
+
 #include <lanelet2_core/primitives/Point.h>
+
+#include <cmath>
+
 namespace autoware::experimental::trajectory
 {
 
@@ -27,38 +33,49 @@ bool is_almost_same(const double s1, const double s2)
 
 bool is_almost_same(const geometry_msgs::msg::Point & p1, const geometry_msgs::msg::Point & p2)
 {
-  return autoware_utils_geometry::calc_distance3d(p1, p2) < k_points_minimum_dist_threshold;
+  return autoware_utils_geometry::calc_distance3d(p1, p2) < k_epsilon_distance;
+}
+
+bool is_almost_same(
+  const geometry_msgs::msg::Quaternion & q1, const geometry_msgs::msg::Quaternion & q2)
+{
+  tf2::Quaternion tf_q1(q1.x, q1.y, q1.z, q1.w);
+  tf2::Quaternion tf_q2(q2.x, q2.y, q2.z, q2.w);
+  tf_q1.normalize();
+  tf_q2.normalize();
+
+  const double dot = tf_q1.dot(tf_q2);
+  return std::abs(std::abs(dot) - 1.0) < k_epsilon_angle;
 }
 
 bool is_almost_same(const geometry_msgs::msg::Pose & p1, const geometry_msgs::msg::Pose & p2)
 {
-  return autoware_utils_geometry::calc_distance3d(p1, p2) < k_points_minimum_dist_threshold;
+  return autoware_utils_geometry::calc_distance3d(p1, p2) < k_epsilon_distance;
 }
 
 bool is_almost_same(
   const autoware_planning_msgs::msg::PathPoint & p1,
   const autoware_planning_msgs::msg::PathPoint & p2)
 {
-  return autoware_utils_geometry::calc_distance3d(p1, p2) < k_points_minimum_dist_threshold;
+  return autoware_utils_geometry::calc_distance3d(p1, p2) < k_epsilon_distance;
 }
 
 bool is_almost_same(
   const autoware_planning_msgs::msg::TrajectoryPoint & p1,
   const autoware_planning_msgs::msg::TrajectoryPoint & p2)
 {
-  return autoware_utils_geometry::calc_distance3d(p1, p2) < k_points_minimum_dist_threshold;
+  return autoware_utils_geometry::calc_distance3d(p1, p2) < k_epsilon_distance;
 }
 
 bool is_almost_same(
   const autoware_internal_planning_msgs::msg::PathPointWithLaneId & p1,
   const autoware_internal_planning_msgs::msg::PathPointWithLaneId & p2)
 {
-  return autoware_utils_geometry::calc_distance3d(p1, p2) < k_points_minimum_dist_threshold;
+  return autoware_utils_geometry::calc_distance3d(p1, p2) < k_epsilon_distance;
 }
 
 bool is_almost_same(const lanelet::ConstPoint3d & p1, const lanelet::ConstPoint3d & p2)
 {
-  return std::hypot(p1.x() - p2.x(), p1.y() - p2.y(), p1.z() - p2.z()) <
-         k_points_minimum_dist_threshold;
+  return std::hypot(p1.x() - p2.x(), p1.y() - p2.y(), p1.z() - p2.z()) < k_epsilon_distance;
 }
 }  // namespace autoware::experimental::trajectory

--- a/common/autoware_trajectory/test/test_plot.hpp
+++ b/common/autoware_trajectory/test/test_plot.hpp
@@ -12,36 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
-#include <pybind11/embed.h>
+#ifndef TEST_PLOT_HPP_
+#define TEST_PLOT_HPP_
 
-#include <cstdlib>
-#include <string>
-
-#ifdef PLOT
-#include "test_plot.hpp"
-
-#include <optional>
-#endif
 namespace autoware::test_utils
 {
 
-bool plot_enabled()
-{
-  const char * env = std::getenv("ENABLE_TEST_PLOT");
-  return env && std::string(env) == "1";
-}
+bool plot_enabled();
 
 }  // namespace autoware::test_utils
 
-int main(int argc, char ** argv)
-{
-#ifdef PLOT
-  std::optional<pybind11::scoped_interpreter> guard;
-  if (autoware::test_utils::plot_enabled()) {
-    guard.emplace();
-  }
-#endif
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
+#endif  // TEST_PLOT_HPP_

--- a/common/autoware_trajectory/test/test_reference_path.cpp
+++ b/common/autoware_trajectory/test/test_reference_path.cpp
@@ -132,7 +132,7 @@ TEST_P(TestCase_Map_Waypoint_Straight_00, TestPathValidity)
              points, points | ranges::views::drop(1), points | ranges::views::drop(2))) {
         EXPECT_TRUE(
           autoware_utils_geometry::calc_distance3d(p1, p2) >=
-          autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+          autoware::experimental::trajectory::k_epsilon_distance);
         EXPECT_TRUE(
           boost::geometry::within(
             lanelet::utils::to2D(lanelet2_utils::from_ros(p2.point.pose.position)),
@@ -274,7 +274,7 @@ TEST_P(TestCase_Map_Waypoint_Curve_00, TestPathValidity)
              points, points | ranges::views::drop(1), points | ranges::views::drop(2))) {
         EXPECT_TRUE(
           autoware_utils_geometry::calc_distance3d(p1, p2) >=
-          autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+          autoware::experimental::trajectory::k_epsilon_distance);
 
         // use p2, because p1/p3 at the end may well be slightly outside of the Lanelets by error
         EXPECT_TRUE(
@@ -484,7 +484,7 @@ INSTANTIATE_TEST_SUITE_P(
 //              points, points | ranges::views::drop(1), points | ranges::views::drop(2))) {
 //         EXPECT_TRUE(
 //           autoware_utils_geometry::calc_distance3d(p1, p2) >=
-//           autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+//           autoware::experimental::trajectory::k_epsilon_distance);
 
 //         // use p2, because p1/p3 at the end may well be slightly outside of the Lanelets by error
 //         EXPECT_TRUE(

--- a/common/autoware_trajectory/test/test_reference_path_vm_10_spec.cpp
+++ b/common/autoware_trajectory/test/test_reference_path_vm_10_spec.cpp
@@ -16,6 +16,7 @@
 #include "autoware/trajectory/threshold.hpp"
 #include "autoware/trajectory/utils/reference_path.hpp"
 #include "test_case.hpp"
+#include "test_plot.hpp"
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <autoware/lanelet2_utils/conversion.hpp>
@@ -251,7 +252,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP0OnEntireLanes)  // NOLINT
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -390,7 +391,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP1OnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -529,7 +530,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP2OnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -668,7 +669,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP3OnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -807,7 +808,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP4OnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -946,7 +947,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP5OnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -1085,7 +1086,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP6OnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -1211,7 +1212,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP1ForwardOnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -1324,7 +1325,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP2ForwardOnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -1424,7 +1425,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP3ForwardOnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -1511,7 +1512,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP4ForwardOnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -1598,7 +1599,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP5ForwardOnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";
@@ -1672,7 +1673,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP6ForwardOnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) + GetParam() +
       ".svg";

--- a/common/autoware_trajectory/test/test_reference_path_vm_10_spec.cpp
+++ b/common/autoware_trajectory/test/test_reference_path_vm_10_spec.cpp
@@ -152,7 +152,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP0OnEntireLanes)  // NOLINT
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(
@@ -291,7 +291,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP1OnEntireLanes)
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(
@@ -430,7 +430,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP2OnEntireLanes)
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(
@@ -569,7 +569,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP3OnEntireLanes)
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(
@@ -708,7 +708,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP4OnEntireLanes)
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(
@@ -847,7 +847,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP5OnEntireLanes)
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(
@@ -986,7 +986,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP6OnEntireLanes)
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(
@@ -1125,7 +1125,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP1ForwardOnEntireLanes)
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(
@@ -1251,7 +1251,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP2ForwardOnEntireLanes)
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(
@@ -1364,7 +1364,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP3ForwardOnEntireLanes)
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(
@@ -1464,7 +1464,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP4ForwardOnEntireLanes)
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(
@@ -1551,7 +1551,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP5ForwardOnEntireLanes)
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(
@@ -1638,7 +1638,7 @@ TEST_P(TestWithVM_01_10_12_Map, FromP6ForwardOnEntireLanes)
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(

--- a/common/autoware_trajectory/test/test_reference_path_vm_10_spec_invalid.cpp
+++ b/common/autoware_trajectory/test/test_reference_path_vm_10_spec_invalid.cpp
@@ -151,7 +151,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP0OnEntireLanes)  // NOLINT
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(
@@ -290,7 +290,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP1OnEntireLanes)
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(
@@ -429,7 +429,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP2OnEntireLanes)
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(
@@ -568,7 +568,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP3OnEntireLanes)
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(
@@ -707,7 +707,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP4OnEntireLanes)
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(
@@ -846,7 +846,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP1ForwardOnEntireLanes)
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(
@@ -972,7 +972,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP2ForwardOnEntireLanes)
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(
@@ -1072,7 +1072,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP3ForwardOnEntireLanes)
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(
@@ -1172,7 +1172,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP4ForwardOnEntireLanes)
          path_points_with_lane_id | ranges::views::drop(2))) {
     EXPECT_TRUE(
       autoware_utils_geometry::calc_distance3d(p1, p2) >=
-      autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+      autoware::experimental::trajectory::k_epsilon_distance);
     EXPECT_TRUE(
       std::fabs(
         autoware_utils_math::normalize_radian(

--- a/common/autoware_trajectory/test/test_reference_path_vm_10_spec_invalid.cpp
+++ b/common/autoware_trajectory/test/test_reference_path_vm_10_spec_invalid.cpp
@@ -16,6 +16,7 @@
 #include "autoware/trajectory/threshold.hpp"
 #include "autoware/trajectory/utils/reference_path.hpp"
 #include "test_case.hpp"
+#include "test_plot.hpp"
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <autoware/lanelet2_utils/conversion.hpp>
@@ -250,7 +251,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP0OnEntireLanes)  // NOLINT
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +
       "test_reference_path_invalid_01.svg";
@@ -389,7 +390,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP1OnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +
       "test_reference_path_invalid_01.svg";
@@ -528,7 +529,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP2OnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +
       "test_reference_path_invalid_01.svg";
@@ -667,7 +668,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP3OnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +
       "test_reference_path_invalid_01.svg";
@@ -806,7 +807,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP4OnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +
       "test_reference_path_invalid_01.svg";
@@ -932,7 +933,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP1ForwardOnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +
       "test_reference_path_invalid_01.svg";
@@ -1032,7 +1033,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP2ForwardOnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +
       "test_reference_path_invalid_01.svg";
@@ -1132,7 +1133,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP3ForwardOnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +
       "test_reference_path_invalid_01.svg";
@@ -1219,7 +1220,7 @@ TEST_F(TestWithVM_01_10_12_Map_Invalid, FromP4ForwardOnEntireLanes)
   }
 
 #ifdef PLOT
-  {
+  if (autoware::test_utils::plot_enabled()) {
     std::string filename =
       std::string(::testing::UnitTest::GetInstance()->current_test_info()->name()) +
       "test_reference_path_invalid_01.svg";

--- a/common/autoware_trajectory/test/test_trajectory_container.cpp
+++ b/common/autoware_trajectory/test/test_trajectory_container.cpp
@@ -162,8 +162,7 @@ TEST(TrajectoryCreatorTest, RestoreTinyCroppedTrajectoryPreservesBoundaries)
   auto trajectory = Trajectory::Builder{}.build(points);
   ASSERT_TRUE(trajectory);
 
-  constexpr double tiny_length =
-    autoware::experimental::trajectory::k_points_minimum_dist_threshold / 10.0;
+  constexpr double tiny_length = autoware::experimental::trajectory::k_epsilon_distance / 10.0;
   const double crop_start = trajectory->length() / 2.0;
   const auto cropped_start_point = trajectory->compute(crop_start);
   const auto cropped_end_point = trajectory->compute(crop_start + tiny_length);
@@ -185,7 +184,7 @@ TEST(TrajectoryCreatorTest, RestoreTinyCroppedTrajectoryPreservesBoundaries)
     std::hypot(
       restored.back().point.pose.position.x - restored.front().point.pose.position.x,
       restored.back().point.pose.position.y - restored.front().point.pose.position.y),
-    autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+    autoware::experimental::trajectory::k_epsilon_distance);
 }
 
 TEST(TrajectoryCreatorTest, CreateFromMultiplePoints)

--- a/common/autoware_trajectory/test/test_trajectory_container_trajectory_point.cpp
+++ b/common/autoware_trajectory/test/test_trajectory_container_trajectory_point.cpp
@@ -106,8 +106,7 @@ TEST(TrajectoryCreatorTestForTrajectoryPoint, RestoreTinyCroppedTrajectoryPreser
   auto trajectory = Trajectory::Builder{}.build(points);
   ASSERT_TRUE(trajectory);
 
-  constexpr double tiny_length =
-    autoware::experimental::trajectory::k_points_minimum_dist_threshold / 10.0;
+  constexpr double tiny_length = autoware::experimental::trajectory::k_epsilon_distance / 10.0;
   const double crop_start = trajectory->length() / 2.0;
   const auto cropped_start_point = trajectory->compute(crop_start);
   const auto cropped_end_point = trajectory->compute(crop_start + tiny_length);
@@ -123,7 +122,7 @@ TEST(TrajectoryCreatorTestForTrajectoryPoint, RestoreTinyCroppedTrajectoryPreser
     std::hypot(
       restored.back().pose.position.x - restored.front().pose.position.x,
       restored.back().pose.position.y - restored.front().pose.position.y),
-    autoware::experimental::trajectory::k_points_minimum_dist_threshold);
+    autoware::experimental::trajectory::k_epsilon_distance);
 }
 
 TEST(TrajectoryCreatorTestForTrajectoryPoint, CreateFromMultiplePoints)

--- a/common/autoware_trajectory/test/test_utils_find_nearest.cpp
+++ b/common/autoware_trajectory/test/test_utils_find_nearest.cpp
@@ -27,7 +27,7 @@ namespace
 
 using autoware::experimental::trajectory::find_first_nearest_index;
 using autoware::experimental::trajectory::find_nearest_index;
-using autoware::experimental::trajectory::k_points_minimum_dist_threshold;
+using autoware::experimental::trajectory::k_epsilon_distance;
 using autoware::experimental::trajectory::Trajectory;
 using autoware_utils_geometry::create_point;
 using autoware_utils_geometry::create_quaternion_from_rpy;
@@ -241,7 +241,7 @@ TEST(Trajectory, FindNearestIndexPointCurvedTrajectory)
 
     auto query = create_point(qx, qy, 0);
     auto s_opt = find_nearest_index(traj, query);
-    EXPECT_NEAR(s_opt, 5.2850123, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(s_opt, 5.2850123, k_epsilon_distance);
   }
 
   {
@@ -259,7 +259,7 @@ TEST(Trajectory, FindNearestIndexPointCurvedTrajectory)
 
     auto query = create_point(qx, qy, 0);
     auto s_opt = find_nearest_index(traj, query);
-    EXPECT_NEAR(s_opt, 3.60253801, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(s_opt, 3.60253801, k_epsilon_distance);
   }
 }
 
@@ -278,7 +278,7 @@ TEST(Trajectory, FindFirstNearestIndexCurvedTrajectory)
     auto query = make_pose(qx, qy, true_theta);
     auto s_opt = find_first_nearest_index(traj, query);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 5.2850123, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 5.2850123, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query));
   }
 
@@ -298,7 +298,7 @@ TEST(Trajectory, FindFirstNearestIndexCurvedTrajectory)
     auto query = make_pose(qx, qy, avg_theta);
     auto s_opt = find_first_nearest_index(traj, query);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 3.60253801, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 3.60253801, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query));
   }
 }
@@ -313,7 +313,7 @@ TEST(Trajectory, FindFirstNearestIndexPoseNoThreshold)
     auto query = make_pose(0.0, 0.0);
     auto s_opt = find_first_nearest_index(traj, query);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 4.4552394e-05, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 4.4552394e-05, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query));
   }
 
@@ -322,7 +322,7 @@ TEST(Trajectory, FindFirstNearestIndexPoseNoThreshold)
     auto query = make_pose(9.0, 9.0);
     auto s_opt = find_first_nearest_index(traj, query);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 10.0846927, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 10.0846927, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query));
   }
 
@@ -331,7 +331,7 @@ TEST(Trajectory, FindFirstNearestIndexPoseNoThreshold)
     auto query = make_pose(0.5, 0.5);
     auto s_opt = find_first_nearest_index(traj, query);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 0.54431653, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 0.54431653, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query));
   }
 
@@ -340,7 +340,7 @@ TEST(Trajectory, FindFirstNearestIndexPoseNoThreshold)
     auto query = make_pose(0.51, 0.51);
     auto s_opt = find_first_nearest_index(traj, query);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 0.55598476, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 0.55598476, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query));
   }
 
@@ -349,7 +349,7 @@ TEST(Trajectory, FindFirstNearestIndexPoseNoThreshold)
     auto query = make_pose(-4.0, 5.0);
     auto s_opt = find_first_nearest_index(traj, query);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 4.4552394e-05, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 4.4552394e-05, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query));
   }
 
@@ -358,7 +358,7 @@ TEST(Trajectory, FindFirstNearestIndexPoseNoThreshold)
     auto query = make_pose(100.0, -3.0);
     auto s_opt = find_first_nearest_index(traj, query);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 8.72879934, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 8.72879934, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query));
   }
 }
@@ -380,7 +380,7 @@ TEST(Trajectory, FindFirstNearestIndexPoseDistThreshold)
     auto query = make_pose(3.0, 0.9);
     auto s_opt = find_first_nearest_index(traj, query, 2.0);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 3.1567543, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 3.1567543, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query, 2.0));
   }
 }
@@ -403,7 +403,7 @@ TEST(Trajectory, FindFirstNearestIndexPoseYawThreshold)
     auto query = make_pose(3.0, 0.0, 0.9);
     auto s_opt = find_first_nearest_index(traj, query, max_d, 2.0);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 2.70806359, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 2.70806359, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query, 2.0));
   }
 }
@@ -418,7 +418,7 @@ TEST(Trajectory, FindFirstNearestIndexPoseDistAndYawThreshold)
     auto query = make_pose(3.0, 0.9, 1.2678071089);
     auto s_opt = find_first_nearest_index(traj, query, 2.0);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 3.1567543, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 3.1567543, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query, 2.0));
   }
 
@@ -440,7 +440,7 @@ TEST(Trajectory, FindFirstNearestIndexPoseTwoMinimaDistAndYawThreshold)
     auto query = make_pose(3.0, 0.9, 1.2678071089);
     auto s_opt = find_first_nearest_index(traj, query, 2.0);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 3.1567543, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 3.1567543, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query, 2.0));
   }
 
@@ -461,7 +461,7 @@ TEST(Trajectory, FindFirstNearestIndexParabolicTrajectoryAboveMinima)
     auto s_opt =
       find_first_nearest_index(traj, query, std::numeric_limits<double>::max(), 1.2707963267948966);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 29.944142653, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 29.944142653, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(
       traj, *s_opt, query, std::numeric_limits<double>::max(), 1.2707963267948966));
   }
@@ -477,7 +477,7 @@ TEST(Trajectory, FindFirstNearestIndexBowTrajectoryLessBases)
     auto query = make_pose(1, 1, yaw);
     auto s_opt = find_first_nearest_index(traj, query);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 1.2181577509092187, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 1.2181577509092187, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query));
   }
   // At intersection, first round
@@ -486,7 +486,7 @@ TEST(Trajectory, FindFirstNearestIndexBowTrajectoryLessBases)
     auto query = make_pose(-0.05, 0, yaw);
     auto s_opt = find_first_nearest_index(traj, query, std::numeric_limits<double>::max(), 1.046);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 2.6770152278921948, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 2.6770152278921948, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(
       traj, *s_opt, query, std::numeric_limits<double>::max(), 1.046));
   }
@@ -497,7 +497,7 @@ TEST(Trajectory, FindFirstNearestIndexBowTrajectoryLessBases)
     auto query = make_pose(-0.05, 0, yaw);
     auto s_opt = find_first_nearest_index(traj, query, std::numeric_limits<double>::max(), 1.046);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 11.501379660920705, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 11.501379660920705, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(
       traj, *s_opt, query, std::numeric_limits<double>::max(), 1.046));
   }
@@ -512,7 +512,7 @@ TEST(Trajectory, FindFirstNearestIndexBowTrajectoryManyBases)
     auto query = make_pose(1, 1, yaw);
     auto s_opt = find_first_nearest_index(traj, query);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 1.2381368903716181, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 1.2381368903716181, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query));
   }
   // At intersection, first round
@@ -521,7 +521,7 @@ TEST(Trajectory, FindFirstNearestIndexBowTrajectoryManyBases)
     auto query = make_pose(-0.05, 0, yaw);
     auto s_opt = find_first_nearest_index(traj, query, std::numeric_limits<double>::max(), 1.046);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 2.6851636870536018, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 2.6851636870536018, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(
       traj, *s_opt, query, std::numeric_limits<double>::max(), 1.046));
   }
@@ -532,7 +532,7 @@ TEST(Trajectory, FindFirstNearestIndexBowTrajectoryManyBases)
     auto query = make_pose(-0.05, 0, yaw);
     auto s_opt = find_first_nearest_index(traj, query, std::numeric_limits<double>::max(), 1.046);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 11.760225108845566, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 11.760225108845566, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(
       traj, *s_opt, query, std::numeric_limits<double>::max(), 1.046));
   }
@@ -547,21 +547,21 @@ TEST(Trajectory, FindFirstNearestIndexVerticalLoop)
       auto query = make_pose(1, 1, -M_PI);
       auto s_opt = find_first_nearest_index(traj, query, 2.0, 1.046);
       ASSERT_TRUE(s_opt.has_value());
-      EXPECT_NEAR(*s_opt, 1.96171, k_points_minimum_dist_threshold);
+      EXPECT_NEAR(*s_opt, 1.96171, k_epsilon_distance);
       EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query, 2, 1.046));
     }
     {
       auto query = make_pose(0, 0.05, -M_PI);
       auto s_opt = find_first_nearest_index(traj, query, 2.0, 1.046);
       ASSERT_TRUE(s_opt.has_value());
-      EXPECT_NEAR(*s_opt, 3.00769, k_points_minimum_dist_threshold);
+      EXPECT_NEAR(*s_opt, 3.00769, k_epsilon_distance);
       EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query, 2, 1.046));
     }
     {
       auto query = make_pose(0, -0.05, -M_PI);
       auto s_opt = find_first_nearest_index(traj, query, 2.0, 1.046);
       ASSERT_TRUE(s_opt.has_value());
-      EXPECT_NEAR(*s_opt, 2.99234, k_points_minimum_dist_threshold);
+      EXPECT_NEAR(*s_opt, 2.99234, k_epsilon_distance);
       EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query, 2, 1.046));
     }
   }
@@ -571,21 +571,21 @@ TEST(Trajectory, FindFirstNearestIndexVerticalLoop)
       auto query = make_pose(1, 1, -M_PI);
       auto s_opt = find_first_nearest_index(traj, query, 2.0, 1.046);
       ASSERT_TRUE(s_opt.has_value());
-      EXPECT_NEAR(*s_opt, 1.99964, k_points_minimum_dist_threshold);
+      EXPECT_NEAR(*s_opt, 1.99964, k_epsilon_distance);
       EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query, 2, 1.046));
     }
     {
       auto query = make_pose(0, 0.05, -M_PI);
       auto s_opt = find_first_nearest_index(traj, query, 2.0, 1.046);
       ASSERT_TRUE(s_opt.has_value());
-      EXPECT_NEAR(*s_opt, 3.00024, k_points_minimum_dist_threshold);
+      EXPECT_NEAR(*s_opt, 3.00024, k_epsilon_distance);
       EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query, 2, 1.046));
     }
     {
       auto query = make_pose(0, -0.05, -M_PI);
       auto s_opt = find_first_nearest_index(traj, query, 2.0, 1.046);
       ASSERT_TRUE(s_opt.has_value());
-      EXPECT_NEAR(*s_opt, 2.99981, k_points_minimum_dist_threshold);
+      EXPECT_NEAR(*s_opt, 2.99981, k_epsilon_distance);
       EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query, 2, 1.046));
     }
   }
@@ -595,21 +595,21 @@ TEST(Trajectory, FindFirstNearestIndexVerticalLoop)
       auto query = make_pose(1, 1, -M_PI);
       auto s_opt = find_first_nearest_index(traj, query, 2.0, 1.046);
       ASSERT_TRUE(s_opt.has_value());
-      EXPECT_NEAR(*s_opt, 1.99967, k_points_minimum_dist_threshold);
+      EXPECT_NEAR(*s_opt, 1.99967, k_epsilon_distance);
       EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query, 2, 1.046));
     }
     {
       auto query = make_pose(0, 0.05, -M_PI);
       auto s_opt = find_first_nearest_index(traj, query, 2.0, 1.046);
       ASSERT_TRUE(s_opt.has_value());
-      EXPECT_NEAR(*s_opt, 3.00011, k_points_minimum_dist_threshold);
+      EXPECT_NEAR(*s_opt, 3.00011, k_epsilon_distance);
       EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query, 2, 1.046));
     }
     {
       auto query = make_pose(0, -0.05, -M_PI);
       auto s_opt = find_first_nearest_index(traj, query, 2.0, 1.046);
       ASSERT_TRUE(s_opt.has_value());
-      EXPECT_NEAR(*s_opt, 3.00011, k_points_minimum_dist_threshold);
+      EXPECT_NEAR(*s_opt, 3.00011, k_epsilon_distance);
       EXPECT_TRUE(is_within_yaw_and_distance_constraint(traj, *s_opt, query, 2, 1.046));
     }
   }
@@ -624,7 +624,7 @@ TEST(Trajectory, FindFirstNearestIndexLollipopTrajectory)
     auto s_opt =
       find_first_nearest_index(traj, query, std::numeric_limits<double>::max(), M_PI / 3);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 1.50006, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 1.50006, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(
       traj, *s_opt, query, std::numeric_limits<double>::max(), M_PI / 3));
   }
@@ -633,7 +633,7 @@ TEST(Trajectory, FindFirstNearestIndexLollipopTrajectory)
     auto s_opt =
       find_first_nearest_index(traj, query, std::numeric_limits<double>::max(), M_PI / 3);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 19.4914, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 19.4914, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(
       traj, *s_opt, query, std::numeric_limits<double>::max(), M_PI / 3));
   }
@@ -642,7 +642,7 @@ TEST(Trajectory, FindFirstNearestIndexLollipopTrajectory)
     auto s_opt =
       find_first_nearest_index(traj, query, std::numeric_limits<double>::max(), M_PI / 3);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 2.99733, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 2.99733, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(
       traj, *s_opt, query, std::numeric_limits<double>::max(), M_PI / 3));
   }
@@ -651,7 +651,7 @@ TEST(Trajectory, FindFirstNearestIndexLollipopTrajectory)
     auto s_opt =
       find_first_nearest_index(traj, query, std::numeric_limits<double>::max(), M_PI / 3);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 9.14898, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 9.14898, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(
       traj, *s_opt, query, std::numeric_limits<double>::max(), M_PI / 3));
   }
@@ -660,7 +660,7 @@ TEST(Trajectory, FindFirstNearestIndexLollipopTrajectory)
     auto s_opt =
       find_first_nearest_index(traj, query, std::numeric_limits<double>::max(), M_PI / 3);
     ASSERT_TRUE(s_opt.has_value());
-    EXPECT_NEAR(*s_opt, 16.9315, k_points_minimum_dist_threshold);
+    EXPECT_NEAR(*s_opt, 16.9315, k_epsilon_distance);
     EXPECT_TRUE(is_within_yaw_and_distance_constraint(
       traj, *s_opt, query, std::numeric_limits<double>::max(), M_PI / 3));
   }

--- a/common/autoware_trajectory/test/test_utils_velocity.cpp
+++ b/common/autoware_trajectory/test/test_utils_velocity.cpp
@@ -54,7 +54,7 @@ TEST(SearchZeroVelocityPosition, FoundAtExactBasePoint)
 
   auto result = search_zero_velocity_position(traj, 0.0, traj.length());
   ASSERT_TRUE(result.has_value());
-  EXPECT_NEAR(result.value(), traj.length() * 2.0 / 3.0, k_zero_velocity_threshold);
+  EXPECT_NEAR(result.value(), traj.length() * 2.0 / 3.0, k_epsilon_velocity);
 }
 
 TEST(SearchZeroVelocityPosition, FoundAtZeroCrossing)
@@ -113,7 +113,7 @@ TEST(SearchZeroVelocityPosition, FoundAtFirstPoint)
 
   auto result = search_zero_velocity_position(traj, 0.0, traj.length());
   ASSERT_TRUE(result.has_value());
-  EXPECT_NEAR(result.value(), 0.0, k_zero_velocity_threshold);
+  EXPECT_NEAR(result.value(), 0.0, k_epsilon_velocity);
 }
 
 TEST(SearchZeroVelocityPosition, FoundAtLastPoint)
@@ -128,7 +128,7 @@ TEST(SearchZeroVelocityPosition, FoundAtLastPoint)
 
   auto result = search_zero_velocity_position(traj, 0.0, traj.length());
   ASSERT_TRUE(result.has_value());
-  EXPECT_NEAR(result.value(), traj.length(), k_zero_velocity_threshold);
+  EXPECT_NEAR(result.value(), traj.length(), k_epsilon_velocity);
 }
 
 TEST(SearchZeroVelocityPosition, FoundWithInterval)


### PR DESCRIPTION
## Description
<!-- Briefly describe the state/problem before this PR -->
Before this PR, `autoware_trajectory` relied on a single monolithic threshold constant (`k_points_minimum_dist_threshold`) for all spatial comparisons. Moreover, base sanitization in `point.cpp` used this same distance threshold to nudge segment lengths, which guaranteed numerical stability at the cost of silently distorting the original point spacing and making exact restoration impossible.

<!-- Describe the changes made (select/add as appropriate) -->
This PR separates **base sanitization** from **numerical stability** into two distinct stages, and introduces granular epsilon constants.

**1. Granular epsilon constants**
- Replace `k_points_minimum_dist_threshold` with `k_epsilon_distance`, `k_epsilon_velocity`, and `k_epsilon_angle`
- Add quaternion `is_almost_same` overload using `k_epsilon_angle`

**2. Base sanitization in `point.cpp` (restoration guarantee)**
- Change base clamping from `k_points_minimum_dist_threshold` to `std::numeric_limits<double>::epsilon()`
- This guarantees only that the base vector remains strictly increasing, preserving the ability to restore the original points
- The actual zero-division avoidance and stronger duplicate filtering are now handled later by each interpolator

**3. Numerical stability inside interpolators**
- Add `remove_duplicate_points` helper
- Parameterize `Linear`, `CubicSpline`, `AkimaSpline`, and `SphericalLinear` with configurable `epsilon_`
- Each interpolator's `build_impl` now calls `remove_duplicate_points(bases, values, epsilon_)` before interpolation
- Spatial builders use `k_epsilon_distance` for deduplication

**4. Updates across the package**
- Update `find_nearest`, `velocity`, `pretty_build`, and tests to use new epsilon constants

## Related links
**Parent Issue:**
- None.

## Notes for reviewers
<!-- Add any notes for reviewers. If none, write "None." -->
- `k_points_minimum_dist_threshold` is kept as a deprecated alias pointing to `k_epsilon_distance` to avoid breaking downstream code immediately.
- Some interpolators (e.g. `LaneIdsInterpolator`, `Stairstep`) do **not** invoke `remove_duplicate_points`; for these interpolators the base sanitization in stage 1 is the only duplicate protection.

## Effects on system behavior
<!-- Describe any effects on overall system behavior. If none, write "None." -->
- `point.cpp` now preserves original point spacing as closely as possible (only nudging by machine epsilon). Exact restoration of input points is guaranteed.
- Interpolators now explicitly remove duplicates based on their configured epsilon before building, ensuring numerical stability without distorting the raw point data.
