### PR TITLE
feat(autoware_agnocast_wrapper): introduce `ExactTime` for message_filter

### DIFF
--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -183,11 +183,11 @@ autoware_agnocast_wrapper_setup(target)
 
 ## Message Filters Support
 
-This package provides wrapper types for `message_filters` (`Subscriber`, `Synchronizer`, `ApproximateTimeSynchronizer`) in the `autoware::agnocast_wrapper::message_filters` namespace. These wrappers transparently switch between `::message_filters` and `agnocast::message_filters` at runtime.
+This package provides wrapper types for `message_filters` (`Subscriber`, `Synchronizer`, `ApproximateTimeSynchronizer`, `ExactTimeSynchronizer`) in the `autoware::agnocast_wrapper::message_filters` namespace. These wrappers transparently switch between `::message_filters` and `agnocast::message_filters` at runtime.
 
 ### Current limitations
 
-- Only `ApproximateTime` synchronization policy is supported (no `ExactTime`).
+- Only `ApproximateTime` and `ExactTime` synchronization policies are supported.
 - Maximum 2 message types per `Synchronizer`.
 - `connectInput()` is not supported; pass `Subscriber` references at construction time.
 
@@ -230,6 +230,7 @@ void onSynchronized(
 | `message_filters::Subscriber<M>`                          | `autoware::agnocast_wrapper::message_filters::Subscriber<M>`                          |
 | `message_filters::Synchronizer<Policy>`                   | `autoware::agnocast_wrapper::message_filters::Synchronizer<Policy>`                   |
 | `message_filters::sync_policies::ApproximateTime<M0, M1>` | `autoware::agnocast_wrapper::message_filters::sync_policies::ApproximateTime<M0, M1>` |
+| `message_filters::sync_policies::ExactTime<M0, M1>`       | `autoware::agnocast_wrapper::message_filters::sync_policies::ExactTime<M0, M1>`       |
 
 ## How to Enable/Disable Agnocast on Build
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -287,7 +287,8 @@ class Synchronizer<sync_policies::ApproximateTime<M0, M1>>
 {
 public:
   Synchronizer(
-    sync_policies::ApproximateTime<M0, M1> policy, Subscriber<M0> & sub0, Subscriber<M1> & sub1)
+    const sync_policies::ApproximateTime<M0, M1> & policy, Subscriber<M0> & sub0,
+    Subscriber<M1> & sub1)
   : ApproximateTimeSynchronizer<M0, M1>(policy.queue_size, sub0, sub1)
   {
   }
@@ -298,7 +299,7 @@ class Synchronizer<sync_policies::ExactTime<M0, M1>> : public ExactTimeSynchroni
 {
 public:
   Synchronizer(
-    sync_policies::ExactTime<M0, M1> policy, Subscriber<M0> & sub0, Subscriber<M1> & sub1)
+    const sync_policies::ExactTime<M0, M1> & policy, Subscriber<M0> & sub0, Subscriber<M1> & sub1)
   : ExactTimeSynchronizer<M0, M1>(policy.queue_size, sub0, sub1)
   {
   }

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -111,7 +111,8 @@ private:
 /// @tparam RclcppPolicy   ::message_filters sync policy type used when running on rclcpp
 ///                        (e.g. ::message_filters::sync_policies::ApproximateTime<M0, M1>).
 /// @tparam AgnocastPolicy agnocast::message_filters sync policy type used when running on
-///                        agnocast (e.g. agnocast::message_filters::sync_policies::ExactTime<M0, M1>).
+///                        agnocast (e.g. agnocast::message_filters::sync_policies::ExactTime<M0,
+///                        M1>).
 /// @tparam M0             First message type to synchronize.
 /// @tparam M1             Second message type to synchronize.
 template <typename RclcppPolicy, typename AgnocastPolicy, typename M0, typename M1>

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -131,8 +131,6 @@ private:
 /// //   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::Image) & img,
 /// //   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::CameraInfo) & info);
 /// @endcode
-namespace detail
-{
 /// @brief Common synchronizer wrapper parameterized by the underlying policy types.
 ///
 /// Both ApproximateTime and ExactTime variants are obtained as `using` aliases of this
@@ -204,10 +202,9 @@ private:
 
   std::variant<RclcppSync, AgnocastSync> sync_;
 };
-}  // namespace detail
 
 template <typename M0, typename M1>
