### PR TITLE
fix: rid of spam messages

### DIFF
--- a/common/autoware_component_interface_specs/CMakeLists.txt
+++ b/common/autoware_component_interface_specs/CMakeLists.txt
@@ -17,6 +17,4 @@ if(BUILD_TESTING)
   )
 endif()
 
-autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
-)
+autoware_ament_auto_package()

--- a/common/autoware_geography_utils/CMakeLists.txt
+++ b/common/autoware_geography_utils/CMakeLists.txt
@@ -34,6 +34,4 @@ if(BUILD_TESTING)
   )
 endif()
 
-autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
-)
+autoware_ament_auto_package()

--- a/common/autoware_interpolation/CMakeLists.txt
+++ b/common/autoware_interpolation/CMakeLists.txt
@@ -21,6 +21,4 @@ if(BUILD_TESTING)
   )
 endif()
 
-autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
-)
+autoware_ament_auto_package()

--- a/common/autoware_kalman_filter/CMakeLists.txt
+++ b/common/autoware_kalman_filter/CMakeLists.txt
@@ -26,6 +26,4 @@ if(BUILD_TESTING)
   target_link_libraries(test_${PROJECT_NAME} ${PROJECT_NAME})
 endif()
 
-autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
-)
+autoware_ament_auto_package()

--- a/common/autoware_marker_utils/CMakeLists.txt
+++ b/common/autoware_marker_utils/CMakeLists.txt
@@ -25,6 +25,4 @@ if(BUILD_TESTING)
   endforeach()
 endif()
 
-autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
-)
+autoware_ament_auto_package()

--- a/common/autoware_motion_utils/CMakeLists.txt
+++ b/common/autoware_motion_utils/CMakeLists.txt
@@ -20,6 +20,4 @@ if(BUILD_TESTING)
   )
 endif()
 
-autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
-)
+autoware_ament_auto_package()

--- a/common/autoware_object_recognition_utils/CMakeLists.txt
+++ b/common/autoware_object_recognition_utils/CMakeLists.txt
@@ -23,6 +23,4 @@ if(BUILD_TESTING)
   )
 endif()
 
-autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
-)
+autoware_ament_auto_package()

--- a/common/autoware_vehicle_info_utils/CMakeLists.txt
+++ b/common/autoware_vehicle_info_utils/CMakeLists.txt
@@ -26,7 +26,6 @@ install(PROGRAMS
 )
 
 autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
     config
     launch

--- a/localization/autoware_core_localization/CMakeLists.txt
+++ b/localization/autoware_core_localization/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   config
   launch

--- a/localization/autoware_ekf_localizer/CMakeLists.txt
+++ b/localization/autoware_ekf_localizer/CMakeLists.txt
@@ -78,7 +78,6 @@ endif()
 # endif()
 
 autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   config
   launch

--- a/localization/autoware_gyro_odometer/CMakeLists.txt
+++ b/localization/autoware_gyro_odometer/CMakeLists.txt
@@ -35,7 +35,6 @@ autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
 )
 
 autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   launch
   config

--- a/localization/autoware_localization_util/CMakeLists.txt
+++ b/localization/autoware_localization_util/CMakeLists.txt
@@ -40,6 +40,5 @@ if(BUILD_TESTING)
 endif()
 
 autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
 )

--- a/localization/autoware_ndt_scan_matcher/CMakeLists.txt
+++ b/localization/autoware_ndt_scan_matcher/CMakeLists.txt
@@ -76,7 +76,6 @@ if(BUILD_TESTING)
 endif()
 
 autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   launch
   config

--- a/localization/autoware_pose_initializer/CMakeLists.txt
+++ b/localization/autoware_pose_initializer/CMakeLists.txt
@@ -36,7 +36,6 @@ if(BUILD_TESTING)
 endif()
 
 autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   launch
   config

--- a/localization/autoware_stop_filter/CMakeLists.txt
+++ b/localization/autoware_stop_filter/CMakeLists.txt
@@ -33,7 +33,6 @@ if(BUILD_TESTING)
 endif()
 
 autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   launch
   config

