### PR TITLE
feat(autoware_agnocast_wrapper): introduce Timer API

### DIFF
--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -19,12 +19,11 @@ Use this when you want the **entire node** to transparently switch between `rclc
 Currently supported APIs:
 
 - Publisher / Subscription / PollingSubscriber
+- Timer (`create_wall_timer`, free `create_timer()`, free `set_period()`)
 - Parameters
 - Logger, Clock
 - Callback groups
 - Node interfaces (partial: `get_node_base_interface()`, `get_node_topics_interface()`, `get_node_parameters_interface()`)
-
-> **Note:** Timer (`create_wall_timer`, `create_timer`) is not yet supported and will be added in a future update.
 
 ```cpp
 #include <autoware/agnocast_wrapper/node.hpp>
@@ -38,12 +37,31 @@ public:
     pub_ = create_publisher<std_msgs::msg::String>("output", 10);
     sub_ = create_subscription<std_msgs::msg::String>(
       "input", 10, [this](std::unique_ptr<const std_msgs::msg::String> msg) { /* ... */ });
+
+    timer_ = create_wall_timer(
+      std::chrono::milliseconds(100), [this]() { /* ... */ });
   }
 
 private:
   autoware::agnocast_wrapper::Publisher<std_msgs::msg::String>::SharedPtr pub_;
   autoware::agnocast_wrapper::Subscription<std_msgs::msg::String>::SharedPtr sub_;
+  autoware::agnocast_wrapper::Timer::SharedPtr timer_;
 };