-using ApproximateTimeSynchronizer = detail::PolicySynchronizer<
+using ApproximateTimeSynchronizer = PolicySynchronizer<
   ::message_filters::sync_policies::ApproximateTime<M0, M1>,
   agnocast::message_filters::sync_policies::ApproximateTime<M0, M1>, M0, M1>;
 
@@ -216,7 +213,7 @@ using ApproximateTimeSynchronizer = detail::PolicySynchronizer<
 /// Same callback signature and zero-copy semantics as ApproximateTimeSynchronizer;
 /// only the sync policy differs (messages must share identical timestamps).
 template <typename M0, typename M1>
-using ExactTimeSynchronizer = detail::PolicySynchronizer<
+using ExactTimeSynchronizer = PolicySynchronizer<
   ::message_filters::sync_policies::ExactTime<M0, M1>,
   agnocast::message_filters::sync_policies::ExactTime<M0, M1>, M0, M1>;
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -101,6 +101,19 @@ private:
 
 /// @brief Common synchronizer wrapper parameterized by the underlying policy types.
 ///        Use through ApproximateTimeSynchronizer or ExactTimeSynchronizer.
+///
+/// At construction, use_agnocast() selects which backend synchronizer to instantiate
+/// inside the internal std::variant; the choice is fixed for the wrapper's lifetime
+/// and all subsequent calls (e.g. registerCallback) are dispatched via std::visit to
+/// the active backend. To add a third policy, instantiate this template with the
+/// corresponding rclcpp and agnocast policy types.
+///
+/// @tparam RclcppPolicy   ::message_filters sync policy type used when running on rclcpp
+///                        (e.g. ::message_filters::sync_policies::ApproximateTime<M0, M1>).
+/// @tparam AgnocastPolicy agnocast::message_filters sync policy type used when running on
+///                        agnocast (e.g. agnocast::message_filters::sync_policies::ExactTime<M0, M1>).
+/// @tparam M0             First message type to synchronize.
+/// @tparam M1             Second message type to synchronize.
 template <typename RclcppPolicy, typename AgnocastPolicy, typename M0, typename M1>
 class PolicySynchronizer
 {
@@ -210,6 +223,8 @@ using ApproximateTimeSynchronizer = PolicySynchronizer<
 ///
 /// Same callback signature and zero-copy semantics as ApproximateTimeSynchronizer;
 /// only the sync policy differs (messages must share identical timestamps).
+/// @note Subject to the same limitations as ApproximateTimeSynchronizer
+///       (max 2 message types, connectInput() not supported).
 /// @see ApproximateTimeSynchronizer for a usage example.
 template <typename M0, typename M1>
 using ExactTimeSynchronizer = PolicySynchronizer<
@@ -223,17 +238,35 @@ using ExactTimeSynchronizer = PolicySynchronizer<
 ///          sync = std::make_shared<Sync>(SyncPolicy(10), sub0, sub1);
 namespace sync_policies
 {
+/// @brief Wrapper-layer ApproximateTime policy tag.
+///
+/// Carries only the queue size; the underlying rclcpp/agnocast policy is selected
+/// inside Synchronizer<ApproximateTime<M0, M1>>. Distinct from
+/// ::message_filters::sync_policies::ApproximateTime and
+/// agnocast::message_filters::sync_policies::ApproximateTime.
+///
+/// @tparam M0 First message type to synchronize.
+/// @tparam M1 Second message type to synchronize.
 template <typename M0, typename M1>
 struct ApproximateTime
 {
-  uint32_t queue_size;
+  uint32_t queue_size;  ///< Queue size forwarded to the underlying sync policy.
   explicit ApproximateTime(uint32_t qs) : queue_size(qs) {}
 };
 
+/// @brief Wrapper-layer ExactTime policy tag.
+///
+/// Carries only the queue size; the underlying rclcpp/agnocast policy is selected
+/// inside Synchronizer<ExactTime<M0, M1>>. Distinct from
+/// ::message_filters::sync_policies::ExactTime and
+/// agnocast::message_filters::sync_policies::ExactTime.
+///
+/// @tparam M0 First message type to synchronize.
+/// @tparam M1 Second message type to synchronize.
 template <typename M0, typename M1>
 struct ExactTime
 {
-  uint32_t queue_size;
+  uint32_t queue_size;  ///< Queue size forwarded to the underlying sync policy.
   explicit ExactTime(uint32_t qs) : queue_size(qs) {}
 };
 }  // namespace sync_policies

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -251,7 +251,7 @@ template <typename M0, typename M1>
 struct ApproximateTime
 {
   uint32_t queue_size;  ///< Queue size forwarded to the underlying sync policy.
-  explicit ApproximateTime(uint32_t qs) : queue_size(qs) {}
+  explicit ApproximateTime(uint32_t qs) noexcept : queue_size(qs) {}
 };
 
 /// @brief Wrapper-layer ExactTime policy tag.
@@ -267,7 +267,7 @@ template <typename M0, typename M1>
 struct ExactTime
 {
   uint32_t queue_size;  ///< Queue size forwarded to the underlying sync policy.
-  explicit ExactTime(uint32_t qs) : queue_size(qs) {}
+  explicit ExactTime(uint32_t qs) noexcept : queue_size(qs) {}
 };
 }  // namespace sync_policies
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -131,14 +131,20 @@ private:
 /// //   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::Image) & img,
 /// //   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::CameraInfo) & info);
 /// @endcode
