### PR TITLE
fix(planning): skip processing empty no_ground_pointcloud to avoid PCL warning spam

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/experimental/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/experimental/node.cpp
@@ -132,6 +132,15 @@ void BehaviorVelocityPlannerNode::onParam()
 bool BehaviorVelocityPlannerNode::processNoGroundPointCloud(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
+
+  if(msg->width == 0 || msg->height == 0) {
+    RCLCPP_INFO_SKIPFIRST_THROTTLE(
+      get_logger(), *get_clock(), logger_throttle_interval,
+      "Received empty no_ground_pointcloud, skipping processing");
+    planner_data_.no_ground_pointcloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    return true;
+  }
+
   geometry_msgs::msg::TransformStamped transform;
   try {
     transform = tf_buffer_.lookupTransform(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/experimental/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/experimental/node.cpp
@@ -132,8 +132,7 @@ void BehaviorVelocityPlannerNode::onParam()
 bool BehaviorVelocityPlannerNode::processNoGroundPointCloud(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
-
-  if(msg->width == 0 || msg->height == 0) {
+  if (msg->width == 0 || msg->height == 0) {
     RCLCPP_INFO_SKIPFIRST_THROTTLE(
       get_logger(), *get_clock(), logger_throttle_interval,
       "Received empty no_ground_pointcloud, skipping processing");

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/experimental/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/experimental/node.cpp
@@ -133,7 +133,7 @@ bool BehaviorVelocityPlannerNode::processNoGroundPointCloud(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
   if (msg->width == 0 || msg->height == 0) {
-    RCLCPP_INFO_SKIPFIRST_THROTTLE(
+    RCLCPP_DEBUG_SKIPFIRST_THROTTLE(
       get_logger(), *get_clock(), logger_throttle_interval,
       "Received empty no_ground_pointcloud, skipping processing");
     planner_data_.no_ground_pointcloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -135,7 +135,7 @@ void BehaviorVelocityPlannerNode::onParam()
 bool BehaviorVelocityPlannerNode::processNoGroundPointCloud(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
-  if(msg->width == 0 || msg->height == 0) {
+  if (msg->width == 0 || msg->height == 0) {
     RCLCPP_INFO_SKIPFIRST_THROTTLE(
       get_logger(), *get_clock(), logger_throttle_interval,
       "Received empty no_ground_pointcloud, skipping processing");

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -135,6 +135,14 @@ void BehaviorVelocityPlannerNode::onParam()
 bool BehaviorVelocityPlannerNode::processNoGroundPointCloud(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
+  if(msg->width == 0 || msg->height == 0) {
+    RCLCPP_INFO_SKIPFIRST_THROTTLE(
+      get_logger(), *get_clock(), logger_throttle_interval,
+      "Received empty no_ground_pointcloud, skipping processing");
+    planner_data_.no_ground_pointcloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    return true;
+  }
+
   geometry_msgs::msg::TransformStamped transform;
   try {
     transform = tf_buffer_.lookupTransform(

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/src/node.cpp
@@ -136,7 +136,7 @@ bool BehaviorVelocityPlannerNode::processNoGroundPointCloud(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
   if (msg->width == 0 || msg->height == 0) {
-    RCLCPP_INFO_SKIPFIRST_THROTTLE(
+    RCLCPP_DEBUG_SKIPFIRST_THROTTLE(
       get_logger(), *get_clock(), logger_throttle_interval,
       "Received empty no_ground_pointcloud, skipping processing");
     planner_data_.no_ground_pointcloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
@@ -234,6 +234,14 @@ MotionVelocityPlannerNode::process_no_ground_pointcloud(
   const bool is_pcl_time_valid = (this->get_clock()->now() - rclcpp::Time(msg->header.stamp)) <
                                  rclcpp::Duration::from_seconds(1.0);
 
+  if(msg->width == 0 || msg->height == 0) {
+    RCLCPP_INFO_SKIPFIRST_THROTTLE(
+      get_logger(), *get_clock(), 5000,  // 5 seconds
+      "Received empty no_ground_pointcloud, skipping processing");
+    planner_data_->no_ground_pointcloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>();
+    return std::nullopt;
+  }
+
   if (
     is_pcl_time_valid && tf_buffer_.canTransform("map", msg->header.frame_id, msg->header.stamp)) {
     transform = tf_buffer_.lookupTransform(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
@@ -235,7 +235,7 @@ MotionVelocityPlannerNode::process_no_ground_pointcloud(
                                  rclcpp::Duration::from_seconds(1.0);
 
   if (msg->width == 0 || msg->height == 0) {
-    RCLCPP_INFO_SKIPFIRST_THROTTLE(
+    RCLCPP_DEBUG_SKIPFIRST_THROTTLE(
       get_logger(), *get_clock(), 5000,  // 5 seconds
       "Received empty no_ground_pointcloud, skipping processing");
     planner_data_->no_ground_pointcloud = std::make_shared < pcl::PointCloud<pcl::PointXYZ>();

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
@@ -230,16 +230,22 @@ std::optional<pcl::PointCloud<pcl::PointXYZ>>
 MotionVelocityPlannerNode::process_no_ground_pointcloud(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
-  geometry_msgs::msg::TransformStamped transform;
-  const bool is_pcl_time_valid = (this->get_clock()->now() - rclcpp::Time(msg->header.stamp)) <
-                                 rclcpp::Duration::from_seconds(1.0);
 
   if (msg->width == 0 || msg->height == 0) {
     RCLCPP_DEBUG_SKIPFIRST_THROTTLE(
       get_logger(), *get_clock(), 5000,  // 5 seconds
       "Received empty no_ground_pointcloud, skipping processing");
-    return std::nullopt;
+    pcl::PointCloud<pcl::PointXYZ> pc_transformed;
+    pc_transformed.header = pcl_conversions::toPCL(msg->header);
+    pc_transformed.header.frame_id = "map";
+    return pc_transformed;
   }
+
+  geometry_msgs::msg::TransformStamped transform;
+  const bool is_pcl_time_valid = (this->get_clock()->now() - rclcpp::Time(msg->header.stamp)) <
+                                 rclcpp::Duration::from_seconds(1.0);
+
+
 
   if (
     is_pcl_time_valid && tf_buffer_.canTransform("map", msg->header.frame_id, msg->header.stamp)) {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
@@ -234,11 +234,11 @@ MotionVelocityPlannerNode::process_no_ground_pointcloud(
   const bool is_pcl_time_valid = (this->get_clock()->now() - rclcpp::Time(msg->header.stamp)) <
                                  rclcpp::Duration::from_seconds(1.0);
 
-  if(msg->width == 0 || msg->height == 0) {
+  if (msg->width == 0 || msg->height == 0) {
     RCLCPP_INFO_SKIPFIRST_THROTTLE(
       get_logger(), *get_clock(), 5000,  // 5 seconds
       "Received empty no_ground_pointcloud, skipping processing");
-    planner_data_->no_ground_pointcloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>();
+    planner_data_->no_ground_pointcloud = std::make_shared < pcl::PointCloud<pcl::PointXYZ>();
     return std::nullopt;
   }
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
@@ -230,7 +230,6 @@ std::optional<pcl::PointCloud<pcl::PointXYZ>>
 MotionVelocityPlannerNode::process_no_ground_pointcloud(
   const sensor_msgs::msg::PointCloud2::ConstSharedPtr msg)
 {
-
   if (msg->width == 0 || msg->height == 0) {
     RCLCPP_DEBUG_SKIPFIRST_THROTTLE(
       get_logger(), *get_clock(), 5000,  // 5 seconds
@@ -244,8 +243,6 @@ MotionVelocityPlannerNode::process_no_ground_pointcloud(
   geometry_msgs::msg::TransformStamped transform;
   const bool is_pcl_time_valid = (this->get_clock()->now() - rclcpp::Time(msg->header.stamp)) <
                                  rclcpp::Duration::from_seconds(1.0);
-
-
 
   if (
     is_pcl_time_valid && tf_buffer_.canTransform("map", msg->header.frame_id, msg->header.stamp)) {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/src/node.cpp
@@ -238,7 +238,6 @@ MotionVelocityPlannerNode::process_no_ground_pointcloud(
     RCLCPP_DEBUG_SKIPFIRST_THROTTLE(
       get_logger(), *get_clock(), 5000,  // 5 seconds
       "Received empty no_ground_pointcloud, skipping processing");
-    planner_data_->no_ground_pointcloud = std::make_shared < pcl::PointCloud<pcl::PointXYZ>();
     return std::nullopt;
   }
 


### PR DESCRIPTION
## Description
While executing planning simulator, the some modules has console spam messages that indicates the point cloud message is empty. 
## Related links

**Parent Issue:**

- Link: https://github.com/autowarefoundation/autoware/issues/6843#issuecomment-4213412231

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

the update tested with docker image file for jazzy and also tested with humble in my local computer.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
