### PR TITLE
feat(autoware_vehicle_info_utils): add base_pose to createFootprint

### DIFF
--- a/common/autoware_vehicle_info_utils/include/autoware/vehicle_info_utils/vehicle_info.hpp
+++ b/common/autoware_vehicle_info_utils/include/autoware/vehicle_info_utils/vehicle_info.hpp
@@ -61,6 +61,7 @@ struct VehicleInfo
    * through front-right edge, center-right point, to front-left edge again to form a enclosed
    * polygon
    * @param margin the longitudinal and lateral inflation margin
+   * @param base_pose optional pose used to transform footprint
    */
   [[nodiscard]] autoware_utils_geometry::LinearRing2d createFootprint(
     const double margin = 0.0,
@@ -71,6 +72,7 @@ struct VehicleInfo
    * through front-right edge, center-right point, to front-left edge again to form a enclosed
    * polygon
    * @param margin the longitudinal and lateral inflation margin
+   * @param base_pose optional pose used to transform footprint
    */
   [[nodiscard]] autoware_utils_geometry::LinearRing2d createFootprint(
     const double lat_margin, const double lon_margin,
@@ -88,6 +90,7 @@ struct VehicleInfo
    * @param rear_lon_margin longitudinal inflation margin at the rear section
    * @param center_at_base_link if true, center point is aligned at base_link (x=0), otherwise
    * placed at wheelbase center
+   * @param base_pose optional pose used to transform footprint
    */
   [[nodiscard]] autoware_utils_geometry::LinearRing2d createFootprint(
     const double front_lat_margin, const double center_lat_margin, const double rear_lat_margin,

--- a/common/autoware_vehicle_info_utils/include/autoware/vehicle_info_utils/vehicle_info.hpp
+++ b/common/autoware_vehicle_info_utils/include/autoware/vehicle_info_utils/vehicle_info.hpp
@@ -17,6 +17,10 @@
 
 #include <autoware_utils_geometry/boost_geometry.hpp>
 
+#include "geometry_msgs/msg/pose.hpp"
+
+#include <optional>
+
 namespace autoware::vehicle_info_utils
 {
 /// Data class for vehicle info
@@ -59,7 +63,8 @@ struct VehicleInfo
    * @param margin the longitudinal and lateral inflation margin
    */
   [[nodiscard]] autoware_utils_geometry::LinearRing2d createFootprint(
-    const double margin = 0.0) const;
+    const double margin = 0.0,
+    const std::optional<geometry_msgs::msg::Pose> & base_pose = std::nullopt) const;
 
   /**
    * @brief calculate the vehicle footprint in clockwise manner starting from the front-left edge,
@@ -68,7 +73,8 @@ struct VehicleInfo
    * @param margin the longitudinal and lateral inflation margin
    */
   [[nodiscard]] autoware_utils_geometry::LinearRing2d createFootprint(
-    const double lat_margin, const double lon_margin) const;
+    const double lat_margin, const double lon_margin,
+    const std::optional<geometry_msgs::msg::Pose> & base_pose = std::nullopt) const;
 
   /**
    * @brief Calculate the vehicle footprint in a clockwise manner, starting from the front-left
@@ -86,7 +92,8 @@ struct VehicleInfo
   [[nodiscard]] autoware_utils_geometry::LinearRing2d createFootprint(
     const double front_lat_margin, const double center_lat_margin, const double rear_lat_margin,
     const double front_lon_margin, const double rear_lon_margin,
-    const bool center_at_base_link = false) const;
+    const bool center_at_base_link = false,
+    const std::optional<geometry_msgs::msg::Pose> & base_pose = std::nullopt) const;
 
   [[nodiscard]] double calcMaxCurvature() const;
   [[nodiscard]] double calcCurvatureFromSteerAngle(const double steer_angle) const;

--- a/common/autoware_vehicle_info_utils/src/vehicle_info.cpp
+++ b/common/autoware_vehicle_info_utils/src/vehicle_info.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/vehicle_info_utils/vehicle_info.hpp"
 
+#include "autoware_utils_geometry/geometry.hpp"
+
 #include <autoware_utils_geometry/boost_geometry.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -21,20 +23,26 @@
 
 namespace autoware::vehicle_info_utils
 {
-autoware_utils_geometry::LinearRing2d VehicleInfo::createFootprint(const double margin) const
+autoware_utils_geometry::LinearRing2d VehicleInfo::createFootprint(
+  const double margin, const std::optional<geometry_msgs::msg::Pose> & base_pose) const
 {
-  return createFootprint(margin, margin);
+  return createFootprint(margin, margin, base_pose);
 }
 
 autoware_utils_geometry::LinearRing2d VehicleInfo::createFootprint(
-  const double lat_margin, const double lon_margin) const
+  const double lat_margin, const double lon_margin,
+  const std::optional<geometry_msgs::msg::Pose> & base_pose) const
 {
-  return createFootprint(lat_margin, lat_margin, lat_margin, lon_margin, lon_margin);
+  // set default value of center_base_link
+  const bool center_at_base_link = false;
+  return createFootprint(
+    lat_margin, lat_margin, lat_margin, lon_margin, lon_margin, center_at_base_link, base_pose);
 }
 
 autoware_utils_geometry::LinearRing2d VehicleInfo::createFootprint(
   const double front_lat_margin, const double center_lat_margin, const double rear_lat_margin,
-  const double front_lon_margin, const double rear_lon_margin, const bool center_at_base_link) const
+  const double front_lon_margin, const double rear_lon_margin, const bool center_at_base_link,
+  const std::optional<geometry_msgs::msg::Pose> & base_pose) const
 {
   using autoware_utils_geometry::LinearRing2d;
   using autoware_utils_geometry::Point2d;
@@ -62,6 +70,13 @@ autoware_utils_geometry::LinearRing2d VehicleInfo::createFootprint(
   footprint.emplace_back(x_rear, y_left_rear);
   footprint.emplace_back(x_center, y_left_center);
   footprint.emplace_back(x_front, y_left_front);
+
+  // only transform if input pose exist, if not return simple base footprint
+  if (base_pose.has_value()) {
+    auto transformed_footprint = autoware_utils_geometry::transform_vector(
+      footprint, autoware_utils_geometry::pose2transform(base_pose.value()));
+    return transformed_footprint;
+  }
 
   return footprint;
 }

--- a/common/autoware_vehicle_info_utils/test/test_vehicle_info_utils.cpp
+++ b/common/autoware_vehicle_info_utils/test/test_vehicle_info_utils.cpp
@@ -14,6 +14,7 @@
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <autoware/vehicle_info_utils/vehicle_info_utils.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 
 #include <gtest/gtest.h>
 
@@ -84,4 +85,78 @@ TEST_F(VehicleInfoUtilTest, check_vehicle_info_value)
     vehicle_info.calcSteerAngleFromCurvature(1.0 / (vehicle_info.wheel_base_m / std::tan(0.7))),
     0.7);
   EXPECT_FLOAT_EQ(vehicle_info.calcSteerAngleFromCurvature(1e-8), 0.0);
+}
+
+TEST_F(VehicleInfoUtilTest, check_internal_pose_transformation)
+{
+  using autoware::vehicle_info_utils::VehicleInfo;
+  using autoware::vehicle_info_utils::VehicleInfoUtils;
+  std::optional<VehicleInfoUtils> vehicle_info_util_opt{std::nullopt};
+  ASSERT_NO_THROW({ vehicle_info_util_opt.emplace(VehicleInfoUtils(*node_)); });
+  const auto & vehicle_info_util = vehicle_info_util_opt.value();
+  const auto vehicle_info = vehicle_info_util.getVehicleInfo();
+
+  // without pose test is in previous test.
+  // translation
+  {
+    geometry_msgs::msg::Pose p;
+    p.position.x = 1.0;
+    p.position.y = 1.5;
+
+    const auto footprint = vehicle_info.createFootprint(0.0, p);
+    // front-left
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::FrontLeftIndex).x(), 2.74 + 1.0 + 1.0);
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::FrontLeftIndex).y(), 1.63 / 2 + 0.1 + 1.5);
+    // front-right
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::FrontRightIndex).x(), 2.74 + 1.0 + 1.0);
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::FrontRightIndex).y(), -(1.63 / 2 + 0.1) + 1.5);
+    // rear-right
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::RearRightIndex).x(), -1.03 + 1.0);
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::RearRightIndex).y(), -(1.63 / 2 + 0.1) + 1.5);
+    // rear-left
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::RearLeftIndex).x(), -1.03 + 1.0);
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::RearLeftIndex).y(), 1.63 / 2 + 0.1 + 1.5);
+  }
+
+  // rotation
+  {
+    geometry_msgs::msg::Pose p{};
+    p.orientation = autoware_utils_geometry::create_quaternion_from_yaw(M_PI / 2);
+
+    const auto footprint = vehicle_info.createFootprint(0.0, p);
+    // front-left
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::FrontLeftIndex).x(), -(1.63 / 2 + 0.1));
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::FrontLeftIndex).y(), 2.74 + 1.0);
+    // front-right
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::FrontRightIndex).x(), 1.63 / 2 + 0.1);
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::FrontRightIndex).y(), 2.74 + 1.0);
+    // rear-right
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::RearRightIndex).x(), 1.63 / 2 + 0.1);
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::RearRightIndex).y(), -1.03);
+    // rear-left
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::RearLeftIndex).x(), -(1.63 / 2 + 0.1));
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::RearLeftIndex).y(), -1.03);
+  }
+
+  // both translation and rotation
+  {
+    geometry_msgs::msg::Pose p{};
+    p.position.x = 1.0;
+    p.position.y = 1.5;
+    p.orientation = autoware_utils_geometry::create_quaternion_from_yaw(M_PI / 2);
+
+    const auto footprint = vehicle_info.createFootprint(0.0, p);
+    // front-left
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::FrontLeftIndex).x(), -(1.63 / 2 + 0.1) + 1.0);
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::FrontLeftIndex).y(), 2.74 + 1.0 + 1.5);
+    // front-right
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::FrontRightIndex).x(), 1.63 / 2 + 0.1 + 1.0);
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::FrontRightIndex).y(), 2.74 + 1.0 + 1.5);
+    // rear-right
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::RearRightIndex).x(), 1.63 / 2 + 0.1 + 1.0);
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::RearRightIndex).y(), -1.03 + 1.5);
+    // rear-left
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::RearLeftIndex).x(), -(1.63 / 2 + 0.1) + 1.0);
+    EXPECT_FLOAT_EQ(footprint.at(VehicleInfo::RearLeftIndex).y(), -1.03 + 1.5);
+  }
 }

--- a/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner/src/lanelet2_plugins/default_planner.cpp
@@ -284,9 +284,9 @@ bool DefaultPlanner::is_goal_valid(const geometry_msgs::msg::Pose & goal)
     closest_lanelet_to_goal, vehicle_info_.max_longitudinal_offset_m, false, route_handler_);
   lanelets_near_goal.insert(lanelets_near_goal.end(), next_lanelets.begin(), next_lanelets.end());
 
-  const auto local_vehicle_footprint = vehicle_info_.createFootprint();
-  autoware_utils_geometry::LinearRing2d goal_footprint = autoware_utils_geometry::transform_vector(
-    local_vehicle_footprint, autoware_utils_geometry::pose2transform(goal));
+  const autoware_utils_geometry::LinearRing2d goal_footprint =
+    vehicle_info_.createFootprint(0.0, goal);
+
   pub_goal_footprint_marker_->publish(visualize_debug_footprint(goal_footprint));
   const auto polygon_footprint = convert_linear_ring_to_polygon(goal_footprint);
 


### PR DESCRIPTION
## Description
Some footprint are generated by using `VehicleInfo::createFootprint` to create `base_footprint` then translate and relocate them to designated pose.
These are used often, thus, this PR add feature to input `base_pose` and implicitly move footprint to designated pose.

The functions will be refactored to use this `base_pose` feature in autoware_universe ([#12586](https://github.com/autowarefoundation/autoware_universe/pull/12586)). 

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Pass CI and Evaluator (https://evaluation.tier4.jp/evaluation/reports/72d0134f-56b8-5664-aa3c-fb2e4450ad7b?project_id=autoware_dev)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