--- a/localization/autoware_twist2accel/CMakeLists.txt
+++ b/localization/autoware_twist2accel/CMakeLists.txt
@@ -16,7 +16,6 @@ autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
 )
 
 autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   launch
   config

--- a/map/autoware_core_map/CMakeLists.txt
+++ b/map/autoware_core_map/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   config
   launch

--- a/map/autoware_map_height_fitter/CMakeLists.txt
+++ b/map/autoware_map_height_fitter/CMakeLists.txt
@@ -18,7 +18,6 @@ rclcpp_components_register_node(${PROJECT_NAME}
 )
 
 autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   launch
   config

--- a/map/autoware_map_loader/CMakeLists.txt
+++ b/map/autoware_map_loader/CMakeLists.txt
@@ -72,7 +72,6 @@ install(PROGRAMS
 )
 
 autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   launch
   config

--- a/map/autoware_map_projection_loader/CMakeLists.txt
+++ b/map/autoware_map_projection_loader/CMakeLists.txt
@@ -57,7 +57,6 @@ if(BUILD_TESTING)
 endif()
 
 autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   launch
   config

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/experimental/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/experimental/node.cpp
@@ -132,6 +132,11 @@ void BehaviorVelocityPlannerNode::onParam()
 bool BehaviorVelocityPlannerNode::processNoGroundPointCloud(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
+  if (msg->width == 0 || msg->height == 0) {
+    // 3 seconds throttle to avoid spamming logs when the point cloud is empty for some reason 
+    RCLCPP_INFO_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), 3000, "[BehaviorVelocityPlanner]: Received empty point cloud for no_ground_pointcloud");
+    return false;
+  }
   geometry_msgs::msg::TransformStamped transform;
   try {
     transform = tf_buffer_.lookupTransform(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/experimental/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/experimental/node.cpp
@@ -133,8 +133,10 @@ bool BehaviorVelocityPlannerNode::processNoGroundPointCloud(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
   if (msg->width == 0 || msg->height == 0) {
-    // 3 seconds throttle to avoid spamming logs when the point cloud is empty for some reason 
-    RCLCPP_INFO_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), 3000, "[BehaviorVelocityPlanner]: Received empty point cloud for no_ground_pointcloud");
+    // 3 seconds throttle to avoid spamming logs when the point cloud is empty for some reason
+    RCLCPP_INFO_SKIPFIRST_THROTTLE(
+      get_logger(), *get_clock(), 3000,
+      "[BehaviorVelocityPlanner]: Received empty point cloud for no_ground_pointcloud");
     return false;
   }
   geometry_msgs::msg::TransformStamped transform;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -135,6 +135,11 @@ void BehaviorVelocityPlannerNode::onParam()
 bool BehaviorVelocityPlannerNode::processNoGroundPointCloud(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
+  if (msg->width == 0 || msg->height == 0) {
+    // 3 seconds throttle to avoid spamming logs when the point cloud is empty for some reason 
+    RCLCPP_INFO_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), 3000, "[BehaviorVelocityPlanner]: Received empty point cloud for no_ground_pointcloud");
+    return false;
+  }
   geometry_msgs::msg::TransformStamped transform;
   try {
     transform = tf_buffer_.lookupTransform(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -136,8 +136,10 @@ bool BehaviorVelocityPlannerNode::processNoGroundPointCloud(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
   if (msg->width == 0 || msg->height == 0) {
-    // 3 seconds throttle to avoid spamming logs when the point cloud is empty for some reason 
-    RCLCPP_INFO_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), 3000, "[BehaviorVelocityPlanner]: Received empty point cloud for no_ground_pointcloud");
+    // 3 seconds throttle to avoid spamming logs when the point cloud is empty for some reason
+    RCLCPP_INFO_SKIPFIRST_THROTTLE(
+      get_logger(), *get_clock(), 3000,
+      "[BehaviorVelocityPlanner]: Received empty point cloud for no_ground_pointcloud");
     return false;
   }
   geometry_msgs::msg::TransformStamped transform;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
@@ -230,6 +230,12 @@ std::optional<pcl::PointCloud<pcl::PointXYZ>>
 MotionVelocityPlannerNode::process_no_ground_pointcloud(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
+  if (msg->width == 0 || msg->height == 0) {
+    // 3 seconds throttle to avoid spamming logs when the point cloud is empty for some reason 
+    RCLCPP_INFO_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), 3000, "[MotionVelocityPlanner]: Received empty point cloud for no_ground_pointcloud");
+    return std::nullopt;
+  }
+
   geometry_msgs::msg::TransformStamped transform;
   const bool is_pcl_time_valid = (this->get_clock()->now() - rclcpp::Time(msg->header.stamp)) <
                                  rclcpp::Duration::from_seconds(1.0);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