-template <typename M0, typename M1>
-class ApproximateTimeSynchronizer
+namespace detail
+{
+/// @brief Common synchronizer wrapper parameterized by the underlying policy types.
+///
+/// Both ApproximateTime and ExactTime variants are obtained as `using` aliases of this
+/// template. Only the policy / synchronizer typedefs differ between them.
+template <typename RclcppPolicy, typename AgnocastPolicy, typename M0, typename M1>
+class PolicySynchronizer
 {
 public:
   using Callback = std::function<void(
     const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0) &, const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1) &)>;
 
-  ApproximateTimeSynchronizer(uint32_t queue_size, Subscriber<M0> & sub0, Subscriber<M1> & sub1)
+  PolicySynchronizer(uint32_t queue_size, Subscriber<M0> & sub0, Subscriber<M1> & sub1)
   : sync_(
       use_agnocast() ? decltype(sync_)(
                          std::in_place_type<AgnocastSync>, AgnocastPolicy(queue_size),
@@ -151,8 +157,8 @@ public:
 
   // Non-movable: registerCallback() passes `this` to the internal synchronizer, so the
   // wrapper's address must remain stable for the lifetime of the internal synchronizer.
-  ApproximateTimeSynchronizer(ApproximateTimeSynchronizer &&) = delete;
-  ApproximateTimeSynchronizer & operator=(ApproximateTimeSynchronizer &&) = delete;
+  PolicySynchronizer(PolicySynchronizer &&) = delete;
+  PolicySynchronizer & operator=(PolicySynchronizer &&) = delete;
 
   void registerCallback(Callback callback)
   {
@@ -161,9 +167,9 @@ public:
       [this](auto & sync) {
         using SyncT = std::decay_t<decltype(sync)>;
         if constexpr (std::is_same_v<SyncT, AgnocastSync>) {
-          sync.registerCallback(&ApproximateTimeSynchronizer::agnocastCallbackAdapter, this);
+          sync.registerCallback(&PolicySynchronizer::agnocastCallbackAdapter, this);
         } else {
-          sync.registerCallback(&ApproximateTimeSynchronizer::rclcppCallbackAdapter, this);
+          sync.registerCallback(&PolicySynchronizer::rclcppCallbackAdapter, this);
         }
       },
       sync_);
@@ -193,88 +199,26 @@ private:
     stored_callback_(p0, p1);
   }
 
-  using RclcppPolicy = ::message_filters::sync_policies::ApproximateTime<M0, M1>;
   using RclcppSync = ::message_filters::Synchronizer<RclcppPolicy>;
-
-  using AgnocastPolicy = agnocast::message_filters::sync_policies::ApproximateTime<M0, M1>;
   using AgnocastSync = agnocast::message_filters::Synchronizer<AgnocastPolicy>;
 
   std::variant<RclcppSync, AgnocastSync> sync_;
 };
