### PR TITLE
fix(autoware_agnocast_wrapper): fix message_filter subscriber to take agnocast_wrapper::Node

### DIFF
--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -52,18 +52,23 @@ public:
     subscribe(node, topic, qos);
   }
 
+  /// @note The backend mode is captured here and reused by unsubscribe().
+  ///       The wrapper Node's backend mode is fixed at construction and does not
+  ///       change for the lifetime of the Node, so the captured value remains valid.
   void subscribe(
     autoware::agnocast_wrapper::Node * node, const std::string & topic,
     const rmw_qos_profile_t qos = rmw_qos_profile_default)
   {
-    using_agnocast_ = node->is_using_agnocast();
-    if (using_agnocast_) {
+    const bool tmp_agnocast = node->is_using_agnocast();
+    if (tmp_agnocast) {
       agnocast_sub_.subscribe(node->get_agnocast_node().get(), topic, qos);
     } else {
       rclcpp_sub_.subscribe(node->get_rclcpp_node().get(), topic, qos);
     }
+    using_agnocast_ = tmp_agnocast;
   }
 
+  /// @note Uses the backend mode captured during the preceding subscribe() call.
   void unsubscribe()
   {
     if (using_agnocast_) {

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp"
+#include "autoware/agnocast_wrapper/node.hpp"
 
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
@@ -45,30 +46,42 @@ public:
   Subscriber() = default;
 
   Subscriber(
-    rclcpp::Node * node, const std::string & topic,
+    autoware::agnocast_wrapper::Node * node, const std::string & topic,
     const rmw_qos_profile_t qos = rmw_qos_profile_default)
   {
     subscribe(node, topic, qos);
   }
 
   void subscribe(
-    rclcpp::Node * node, const std::string & topic,
+    autoware::agnocast_wrapper::Node * node, const std::string & topic,
     const rmw_qos_profile_t qos = rmw_qos_profile_default)
   {
     if (use_agnocast()) {
-      agnocast_sub_.subscribe(node, topic, qos);
+      agnocast_sub_.subscribe(node->get_agnocast_node().get(), topic, qos);
     } else {
-      rclcpp_sub_.subscribe(node, topic, qos);
+      rclcpp_sub_.subscribe(node->get_rclcpp_node().get(), topic, qos);
+    }
+  }
+
+  void unsubscribe()
+  {
+    if (use_agnocast()) {
+      agnocast_sub_.unsubscribe();
+    } else {
+      rclcpp_sub_.unsubscribe();
     }
   }
 
   // Internal API: used by ApproximateTimeSynchronizer. Not intended for downstream use.
-  ::message_filters::Subscriber<M> & rclcpp_subscriber() { return rclcpp_sub_; }
-  agnocast::message_filters::Subscriber<M> & agnocast_subscriber() { return agnocast_sub_; }
+  ::message_filters::Subscriber<M, rclcpp::Node> & rclcpp_subscriber() { return rclcpp_sub_; }
+  agnocast::message_filters::Subscriber<M, agnocast::Node> & agnocast_subscriber()
+  {
+    return agnocast_sub_;
+  }
 
 private:
-  ::message_filters::Subscriber<M> rclcpp_sub_;
-  agnocast::message_filters::Subscriber<M> agnocast_sub_;
+  ::message_filters::Subscriber<M, rclcpp::Node> rclcpp_sub_;
+  agnocast::message_filters::Subscriber<M, agnocast::Node> agnocast_sub_;
 };
 
 /// @brief Wrapper ApproximateTime Synchronizer that switches between

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -69,6 +69,7 @@ public:
   }
 
   /// @note Uses the backend mode captured during the preceding subscribe() call.
+  ///       Calling this before subscribe() is a harmless no-op.
   void unsubscribe()
   {
     if (using_agnocast_) {

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -56,7 +56,8 @@ public:
     autoware::agnocast_wrapper::Node * node, const std::string & topic,
     const rmw_qos_profile_t qos = rmw_qos_profile_default)
   {
-    if (use_agnocast()) {
+    using_agnocast_ = node->is_using_agnocast();
+    if (using_agnocast_) {
       agnocast_sub_.subscribe(node->get_agnocast_node().get(), topic, qos);
     } else {
       rclcpp_sub_.subscribe(node->get_rclcpp_node().get(), topic, qos);
@@ -65,7 +66,7 @@ public:
 
   void unsubscribe()
   {
-    if (use_agnocast()) {
+    if (using_agnocast_) {
       agnocast_sub_.unsubscribe();
     } else {
       rclcpp_sub_.unsubscribe();
@@ -80,6 +81,7 @@ public:
   }
 
 private:
+  bool using_agnocast_ = false;
   ::message_filters::Subscriber<M, rclcpp::Node> rclcpp_sub_;
   agnocast::message_filters::Subscriber<M, agnocast::Node> agnocast_sub_;
 };

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -48,6 +48,13 @@ using OnSetParametersCallbackType =
 
 /// @brief Node wrapper class that can switch between rclcpp::Node and agnocast::Node at runtime
 /// based on the ENABLE_AGNOCAST environment variable.
+///
+/// @invariant The backend variant (rclcpp::Node or agnocast::Node) is chosen at construction
+///            and never mutates for the lifetime of the Node.
+/// @invariant `is_using_agnocast() == true`  iff `get_agnocast_node()` returns a valid
+///            shared_ptr without throwing.
+/// @invariant `is_using_agnocast() == false` iff `get_rclcpp_node()`   returns a valid
+///            shared_ptr without throwing.
 class Node
 {
 public:
@@ -251,11 +258,14 @@ public:
   // ===== Internal node access (for Executor) =====
   // Callers must check is_using_agnocast() before calling get_agnocast_node()/get_rclcpp_node().
   // Accessing the inactive variant will throw std::runtime_error.
+  // The return value is fixed for the lifetime of the Node (see class-level @invariant).
   bool is_using_agnocast() const
   {
     return std::holds_alternative<std::shared_ptr<agnocast::Node>>(node_);
   }
 
+  /// @pre `is_using_agnocast() == true`. Under this precondition, this method is guaranteed
+  ///      to return a valid non-null shared_ptr without throwing.
   /// @throws std::runtime_error if Agnocast is not enabled (check is_using_agnocast() first)
   std::shared_ptr<agnocast::Node> get_agnocast_node() const
   {
@@ -267,6 +277,8 @@ public:
       "Check is_using_agnocast() before calling this method.");
   }
 
+  /// @pre `is_using_agnocast() == false`. Under this precondition, this method is guaranteed
+  ///      to return a valid non-null shared_ptr without throwing.
   /// @throws std::runtime_error if the node is in agnocast mode (check !is_using_agnocast() first)
   std::shared_ptr<rclcpp::Node> get_rclcpp_node() const
   {


### PR DESCRIPTION
## Description
Make `agnocast_wrapper::message_filters::Subscriber` usable from nodes that inherit　`autoware::agnocast_wrapper::Node`, and expose `unsubscribe()`.

### Changes
  - `Subscriber` now takes `autoware::agnocast_wrapper::Node *` instead of `rclcpp::Node *`, and dispatches internally via `node->get_agnocast_node()` / `node->get_rclcpp_node()`.
  - Add `Subscriber::unsubscribe()`.
  - Explicitly specify `NodeType` template arguments: `::message_filters::Subscriber<M, rclcpp::Node>` and `agnocast::message_filters::Subscriber<M, agnocast::Node>`.

## Motivation
This is a bug fix. Since this feature is still unused in the autoware nodes, it hasn't come up. 
Previously the wrapper required a `rclcpp::Node *`, so nodes inheriting `autoware::agnocast_wrapper::Node` had to pass `get_rclcpp_node().get()` — which throws `std::runtime_error` in agnocast mode. The new signature lets the wrapper route to the correct underlying node in both modes, so `autoware::agnocast_wrapper::Node` inheritence work safely.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