@@ -231,8 +231,10 @@ MotionVelocityPlannerNode::process_no_ground_pointcloud(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
   if (msg->width == 0 || msg->height == 0) {
-    // 3 seconds throttle to avoid spamming logs when the point cloud is empty for some reason 
-    RCLCPP_INFO_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), 3000, "[MotionVelocityPlanner]: Received empty point cloud for no_ground_pointcloud");
+    // 3 seconds throttle to avoid spamming logs when the point cloud is empty for some reason
+    RCLCPP_INFO_SKIPFIRST_THROTTLE(
+      get_logger(), *get_clock(), 3000,
+      "[MotionVelocityPlanner]: Received empty point cloud for no_ground_pointcloud");
     return std::nullopt;
   }
 

--- a/sensing/autoware_core_sensing/CMakeLists.txt
+++ b/sensing/autoware_core_sensing/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   launch
 )

--- a/sensing/autoware_crop_box_filter/CMakeLists.txt
+++ b/sensing/autoware_crop_box_filter/CMakeLists.txt
@@ -34,7 +34,6 @@ if(BUILD_TESTING)
 endif()
 
 autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   launch
   config

--- a/sensing/autoware_downsample_filters/CMakeLists.txt
+++ b/sensing/autoware_downsample_filters/CMakeLists.txt
@@ -25,7 +25,6 @@ rclcpp_components_register_node(${PROJECT_NAME}
   EXECUTABLE ${VOXEL_GRID}_node)
 
 autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   launch
   config

--- a/sensing/autoware_gnss_poser/CMakeLists.txt
+++ b/sensing/autoware_gnss_poser/CMakeLists.txt
@@ -32,7 +32,6 @@ if(BUILD_TESTING)
 endif()
 
 autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   config
   launch

--- a/sensing/autoware_vehicle_velocity_converter/CMakeLists.txt
+++ b/sensing/autoware_vehicle_velocity_converter/CMakeLists.txt
@@ -29,7 +29,6 @@ if(BUILD_TESTING)
 endif()
 
 autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   launch
   config

--- a/testing/autoware_planning_test_manager/CMakeLists.txt
+++ b/testing/autoware_planning_test_manager/CMakeLists.txt
@@ -14,6 +14,4 @@ if(BUILD_TESTING)
   )
 endif()
 
-autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
-)
+autoware_ament_auto_package()

--- a/testing/autoware_testing/CMakeLists.txt
+++ b/testing/autoware_testing/CMakeLists.txt
@@ -9,6 +9,5 @@ list(APPEND ${PROJECT_NAME}_CONFIG_EXTRAS
 )
 
 autoware_ament_auto_package(
-  USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE cmake autoware_testing
 )


### PR DESCRIPTION
## Description
Rid of empty cloud messages with the new version of PCL, and also the USE_SCOPED_HEADER_INSTALL_DIR macro from cmake files that is not supported by jazzy anymore.

## Related links

**Parent Issue:**

- Link https://github.com/autowarefoundation/autoware/issues/6843#issuecomment-4213412231

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
I have tested this features with simple planning simulator.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
