### PR TITLE
feat(autoware_agnocast_wrapper): spawn agnocast_discovery_agent from launch wrapper

### DIFF
--- a/common/autoware_agnocast_wrapper/CMakeLists.txt
+++ b/common/autoware_agnocast_wrapper/CMakeLists.txt
@@ -97,4 +97,11 @@ install(
   DESTINATION share/${PROJECT_NAME}
 )
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(test_discovery_agent_launch
+    test/test_discovery_agent_launch.py
+  )
+endif()
+
 autoware_ament_auto_package()

--- a/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.py
+++ b/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.py
@@ -25,16 +25,25 @@ Provides the following launch configurations:
 - ld_preload_value: LD_PRELOAD value with heaphook prepended when Agnocast is enabled
 - container_package: resolved component container package name
 - container_executable: resolved component container executable name
+
+Side effect (when ENABLE_AGNOCAST=1): emits exactly one
+``agnocast_discovery_agent`` per ``ros2 launch`` invocation. The actual spawn
+(and its tree-wide deduplication) lives in ``discovery_agent.launch.py``, which
+this file includes.
 """
 
 import os
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription
 from launch.actions import OpaqueFunction
 from launch.actions import SetLaunchConfiguration
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import EnvironmentVariable
 from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
 
 
 def _resolve_agnocast_env(context):
@@ -83,5 +92,16 @@ def generate_launch_description():
                 default_value=EnvironmentVariable("ENABLE_AGNOCAST", default_value="0"),
             ),
             OpaqueFunction(function=_resolve_agnocast_env),
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(
+                    PathJoinSubstitution(
+                        [
+                            FindPackageShare("autoware_agnocast_wrapper"),
+                            "launch",
+                            "discovery_agent.launch.py",
+                        ]
+                    )
+                )
+            ),
         ]
     )

--- a/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.xml
+++ b/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.xml
@@ -29,4 +29,13 @@
   <let name="container_executable" value="component_container_mt" if="$(eval &quot;'$(var use_agnocast)' != '1' and '$(var use_multithread)' == 'true'&quot;)"/>
   <let name="container_executable" value="agnocast_component_container" if="$(eval &quot;'$(var use_agnocast)' == '1' and '$(var use_multithread)' != 'true'&quot;)"/>
   <let name="container_executable" value="agnocast_component_container_cie" if="$(eval &quot;'$(var use_agnocast)' == '1' and '$(var use_multithread)' == 'true'&quot;)"/>
+
+  <!--
+    Spawn the per-IPC-namespace discovery agent (a singleton) when Agnocast is
+    enabled. This file is included once per agnocast-using node, so the spawn
+    and its tree-wide deduplication live in discovery_agent.launch.py, shared
+    with the Python wrapper. That file gates on ENABLE_AGNOCAST itself, so the
+    include is unconditional here.
+  -->
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/discovery_agent.launch.py"/>
 </launch>

--- a/common/autoware_agnocast_wrapper/launch/discovery_agent.launch.py
+++ b/common/autoware_agnocast_wrapper/launch/discovery_agent.launch.py
@@ -1,0 +1,59 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Spawn exactly one ``agnocast_discovery_agent`` per ``ros2 launch`` invocation.
+
+``agnocast_env.launch.{xml,py}`` is included once per agnocast-using node, but the
+discovery agent is a per-IPC-namespace singleton — one per launch tree is enough.
+Both wrappers include this file; the guard marker lives on the ``LaunchContext``
+*globals* so deduplication works across the whole launch tree, including the
+XML -> Python include boundary.
+
+Spawns only when ``ENABLE_AGNOCAST=1`` (read from the environment directly so it
+does not depend on the including scope). The agent's own ``flock(2)`` remains the
+cross-invocation safety net for separate ``ros2 launch`` runs against the same
+IPC namespace.
+"""
+
+import os
+
+from launch import LaunchDescription
+from launch.actions import OpaqueFunction
+from launch_ros.actions import Node
+
+# Marker key on the LaunchContext globals (tree-wide, not scope-local).
+_DISCOVERY_AGENT_SPAWNED_FLAG = "_agnocast_discovery_agent_spawned"
+
+
+def _spawn_once(context):
+    if os.environ.get("ENABLE_AGNOCAST", "0") != "1":
+        return []
+    if context.get_locals_as_dict().get(_DISCOVERY_AGENT_SPAWNED_FLAG):
+        return []
+    context.extend_globals({_DISCOVERY_AGENT_SPAWNED_FLAG: True})
+    return [
+        Node(
+            package="ros2agnocast_discovery_agent",
+            executable="discovery_agent",
+            name="agnocast_discovery_agent",
+            # Pin to root: which include wins the deduplication race is arbitrary,
+            # so without this the singleton would inherit some node's namespace.
+            namespace="/",
+            output="screen",
+        ),
+    ]
+
+
+def generate_launch_description():
+    return LaunchDescription([OpaqueFunction(function=_spawn_once)])

