### PR TITLE
fix(autoware_downsample_filters): typo

### DIFF
--- a/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/faster_voxel_grid_downsample_filter.cpp
+++ b/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/faster_voxel_grid_downsample_filter.cpp
@@ -165,7 +165,7 @@ FasterVoxelGridDownsampleFilter::calc_centroids_each_voxel(
   for (size_t global_offset = 0; global_offset + input->point_step <= input->data.size();
        global_offset += input->point_step) {
     Eigen::Vector4f point = get_point_from_global_offset(input, global_offset);
-    if (std::isfinite(point[0]) && std::isfinite(point[1]), std::isfinite(point[2])) {
+    if (std::isfinite(point[0]) && std::isfinite(point[1]) && std::isfinite(point[2])) {
       // Calculate the voxel index to which the point belongs
       int ijk0 = static_cast<int>(
         std::floor(point[0] * inverse_voxel_size_[0]) - static_cast<float>(min_voxel[0]));


### PR DESCRIPTION
## Description

Fix small typo: `if (a && b, c) { ... }` is the same as `a && b; if (c) { ... }`

Found it in robostack-humble repo: https://github.com/RoboStack/ros-humble/blob/main/patch/ros-humble-autoware-downsample-filters.patch

## Related links

N/A

## How was this PR tested?

Not tested

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

Correctly discard points with `inf`/`NaN`.