### PR TITLE
fix(autoware_trajectory): detect terminal intervals

### DIFF
--- a/common/autoware_trajectory/src/utils/find_intervals.cpp
+++ b/common/autoware_trajectory/src/utils/find_intervals.cpp
@@ -40,7 +40,8 @@ std::vector<Interval> find_intervals_impl(
         start = bases.at(i);  // Start a new interval}
       }
       is_started = true;  // Set the flag to indicate the interval has started
-    } else if (is_started && !constraint(bases.at(i))) {
+    }
+    if (is_started && !constraint(bases.at(i))) {
       // End the current interval if the constraint fails or it's the last element
       double end = autoware::experimental::trajectory::detail::upper_bound_by_predicate(
         bases.at(i - 1), bases.at(i), constraint, static_cast<size_t>(max_iter));

--- a/common/autoware_trajectory/test/test_utils_temporal_trajectory.cpp
+++ b/common/autoware_trajectory/test/test_utils_temporal_trajectory.cpp
@@ -148,6 +148,29 @@ TEST(FindIntervalsTemporal, ReturnsStopIntervalWithDistance)
   EXPECT_NEAR(intervals.front().end.distance, 2.0, 1e-3);
 }
 
+TEST(FindIntervalsTemporal, ReturnsStopIntervalAtLastPoint)
+{
+  const auto points = make_points({
+    {0.0, 0.0, 2.0F},
+    {1.0, 1.0, 1.0F},
+    {2.0, 2.0, 0.0F},
+  });
+
+  const auto trajectory_result = TemporalTrajectory::Builder{}.build(points);
+  ASSERT_TRUE(trajectory_result.has_value());
+
+  const auto intervals = autoware::experimental::trajectory::find_intervals(
+    trajectory_result.value(), [](const auto & point) {
+      return std::abs(point.longitudinal_velocity_mps) <=
+             autoware::experimental::trajectory::k_epsilon_velocity;
+    });
+  ASSERT_EQ(intervals.size(), 1U);
+  EXPECT_NEAR(intervals.front().start.time, 2.0, 1e-6);
+  EXPECT_NEAR(intervals.front().end.time, 2.0, 1e-6);
+  EXPECT_NEAR(intervals.front().start.distance, 2.0, 1e-3);
+  EXPECT_NEAR(intervals.front().end.distance, 2.0, 1e-3);
+}
+
 TEST(FindIntervalsTemporal, RespectsVelocityThreshold)
 {
   const auto points = make_points({


### PR DESCRIPTION
  ## Description
  Before this PR, `autoware_trajectory` could drop an interval when the constraint became true only at the final trajectory base. This caused `find_intervals()` to return no interval for terminal single-point matches,
  such as a trajectory that only stops at its last point.

  This PR fixes terminal interval detection.
  - Updates `find_intervals_impl()` to close an interval even when it starts at the final base.
  - Adds a regression test for a temporal trajectory whose stop interval exists only at the last point.

  ## Related links
  **Parent Issue:**
  - None.

  ## Notes for reviewers
  This fixes the root cause of `autoware_trajectory_validator` failing to recognize a stop point at the end of a trajectory.

  ## Interface changes
  ### ROS Parameter Changes
  None.

  ### Topic changes
  None.

  ## Effects on system behavior
  `find_intervals()` now correctly reports intervals that consist of the final sampled point only.