+```
+
+#### Timer notes
+
+`create_timer()` is provided as a **free function** (not a member) because `rclcpp::Node::create_timer` was added in Jazzy and does not exist on Humble. The free form is portable across both:
+
+```cpp
+timer_ = autoware::agnocast_wrapper::create_timer(
+  this, this->get_clock(), rclcpp::Duration::from_seconds(0.1), [this]() { /* ... */ });
+```
+
+`set_period()` is likewise a **free function**. `rclcpp::TimerBase` has no `set_period` member, so the free form is the only portable spelling across both builds:
+
+```cpp
+autoware::agnocast_wrapper::set_period(timer_, std::chrono::milliseconds(200));
 ```
 
 To use the Node wrapper in your package, add the following to your `CMakeLists.txt`:

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -29,6 +29,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <memory>
+#include <stdexcept>
 #include <type_traits>
 
 #define AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) \
@@ -747,6 +748,13 @@ typename Publisher<MessageT>::SharedPtr create_publisher(
 /// Calling any other rclcpp::TimerBase method compiles in non-Agnocast builds
 /// but breaks once Agnocast is enabled. Stay within the wrapper's surface to
 /// remain portable.
+///
+/// Exception contract: the exception type and "throw vs no-op" behavior of
+/// these methods is not normalized across backends — the rclcpp backend tends
+/// to throw rclcpp::exceptions::RCLError on rcl failure, while the Agnocast
+/// backend may throw std::runtime_error or silently return a sentinel. This
+/// asymmetry exists across the wrapper as a whole (not Timer-specific) and is
+/// expected to be normalized in a follow-up.
 class Timer
 {
 public:
@@ -820,8 +828,18 @@ private:
 /// in non-Agnocast builds rclcpp::TimerBase has no set_period member, so a
 /// free overload is the only portable form. Timer::set_period is private to
 /// prevent member-style calls that would not survive the non-Agnocast build.
+///
+/// @throws std::invalid_argument if period is negative or equal to
+///   std::chrono::nanoseconds::max() (mirrors rclcpp::create_wall_timer's
+///   precondition 0 <= period < nanoseconds::max()).
 inline void set_period(const Timer::SharedPtr & timer, std::chrono::nanoseconds period)
 {
+  if (period < std::chrono::nanoseconds::zero()) {
+    throw std::invalid_argument{"timer period cannot be negative"};
+  }
+  if (period == std::chrono::nanoseconds::max()) {
+    throw std::invalid_argument{"timer period must be less than std::chrono::nanoseconds::max()"};
+  }
   timer->set_period(period);
 }
 
@@ -838,6 +856,7 @@ inline void set_period(const Timer::SharedPtr & timer, std::chrono::nanoseconds 
 
 #include <chrono>
 #include <memory>
+#include <stdexcept>
 #include <type_traits>
 
 namespace autoware::agnocast_wrapper
@@ -848,8 +867,19 @@ namespace autoware::agnocast_wrapper
 /// rclcpp::TimerBase has no set_period member, so we provide a free overload
 /// that falls back to the rcl C API. Mirrors the Agnocast-build overload on
 /// Timer::SharedPtr so the same call site works in both builds.
+///
+/// @throws std::invalid_argument if period is negative or equal to
+///   std::chrono::nanoseconds::max() (mirrors rclcpp::create_wall_timer's
+///   precondition 0 <= period < nanoseconds::max()).
+/// @throws rclcpp::exceptions::RCLError on rcl-level failure.
 inline void set_period(const rclcpp::TimerBase::SharedPtr & timer, std::chrono::nanoseconds period)
 {
+  if (period < std::chrono::nanoseconds::zero()) {
+    throw std::invalid_argument{"timer period cannot be negative"};
+  }
+  if (period == std::chrono::nanoseconds::max()) {
+    throw std::invalid_argument{"timer period must be less than std::chrono::nanoseconds::max()"};
+  }
   int64_t old_period = 0;
   const rcl_ret_t ret =
     rcl_timer_exchange_period(timer->get_timer_handle().get(), period.count(), &old_period);

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -814,6 +814,12 @@ private:
   }
 };
 
+/// @brief Set the timer period.
+///
+/// Provided as a free function so the same call site compiles in both builds:
+/// in non-Agnocast builds rclcpp::TimerBase has no set_period member, so a
+/// free overload is the only portable form. Timer::set_period is private to
+/// prevent member-style calls that would not survive the non-Agnocast build.
 inline void set_period(const Timer::SharedPtr & timer, std::chrono::nanoseconds period)
 {
   timer->set_period(period);
@@ -837,7 +843,11 @@ inline void set_period(const Timer::SharedPtr & timer, std::chrono::nanoseconds 
 namespace autoware::agnocast_wrapper
 {
 
-// rclcpp::TimerBase has no set_period API; fall back to the rcl C API.
+/// @brief Set the timer period (non-Agnocast build).
+///
+/// rclcpp::TimerBase has no set_period member, so we provide a free overload
+/// that falls back to the rcl C API. Mirrors the Agnocast-build overload on
+/// Timer::SharedPtr so the same call site works in both builds.
 inline void set_period(const rclcpp::TimerBase::SharedPtr & timer, std::chrono::nanoseconds period)
 {
   int64_t old_period = 0;

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -732,14 +732,21 @@ typename Publisher<MessageT>::SharedPtr create_publisher(
   }
 }
 
-/// Cross-build portability note
+/// @brief Type-erased timer handle for the Agnocast build.
 ///
-/// In non-Agnocast builds, AUTOWARE_TIMER_PTR resolves to
-/// rclcpp::TimerBase::SharedPtr and exposes the full rclcpp API. In Agnocast
-/// builds it resolves to the Timer wrapper, which only exposes cancel/reset/
-/// is_canceled/time_until_trigger and the free set_period(). Calling any other
-/// rclcpp::TimerBase method compiles in non-Agnocast builds but breaks once
-/// Agnocast is enabled. Stay within the wrapper's surface to remain portable.
+/// Backed by AgnocastTimer or ROS2Timer depending on whether Agnocast is
+/// active at runtime. Must be obtained via Node::create_wall_timer() or the
+/// free create_timer() — do not construct directly. set_period() is
+/// intentionally private; use the free set_period(Timer::SharedPtr, ...)
+/// instead, which is also available in non-Agnocast builds.
+///
+/// Cross-build portability: in non-Agnocast builds AUTOWARE_TIMER_PTR
+/// resolves to rclcpp::TimerBase::SharedPtr and exposes the full rclcpp API;
+/// in Agnocast builds it resolves to this wrapper, which only exposes
+/// cancel/reset/is_canceled/time_until_trigger and the free set_period().
+/// Calling any other rclcpp::TimerBase method compiles in non-Agnocast builds
+/// but breaks once Agnocast is enabled. Stay within the wrapper's surface to
+/// remain portable.
 class Timer
 {
 public:

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -732,6 +732,14 @@ typename Publisher<MessageT>::SharedPtr create_publisher(
   }
 }
 
+/// Cross-build portability note
+///
+/// In non-Agnocast builds, AUTOWARE_TIMER_PTR resolves to
+/// rclcpp::TimerBase::SharedPtr and exposes the full rclcpp API. In Agnocast
+/// builds it resolves to the Timer wrapper, which only exposes cancel/reset/
+/// is_canceled/time_until_trigger and the free set_period(). Calling any other
+/// rclcpp::TimerBase method compiles in non-Agnocast builds but breaks once
+/// Agnocast is enabled. Stay within the wrapper's surface to remain portable.
 class Timer
 {
 public:

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -763,8 +763,8 @@ public:
 
   virtual void cancel() = 0;
   virtual void reset() = 0;
-  virtual bool is_canceled() const = 0;
-  virtual std::chrono::nanoseconds time_until_trigger() const = 0;
+  virtual bool is_canceled() = 0;
+  virtual std::chrono::nanoseconds time_until_trigger() = 0;
 
 private:
   // Private so callers must use the free set_period() function, which also works in the
@@ -782,11 +782,8 @@ public:
 
   void cancel() override { timer_->cancel(); }
   void reset() override { timer_->reset(); }
-  bool is_canceled() const override { return timer_->is_canceled(); }
-  std::chrono::nanoseconds time_until_trigger() const override
-  {
-    return timer_->time_until_trigger();
-  }
+  bool is_canceled() override { return timer_->is_canceled(); }
+  std::chrono::nanoseconds time_until_trigger() override { return timer_->time_until_trigger(); }
 
 private:
   void set_period(std::chrono::nanoseconds period) override { timer_->set_period(period); }
@@ -801,11 +798,8 @@ public:
 
   void cancel() override { timer_->cancel(); }
   void reset() override { timer_->reset(); }
-  bool is_canceled() const override { return timer_->is_canceled(); }
-  std::chrono::nanoseconds time_until_trigger() const override
-  {
-    return timer_->time_until_trigger();
-  }
+  bool is_canceled() override { return timer_->is_canceled(); }
+  std::chrono::nanoseconds time_until_trigger() override { return timer_->time_until_trigger(); }
 
 private:
   // rclcpp::TimerBase does not expose a set_period API; fall back to the rcl C API and

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -826,6 +826,9 @@ private:
 /// @throws std::invalid_argument if period is negative or equal to
 ///   std::chrono::nanoseconds::max() (mirrors rclcpp::create_wall_timer's
 ///   precondition 0 <= period < nanoseconds::max()).
+/// @throws rclcpp::exceptions::RCLError on rcl-level failure when the ROS 2
+///   backend is active (see Timer's class-level note on exception asymmetry
+///   between backends).
 inline void set_period(const Timer::SharedPtr & timer, std::chrono::nanoseconds period)
 {
   if (period < std::chrono::nanoseconds::zero()) {

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -22,7 +22,11 @@
 #include "autoware_utils_rclcpp/polling_subscriber.hpp"
 
 #include <agnocast/agnocast.hpp>
+#include <rclcpp/exceptions/exceptions.hpp>
 
+#include <rcl/timer.h>
+
+#include <chrono>
 #include <cstdlib>
 #include <memory>
 #include <type_traits>
@@ -44,6 +48,7 @@
   typename autoware::agnocast_wrapper::Publisher<MessageT>::SharedPtr
 #define AUTOWARE_POLLING_SUBSCRIBER_PTR(MessageT) \
   typename autoware::agnocast_wrapper::PollingSubscriber<MessageT>::SharedPtr
+#define AUTOWARE_TIMER_PTR autoware::agnocast_wrapper::Timer::SharedPtr
 
 #define AUTOWARE_CREATE_SUBSCRIPTION(message_type, topic, qos, callback, options) \
   autoware::agnocast_wrapper::create_subscription<message_type>(this, topic, qos, callback, options)
@@ -727,16 +732,108 @@ typename Publisher<MessageT>::SharedPtr create_publisher(
   }
 }
 
+class Timer
+{
+public:
+  using SharedPtr = std::shared_ptr<Timer>;
+  virtual ~Timer() = default;
+
+  virtual void cancel() = 0;
+  virtual void reset() = 0;
+  virtual bool is_canceled() const = 0;
+  virtual std::chrono::nanoseconds time_until_trigger() const = 0;
+
+private:
+  // Private so callers must use the free set_period() function, which also works in the
+  // non-agnocast build (where AUTOWARE_TIMER_PTR is a plain rclcpp::TimerBase, no set_period).
+  virtual void set_period(std::chrono::nanoseconds period) = 0;
+  friend void set_period(const SharedPtr & timer, std::chrono::nanoseconds period);
+};
+
+class AgnocastTimer : public Timer
+{
+  std::shared_ptr<agnocast::TimerBase> timer_;
+
+public:
+  explicit AgnocastTimer(std::shared_ptr<agnocast::TimerBase> timer) : timer_(std::move(timer)) {}
+
+  void cancel() override { timer_->cancel(); }
+  void reset() override { timer_->reset(); }
+  bool is_canceled() const override { return timer_->is_canceled(); }
+  std::chrono::nanoseconds time_until_trigger() const override
+  {
+    return timer_->time_until_trigger();
+  }
+
+private:
+  void set_period(std::chrono::nanoseconds period) override { timer_->set_period(period); }
+};
+
+class ROS2Timer : public Timer
+{
+  rclcpp::TimerBase::SharedPtr timer_;
+
+public:
+  explicit ROS2Timer(rclcpp::TimerBase::SharedPtr timer) : timer_(std::move(timer)) {}
+
+  void cancel() override { timer_->cancel(); }
+  void reset() override { timer_->reset(); }
+  bool is_canceled() const override { return timer_->is_canceled(); }
+  std::chrono::nanoseconds time_until_trigger() const override
+  {
+    return timer_->time_until_trigger();
+  }
+
+private:
+  // rclcpp::TimerBase does not expose a set_period API; fall back to the rcl C API and
+  // convert the rcl_ret_t to an rclcpp::exceptions::RCLError (matching the throw style used
+  // by the other rclcpp timer methods such as cancel/reset/time_until_trigger).
+  void set_period(std::chrono::nanoseconds period) override
+  {
+    int64_t old_period = 0;
+    const rcl_ret_t ret =
+      rcl_timer_exchange_period(timer_->get_timer_handle().get(), period.count(), &old_period);
+    if (ret != RCL_RET_OK) {
+      rclcpp::exceptions::throw_from_rcl_error(ret, "Failed to set timer period");
+    }
+  }
+};
+
+inline void set_period(const Timer::SharedPtr & timer, std::chrono::nanoseconds period)
+{
+  timer->set_period(period);
+}
+
 }  // namespace autoware::agnocast_wrapper
 
 #else
 
 #include "autoware_utils_rclcpp/polling_subscriber.hpp"
 
+#include <rclcpp/exceptions/exceptions.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <rcl/timer.h>
+
+#include <chrono>
 #include <memory>
 #include <type_traits>
+
+namespace autoware::agnocast_wrapper
+{
+
+// rclcpp::TimerBase has no set_period API; fall back to the rcl C API.
+inline void set_period(const rclcpp::TimerBase::SharedPtr & timer, std::chrono::nanoseconds period)
+{
+  int64_t old_period = 0;
+  const rcl_ret_t ret =
+    rcl_timer_exchange_period(timer->get_timer_handle().get(), period.count(), &old_period);
+  if (ret != RCL_RET_OK) {
+    rclcpp::exceptions::throw_from_rcl_error(ret, "Failed to set timer period");
+  }
+}
+
+}  // namespace autoware::agnocast_wrapper
 
 #define AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) std::unique_ptr<MessageT>
 // For publisher (mutable message)
@@ -747,6 +844,7 @@ typename Publisher<MessageT>::SharedPtr create_publisher(
 #define AUTOWARE_PUBLISHER_PTR(MessageT) typename rclcpp::Publisher<MessageT>::SharedPtr
 #define AUTOWARE_POLLING_SUBSCRIBER_PTR(MessageT) \
   typename autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT>::SharedPtr
+#define AUTOWARE_TIMER_PTR rclcpp::TimerBase::SharedPtr
 
 #define AUTOWARE_CREATE_SUBSCRIPTION(message_type, topic, qos, callback, options) \
   this->create_subscription<message_type>(topic, qos, callback, options)

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -345,7 +345,7 @@ Timer::SharedPtr create_timer(
   Node * node, rclcpp::Clock::SharedPtr clock, rclcpp::Duration period, CallbackT && callback,
   rclcpp::CallbackGroup::SharedPtr group = nullptr)
 {
-  if (node->is_using_agnocast()) {
+  if (use_agnocast()) {
     return std::make_shared<AgnocastTimer>(agnocast::create_timer(
       node->get_agnocast_node().get(), clock, period, std::forward<CallbackT>(callback), group));
   }

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -20,6 +20,7 @@
 
 #include <rclcpp/version.h>
 
+#include <chrono>
 #include <map>
 #include <memory>
 #include <stdexcept>
@@ -248,6 +249,24 @@ public:
       topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)));
   }
 
+  // ===== Timer =====
+  template <typename DurationRepT = int64_t, typename DurationT = std::milli, typename CallbackT>
+  Timer::SharedPtr create_wall_timer(
+    std::chrono::duration<DurationRepT, DurationT> period, CallbackT && callback,
+    rclcpp::CallbackGroup::SharedPtr group = nullptr)
+  {
+    return visit_node([&](auto & n) -> Timer::SharedPtr {
+      using NodeT = std::decay_t<decltype(*n)>;
+      if constexpr (std::is_same_v<NodeT, agnocast::Node>) {
+        return std::make_shared<AgnocastTimer>(
+          n->create_wall_timer(period, std::forward<CallbackT>(callback), group));
+      } else {
+        return std::make_shared<ROS2Timer>(
+          n->create_wall_timer(period, std::forward<CallbackT>(callback), group));
+      }
+    });
+  }
+
   // ===== Internal node access (for Executor) =====
   // Callers must check is_using_agnocast() before calling get_agnocast_node()/get_rclcpp_node().
   // Accessing the inactive variant will throw std::runtime_error.
@@ -303,6 +322,19 @@ std::shared_ptr<rclcpp::Node> to_rclcpp_node(const std::shared_ptr<T> & node)
   return node->get_rclcpp_node();
 }
 
+template <typename CallbackT>
+Timer::SharedPtr create_timer(
+  Node * node, rclcpp::Clock::SharedPtr clock, rclcpp::Duration period, CallbackT && callback,
+  rclcpp::CallbackGroup::SharedPtr group = nullptr)
+{
+  if (node->is_using_agnocast()) {
+    return std::make_shared<AgnocastTimer>(agnocast::create_timer(
+      node->get_agnocast_node().get(), clock, period, std::forward<CallbackT>(callback), group));
+  }
+  return std::make_shared<ROS2Timer>(rclcpp::create_timer(
+    node->get_rclcpp_node().get(), clock, period, std::forward<CallbackT>(callback), group));
+}
+
 }  // namespace autoware::agnocast_wrapper
 
 #else
@@ -317,6 +349,14 @@ template <typename T>
 std::shared_ptr<rclcpp::Node> to_rclcpp_node(const std::shared_ptr<T> & node)
 {
   return node;
+}
+
+template <typename CallbackT>
+rclcpp::TimerBase::SharedPtr create_timer(
+  Node * node, rclcpp::Clock::SharedPtr clock, rclcpp::Duration period, CallbackT && callback,
+  rclcpp::CallbackGroup::SharedPtr group = nullptr)
+{
+  return rclcpp::create_timer(node, clock, period, std::forward<CallbackT>(callback), group);
 }
 
 }  // namespace autoware::agnocast_wrapper

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -322,6 +322,12 @@ std::shared_ptr<rclcpp::Node> to_rclcpp_node(const std::shared_ptr<T> & node)
   return node->get_rclcpp_node();
 }
 
+/// @brief Create a timer driven by an explicit clock.
+///
+/// Provided as a free function rather than a Node member because
+/// rclcpp::Node::create_timer was added in Jazzy and does not exist on Humble;
+/// the free rclcpp::create_timer() is available on both. Mirrors the
+/// non-Agnocast-build overload so the same call site works in both builds.
 template <typename CallbackT>
 Timer::SharedPtr create_timer(
   Node * node, rclcpp::Clock::SharedPtr clock, rclcpp::Duration period, CallbackT && callback,
@@ -351,6 +357,11 @@ std::shared_ptr<rclcpp::Node> to_rclcpp_node(const std::shared_ptr<T> & node)
   return node;
 }
 
+/// @brief Create a timer driven by an explicit clock (non-Agnocast build).
+///
+/// Provided as a free function rather than a Node member because
+/// rclcpp::Node::create_timer was added in Jazzy and does not exist on Humble;
+/// the free rclcpp::create_timer() is available on both.
 template <typename CallbackT>
 rclcpp::TimerBase::SharedPtr create_timer(
   Node * node, rclcpp::Clock::SharedPtr clock, rclcpp::Duration period, CallbackT && callback,


### PR DESCRIPTION
## Description
Add timer support to `autoware_agnocast_wrapper`, so nodes can create timers that switch between rclcpp and Agnocast at runtime.

### Added API
  - `Timer` — type-erased timer handle (`Timer::SharedPtr`), backed by `AgnocastTimer` / `ROS2Timer`; exposes `cancel` / `reset` / `is_canceled` / `set_period` / `time_until_trigger`.
  - `Node::create_wall_timer(...)` — member functions.
  - `create_timer(Node *, clock, period, callback, group)` — free function.

### Background: timer API availability
  | API form | ROS 2 Humble | ROS 2 Jazzy | agnocast |
  |---|---|---|---|
  | `create_timer` member function (`Node::`) | ❌ | ✅ | ✅ |
  | `create_timer` free function | ✅ | ✅ | ✅ |
  | `create_wall_timer` member function (`Node::`) | ✅ | ✅ | ✅ |
  | `create_wall_timer` free function | ⚠️  | ⚠️  | ❌ |

  ⚠️  = only the `create_wall_timer(period, callback, group, node_base*, node_timers*)` form exists; no overload takes a node directly.

### Design rationale
  **`create_timer` is a free function**, not a `Node` member: `rclcpp::Node::create_timer` does not exist in Humble (added in Jazzy), so a member function would fail to compile against Humble. The `rclcpp::create_timer` free function exists on all distributions. Since `create_timer` member function isn't used in Autoware currently, skipped to support in this wrapper.

  **`create_wall_timer` is a member function**: `rclcpp::Node::create_wall_timer` exists on both Humble and Jazzy, and there is no node-taking `create_wall_timer` free function in rclcpp or agnocast to mirror.

  **`set_period` is a free function, and the wrapper `Timer`'s `set_period` method is `private`**: in the non-agnocast build `AUTOWARE_TIMER_PTR` is `rclcpp::TimerBase::SharedPtr`, and `rclcpp::TimerBase` has no `set_period` API. If `set_period` were a public method on the wrapper `Timer`, `timer->set_period(...)` would compile in the Agnocast build but fail in the non-agnocast build. Making the method `private` removes that footgun.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
