### PR TITLE
feat(autoware_trajectory): add azimuth, elevation, and curvature computation methods

### DIFF
--- a/common/autoware_trajectory/include/autoware/trajectory/temporal_trajectory.hpp
+++ b/common/autoware_trajectory/include/autoware/trajectory/temporal_trajectory.hpp
@@ -90,6 +90,54 @@ public:
   [[nodiscard]] PointType compute_from_distance(const double s) const;
 
   /**
+   * @brief Compute the azimuth angle at a given time.
+   * @param[in] t Query time in seconds.
+   * @return Azimuth in radians.
+   * @throw std::out_of_range If t is outside [start_time(), end_time()].
+   */
+  [[nodiscard]] double azimuth_from_time(const double t) const;
+
+  /**
+   * @brief Compute the azimuth angle at a given arc length.
+   * @param[in] s Query arc length in meters.
+   * @return Azimuth in radians.
+   * @throw std::out_of_range If s is outside [0, length()].
+   */
+  [[nodiscard]] double azimuth_from_distance(const double s) const;
+
+  /**
+   * @brief Compute the elevation angle at a given time.
+   * @param[in] t Query time in seconds.
+   * @return Elevation in radians.
+   * @throw std::out_of_range If t is outside [start_time(), end_time()].
+   */
+  [[nodiscard]] double elevation_from_time(const double t) const;
+
+  /**
+   * @brief Compute the elevation angle at a given arc length.
+   * @param[in] s Query arc length in meters.
+   * @return Elevation in radians.
+   * @throw std::out_of_range If s is outside [0, length()].
+   */
+  [[nodiscard]] double elevation_from_distance(const double s) const;
+
+  /**
+   * @brief Compute the curvature at a given time.
+   * @param[in] t Query time in seconds.
+   * @return Curvature.
+   * @throw std::out_of_range If t is outside [start_time(), end_time()].
+   */
+  [[nodiscard]] double curvature_from_time(const double t) const;
+
+  /**
+   * @brief Compute the curvature at a given arc length.
+   * @param[in] s Query arc length in meters.
+   * @return Curvature.
+   * @throw std::out_of_range If s is outside [0, length()].
+   */
+  [[nodiscard]] double curvature_from_distance(const double s) const;
+
+  /**
    * @brief Convert time to arc length.
    * @param[in] t Query time in seconds.
    * @return Arc length in meters.

--- a/common/autoware_trajectory/src/temporal_trajectory.cpp
+++ b/common/autoware_trajectory/src/temporal_trajectory.cpp
@@ -112,6 +112,39 @@ TemporalTrajectory::PointType TemporalTrajectory::compute_from_distance(const do
   return point;
 }
 
+double TemporalTrajectory::azimuth_from_time(const double t) const
+{
+  return spatial_trajectory_.azimuth(time_to_distance(t));
+}
+
+double TemporalTrajectory::azimuth_from_distance(const double s) const
+{
+  detail::throw_if_out_of_range(s, 0.0, length(), "distance");
+  return spatial_trajectory_.azimuth(s);
+}
+
+double TemporalTrajectory::elevation_from_time(const double t) const
+{
+  return spatial_trajectory_.elevation(time_to_distance(t));
+}
+
+double TemporalTrajectory::elevation_from_distance(const double s) const
+{
+  detail::throw_if_out_of_range(s, 0.0, length(), "distance");
+  return spatial_trajectory_.elevation(s);
+}
+
+double TemporalTrajectory::curvature_from_time(const double t) const
+{
+  return spatial_trajectory_.curvature(time_to_distance(t));
+}
+
+double TemporalTrajectory::curvature_from_distance(const double s) const
+{
+  detail::throw_if_out_of_range(s, 0.0, length(), "distance");
+  return spatial_trajectory_.curvature(s);
+}
+
 double TemporalTrajectory::time_to_distance(const double t) const
 {
   detail::throw_if_out_of_range(t, start_time(), end_time(), "time");

--- a/common/autoware_trajectory/test/test_temporal_trajectory.cpp
+++ b/common/autoware_trajectory/test/test_temporal_trajectory.cpp
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
 #include <vector>
 
 namespace
@@ -29,6 +30,8 @@ struct PointParam
 {
   double time{};
   double x{};
+  double y = 0.0;
+  double z = 0.0;
   float velocity = 1.0F;
 };
 
@@ -39,7 +42,8 @@ std::vector<TrajectoryPoint> make_points(const std::initializer_list<PointParam>
   for (const auto & init : inits) {
     TrajectoryPoint point;
     point.pose.position.x = init.x;
-    point.pose.position.y = 0.0;
+    point.pose.position.y = init.y;
+    point.pose.position.z = init.z;
     point.longitudinal_velocity_mps = init.velocity;
     point.time_from_start = rclcpp::Duration::from_seconds(init.time);
     points.push_back(point);
@@ -142,11 +146,11 @@ TEST(TemporalTrajectory, DistanceToTimeAtDuplicatePoints)
 TEST(TemporalTrajectory, DistanceToTimeReturnsEndTimeAtStopPoint)
 {
   const auto points = make_points({
-    {0.0, 0.0, 1.0F},
-    {1.0, 1.0, 1.0F},
-    {2.0, 2.0, 0.0F},
-    {3.0, 2.0, 0.0F},
-    {4.0, 2.0, 0.0F},
+    {0.0, 0.0, 0.0, 0.0, 1.0F},
+    {1.0, 1.0, 0.0, 0.0, 1.0F},
+    {2.0, 2.0, 0.0, 0.0, 0.0F},
+    {3.0, 2.0, 0.0, 0.0, 0.0F},
+    {4.0, 2.0, 0.0, 0.0, 0.0F},
   });
 
   const auto trajectory_result = TemporalTrajectory::Builder{}.build(points);
@@ -361,4 +365,108 @@ TEST(TemporalTrajectory, ComputeFromTimeAtBoundaries)
   EXPECT_NEAR(rclcpp::Duration(at_start.time_from_start).seconds(), 0.0, 1e-6);
   EXPECT_NEAR(at_end.pose.position.x, 3.0, 1e-6);
   EXPECT_NEAR(rclcpp::Duration(at_end.time_from_start).seconds(), 3.0, 1e-6);
+}
+
+TEST(TemporalTrajectory, AzimuthFromDistance)
+{
+  const auto points = make_points({
+    {0.0, 0.0, 0.0},
+    {1.0, 1.0, 1.0},
+    {2.0, 2.0, 2.0},
+  });
+
+  const auto trajectory_result = TemporalTrajectory::Builder{}.build(points);
+  ASSERT_TRUE(trajectory_result.has_value());
+  const auto & trajectory = trajectory_result.value();
+
+  EXPECT_NEAR(trajectory.azimuth_from_distance(0.5), M_PI / 4.0, M_PI / 10.0);
+  EXPECT_NEAR(trajectory.azimuth_from_distance(1.5), M_PI / 4.0, M_PI / 10.0);
+}
+
+TEST(TemporalTrajectory, AzimuthFromTime)
+{
+  const auto points = make_points({
+    {0.0, 0.0, 0.0},
+    {1.0, 1.0, 1.0},
+    {2.0, 2.0, 2.0},
+  });
+
+  const auto trajectory_result = TemporalTrajectory::Builder{}.build(points);
+  ASSERT_TRUE(trajectory_result.has_value());
+  const auto & trajectory = trajectory_result.value();
+
+  EXPECT_NEAR(trajectory.azimuth_from_time(0.5), M_PI / 4.0, M_PI / 10.0);
+  EXPECT_NEAR(trajectory.azimuth_from_time(1.5), M_PI / 4.0, M_PI / 10.0);
+}
+
+TEST(TemporalTrajectory, ElevationFromDistance)
+{
+  const auto points = make_points({
+    {0.0, 0.0, 0.0, 0.0},
+    {1.0, 1.0, 0.0, 1.0},
+    {2.0, 2.0, 0.0, 2.0},
+  });
+
+  const auto trajectory_result = TemporalTrajectory::Builder{}.build(points);
+  ASSERT_TRUE(trajectory_result.has_value());
+  const auto & trajectory = trajectory_result.value();
+
+  const auto e1 = trajectory.elevation_from_distance(0.5);
+  const auto e2 = trajectory.elevation_from_distance(1.5);
+  EXPECT_NEAR(e1, M_PI / 4.0, M_PI / 10.0);
+  EXPECT_NEAR(e2, M_PI / 4.0, M_PI / 10.0);
+}
+
+TEST(TemporalTrajectory, ElevationFromTime)
+{
+  const auto points = make_points({
+    {0.0, 0.0, 0.0, 0.0},
+    {1.0, 1.0, 0.0, 1.0},
+    {2.0, 2.0, 0.0, 2.0},
+  });
+
+  const auto trajectory_result = TemporalTrajectory::Builder{}.build(points);
+  ASSERT_TRUE(trajectory_result.has_value());
+  const auto & trajectory = trajectory_result.value();
+
+  const auto e1 = trajectory.elevation_from_time(0.5);
+  const auto e2 = trajectory.elevation_from_time(1.5);
+  EXPECT_NEAR(e1, M_PI / 4.0, M_PI / 10.0);
+  EXPECT_NEAR(e2, M_PI / 4.0, M_PI / 10.0);
+}
+
+TEST(TemporalTrajectory, CurvatureFromDistance)
+{
+  constexpr double radius = 5.0;
+  const auto points = make_points({
+    {0.0, radius, 0.0},
+    {1.0, radius * std::cos(M_PI / 6.0), radius * std::sin(M_PI / 6.0)},
+    {2.0, radius * std::cos(M_PI / 3.0), radius * std::sin(M_PI / 3.0)},
+    {3.0, 0.0, radius},
+  });
+
+  const auto trajectory_result = TemporalTrajectory::Builder{}.build(points);
+  ASSERT_TRUE(trajectory_result.has_value());
+  const auto & trajectory = trajectory_result.value();
+
+  const auto curvature = trajectory.curvature_from_distance(1.5);
+  EXPECT_NEAR(curvature, 1.0 / radius, 1e-1);
+}
+
+TEST(TemporalTrajectory, CurvatureFromTime)
+{
+  constexpr double radius = 5.0;
+  const auto points = make_points({
+    {0.0, radius, 0.0},
+    {1.0, radius * std::cos(M_PI / 6.0), radius * std::sin(M_PI / 6.0)},
+    {2.0, radius * std::cos(M_PI / 3.0), radius * std::sin(M_PI / 3.0)},
+    {3.0, 0.0, radius},
+  });
+
+  const auto trajectory_result = TemporalTrajectory::Builder{}.build(points);
+  ASSERT_TRUE(trajectory_result.has_value());
+  const auto & trajectory = trajectory_result.value();
+
+  const auto curvature = trajectory.curvature_from_time(1.5);
+  EXPECT_NEAR(curvature, 1.0 / radius, 1e-1);
 }


### PR DESCRIPTION
## Description
<!-- Briefly describe the state/problem before this PR -->
Before this PR, `TemporalTrajectory` did not expose geometric query methods such as `curvature`, `azimuth`, and `elevation` that were already available on the underlying spatial `Trajectory<Point>`. Users had to manually convert time to distance and call the spatial trajectory API, which was cumbersome and error-prone.

<!-- Describe the changes made (select/add as appropriate) -->
This PR adds geometry evaluation methods to `TemporalTrajectory`.
- Added `curvature_from_time(double t) const`
- Added `curvature_from_distance(double s) const`
- Added `azimuth_from_time(double t) const`
- Added `azimuth_from_distance(double s) const`
- Added `elevation_from_time(double t) const`
- Added `elevation_from_distance(double s) const`

These methods mirror the existing `compute_from_time` / `compute_from_distance` pattern: `_from_time` variants convert time to distance internally and then delegate to the spatial trajectory, while `_from_distance` variants perform range validation and forward directly to the wrapped spatial trajectory.

## Related links
**Parent Issue:**
- None.

## Notes for reviewers
<!-- Add any notes for reviewers. If none, write "None." -->
None.

## Effects on system behavior
<!-- Describe any effects on overall system behavior. If none, write "None." -->
None.
