### PR TITLE
fix(ci): modernize cppcheck workflows and switch full scan to push-to-main

### DIFF
--- a/.github/workflows/cppcheck-differential.yaml
+++ b/.github/workflows/cppcheck-differential.yaml
@@ -5,34 +5,26 @@ on:
 
 jobs:
   cppcheck-differential:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container: ros:jazzy
 
     steps:
       - name: Set PR fetch depth
         run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
 
       - name: Checkout PR branch and all PR commits
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: ${{ env.PR_FETCH_DEPTH }}
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y git
+      - name: Set git safe directory
+        run: git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
-      - name: Install colcon
+      - name: Install Cppcheck
         run: |
-          sudo sh -c 'echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list'
-          curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
-          sudo apt update
-          sudo apt install python3-colcon-common-extensions
-
-      # cppcheck from apt does not yet support --check-level args, and thus install from snap
-      - name: Install Cppcheck from snap
-        run: |
-          sudo snap install cppcheck
+          apt-get update
+          apt-get install -y cppcheck
 
       - name: Fetch the base branch with enough history for a common merge-base commit
         run: git fetch origin ${{ github.base_ref }}
@@ -64,7 +56,7 @@ jobs:
           done
           echo "filtered-full-paths=$filtered_paths" >> $GITHUB_OUTPUT
 
-      # cspell: ignore suppr, Dslots
+      # cspell: ignore suppr Dslots
       - name: Run Cppcheck on modified packages
         if: ${{ steps.filter-paths-no-cpp-files.outputs.filtered-full-paths != '' }}
         continue-on-error: true

--- a/.github/workflows/cppcheck.yaml
+++ b/.github/workflows/cppcheck.yaml
@@ -1,36 +1,38 @@
-name: cppcheck-weekly
+name: cppcheck
 
 on:
-  schedule:
-    - cron: 0 0 * * 1
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:
-  cppcheck-weekly:
-    runs-on: ubuntu-22.04
+  cppcheck:
+    runs-on: ubuntu-latest
+    container: ros:jazzy
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      # cppcheck from apt does not yet support --check-level args, and thus install from snap
-      - name: Install Cppcheck from snap
+      - name: Install Cppcheck
         run: |
-          sudo snap install cppcheck
+          apt-get update
+          apt-get install -y cppcheck
 
-      # cspell: ignore suppr, Dslots
+      # cspell: ignore suppr Dslots
       - name: Run Cppcheck on all files
         continue-on-error: true
         id: cppcheck
         run: |
-          cppcheck --enable=all --inconclusive --check-level=exhaustive -D'PLUGINLIB_EXPORT_CLASS(class_type, base_class)=' -Dslots= -DQ_SLOTS= --suppress=*:*/test/* --error-exitcode=1 --xml --inline-suppr . 2> cppcheck-report.xml
+          cppcheck --enable=all --inconclusive --check-level=exhaustive -D'PLUGINLIB_EXPORT_CLASS(class_type, base_class)=' -Dslots= -DQ_SLOTS= --error-exitcode=1 --xml --suppressions-list=.cppcheck_suppressions --inline-suppr . 2> cppcheck-report.xml
         shell: bash
 
       - name: Count errors by error ID and severity
         run: |
           #!/bin/bash
           temp_file=$(mktemp)
-          grep -oP '(?<=id=")[^"]+" severity="[^"]+' cppcheck-report.xml | sed 's/" severity="/,/g' > "$temp_file"
+          grep -oP '(?<=id=")[^"]+" severity="[^"]+' cppcheck-report.xml | sed 's/" severity="/,/g' > "$temp_file" || true
           echo "Error counts by error ID and severity:"
           sort "$temp_file" | uniq -c
           rm "$temp_file"


### PR DESCRIPTION
- Replace `cppcheck-weekly.yaml` (Monday cron) with `cppcheck.yaml` (push to main + `workflow_dispatch`), modernize both workflows to `ros:jazzy` + apt cppcheck, and load `.cppcheck_suppressions` from the full scan
- Syncs the cppcheck CI from autoware_universe (autowarefoundation/autoware_universe#12459, autowarefoundation/autoware_universe#12461)
- [`.cppcheck_suppressions`](https://github.com/autowarefoundation/autoware_core/blob/19290be7662f4a7b9cee887b9b5b5bd89140979b/.cppcheck_suppressions) intentionally left unchanged — testing whether core can stay clean with its existing (smaller) list

## Why

`cppcheck-weekly` has been failing every Monday for 10+ consecutive weeks because the workflow used `--suppress=*:*/test/*` on the CLI instead of `--suppressions-list=.cppcheck_suppressions`, so the file was never loaded — even though it already listed every error ID the runs were tripping on. After the fix the full scan runs in seconds, so the weekly cadence no longer makes sense; switching to push-to-main mirrors what universe just did and surfaces regressions immediately.

---

## Test plan

- [ ] `cppcheck-differential` check passes on this PR
- [ ] Dispatch the new `cppcheck` workflow on this branch and confirm it goes green (or surface any genuine errors the broken weekly was masking):
  ```bash
  gh workflow run cppcheck.yaml --ref ci/sync-cppcheck-from-universe
  gh run list --workflow=cppcheck.yaml --branch ci/sync-cppcheck-from-universe --limit 1
  ```
- [ ] If the run flags errors in [`common/autoware_trajectory/examples`](https://github.com/autowarefoundation/autoware_core/blob/19290be7662f4a7b9cee887b9b5b5bd89140979b/common/autoware_trajectory/examples) / [`common/autoware_lanelet2_utils/examples`](https://github.com/autowarefoundation/autoware_core/blob/19290be7662f4a7b9cee887b9b5b5bd89140979b/common/autoware_lanelet2_utils/examples) or `useInitializationList`, follow up by adding the matching entries to [`.cppcheck_suppressions`](https://github.com/autowarefoundation/autoware_core/blob/19290be7662f4a7b9cee887b9b5b5bd89140979b/.cppcheck_suppressions) (universe carries those)
- [ ] Update branch protection / required status checks: `cppcheck-weekly` → `cppcheck`