+}  // namespace detail
+
+template <typename M0, typename M1>
+using ApproximateTimeSynchronizer = detail::PolicySynchronizer<
+  ::message_filters::sync_policies::ApproximateTime<M0, M1>,
+  agnocast::message_filters::sync_policies::ApproximateTime<M0, M1>, M0, M1>;
 
 /// @brief Wrapper ExactTime Synchronizer mirroring ApproximateTimeSynchronizer.
 ///
 /// Same callback signature and zero-copy semantics as ApproximateTimeSynchronizer;
 /// only the sync policy differs (messages must share identical timestamps).
 template <typename M0, typename M1>
-class ExactTimeSynchronizer
-{
-public:
-  using Callback = std::function<void(
-    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0) &, const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1) &)>;
-
-  ExactTimeSynchronizer(uint32_t queue_size, Subscriber<M0> & sub0, Subscriber<M1> & sub1)
-  : sync_(
-      use_agnocast() ? decltype(sync_)(
-                         std::in_place_type<AgnocastSync>, AgnocastPolicy(queue_size),
-                         sub0.agnocast_subscriber(), sub1.agnocast_subscriber())
-                     : decltype(sync_)(
-                         std::in_place_type<RclcppSync>, RclcppPolicy(queue_size),
-                         sub0.rclcpp_subscriber(), sub1.rclcpp_subscriber()))
-  {
-  }
-
-  // Non-movable: registerCallback() passes `this` to the internal synchronizer, so the
-  // wrapper's address must remain stable for the lifetime of the internal synchronizer.
-  ExactTimeSynchronizer(ExactTimeSynchronizer &&) = delete;
-  ExactTimeSynchronizer & operator=(ExactTimeSynchronizer &&) = delete;
-
-  void registerCallback(Callback callback)
-  {
-    stored_callback_ = std::move(callback);
-    std::visit(
-      [this](auto & sync) {
-        using SyncT = std::decay_t<decltype(sync)>;
-        if constexpr (std::is_same_v<SyncT, AgnocastSync>) {
-          sync.registerCallback(&ExactTimeSynchronizer::agnocastCallbackAdapter, this);
-        } else {
-          sync.registerCallback(&ExactTimeSynchronizer::rclcppCallbackAdapter, this);
-        }
-      },
-      sync_);
-  }
-
-private:
-  Callback stored_callback_;
-
-  using M0Event = agnocast::message_filters::MessageEvent<const M0>;
-  using M1Event = agnocast::message_filters::MessageEvent<const M1>;
-
-  void agnocastCallbackAdapter(const M0Event & e0, const M1Event & e1)
-  {
-    const auto p0 =
-      AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)(agnocast::ipc_shared_ptr<const M0>(e0.getMessage()));
-    const auto p1 =
-      AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)(agnocast::ipc_shared_ptr<const M1>(e1.getMessage()));
-    stored_callback_(p0, p1);
-  }
-
-  void rclcppCallbackAdapter(
-    const typename M0::ConstSharedPtr & m0, const typename M1::ConstSharedPtr & m1)
-  {
-    const auto p0 = AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)(std::shared_ptr<const M0>(m0));
-    const auto p1 = AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)(std::shared_ptr<const M1>(m1));
-    stored_callback_(p0, p1);
-  }
-
-  using RclcppPolicy = ::message_filters::sync_policies::ExactTime<M0, M1>;
-  using RclcppSync = ::message_filters::Synchronizer<RclcppPolicy>;
-
-  using AgnocastPolicy = agnocast::message_filters::sync_policies::ExactTime<M0, M1>;
-  using AgnocastSync = agnocast::message_filters::Synchronizer<AgnocastPolicy>;
-
-  std::variant<RclcppSync, AgnocastSync> sync_;
-};
+using ExactTimeSynchronizer = detail::PolicySynchronizer<
+  ::message_filters::sync_policies::ExactTime<M0, M1>,
+  agnocast::message_filters::sync_policies::ExactTime<M0, M1>, M0, M1>;
 
 /// @brief Policy and Synchronizer types that mirror the rclcpp message_filters API.
 ///        Allows node code to use the same pattern as rclcpp:

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -19,6 +19,7 @@
 
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
+#include <message_filters/sync_policies/exact_time.h>
 #include <message_filters/synchronizer.h>
 
 #include <functional>
@@ -32,6 +33,7 @@
 
 #include <agnocast/message_filters/subscriber.hpp>
 #include <agnocast/message_filters/sync_policies/approximate_time.hpp>
