### PR TITLE
refactor(`pose_initializer`): extract auto-init logic and add its tests

### DIFF
--- a/localization/autoware_pose_initializer/CMakeLists.txt
+++ b/localization/autoware_pose_initializer/CMakeLists.txt
@@ -33,6 +33,7 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
   add_testcase(test/test_copy_vector_to_array.cpp)
+  add_testcase(test/test_pose_initializer_core.cpp)
 endif()
 
 autoware_ament_auto_package(

--- a/localization/autoware_pose_initializer/CMakeLists.txt
+++ b/localization/autoware_pose_initializer/CMakeLists.txt
@@ -26,7 +26,7 @@ if(BUILD_TESTING)
     string(REGEX REPLACE ".cpp" "" test_name ${filename})
     ament_add_gmock(${test_name} ${filepath})
     target_include_directories(${test_name} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-    target_link_libraries(${test_name} fmt)
+    target_link_libraries(${test_name} ${PROJECT_NAME} fmt)
     ament_target_dependencies(${test_name} ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS})
   endfunction()
 

--- a/localization/autoware_pose_initializer/src/gnss_module.hpp
+++ b/localization/autoware_pose_initializer/src/gnss_module.hpp
@@ -15,6 +15,8 @@
 #ifndef GNSS_MODULE_HPP_
 #define GNSS_MODULE_HPP_
 
+#include "pose_initializer_core_interfaces.hpp"
+
 #include <autoware/map_height_fitter/map_height_fitter.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -22,14 +24,14 @@
 
 namespace autoware::pose_initializer
 {
-class GnssModule
+class GnssModule : public GnssProvider
 {
 private:
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
 
 public:
   explicit GnssModule(rclcpp::Node * node);
-  PoseWithCovarianceStamped get_pose();
+  PoseWithCovarianceStamped get_pose() override;
 
 private:
   void on_pose(PoseWithCovarianceStamped::ConstSharedPtr msg);

--- a/localization/autoware_pose_initializer/src/localization_module.hpp
+++ b/localization/autoware_pose_initializer/src/localization_module.hpp
@@ -15,6 +15,8 @@
 #ifndef LOCALIZATION_MODULE_HPP_
 #define LOCALIZATION_MODULE_HPP_
 
+#include "pose_initializer_core_interfaces.hpp"
+
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_internal_localization_msgs/srv/pose_with_covariance_stamped.hpp>
@@ -25,7 +27,7 @@
 
 namespace autoware::pose_initializer
 {
-class LocalizationModule
+class LocalizationModule : public PoseAligner
 {
 private:
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
@@ -33,7 +35,8 @@ private:
 
 public:
   LocalizationModule(rclcpp::Node * node, const std::string & service_name);
-  std::tuple<PoseWithCovarianceStamped, bool> align_pose(const PoseWithCovarianceStamped & pose);
+  std::tuple<PoseWithCovarianceStamped, bool> align_pose(
+    const PoseWithCovarianceStamped & pose) override;
 
 private:
   rclcpp::Logger logger_;

--- a/localization/autoware_pose_initializer/src/pose_initializer_core.cpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core.cpp
@@ -16,6 +16,8 @@
 
 #include "copy_vector_to_array.hpp"
 #include "ekf_localization_trigger_module.hpp"
+#include "gnss_module.hpp"
+#include "localization_module.hpp"
 #include "ndt_localization_trigger_module.hpp"
 #include "pose_error_check_module.hpp"
 #include "pose_initializer_core_logic.hpp"

--- a/localization/autoware_pose_initializer/src/pose_initializer_core.cpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core.cpp
@@ -16,10 +16,9 @@
 
 #include "copy_vector_to_array.hpp"
 #include "ekf_localization_trigger_module.hpp"
-#include "gnss_module.hpp"
-#include "localization_module.hpp"
 #include "ndt_localization_trigger_module.hpp"
 #include "pose_error_check_module.hpp"
+#include "pose_initializer_core_logic.hpp"
 #include "stop_check_module.hpp"
 
 #include <autoware/qos_utils/qos_compatibility.hpp>
@@ -28,8 +27,6 @@
 
 #include <memory>
 #include <sstream>
-#include <vector>
-
 namespace autoware::pose_initializer
 {
 PoseInitializer::PoseInitializer(const rclcpp::NodeOptions & options)
@@ -73,6 +70,8 @@ PoseInitializer::PoseInitializer(const rclcpp::NodeOptions & options)
   if (declare_parameter<bool>("pose_error_check_enabled")) {
     pose_error_check_ = std::make_unique<PoseErrorCheckModule>(this);
   }
+  core_ = std::make_unique<PoseInitializerCore>(
+    gnss_.get(), ndt_.get(), yabloc_.get(), pose_error_check_.get());
   logger_configure_ = std::make_unique<autoware_utils_logging::LoggerLevelConfigure>(this);
 
   change_state(State::Message::UNINITIALIZED);
@@ -103,6 +102,8 @@ PoseInitializer::PoseInitializer(const rclcpp::NodeOptions & options)
     set_user_defined_initial_pose(initial_pose, true);
   }
 }
+
+PoseInitializer::~PoseInitializer() = default;
 
 void PoseInitializer::change_state(State::Message::_state_type state)
 {
@@ -171,31 +172,17 @@ void PoseInitializer::on_initialize(
       change_state(State::Message::INITIALIZING);
       change_node_trigger(false, false);
 
-      auto pose =
-        req->pose_with_covariance.empty() ? get_gnss_pose() : req->pose_with_covariance.front();
-      bool reliable = true;
-      if (ndt_) {
-        std::tie(pose, reliable) = ndt_->align_pose(pose);
-      } else if (yabloc_) {
-        // If both the NDT and YabLoc initializer are enabled, prioritize NDT as it offers more
-        // accuracy pose.
-        std::tie(pose, reliable) = yabloc_->align_pose(pose);
-      }
+      const auto outcome = core_->compute_auto_initial_pose(
+        req->pose_with_covariance, output_pose_covariance_, gnss_particle_covariance_);
 
       diagnostics_pose_reliable_->clear();
 
       // check pose error between gnss pose and initial pose result
-      if (pose_error_check_ && gnss_) {
-        const auto latest_gnss_pose = get_gnss_pose();
-
-        double gnss_error_2d;
-        const bool is_gnss_pose_error_small = pose_error_check_->check_pose_error(
-          latest_gnss_pose.pose.pose, pose.pose.pose, gnss_error_2d);
-
-        diagnostics_pose_reliable_->add_key_value("gnss_pose_error_2d", gnss_error_2d);
+      if (outcome.has_gnss_pose_error) {
+        diagnostics_pose_reliable_->add_key_value("gnss_pose_error_2d", outcome.gnss_error_2d);
         diagnostics_pose_reliable_->add_key_value(
-          "is_gnss_pose_error_small", is_gnss_pose_error_small);
-        if (!is_gnss_pose_error_small) {
+          "is_gnss_pose_error_small", outcome.is_gnss_pose_error_small);
+        if (!outcome.is_gnss_pose_error_small) {
           std::stringstream message;
           message << " Large error between Initial Pose and GNSS Pose.";
           diagnostics_pose_reliable_->update_level_and_message(
@@ -203,8 +190,8 @@ void PoseInitializer::on_initialize(
         }
       }
       // check initial pose result and publish diagnostics
-      diagnostics_pose_reliable_->add_key_value("is_initial_pose_reliable", reliable);
-      if (!reliable) {
+      diagnostics_pose_reliable_->add_key_value("is_initial_pose_reliable", outcome.reliable);
+      if (!outcome.reliable) {
         std::stringstream message;
         message << "Initial Pose Estimation is Unstable.";
         diagnostics_pose_reliable_->update_level_and_message(
@@ -212,8 +199,7 @@ void PoseInitializer::on_initialize(
       }
       diagnostics_pose_reliable_->publish(this->now());
 
-      pose.pose.covariance = output_pose_covariance_;
-      pub_reset_->publish(pose);
+      pub_reset_->publish(outcome.pose);
 
       change_node_trigger(true, false);
       res->status.success = true;
@@ -251,20 +237,6 @@ void PoseInitializer::on_initialize(
     res->status.message = error.message;
     change_state(State::Message::UNINITIALIZED);
   }
-}
-
-geometry_msgs::msg::PoseWithCovarianceStamped PoseInitializer::get_gnss_pose()
-{
-  if (gnss_) {
-    PoseWithCovarianceStamped pose = gnss_->get_pose();
-    pose.pose.covariance = gnss_particle_covariance_;
-    return pose;
-  }
-  autoware_adapi_v1_msgs::msg::ResponseStatus respose_status;
-  respose_status.success = false;
-  respose_status.code = Initialize::Service::Response::ERROR_GNSS_SUPPORT;
-  respose_status.message = "GNSS is not supported.";
-  throw respose_status;
 }
 }  // namespace autoware::pose_initializer
 

--- a/localization/autoware_pose_initializer/src/pose_initializer_core.hpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core.hpp
@@ -24,6 +24,7 @@
 #include <autoware_internal_localization_msgs/srv/initialize_localization.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 
+#include <array>
 #include <memory>
 #include <string>
 
@@ -35,11 +36,13 @@ class LocalizationModule;
 class GnssModule;
 class EkfLocalizationTriggerModule;
 class NdtLocalizationTriggerModule;
+class PoseInitializerCore;
 
 class PoseInitializer : public rclcpp::Node
 {
 public:
   explicit PoseInitializer(const rclcpp::NodeOptions & options);
+  ~PoseInitializer() override;
 
 private:
   using Initialize = autoware::component_interface_specs::localization::Initialize;
@@ -62,6 +65,7 @@ private:
   std::unique_ptr<NdtLocalizationTriggerModule> ndt_localization_trigger_;
   std::unique_ptr<autoware_utils_logging::LoggerLevelConfigure> logger_configure_;
   std::unique_ptr<autoware_utils_diagnostics::DiagnosticsInterface> diagnostics_pose_reliable_;
+  std::unique_ptr<PoseInitializerCore> core_;
   double stop_check_duration_;
 
   void change_node_trigger(bool flag, bool need_spin = false);
@@ -71,7 +75,6 @@ private:
   void on_initialize(
     const Initialize::Service::Request::SharedPtr req,
     const Initialize::Service::Response::SharedPtr res);
-  PoseWithCovarianceStamped get_gnss_pose();
 };
 }  // namespace autoware::pose_initializer
 

--- a/localization/autoware_pose_initializer/src/pose_initializer_core_interfaces.hpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core_interfaces.hpp
@@ -12,29 +12,39 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef POSE_ERROR_CHECK_MODULE_HPP_
-#define POSE_ERROR_CHECK_MODULE_HPP_
-
-#include "pose_initializer_core_interfaces.hpp"
-
-#include <rclcpp/rclcpp.hpp>
+#ifndef POSE_INITIALIZER_CORE_INTERFACES_HPP_
+#define POSE_INITIALIZER_CORE_INTERFACES_HPP_
 
 #include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
+
+#include <tuple>
 
 namespace autoware::pose_initializer
 {
-class PoseErrorCheckModule : public PoseErrorChecker
+class GnssProvider
 {
 public:
-  explicit PoseErrorCheckModule(rclcpp::Node * node);
-  bool check_pose_error(
-    const geometry_msgs::msg::Pose & reference_pose, const geometry_msgs::msg::Pose & result_pose,
-    double & error_2d) override;
+  virtual ~GnssProvider() = default;
+  virtual geometry_msgs::msg::PoseWithCovarianceStamped get_pose() = 0;
+};
 
-private:
-  rclcpp::Node * node_;
-  double pose_error_threshold_;
+class PoseAligner
+{
+public:
+  virtual ~PoseAligner() = default;
+  virtual std::tuple<geometry_msgs::msg::PoseWithCovarianceStamped, bool> align_pose(
+    const geometry_msgs::msg::PoseWithCovarianceStamped & pose) = 0;
+};
+
+class PoseErrorChecker
+{
+public:
+  virtual ~PoseErrorChecker() = default;
+  virtual bool check_pose_error(
+    const geometry_msgs::msg::Pose & reference_pose, const geometry_msgs::msg::Pose & result_pose,
+    double & error_2d) = 0;
 };
 }  // namespace autoware::pose_initializer
 
-#endif  // POSE_ERROR_CHECK_MODULE_HPP_
+#endif  // POSE_INITIALIZER_CORE_INTERFACES_HPP_

--- a/localization/autoware_pose_initializer/src/pose_initializer_core_logic.hpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core_logic.hpp
@@ -15,9 +15,7 @@
 #ifndef POSE_INITIALIZER_CORE_LOGIC_HPP_
 #define POSE_INITIALIZER_CORE_LOGIC_HPP_
 
-#include "gnss_module.hpp"
-#include "localization_module.hpp"
-#include "pose_error_check_module.hpp"
+#include "pose_initializer_core_interfaces.hpp"
 
 #include <autoware/component_interface_specs/localization.hpp>
 
@@ -43,8 +41,8 @@ class PoseInitializerCore
 {
 public:
   PoseInitializerCore(
-    GnssModule * gnss, LocalizationModule * ndt, LocalizationModule * yabloc,
-    PoseErrorCheckModule * pose_error_check)
+    GnssProvider * gnss, PoseAligner * ndt, PoseAligner * yabloc,
+    PoseErrorChecker * pose_error_check)
   : gnss_(gnss), ndt_(ndt), yabloc_(yabloc), pose_error_check_(pose_error_check)
   {
   }
@@ -94,10 +92,10 @@ public:
   }
 
 private:
-  GnssModule * gnss_;
-  LocalizationModule * ndt_;
-  LocalizationModule * yabloc_;
-  PoseErrorCheckModule * pose_error_check_;
+  GnssProvider * gnss_;
+  PoseAligner * ndt_;
+  PoseAligner * yabloc_;
+  PoseErrorChecker * pose_error_check_;
 };
 }  // namespace autoware::pose_initializer
 

--- a/localization/autoware_pose_initializer/src/pose_initializer_core_logic.hpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core_logic.hpp
@@ -1,0 +1,104 @@
+// Copyright 2024 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POSE_INITIALIZER_CORE_LOGIC_HPP_
+#define POSE_INITIALIZER_CORE_LOGIC_HPP_
+
+#include "gnss_module.hpp"
+#include "localization_module.hpp"
+#include "pose_error_check_module.hpp"
+
+#include <autoware/component_interface_specs/localization.hpp>
+
+#include <autoware_adapi_v1_msgs/msg/response_status.hpp>
+#include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
+
+#include <array>
+#include <tuple>
+#include <vector>
+
+namespace autoware::pose_initializer
+{
+struct AutoInitializeOutcome
+{
+  geometry_msgs::msg::PoseWithCovarianceStamped pose;
+  bool reliable{true};
+  bool has_gnss_pose_error{false};
+  double gnss_error_2d{0.0};
+  bool is_gnss_pose_error_small{true};
+};
+
+class PoseInitializerCore
+{
+public:
+  PoseInitializerCore(
+    GnssModule * gnss, LocalizationModule * ndt, LocalizationModule * yabloc,
+    PoseErrorCheckModule * pose_error_check)
+  : gnss_(gnss), ndt_(ndt), yabloc_(yabloc), pose_error_check_(pose_error_check)
+  {
+  }
+
+  geometry_msgs::msg::PoseWithCovarianceStamped get_gnss_pose(
+    const std::array<double, 36> & gnss_covariance) const
+  {
+    using Initialize = autoware::component_interface_specs::localization::Initialize;
+
+    if (gnss_) {
+      geometry_msgs::msg::PoseWithCovarianceStamped pose = gnss_->get_pose();
+      pose.pose.covariance = gnss_covariance;
+      return pose;
+    }
+    autoware_adapi_v1_msgs::msg::ResponseStatus response_status;
+    response_status.success = false;
+    response_status.code = Initialize::Service::Response::ERROR_GNSS_SUPPORT;
+    response_status.message = "GNSS is not supported.";
+    throw response_status;
+  }
+
+  template <typename PoseContainer>
+  AutoInitializeOutcome compute_auto_initial_pose(
+    const PoseContainer & input_pose, const std::array<double, 36> & output_covariance,
+    const std::array<double, 36> & gnss_covariance) const
+  {
+    AutoInitializeOutcome outcome;
+    outcome.pose = input_pose.empty() ? get_gnss_pose(gnss_covariance) : input_pose.front();
+
+    if (ndt_) {
+      std::tie(outcome.pose, outcome.reliable) = ndt_->align_pose(outcome.pose);
+    } else if (yabloc_) {
+      // If both the NDT and YabLoc initializer are enabled, prioritize NDT as it offers more
+      // accuracy pose.
+      std::tie(outcome.pose, outcome.reliable) = yabloc_->align_pose(outcome.pose);
+    }
+
+    if (pose_error_check_ && gnss_) {
+      const auto latest_gnss_pose = get_gnss_pose(gnss_covariance);
+      outcome.has_gnss_pose_error = true;
+      outcome.is_gnss_pose_error_small = pose_error_check_->check_pose_error(
+        latest_gnss_pose.pose.pose, outcome.pose.pose.pose, outcome.gnss_error_2d);
+    }
+
+    outcome.pose.pose.covariance = output_covariance;
+    return outcome;
+  }
+
+private:
+  GnssModule * gnss_;
+  LocalizationModule * ndt_;
+  LocalizationModule * yabloc_;
+  PoseErrorCheckModule * pose_error_check_;
+};
+}  // namespace autoware::pose_initializer
+
+#endif  // POSE_INITIALIZER_CORE_LOGIC_HPP_

--- a/localization/autoware_pose_initializer/test/test_pose_initializer_core.cpp
+++ b/localization/autoware_pose_initializer/test/test_pose_initializer_core.cpp
@@ -14,8 +14,9 @@
 
 #include "../src/pose_initializer_core_logic.hpp"
 
-#include <gmock/gmock.h>
 #include <rclcpp/rclcpp.hpp>
+
+#include <gmock/gmock.h>
 
 #include <array>
 #include <chrono>
@@ -29,15 +30,9 @@ namespace
 class RclcppFixture : public ::testing::Test
 {
 public:
-  static void SetUpTestSuite()
-  {
-    rclcpp::init(0, nullptr);
-  }
+  static void SetUpTestSuite() { rclcpp::init(0, nullptr); }
 
-  static void TearDownTestSuite()
-  {
-    rclcpp::shutdown();
-  }
+  static void TearDownTestSuite() { rclcpp::shutdown(); }
 };
 
 geometry_msgs::msg::PoseWithCovarianceStamped make_pose(double x, double y)
@@ -82,8 +77,7 @@ TEST(PoseInitializerCore, UsesInputPoseAndSetsOutputCovariance)
   const auto output_covariance = make_covariance(0.5);
   const std::array<double, 36> gnss_covariance{};
 
-  const auto outcome =
-    core.compute_auto_initial_pose(input, output_covariance, gnss_covariance);
+  const auto outcome = core.compute_auto_initial_pose(input, output_covariance, gnss_covariance);
 
   EXPECT_DOUBLE_EQ(outcome.pose.pose.pose.position.x, 1.0);
   EXPECT_DOUBLE_EQ(outcome.pose.pose.pose.position.y, 2.0);
@@ -99,8 +93,8 @@ TEST_F(RclcppFixture, UsesGnssPoseWhenInputEmpty)
   auto node = std::make_shared<rclcpp::Node>("pose_initializer_core_gnss", options);
   GnssModule gnss(node.get());
 
-  auto publisher = node->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
-    "gnss_pose_cov", 1);
+  auto publisher =
+    node->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("gnss_pose_cov", 1);
   auto message = make_pose(3.0, 4.0);
   message.header.stamp = node->now();
   publisher->publish(message);
@@ -114,8 +108,7 @@ TEST_F(RclcppFixture, UsesGnssPoseWhenInputEmpty)
   const auto gnss_covariance = make_covariance(0.75);
   std::vector<geometry_msgs::msg::PoseWithCovarianceStamped> input;
 
-  const auto outcome =
-    core.compute_auto_initial_pose(input, output_covariance, gnss_covariance);
+  const auto outcome = core.compute_auto_initial_pose(input, output_covariance, gnss_covariance);
 
   EXPECT_DOUBLE_EQ(outcome.pose.pose.pose.position.x, 3.0);
   EXPECT_DOUBLE_EQ(outcome.pose.pose.pose.position.y, 4.0);
@@ -132,8 +125,8 @@ TEST_F(RclcppFixture, ReportsPoseErrorStatusWhenEnabled)
   GnssModule gnss(node.get());
   PoseErrorCheckModule pose_error_check(node.get());
 
-  auto publisher = node->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
-    "gnss_pose_cov", 1);
+  auto publisher =
+    node->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("gnss_pose_cov", 1);
   auto message = make_pose(0.0, 0.0);
   message.header.stamp = node->now();
   publisher->publish(message);

--- a/localization/autoware_pose_initializer/test/test_pose_initializer_core.cpp
+++ b/localization/autoware_pose_initializer/test/test_pose_initializer_core.cpp
@@ -1,0 +1,156 @@
+// Copyright 2024 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/pose_initializer_core_logic.hpp"
+
+#include <gmock/gmock.h>
+#include <rclcpp/rclcpp.hpp>
+
+#include <array>
+#include <chrono>
+#include <memory>
+#include <vector>
+
+namespace autoware::pose_initializer
+{
+namespace
+{
+class RclcppFixture : public ::testing::Test
+{
+public:
+  static void SetUpTestSuite()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestSuite()
+  {
+    rclcpp::shutdown();
+  }
+};
+
+geometry_msgs::msg::PoseWithCovarianceStamped make_pose(double x, double y)
+{
+  geometry_msgs::msg::PoseWithCovarianceStamped pose;
+  pose.header.frame_id = "map";
+  pose.pose.pose.position.x = x;
+  pose.pose.pose.position.y = y;
+  return pose;
+}
+
+std::array<double, 36> make_covariance(double seed)
+{
+  std::array<double, 36> covariance{};
+  covariance.front() = seed;
+  covariance.back() = seed + 1.0;
+  return covariance;
+}
+
+void spin_until_gnss_available(
+  GnssModule & gnss, rclcpp::executors::SingleThreadedExecutor & executor)
+{
+  for (int i = 0; i < 10; ++i) {
+    executor.spin_some();
+    try {
+      (void)gnss.get_pose();
+      return;
+    } catch (const autoware_adapi_v1_msgs::msg::ResponseStatus &) {
+      // Keep spinning until GNSS data is ready.
+    }
+  }
+  FAIL() << "GNSS pose did not arrive in time.";
+}
+}  // namespace
+
+TEST(PoseInitializerCore, UsesInputPoseAndSetsOutputCovariance)
+{
+  PoseInitializerCore core(nullptr, nullptr, nullptr, nullptr);
+
+  std::vector<geometry_msgs::msg::PoseWithCovarianceStamped> input;
+  input.push_back(make_pose(1.0, 2.0));
+  const auto output_covariance = make_covariance(0.5);
+  const std::array<double, 36> gnss_covariance{};
+
+  const auto outcome =
+    core.compute_auto_initial_pose(input, output_covariance, gnss_covariance);
+
+  EXPECT_DOUBLE_EQ(outcome.pose.pose.pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(outcome.pose.pose.pose.position.y, 2.0);
+  EXPECT_EQ(outcome.pose.pose.covariance.front(), output_covariance.front());
+  EXPECT_EQ(outcome.pose.pose.covariance.back(), output_covariance.back());
+  EXPECT_FALSE(outcome.has_gnss_pose_error);
+  EXPECT_TRUE(outcome.reliable);
+}
+
+TEST_F(RclcppFixture, UsesGnssPoseWhenInputEmpty)
+{
+  auto options = rclcpp::NodeOptions().append_parameter_override("gnss_pose_timeout", 1.0);
+  auto node = std::make_shared<rclcpp::Node>("pose_initializer_core_gnss", options);
+  GnssModule gnss(node.get());
+
+  auto publisher = node->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
+    "gnss_pose_cov", 1);
+  auto message = make_pose(3.0, 4.0);
+  message.header.stamp = node->now();
+  publisher->publish(message);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+  spin_until_gnss_available(gnss, executor);
+
+  PoseInitializerCore core(&gnss, nullptr, nullptr, nullptr);
+  const auto output_covariance = make_covariance(0.25);
+  const auto gnss_covariance = make_covariance(0.75);
+  std::vector<geometry_msgs::msg::PoseWithCovarianceStamped> input;
+
+  const auto outcome =
+    core.compute_auto_initial_pose(input, output_covariance, gnss_covariance);
+
+  EXPECT_DOUBLE_EQ(outcome.pose.pose.pose.position.x, 3.0);
+  EXPECT_DOUBLE_EQ(outcome.pose.pose.pose.position.y, 4.0);
+  EXPECT_EQ(outcome.pose.pose.covariance.front(), output_covariance.front());
+  EXPECT_TRUE(outcome.reliable);
+}
+
+TEST_F(RclcppFixture, ReportsPoseErrorStatusWhenEnabled)
+{
+  auto options = rclcpp::NodeOptions()
+                   .append_parameter_override("gnss_pose_timeout", 1.0)
+                   .append_parameter_override("pose_error_threshold", 0.5);
+  auto node = std::make_shared<rclcpp::Node>("pose_initializer_core_pose_error", options);
+  GnssModule gnss(node.get());
+  PoseErrorCheckModule pose_error_check(node.get());
+
+  auto publisher = node->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>(
+    "gnss_pose_cov", 1);
+  auto message = make_pose(0.0, 0.0);
+  message.header.stamp = node->now();
+  publisher->publish(message);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+  spin_until_gnss_available(gnss, executor);
+
+  PoseInitializerCore core(&gnss, nullptr, nullptr, &pose_error_check);
+  std::vector<geometry_msgs::msg::PoseWithCovarianceStamped> input;
+  input.push_back(make_pose(10.0, 0.0));
+
+  const auto outcome =
+    core.compute_auto_initial_pose(input, make_covariance(1.0), make_covariance(2.0));
+
+  EXPECT_TRUE(outcome.has_gnss_pose_error);
+  EXPECT_FALSE(outcome.is_gnss_pose_error_small);
+  EXPECT_GT(outcome.gnss_error_2d, 0.5);
+}
+}  // namespace autoware::pose_initializer

--- a/localization/autoware_pose_initializer/test/test_pose_initializer_core.cpp
+++ b/localization/autoware_pose_initializer/test/test_pose_initializer_core.cpp
@@ -14,25 +14,57 @@
 
 #include "../src/pose_initializer_core_logic.hpp"
 
-#include <rclcpp/rclcpp.hpp>
-
 #include <gmock/gmock.h>
 
 #include <array>
-#include <chrono>
-#include <memory>
+#include <cmath>
+#include <optional>
 #include <vector>
 
 namespace autoware::pose_initializer
 {
 namespace
 {
-class RclcppFixture : public ::testing::Test
+class FakeGnssModule : public GnssProvider
 {
 public:
-  static void SetUpTestSuite() { rclcpp::init(0, nullptr); }
+  void set_pose(const geometry_msgs::msg::PoseWithCovarianceStamped & pose) { pose_ = pose; }
 
-  static void TearDownTestSuite() { rclcpp::shutdown(); }
+  geometry_msgs::msg::PoseWithCovarianceStamped get_pose() override
+  {
+    if (!pose_) {
+      autoware_adapi_v1_msgs::msg::ResponseStatus response_status;
+      response_status.success = false;
+      response_status.code =
+        autoware::component_interface_specs::localization::Initialize::Service::Response::
+          ERROR_GNSS;
+      response_status.message = "The GNSS pose has not arrived.";
+      throw response_status;
+    }
+    return *pose_;
+  }
+
+private:
+  std::optional<geometry_msgs::msg::PoseWithCovarianceStamped> pose_;
+};
+
+class FakePoseErrorCheckModule : public PoseErrorChecker
+{
+public:
+  explicit FakePoseErrorCheckModule(double threshold) : threshold_(threshold) {}
+
+  bool check_pose_error(
+    const geometry_msgs::msg::Pose & reference_pose, const geometry_msgs::msg::Pose & result_pose,
+    double & error_2d) override
+  {
+    const double diff_x = reference_pose.position.x - result_pose.position.x;
+    const double diff_y = reference_pose.position.y - result_pose.position.y;
+    error_2d = std::sqrt(diff_x * diff_x + diff_y * diff_y);
+    return error_2d < threshold_;
+  }
+
+private:
+  double threshold_{0.0};
 };
 
 geometry_msgs::msg::PoseWithCovarianceStamped make_pose(double x, double y)
@@ -52,20 +84,6 @@ std::array<double, 36> make_covariance(double seed)
   return covariance;
 }
 
-void spin_until_gnss_available(
-  GnssModule & gnss, rclcpp::executors::SingleThreadedExecutor & executor)
-{
-  for (int i = 0; i < 10; ++i) {
-    executor.spin_some();
-    try {
-      (void)gnss.get_pose();
-      return;
-    } catch (const autoware_adapi_v1_msgs::msg::ResponseStatus &) {
-      // Keep spinning until GNSS data is ready.
-    }
-  }
-  FAIL() << "GNSS pose did not arrive in time.";
-}
 }  // namespace
 
 TEST(PoseInitializerCore, UsesInputPoseAndSetsOutputCovariance)
@@ -87,21 +105,10 @@ TEST(PoseInitializerCore, UsesInputPoseAndSetsOutputCovariance)
   EXPECT_TRUE(outcome.reliable);
 }
 
-TEST_F(RclcppFixture, UsesGnssPoseWhenInputEmpty)
+TEST(PoseInitializerCore, UsesGnssPoseWhenInputEmpty)
 {
-  auto options = rclcpp::NodeOptions().append_parameter_override("gnss_pose_timeout", 1.0);
-  auto node = std::make_shared<rclcpp::Node>("pose_initializer_core_gnss", options);
-  GnssModule gnss(node.get());
-
-  auto publisher =
-    node->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("gnss_pose_cov", 1);
-  auto message = make_pose(3.0, 4.0);
-  message.header.stamp = node->now();
-  publisher->publish(message);
-
-  rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(node);
-  spin_until_gnss_available(gnss, executor);
+  FakeGnssModule gnss;
+  gnss.set_pose(make_pose(3.0, 4.0));
 
   PoseInitializerCore core(&gnss, nullptr, nullptr, nullptr);
   const auto output_covariance = make_covariance(0.25);
@@ -116,24 +123,11 @@ TEST_F(RclcppFixture, UsesGnssPoseWhenInputEmpty)
   EXPECT_TRUE(outcome.reliable);
 }
 
-TEST_F(RclcppFixture, ReportsPoseErrorStatusWhenEnabled)
+TEST(PoseInitializerCore, ReportsPoseErrorStatusWhenEnabled)
 {
-  auto options = rclcpp::NodeOptions()
-                   .append_parameter_override("gnss_pose_timeout", 1.0)
-                   .append_parameter_override("pose_error_threshold", 0.5);
-  auto node = std::make_shared<rclcpp::Node>("pose_initializer_core_pose_error", options);
-  GnssModule gnss(node.get());
-  PoseErrorCheckModule pose_error_check(node.get());
-
-  auto publisher =
-    node->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("gnss_pose_cov", 1);
-  auto message = make_pose(0.0, 0.0);
-  message.header.stamp = node->now();
-  publisher->publish(message);
-
-  rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(node);
-  spin_until_gnss_available(gnss, executor);
+  FakeGnssModule gnss;
+  gnss.set_pose(make_pose(0.0, 0.0));
+  FakePoseErrorCheckModule pose_error_check(0.5);
 
   PoseInitializerCore core(&gnss, nullptr, nullptr, &pose_error_check);
   std::vector<geometry_msgs::msg::PoseWithCovarianceStamped> input;

--- a/localization/autoware_pose_initializer/test/test_pose_initializer_core.cpp
+++ b/localization/autoware_pose_initializer/test/test_pose_initializer_core.cpp
@@ -35,9 +35,8 @@ public:
     if (!pose_) {
       autoware_adapi_v1_msgs::msg::ResponseStatus response_status;
       response_status.success = false;
-      response_status.code =
-        autoware::component_interface_specs::localization::Initialize::Service::Response::
-          ERROR_GNSS;
+      response_status.code = autoware::component_interface_specs::localization::Initialize::
+        Service::Response::ERROR_GNSS;
       response_status.message = "The GNSS pose has not arrived.";
       throw response_status;
     }


### PR DESCRIPTION
## Description

:warning: ~~This PR is created based on Codex-generated code and may require manual adjustments. I'll make this PR ready for review after reviewing and testing by myself.~~

**→ Now I reviewed and fixed. Should be ready for review.**

- Extracted auto-initialization computation into `PoseInitializerCore` and isolated logic in a dedicated header.
- Added unit tests for core auto-initialization logic and GNSS/pose error paths.

## Related links
- N/A

## How was this PR tested?

### Unit Tests
I checked all tests passed:
- `colcon test --packages-select autoware_pose_initializer`

### Using AWSIM
- Build the Autoware following tutorial provided by [Quick start demo for AWSIM](https://tier4.github.io/AWSIM/GettingStarted/QuickStartDemo/)
- Run Autoware:
```bash
$ source install/setup.bash
$ ros2 launch \
    autoware_launch \
    e2e_simulator.launch.xml \
    vehicle_model:=sample_vehicle \
    sensor_model:=awsim_sensor_kit \
    map_path:=$HOME/autoware_map/nishishinjuku_autoware_map
```
- Open another terminal and run AWSIM by following the [tutorial](https://tier4.github.io/AWSIM/GettingStarted/QuickStartDemo/#3-download-awsim-demo)

## Notes for reviewers
- The new core logic lives in `pose_initializer_core_logic.hpp` to keep ROS2 wiring in the node file.

## Interface changes
- Added internal header `pose_initializer_core_logic.hpp` (not installed).

### Topic changes
- None.

## Effects on system behavior
- No functional behavior change; refactor + added unit tests only.

