### PR TITLE
fix(ndt_scan_matcher): don't include removed PCL headers

### DIFF
--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multi_voxel_grid_covariance_omp.h
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multi_voxel_grid_covariance_omp.h
@@ -61,7 +61,7 @@
 // clang-format off
 #include <pcl/pcl_macros.h>
 // clang-format on
-#include <pcl/filters/boost.h>
+#include <boost/shared_ptr.hpp>
 #include <pcl/filters/voxel_grid.h>
 #include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/point_types.h>

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multi_voxel_grid_covariance_omp.h
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multi_voxel_grid_covariance_omp.h
@@ -62,6 +62,7 @@
 #include <pcl/pcl_macros.h>
 // clang-format on
 #include <boost/shared_ptr.hpp>
+
 #include <pcl/filters/voxel_grid.h>
 #include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/point_types.h>

--- a/localization/autoware_ndt_scan_matcher/src/ndt_omp/multi_voxel_grid_covariance_omp_impl.hpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_omp/multi_voxel_grid_covariance_omp_impl.hpp
@@ -56,7 +56,6 @@
 
 #include <autoware/ndt_scan_matcher/ndt_omp/multi_voxel_grid_covariance_omp.h>
 #include <pcl/common/common.h>
-#include <pcl/filters/boost.h>
 
 #include <limits>
 #include <map>


### PR DESCRIPTION
## Description
`pcl/filters/boost.h` [was removed][1] in the PCL 1.15.0 release. None of the Boost headers it previously included are needed for compilation, so the includes can simply be removed.

[1]: https://github.com/PointCloudLibrary/pcl/commit/3ae4df5ede96d08408b500ee83d551151dd2a3da#diff-cb7d245fd1697b5c4a72cbb9807284c28f4166cd23c267211b85a7d4dee7f507L49-L54

## Related links

- https://github.com/PointCloudLibrary/pcl/commit/3ae4df5ede96d08408b500ee83d551151dd2a3da#diff-cb7d245fd1697b5c4a72cbb9807284c28f4166cd23c267211b85a7d4dee7f507L49-L54

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

(ADDED by @sasakisasaki ) All required CIs (such as [this](https://github.com/autowarefoundation/autoware_core/actions/runs/25722406979/job/75534420761?pr=1070)) passed. I believe this is enough test for this PR.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