+#include <agnocast/message_filters/sync_policies/exact_time.hpp>
 #include <agnocast/message_filters/synchronizer.hpp>
 
 namespace autoware::agnocast_wrapper
@@ -88,7 +90,8 @@ public:
     std::visit([](auto & sub) { sub.unsubscribe(); }, sub_);
   }
 
-  // Internal API: used by ApproximateTimeSynchronizer. Not intended for downstream use.
+  // Internal API: used by ApproximateTimeSynchronizer / ExactTimeSynchronizer.
+  // Not intended for downstream use.
   RclcppSubscriber & rclcpp_subscriber() { return std::get<RclcppSubscriber>(sub_); }
   AgnocastSubscriber & agnocast_subscriber() { return std::get<AgnocastSubscriber>(sub_); }
 
@@ -105,7 +108,6 @@ private:
 /// preserving zero-copy semantics during the callback lifetime.
 ///
 /// @note Current limitations:
-///   - Only ApproximateTime synchronization policy is supported (no ExactTime).
 ///   - Maximum 2 message types per Synchronizer.
 ///   - connectInput() is not supported; pass Subscriber references at construction time.
 ///
@@ -200,6 +202,80 @@ private:
   std::variant<RclcppSync, AgnocastSync> sync_;
 };
 
+/// @brief Wrapper ExactTime Synchronizer mirroring ApproximateTimeSynchronizer.
+///
+/// Same callback signature and zero-copy semantics as ApproximateTimeSynchronizer;
+/// only the sync policy differs (messages must share identical timestamps).
+template <typename M0, typename M1>
+class ExactTimeSynchronizer
+{
+public:
+  using Callback = std::function<void(
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0) &, const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1) &)>;
+
+  ExactTimeSynchronizer(uint32_t queue_size, Subscriber<M0> & sub0, Subscriber<M1> & sub1)
+  : sync_(
+      use_agnocast() ? decltype(sync_)(
+                         std::in_place_type<AgnocastSync>, AgnocastPolicy(queue_size),
+                         sub0.agnocast_subscriber(), sub1.agnocast_subscriber())
+                     : decltype(sync_)(
+                         std::in_place_type<RclcppSync>, RclcppPolicy(queue_size),
+                         sub0.rclcpp_subscriber(), sub1.rclcpp_subscriber()))
+  {
+  }
+
+  // Non-movable: registerCallback() passes `this` to the internal synchronizer, so the
+  // wrapper's address must remain stable for the lifetime of the internal synchronizer.
+  ExactTimeSynchronizer(ExactTimeSynchronizer &&) = delete;
+  ExactTimeSynchronizer & operator=(ExactTimeSynchronizer &&) = delete;
+
+  void registerCallback(Callback callback)
+  {
+    stored_callback_ = std::move(callback);
+    std::visit(
+      [this](auto & sync) {
+        using SyncT = std::decay_t<decltype(sync)>;
+        if constexpr (std::is_same_v<SyncT, AgnocastSync>) {
+          sync.registerCallback(&ExactTimeSynchronizer::agnocastCallbackAdapter, this);
+        } else {
+          sync.registerCallback(&ExactTimeSynchronizer::rclcppCallbackAdapter, this);
+        }
+      },
+      sync_);
+  }
+
+private:
+  Callback stored_callback_;
+
+  using M0Event = agnocast::message_filters::MessageEvent<const M0>;
+  using M1Event = agnocast::message_filters::MessageEvent<const M1>;
+
+  void agnocastCallbackAdapter(const M0Event & e0, const M1Event & e1)
+  {
+    const auto p0 =
+      AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)(agnocast::ipc_shared_ptr<const M0>(e0.getMessage()));
+    const auto p1 =
+      AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)(agnocast::ipc_shared_ptr<const M1>(e1.getMessage()));
+    stored_callback_(p0, p1);
+  }
+
+  void rclcppCallbackAdapter(
+    const typename M0::ConstSharedPtr & m0, const typename M1::ConstSharedPtr & m1)
+  {
+    const auto p0 = AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)(std::shared_ptr<const M0>(m0));
+    const auto p1 = AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)(std::shared_ptr<const M1>(m1));
+    stored_callback_(p0, p1);
+  }
+
+  using RclcppPolicy = ::message_filters::sync_policies::ExactTime<M0, M1>;
+  using RclcppSync = ::message_filters::Synchronizer<RclcppPolicy>;
+
+  using AgnocastPolicy = agnocast::message_filters::sync_policies::ExactTime<M0, M1>;
+  using AgnocastSync = agnocast::message_filters::Synchronizer<AgnocastPolicy>;
+
+  std::variant<RclcppSync, AgnocastSync> sync_;
+};
+
 /// @brief Policy and Synchronizer types that mirror the rclcpp message_filters API.
 ///        Allows node code to use the same pattern as rclcpp:
 ///          using SyncPolicy = sync_policies::ApproximateTime<M0, M1>;