--- a/common/autoware_agnocast_wrapper/package.xml
+++ b/common/autoware_agnocast_wrapper/package.xml
@@ -27,7 +27,11 @@
   <depend>tf2_ros</depend>
 
   <exec_depend condition="$ENABLE_AGNOCAST == 1">agnocast_components</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend condition="$ENABLE_AGNOCAST == 1">ros2agnocast_discovery_agent</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/common/autoware_agnocast_wrapper/test/test_discovery_agent_launch.py
+++ b/common/autoware_agnocast_wrapper/test/test_discovery_agent_launch.py
@@ -1,0 +1,69 @@
+# Copyright 2026 TIER IV, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for discovery_agent.launch.py's tree-wide deduplication.
+
+These exercise the spawn helper against a real ``LaunchContext`` — no agent
+executable, kmod or ``ros2 launch`` is needed.
+"""
+
+# cspell:ignore delenv
+
+import importlib.util
+import os
+
+from launch import LaunchContext
+from launch_ros.actions import Node
+import pytest
+
+
+def _load():
+    path = os.path.join(os.path.dirname(__file__), "..", "launch", "discovery_agent.launch.py")
+    spec = importlib.util.spec_from_file_location("discovery_agent_launch", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def mod():
+    return _load()
+
+
+def test_spawns_one_agent_per_launch_tree(mod, monkeypatch):
+    """Within one launch tree (shared context) only the first include spawns."""
+    monkeypatch.setenv("ENABLE_AGNOCAST", "1")
+    ctx = LaunchContext()
+    first = mod._spawn_once(ctx)
+    second = mod._spawn_once(ctx)
+    third = mod._spawn_once(ctx)
+    assert len(first) == 1
+    assert isinstance(first[0], Node)
+    assert second == []
+    assert third == []
+
+
+def test_separate_launch_trees_each_spawn(mod, monkeypatch):
+    """A fresh context (separate ros2 launch invocation) spawns again."""
+    monkeypatch.setenv("ENABLE_AGNOCAST", "1")
+    assert len(mod._spawn_once(LaunchContext())) == 1
+    assert len(mod._spawn_once(LaunchContext())) == 1
+
+
+def test_no_spawn_when_agnocast_disabled(mod, monkeypatch):
+    """Nothing is spawned unless ENABLE_AGNOCAST is exactly "1"."""
+    monkeypatch.setenv("ENABLE_AGNOCAST", "0")
+    assert mod._spawn_once(LaunchContext()) == []
+    monkeypatch.delenv("ENABLE_AGNOCAST", raising=False)
+    assert mod._spawn_once(LaunchContext()) == []


### PR DESCRIPTION
## Description

Spawn the per-IPC-namespace `agnocast_discovery_agent` from `agnocast_env.launch.{py,xml}` when `ENABLE_AGNOCAST=1`, so the cross-IPC-namespace bridge auto-generation in [`autowarefoundation/agnocast`](https://github.com/autowarefoundation/agnocast) works in Autoware without touching `autoware_launch`.

The agent is a per-IPC-namespace singleton, but the wrapper is included once per agnocast node, so a launch would otherwise start it many times. Both wrappers now include a shared `launch/discovery_agent.launch.py` that dedups **tree-wide** via `LaunchContext` globals (`extend_globals` / `get_locals_as_dict`) — unlike a `LaunchConfiguration` flag, globals are not popped per scoped `GroupAction`, so the guard survives ROS-namespace groups and the XML→Python boundary. Result: **one agent per launch tree**, pinned to `namespace="/"`, with the agent's `flock(2)` left as a cross-invocation safety net.

- No-op when `ENABLE_AGNOCAST=0` (default).
- Adds `<exec_depend condition="$ENABLE_AGNOCAST == 1">ros2agnocast_discovery_agent</exec_depend>` so the executable resolves at runtime. This package ships in Agnocast v2.3.5; until the Agnocast version referenced by Autoware is bumped to it, the `*-agnocast` rosdep job stays red (`Cannot locate rosdep definition`). This PR is intended to merge after that bump, so it is expected and not a blocker.

`agnocast_env.launch.{py,xml}` is already the single hook every agnocast node imports, so it is the natural place to spawn the agent — `autoware_launch` stays untouched.

## Limitations

- Assumes **one IPC namespace per `ros2 launch`** (true for standard Autoware). A launch that spans multiple IPC namespaces (e.g. an `unshare --ipc` prefix) gets an agent in only one of them.
- Gates on `ENABLE_AGNOCAST`, not the per-include `use_agnocast` override from [#1123](https://github.com/autowarefoundation/autoware_core/pull/1123). The documented direction (`use_agnocast:=0` while env is `1`) is fine. The reverse (`env=0` + `use_agnocast:=1`, not documented in #1123) spawns no agent for that node; impact is limited to cross-namespace bridging/observability (intra-namespace pub/sub is unaffected).

Both are removed by the per-IPC-namespace auto-start in Transitional, which ties the agent to actual Agnocast init rather than to launch args.

## Related

Depends on [`agnocast#1350`](https://github.com/autowarefoundation/agnocast/pull/1350) (the package). The agent's `flock(2)` check is [`#1353`](https://github.com/autowarefoundation/agnocast/pull/1353); a duplicate that loses the lock exits cleanly per [`#1380`](https://github.com/autowarefoundation/agnocast/pull/1380).

## Transitional

This launch-side spawn is a bootstrap. Once agnocastlib/kmod auto-starts the agent per IPC namespace (like the existing `poll_for_unlink` daemon), `discovery_agent.launch.py`, both includes, and the `<exec_depend>` can be removed.

## Testing

- [x] New pytest `test/test_discovery_agent_launch.py` (no kmod / executable / launch needed): one agent per tree, one per fresh tree, none when `ENABLE_AGNOCAST != 1`.
- [x] `pre-commit`, `ament_lint_cmake`, `ament_copyright`, `ament_xmllint`, flake8 — pass.
- [x] Runtime, with the local `ros2agnocast_discovery_agent` sourced: `ENABLE_AGNOCAST=1` single include → 1 agent + lock file; `=0` → 0. Parent launch including the wrapper **3×** (`.xml`/`.py` mix), each in a separate ROS-namespace `<group>` → **1 agent at `__ns:=/`** (guard survives scoped groups).

<details>
<summary>Manual reproduction</summary>

Prereqs: kmod loaded; `ros2agnocast_discovery_agent` built + sourced (it lives in the agnocast workspace).

```bash
# autoware_core has a stale duplicate in autoware_universe, so restrict to core.
cd ~/autoware
colcon build --packages-select autoware_agnocast_wrapper \
  --base-paths src/core/autoware_core --symlink-install
source ~/autoware/install/setup.bash
source ~/agnocast/install/setup.bash

SHARE="$(ros2 pkg prefix autoware_agnocast_wrapper)/share/autoware_agnocast_wrapper/launch"
PARENT="$(mktemp -d)/parent.launch.xml"
cat >"$PARENT" <<EOF
<launch>
  <group> <push-ros-namespace namespace="a"/> <include file="$SHARE/agnocast_env.launch.xml"/> </group>
  <group> <push-ros-namespace namespace="b"/> <include file="$SHARE/agnocast_env.launch.xml"/> </group>
  <group> <push-ros-namespace namespace="c"/> <include file="$SHARE/agnocast_env.launch.py"/> </group>
</launch>
EOF
RE='lib/ros2agnocast_discovery_agent/discovery_agent'
ENABLE_AGNOCAST=1 ros2 launch "$PARENT" & LP=$!; sleep 6; pgrep -fc "$RE"  # => 1
kill "$LP"; pkill -f "$RE"; sleep 1
ENABLE_AGNOCAST=0 ros2 launch "$PARENT" & LP=$!; sleep 6; pgrep -fc "$RE"  # => 0
kill "$LP"; pkill -f "$RE"
```

A `LaunchConfiguration` flag would re-spawn per group (3 agents); globals give 1, at `__ns:=/`.

</details>