@@ -213,16 +289,23 @@ struct ApproximateTime
   uint32_t queue_size;
   explicit ApproximateTime(uint32_t qs) : queue_size(qs) {}
 };
+
+template <typename M0, typename M1>
+struct ExactTime
+{
+  uint32_t queue_size;
+  explicit ExactTime(uint32_t qs) : queue_size(qs) {}
+};
 }  // namespace sync_policies
 
-/// @brief Primary Synchronizer template — only the ApproximateTime specialization is supported.
+/// @brief Primary Synchronizer template — supports ApproximateTime and ExactTime specializations.
 template <typename Policy>
 class Synchronizer
 {
   static_assert(
     sizeof(Policy) == 0,
-    "Only sync_policies::ApproximateTime<M0, M1> is supported. "
-    "ExactTime and policies with more than 2 message types are not implemented.");
+    "Only sync_policies::ApproximateTime<M0, M1> and sync_policies::ExactTime<M0, M1> "
+    "are supported. Policies with more than 2 message types are not implemented.");
 };
 
 template <typename M0, typename M1>
@@ -233,6 +316,17 @@ public:
   Synchronizer(
     sync_policies::ApproximateTime<M0, M1> policy, Subscriber<M0> & sub0, Subscriber<M1> & sub1)
   : ApproximateTimeSynchronizer<M0, M1>(policy.queue_size, sub0, sub1)
+  {
+  }
+};
+
+template <typename M0, typename M1>
+class Synchronizer<sync_policies::ExactTime<M0, M1>> : public ExactTimeSynchronizer<M0, M1>
+{
+public:
+  Synchronizer(
+    sync_policies::ExactTime<M0, M1> policy, Subscriber<M0> & sub0, Subscriber<M1> & sub1)
+  : ExactTimeSynchronizer<M0, M1>(policy.queue_size, sub0, sub1)
   {
   }
 };
@@ -256,10 +350,16 @@ template <typename M0, typename M1>
 using ApproximateTimeSynchronizer =
   ::message_filters::Synchronizer<::message_filters::sync_policies::ApproximateTime<M0, M1>>;
 
+template <typename M0, typename M1>
+using ExactTimeSynchronizer =
+  ::message_filters::Synchronizer<::message_filters::sync_policies::ExactTime<M0, M1>>;
+
 namespace sync_policies
 {
 template <typename M0, typename M1>
 using ApproximateTime = ::message_filters::sync_policies::ApproximateTime<M0, M1>;
+template <typename M0, typename M1>
+using ExactTime = ::message_filters::sync_policies::ExactTime<M0, M1>;
 }  // namespace sync_policies
 
 template <typename Policy>

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -99,42 +99,8 @@ private:
   std::variant<RclcppSubscriber, AgnocastSubscriber> sub_;
 };
 
-/// @brief Wrapper ApproximateTime Synchronizer that switches between
-///        rclcpp and agnocast message_filters at runtime.
-///
-/// The callback receives `(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)&,
-///                         const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)&)`.
-/// In agnocast mode, message_ptrs are created from the ipc_shared_ptrs,
-/// preserving zero-copy semantics during the callback lifetime.
-///
-/// @note Current limitations:
-///   - Maximum 2 message types per Synchronizer.
-///   - connectInput() is not supported; pass Subscriber references at construction time.
-///
-/// @code
-/// using namespace autoware::agnocast_wrapper::message_filters;
-///
-/// Subscriber<sensor_msgs::msg::Image> image_sub;
-/// Subscriber<sensor_msgs::msg::CameraInfo> info_sub;
-/// image_sub.subscribe(node, "/camera/image", rmw_qos_profile_sensor_data);
-/// info_sub.subscribe(node, "/camera/info", rmw_qos_profile_sensor_data);
-///
-/// using Policy = sync_policies::ApproximateTime<
-///     sensor_msgs::msg::Image, sensor_msgs::msg::CameraInfo>;
-/// auto sync = std::make_shared<Synchronizer<Policy>>(Policy(10), image_sub, info_sub);
-///
-/// sync->registerCallback(
-///   std::bind(&MyNode::onSynchronized, this, std::placeholders::_1, std::placeholders::_2));
-///
-/// // Where the callback method signature is:
-/// // void onSynchronized(
-/// //   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::Image) & img,
-/// //   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::CameraInfo) & info);
-/// @endcode
 /// @brief Common synchronizer wrapper parameterized by the underlying policy types.
-///
-/// Both ApproximateTime and ExactTime variants are obtained as `using` aliases of this
-/// template. Only the policy / synchronizer typedefs differ between them.
+///        Use through ApproximateTimeSynchronizer or ExactTimeSynchronizer.
 template <typename RclcppPolicy, typename AgnocastPolicy, typename M0, typename M1>
 class PolicySynchronizer
 {
@@ -203,6 +169,38 @@ private:
   std::variant<RclcppSync, AgnocastSync> sync_;
 };
 
+/// @brief Wrapper ApproximateTime Synchronizer that switches between
+///        rclcpp and agnocast message_filters at runtime.
+///
+/// The callback receives `(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)&,
+///                         const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)&)`.
+/// In agnocast mode, message_ptrs are created from the ipc_shared_ptrs,
+/// preserving zero-copy semantics during the callback lifetime.
+///
+/// @note Current limitations:
+///   - Maximum 2 message types per Synchronizer.
+///   - connectInput() is not supported; pass Subscriber references at construction time.
+///
+/// @code
+/// using namespace autoware::agnocast_wrapper::message_filters;
+///
+/// Subscriber<sensor_msgs::msg::Image> image_sub;
+/// Subscriber<sensor_msgs::msg::CameraInfo> info_sub;
+/// image_sub.subscribe(node, "/camera/image", rmw_qos_profile_sensor_data);
+/// info_sub.subscribe(node, "/camera/info", rmw_qos_profile_sensor_data);
+///
+/// using Policy = sync_policies::ApproximateTime<
+///     sensor_msgs::msg::Image, sensor_msgs::msg::CameraInfo>;
+/// auto sync = std::make_shared<Synchronizer<Policy>>(Policy(10), image_sub, info_sub);
+///
+/// sync->registerCallback(
+///   std::bind(&MyNode::onSynchronized, this, std::placeholders::_1, std::placeholders::_2));
+///
+/// // Where the callback method signature is:
+/// // void onSynchronized(
+/// //   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::Image) & img,
+/// //   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::CameraInfo) & info);
+/// @endcode
 template <typename M0, typename M1>
 using ApproximateTimeSynchronizer = PolicySynchronizer<
   ::message_filters::sync_policies::ApproximateTime<M0, M1>,
@@ -212,6 +210,7 @@ using ApproximateTimeSynchronizer = PolicySynchronizer<
 ///
 /// Same callback signature and zero-copy semantics as ApproximateTimeSynchronizer;
 /// only the sync policy differs (messages must share identical timestamps).
+/// @see ApproximateTimeSynchronizer for a usage example.
 template <typename M0, typename M1>
 using ExactTimeSynchronizer = PolicySynchronizer<
   ::message_filters::sync_policies::ExactTime<M0, M1>,


### PR DESCRIPTION
## Description
Add `ExactTime` synchronization policy support to `autoware_agnocast_wrapper::message_filters`, mirroring the existing `ApproximateTime` implementation. Previously, only `ApproximateTime` was supported and any other policy triggered a `static_assert` failure.

  ## Changes
  - New `ExactTimeSynchronizer<M0, M1>` class with the same callback signature and zero-copy semantics as `ApproximateTimeSynchronizer`.
  - New `sync_policies::ExactTime<M0, M1>` policy struct.
  - New `Synchronizer<sync_policies::ExactTime<M0, M1>>` specialization so callers can use the same `Synchronizer<Policy>` pattern as rclcpp.
  - Updated the primary `Synchronizer` `static_assert` message and removed the stale "no ExactTime" limitation note from the doc comment.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
