### PR TITLE
feat(autoware_agnocast_wrapper): introduce tf2 API

### DIFF
--- a/common/autoware_agnocast_wrapper/CMakeLists.txt
+++ b/common/autoware_agnocast_wrapper/CMakeLists.txt
@@ -7,6 +7,9 @@ autoware_package()
 find_package(rclcpp REQUIRED)
 find_package(autoware_utils_rclcpp REQUIRED)
 find_package(message_filters REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
 
 if(DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
   find_package(agnocastlib REQUIRED)
@@ -29,6 +32,9 @@ if("$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
     agnocastlib
     autoware_utils_rclcpp
     message_filters
+    geometry_msgs
+    tf2
+    tf2_ros
   )
   target_compile_definitions(${PROJECT_NAME} PUBLIC USE_AGNOCAST_ENABLED)
 else()
@@ -36,6 +42,9 @@ else()
     rclcpp
     autoware_utils_rclcpp
     message_filters
+    geometry_msgs
+    tf2
+    tf2_ros
   )
 endif()
 
@@ -46,9 +55,12 @@ ament_export_include_directories(
 ament_export_dependencies(
   autoware_utils_rclcpp
   class_loader
+  geometry_msgs
   message_filters
   rclcpp
   rclcpp_components
+  tf2
+  tf2_ros
 )
 
 if(DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -248,7 +248,8 @@ The node-taking constructors require a Method 2 node (`autoware::agnocast_wrappe
 class MyNode : public autoware::agnocast_wrapper::Node
 {
 public:
-  MyNode() : autoware::agnocast_wrapper::Node("my_node")
+  MyNode()
+  : autoware::agnocast_wrapper::Node("my_node"), tf_buffer_(this->get_clock())
   {
     // `*this` is a node derived from autoware::agnocast_wrapper::Node.
     tf_listener_ = std::make_unique<autoware::agnocast_wrapper::TransformListener>(
@@ -257,7 +258,7 @@ public:
   }
 
 private:
-  autoware::agnocast_wrapper::Buffer tf_buffer_{this->get_clock()};
+  autoware::agnocast_wrapper::Buffer tf_buffer_;
   std::unique_ptr<autoware::agnocast_wrapper::TransformListener> tf_listener_;
   std::unique_ptr<autoware::agnocast_wrapper::TransformBroadcaster> tf_broadcaster_;
 };

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -231,6 +231,51 @@ void onSynchronized(
 | `message_filters::Synchronizer<Policy>`                   | `autoware::agnocast_wrapper::message_filters::Synchronizer<Policy>`                   |
 | `message_filters::sync_policies::ApproximateTime<M0, M1>` | `autoware::agnocast_wrapper::message_filters::sync_policies::ApproximateTime<M0, M1>` |
 
+## tf2 Support
+
+This package provides wrapper types for tf2 (`TransformListener`, `TransformBroadcaster`, `StaticTransformBroadcaster`, `Buffer`) in the `autoware::agnocast_wrapper` namespace. The listener and broadcasters transparently switch between their `tf2_ros` and `agnocast` implementations at runtime, depending on whether the given node is running in Agnocast mode.
+
+The node-taking constructors require a Method 2 node (`autoware::agnocast_wrapper::Node`). This is needed because an AgnocastOnly executor does not spin a plain `tf2_ros::TransformListener` (a ROS 2 subscription); routing `/tf` through Agnocast keeps tf callbacks firing.
+
+`Buffer` aliases to `agnocast::Buffer` in Agnocast-enabled builds and `tf2_ros::Buffer` otherwise. The agnocast variant intentionally omits APIs that would silently break under an AgnocastOnly executor (currently `waitForTransform` / `setCreateTimerInterface` and the `/tf2_frames` debug service), so misuse is caught at compile time.
+
+### Usage example
+
+```cpp
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/tf2.hpp>
+
+class MyNode : public autoware::agnocast_wrapper::Node
+{
+public:
+  MyNode() : autoware::agnocast_wrapper::Node("my_node")
+  {
+    // `*this` is a node derived from autoware::agnocast_wrapper::Node.
+    tf_listener_ = std::make_unique<autoware::agnocast_wrapper::TransformListener>(
+      tf_buffer_, *this);
+    tf_broadcaster_ = std::make_unique<autoware::agnocast_wrapper::TransformBroadcaster>(*this);
+  }
+
+private:
+  autoware::agnocast_wrapper::Buffer tf_buffer_{this->get_clock()};
+  std::unique_ptr<autoware::agnocast_wrapper::TransformListener> tf_listener_;
+  std::unique_ptr<autoware::agnocast_wrapper::TransformBroadcaster> tf_broadcaster_;
+};
+```
+
+### Migration guide (from `tf2_ros`)
+
+| Before                                                | After                                                    |
+| ----------------------------------------------------- | -------------------------------------------------------- |
+| `#include <tf2_ros/transform_listener.hpp>`           | `#include <autoware/agnocast_wrapper/tf2.hpp>`           |
+| `#include <tf2_ros/buffer.hpp>`                       | `#include <autoware/agnocast_wrapper/tf2.hpp>`           |
+| `#include <tf2_ros/transform_broadcaster.hpp>`        | `#include <autoware/agnocast_wrapper/tf2.hpp>`           |
+| `#include <tf2_ros/static_transform_broadcaster.hpp>` | `#include <autoware/agnocast_wrapper/tf2.hpp>`           |
+| `tf2_ros::TransformListener`                          | `autoware::agnocast_wrapper::TransformListener`          |
+| `tf2_ros::Buffer`                                     | `autoware::agnocast_wrapper::Buffer`                     |
+| `tf2_ros::TransformBroadcaster`                       | `autoware::agnocast_wrapper::TransformBroadcaster`       |
+| `tf2_ros::StaticTransformBroadcaster`                 | `autoware::agnocast_wrapper::StaticTransformBroadcaster` |
+
 ## How to Enable/Disable Agnocast on Build
 
 To build Autoware **with** Agnocast:

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
@@ -42,7 +42,7 @@
 namespace autoware::agnocast_wrapper
 {
 
-// TODO: agnocast::Buffer currently does not implement waitForTransform, so it has no
+// TODO(Koichi98): agnocast::Buffer currently does not implement waitForTransform, so it has no
 // dependency on the agnocast executor — that lets us alias it directly here, which surfaces
 // the AgnocastOnly-safety constraint at compile time (the async API simply does not exist
 // on the wrapper type). Once waitForTransform is added, this alias must become a

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
@@ -74,8 +74,8 @@ public:
   /// forward nothing, so each backend keeps its own non-trivial option defaults.
   TransformListener(
     tf2::BufferCore & buffer, Node & node, bool spin_thread, const rclcpp::QoS & qos,
-    const rclcpp::QoS & static_qos, const agnocast::SubscriptionOptions & options,
-    const agnocast::SubscriptionOptions & static_options)
+    const rclcpp::QoS & static_qos, const AUTOWARE_SUBSCRIPTION_OPTIONS & options,
+    const AUTOWARE_SUBSCRIPTION_OPTIONS & static_options)
   : impl_(
       use_agnocast()
         ? decltype(impl_)(
@@ -141,7 +141,7 @@ public:
   }
 
   TransformBroadcaster(
-    Node & node, const rclcpp::QoS & qos, const agnocast::PublisherOptions & options)
+    Node & node, const rclcpp::QoS & qos, const AUTOWARE_PUBLISHER_OPTIONS & options)
   : impl_(
       use_agnocast()
         ? decltype(impl_)(
@@ -198,7 +198,7 @@ public:
   }
 
   StaticTransformBroadcaster(
-    Node & node, const rclcpp::QoS & qos, const agnocast::PublisherOptions & options)
+    Node & node, const rclcpp::QoS & qos, const AUTOWARE_PUBLISHER_OPTIONS & options)
   : impl_(
       use_agnocast()
         ? decltype(impl_)(
@@ -267,8 +267,8 @@ public:
 
   TransformListener(
     tf2::BufferCore & buffer, Node & node, bool spin_thread, const rclcpp::QoS & qos,
-    const rclcpp::QoS & static_qos, const rclcpp::SubscriptionOptions & options,
-    const rclcpp::SubscriptionOptions & static_options)
+    const rclcpp::QoS & static_qos, const AUTOWARE_SUBSCRIPTION_OPTIONS & options,
+    const AUTOWARE_SUBSCRIPTION_OPTIONS & static_options)
   : impl_(buffer, &node, spin_thread, qos, static_qos, options, static_options)
   {
   }
@@ -297,7 +297,7 @@ public:
   }
 
   TransformBroadcaster(
-    Node & node, const rclcpp::QoS & qos, const rclcpp::PublisherOptions & options)
+    Node & node, const rclcpp::QoS & qos, const AUTOWARE_PUBLISHER_OPTIONS & options)
   : impl_(&node, qos, options)
   {
   }
@@ -331,7 +331,7 @@ public:
   }
 
   StaticTransformBroadcaster(
-    Node & node, const rclcpp::QoS & qos, const rclcpp::PublisherOptions & options)
+    Node & node, const rclcpp::QoS & qos, const AUTOWARE_PUBLISHER_OPTIONS & options)
   : impl_(&node, qos, options)
   {
   }

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
@@ -42,6 +42,10 @@
 namespace autoware::agnocast_wrapper
 {
 
+/// @brief Buffer alias — agnocast::Buffer here, tf2_ros::Buffer in the disabled build.
+///        Unlike the listener / broadcaster wrappers, there is no runtime dispatch; the
+///        choice is fixed at build time, and agnocast::Buffer omits APIs that would break
+///        under an AgnocastOnly executor (e.g. waitForTransform) so misuse fails to compile.
 // TODO(Koichi98): agnocast::Buffer currently does not implement waitForTransform, so it has no
 // dependency on the agnocast executor — that lets us alias it directly here, which surfaces
 // the AgnocastOnly-safety constraint at compile time (the async API simply does not exist
@@ -49,7 +53,16 @@ namespace autoware::agnocast_wrapper
 // runtime-dispatched wrapper class.
 using Buffer = agnocast::Buffer;
 
-/// @brief TransformListener wrapper; requires a Method 2 node (autoware::agnocast_wrapper::Node).
+/// @brief Wrapper TransformListener that switches between tf2_ros and agnocast
+///        TransformListener implementations at runtime.
+///
+/// @invariant The backend is selected from use_agnocast() at construction and never
+///            changes, so the held impl's identity is stable for the wrapper's lifetime.
+///
+/// The node-taking constructors require a Method 2 node (autoware::agnocast_wrapper::Node)
+/// because an AgnocastOnly executor does not spin a plain tf2_ros::TransformListener; in
+/// Agnocast-enabled mode the agnocast backend must own the /tf subscription instead.
+/// See the README for a usage example.
 class TransformListener
 {
 public:
@@ -72,8 +85,10 @@ public:
   {
   }
 
-  /// @brief A separate overload, not defaulted options parameters: the no-options constructors
-  /// forward nothing, so each backend keeps its own non-trivial option defaults.
+  /// @brief Options-taking overload. Kept separate (not defaulted parameters) so the
+  ///        no-options ctor preserves each backend's own non-trivial option defaults.
+  ///        On the rclcpp path only the subset shared with agnocast::SubscriptionOptions
+  ///        is forwarded; other rclcpp fields stay at their rclcpp defaults.
   TransformListener(
     tf2::BufferCore & buffer, Node & node, bool spin_thread, const rclcpp::QoS & qos,
     const rclcpp::QoS & static_qos, const AUTOWARE_SUBSCRIPTION_OPTIONS & options,
@@ -115,6 +130,8 @@ public:
   {
   }
 
+  // Non-copyable and non-movable: matches the wrapped tf2_ros / agnocast types, which own
+  // subscriptions bound to the supplied node at construction.
   TransformListener(const TransformListener &) = delete;
   TransformListener & operator=(const TransformListener &) = delete;
   TransformListener(TransformListener &&) = delete;
@@ -124,8 +141,12 @@ private:
   std::variant<RclcppImpl, AgnocastImpl> impl_;
 };
 
-/// @brief TransformBroadcaster wrapper; requires a Method 2 node
-/// (autoware::agnocast_wrapper::Node).
+/// @brief Wrapper TransformBroadcaster that switches between tf2_ros and agnocast
+///        TransformBroadcaster implementations at runtime.
+///
+/// Same backend-fixed-at-construction guarantee as TransformListener. Requires a
+/// Method 2 node so the agnocast backend can own the /tf publisher under an
+/// AgnocastOnly executor. sendTransform() dispatches via std::visit to the active impl.
 class TransformBroadcaster
 {
 public:
@@ -145,6 +166,8 @@ public:
   {
   }
 
+  /// @brief Options-taking overload; same separate-overload rationale as TransformListener.
+  ///        Only qos_overriding_options crosses to the rclcpp side (the shared field).
   TransformBroadcaster(
     Node & node, const rclcpp::QoS & qos, const AUTOWARE_PUBLISHER_OPTIONS & options)
   : impl_(
@@ -162,6 +185,8 @@ public:
   {
   }
 
+  // Non-copyable and non-movable: matches the wrapped types, which own the /tf publisher
+  // bound to the supplied node at construction.
   TransformBroadcaster(const TransformBroadcaster &) = delete;
   TransformBroadcaster & operator=(const TransformBroadcaster &) = delete;
   TransformBroadcaster(TransformBroadcaster &&) = delete;
@@ -181,7 +206,10 @@ private:
   std::variant<RclcppImpl, AgnocastImpl> impl_;
 };
 
-/// @brief StaticTransformBroadcaster wrapper; requires a Method 2 node.
+/// @brief Wrapper StaticTransformBroadcaster mirroring TransformBroadcaster, but for
+///        /tf_static. Same backend-fixed-at-construction guarantee and Method-2-node
+///        requirement; the options-taking ctor has a Humble-specific intra-process tweak
+///        (see the inline comment on that branch).
 class StaticTransformBroadcaster
 {
 public:
@@ -201,6 +229,8 @@ public:
   {
   }
 
+  /// @brief Options-taking overload; same rationale as TransformBroadcaster's. Humble adds
+  ///        an intra-process tweak on the rclcpp side (see the #if branch below).
   StaticTransformBroadcaster(
     Node & node, const rclcpp::QoS & qos, const AUTOWARE_PUBLISHER_OPTIONS & options)
   : impl_(
@@ -225,6 +255,8 @@ public:
   {
   }
 
+  // Non-copyable and non-movable: matches the wrapped types, which own the /tf_static
+  // publisher bound to the supplied node at construction.
   StaticTransformBroadcaster(const StaticTransformBroadcaster &) = delete;
   StaticTransformBroadcaster & operator=(const StaticTransformBroadcaster &) = delete;
   StaticTransformBroadcaster(StaticTransformBroadcaster &&) = delete;

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
@@ -92,7 +92,8 @@ public:
             rclcpp::SubscriptionOptions ros2_static_options;
             ros2_static_options.callback_group = static_options.callback_group;
             ros2_static_options.qos_overriding_options = static_options.qos_overriding_options;
-            ros2_static_options.ignore_local_publications = static_options.ignore_local_publications;
+            ros2_static_options.ignore_local_publications =
+              static_options.ignore_local_publications;
             return decltype(impl_)(
               std::in_place_type<RclcppImpl>,
               std::make_unique<tf2_ros::TransformListener>(

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
@@ -1,0 +1,360 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "autoware/agnocast_wrapper/node.hpp"
+
+#include <rclcpp/qos.hpp>
+#include <tf2/buffer_core.hpp>
+#include <tf2_ros/buffer.hpp>
+#include <tf2_ros/qos.hpp>
+#include <tf2_ros/static_transform_broadcaster.hpp>
+#include <tf2_ros/transform_broadcaster.hpp>
+#include <tf2_ros/transform_listener.hpp>
+
+#include <geometry_msgs/msg/transform_stamped.hpp>
+
+#include <rclcpp/version.h>
+
+#include <memory>
+#include <variant>
+#include <vector>
+
+#ifdef USE_AGNOCAST_ENABLED
+
+#include <agnocast/node/tf2/buffer.hpp>
+#include <agnocast/node/tf2/static_transform_broadcaster.hpp>
+#include <agnocast/node/tf2/transform_broadcaster.hpp>
+#include <agnocast/node/tf2/transform_listener.hpp>
+
+namespace autoware::agnocast_wrapper
+{
+
+// TODO: agnocast::Buffer currently does not implement waitForTransform, so it has no
+// dependency on the agnocast executor — that lets us alias it directly here, which surfaces
+// the AgnocastOnly-safety constraint at compile time (the async API simply does not exist
+// on the wrapper type). Once waitForTransform is added, this alias must become a
+// runtime-dispatched wrapper class.
+using Buffer = agnocast::Buffer;
+
+/// @brief TransformListener wrapper; requires a Method 2 node (autoware::agnocast_wrapper::Node).
+class TransformListener
+{
+public:
+  TransformListener(
+    tf2::BufferCore & buffer, Node & node, bool spin_thread = true,
+    const rclcpp::QoS & qos = tf2_ros::DynamicListenerQoS(),
+    const rclcpp::QoS & static_qos = tf2_ros::StaticListenerQoS())
+  : impl_(
+      use_agnocast()
+        ? decltype(impl_)(
+            std::in_place_index<1>, std::make_unique<agnocast::TransformListener>(
+                                      buffer, *node.get_agnocast_node(), spin_thread, qos,
+                                      static_qos))
+        : decltype(impl_)(
+            std::in_place_index<0>, std::make_unique<tf2_ros::TransformListener>(
+                                      buffer, node.get_rclcpp_node().get(), spin_thread, qos,
+                                      static_qos)))
+  {
+  }
+
+  /// @brief A separate overload, not defaulted options parameters: the no-options constructors
+  /// forward nothing, so each backend keeps its own non-trivial option defaults.
+  TransformListener(
+    tf2::BufferCore & buffer, Node & node, bool spin_thread, const rclcpp::QoS & qos,
+    const rclcpp::QoS & static_qos, const agnocast::SubscriptionOptions & options,
+    const agnocast::SubscriptionOptions & static_options)
+  : impl_(
+      use_agnocast()
+        ? decltype(impl_)(
+            std::in_place_index<1>, std::make_unique<agnocast::TransformListener>(
+                                      buffer, *node.get_agnocast_node(), spin_thread, qos,
+                                      static_qos, options, static_options))
+        : [&] {
+            rclcpp::SubscriptionOptions ros2_options;
+            ros2_options.callback_group = options.callback_group;
+            ros2_options.qos_overriding_options = options.qos_overriding_options;
+            rclcpp::SubscriptionOptions ros2_static_options;
+            ros2_static_options.callback_group = static_options.callback_group;
+            ros2_static_options.qos_overriding_options = static_options.qos_overriding_options;
+            return decltype(impl_)(
+              std::in_place_index<0>,
+              std::make_unique<tf2_ros::TransformListener>(
+                buffer, node.get_rclcpp_node().get(), spin_thread, qos, static_qos, ros2_options,
+                ros2_static_options));
+          }())
+  {
+  }
+
+  /// @brief Buffer-only constructor; the underlying listener creates its own node internally.
+  explicit TransformListener(tf2::BufferCore & buffer, bool spin_thread = true)
+  : impl_(
+      use_agnocast()
+        ? decltype(impl_)(
+            std::in_place_index<1>,
+            std::make_unique<agnocast::TransformListener>(buffer, spin_thread))
+        : decltype(impl_)(
+            std::in_place_index<0>,
+            std::make_unique<tf2_ros::TransformListener>(buffer, spin_thread)))
+  {
+  }
+
+  TransformListener(const TransformListener &) = delete;
+  TransformListener & operator=(const TransformListener &) = delete;
+  TransformListener(TransformListener &&) = delete;
+  TransformListener & operator=(TransformListener &&) = delete;
+
+private:
+  std::variant<
+    std::unique_ptr<tf2_ros::TransformListener>, std::unique_ptr<agnocast::TransformListener>>
+    impl_;
+};
+
+/// @brief TransformBroadcaster wrapper; requires a Method 2 node
+/// (autoware::agnocast_wrapper::Node).
+class TransformBroadcaster
+{
+public:
+  explicit TransformBroadcaster(
+    Node & node, const rclcpp::QoS & qos = tf2_ros::DynamicBroadcasterQoS())
+  : impl_(
+      use_agnocast()
+        ? decltype(impl_)(
+            std::in_place_index<1>,
+            std::make_unique<agnocast::TransformBroadcaster>(*node.get_agnocast_node(), qos))
+        : decltype(impl_)(
+            std::in_place_index<0>,
+            std::make_unique<tf2_ros::TransformBroadcaster>(node.get_rclcpp_node().get(), qos)))
+  {
+  }
+
+  TransformBroadcaster(
+    Node & node, const rclcpp::QoS & qos, const agnocast::PublisherOptions & options)
+  : impl_(
+      use_agnocast()
+        ? decltype(impl_)(
+            std::in_place_index<1>, std::make_unique<agnocast::TransformBroadcaster>(
+                                      *node.get_agnocast_node(), qos, options))
+        : [&] {
+            rclcpp::PublisherOptions ros2_options;
+            ros2_options.qos_overriding_options = options.qos_overriding_options;
+            return decltype(impl_)(
+              std::in_place_index<0>, std::make_unique<tf2_ros::TransformBroadcaster>(
+                                        node.get_rclcpp_node().get(), qos, ros2_options));
+          }())
+  {
+  }
+
+  TransformBroadcaster(const TransformBroadcaster &) = delete;
+  TransformBroadcaster & operator=(const TransformBroadcaster &) = delete;
+  TransformBroadcaster(TransformBroadcaster &&) = delete;
+  TransformBroadcaster & operator=(TransformBroadcaster &&) = delete;
+
+  void sendTransform(const geometry_msgs::msg::TransformStamped & transform)
+  {
+    std::visit([&](auto & impl) { impl->sendTransform(transform); }, impl_);
+  }
+
+  void sendTransform(const std::vector<geometry_msgs::msg::TransformStamped> & transforms)
+  {
+    std::visit([&](auto & impl) { impl->sendTransform(transforms); }, impl_);
+  }
+
+private:
+  std::variant<
+    std::unique_ptr<tf2_ros::TransformBroadcaster>,
+    std::unique_ptr<agnocast::TransformBroadcaster>>
+    impl_;
+};
+
+/// @brief StaticTransformBroadcaster wrapper; requires a Method 2 node.
+class StaticTransformBroadcaster
+{
+public:
+  explicit StaticTransformBroadcaster(
+    Node & node, const rclcpp::QoS & qos = tf2_ros::StaticBroadcasterQoS())
+  : impl_(
+      use_agnocast()
+        ? decltype(impl_)(
+            std::in_place_index<1>,
+            std::make_unique<agnocast::StaticTransformBroadcaster>(
+              *node.get_agnocast_node(), qos))
+        : decltype(impl_)(
+            std::in_place_index<0>, std::make_unique<tf2_ros::StaticTransformBroadcaster>(
+                                      node.get_rclcpp_node().get(), qos)))
+  {
+  }
+
+  StaticTransformBroadcaster(
+    Node & node, const rclcpp::QoS & qos, const agnocast::PublisherOptions & options)
+  : impl_(
+      use_agnocast()
+        ? decltype(impl_)(
+            std::in_place_index<1>, std::make_unique<agnocast::StaticTransformBroadcaster>(
+                                      *node.get_agnocast_node(), qos, options))
+        : [&] {
+            rclcpp::PublisherOptions ros2_options;
+            ros2_options.qos_overriding_options = options.qos_overriding_options;
+#if RCLCPP_VERSION_MAJOR < 28
+            // Humble: rclcpp intra-process doesn't support transient_local, so /tf_static needs
+            // it off. tf2_ros::StaticTransformBroadcaster did this in its default options
+            // pre-Jazzy; Jazzy (rclcpp 28+) removed it.
+            ros2_options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
+#endif
+            return decltype(impl_)(
+              std::in_place_index<0>, std::make_unique<tf2_ros::StaticTransformBroadcaster>(
+                                        node.get_rclcpp_node().get(), qos, ros2_options));
+          }())
+  {
+  }
+
+  StaticTransformBroadcaster(const StaticTransformBroadcaster &) = delete;
+  StaticTransformBroadcaster & operator=(const StaticTransformBroadcaster &) = delete;
+  StaticTransformBroadcaster(StaticTransformBroadcaster &&) = delete;
+  StaticTransformBroadcaster & operator=(StaticTransformBroadcaster &&) = delete;
+
+  void sendTransform(const geometry_msgs::msg::TransformStamped & transform)
+  {
+    std::visit([&](auto & impl) { impl->sendTransform(transform); }, impl_);
+  }
+
+  void sendTransform(const std::vector<geometry_msgs::msg::TransformStamped> & transforms)
+  {
+    std::visit([&](auto & impl) { impl->sendTransform(transforms); }, impl_);
+  }
+
+private:
+  std::variant<
+    std::unique_ptr<tf2_ros::StaticTransformBroadcaster>,
+    std::unique_ptr<agnocast::StaticTransformBroadcaster>>
+    impl_;
+};
+
+}  // namespace autoware::agnocast_wrapper
+
+#else
+
+namespace autoware::agnocast_wrapper
+{
+
+// Agnocast-disabled build: thin composition wrappers over the tf2_ros types. Constructor
+// signatures match the agnocast-enabled build above.
+
+using Buffer = tf2_ros::Buffer;
+
+class TransformListener
+{
+public:
+  TransformListener(
+    tf2::BufferCore & buffer, Node & node, bool spin_thread = true,
+    const rclcpp::QoS & qos = tf2_ros::DynamicListenerQoS(),
+    const rclcpp::QoS & static_qos = tf2_ros::StaticListenerQoS())
+  : impl_(buffer, &node, spin_thread, qos, static_qos)
+  {
+  }
+
+  TransformListener(
+    tf2::BufferCore & buffer, Node & node, bool spin_thread, const rclcpp::QoS & qos,
+    const rclcpp::QoS & static_qos, const rclcpp::SubscriptionOptions & options,
+    const rclcpp::SubscriptionOptions & static_options)
+  : impl_(buffer, &node, spin_thread, qos, static_qos, options, static_options)
+  {
+  }
+
+  explicit TransformListener(tf2::BufferCore & buffer, bool spin_thread = true)
+  : impl_(buffer, spin_thread)
+  {
+  }
+
+  TransformListener(const TransformListener &) = delete;
+  TransformListener & operator=(const TransformListener &) = delete;
+  TransformListener(TransformListener &&) = delete;
+  TransformListener & operator=(TransformListener &&) = delete;
+
+private:
+  tf2_ros::TransformListener impl_;
+};
+
+class TransformBroadcaster
+{
+public:
+  explicit TransformBroadcaster(
+    Node & node, const rclcpp::QoS & qos = tf2_ros::DynamicBroadcasterQoS())
+  : impl_(&node, qos)
+  {
+  }
+
+  TransformBroadcaster(
+    Node & node, const rclcpp::QoS & qos, const rclcpp::PublisherOptions & options)
+  : impl_(&node, qos, options)
+  {
+  }
+
+  TransformBroadcaster(const TransformBroadcaster &) = delete;
+  TransformBroadcaster & operator=(const TransformBroadcaster &) = delete;
+  TransformBroadcaster(TransformBroadcaster &&) = delete;
+  TransformBroadcaster & operator=(TransformBroadcaster &&) = delete;
+
+  void sendTransform(const geometry_msgs::msg::TransformStamped & transform)
+  {
+    impl_.sendTransform(transform);
+  }
+
+  void sendTransform(const std::vector<geometry_msgs::msg::TransformStamped> & transforms)
+  {
+    impl_.sendTransform(transforms);
+  }
+
+private:
+  tf2_ros::TransformBroadcaster impl_;
+};
+
+class StaticTransformBroadcaster
+{
+public:
+  explicit StaticTransformBroadcaster(
+    Node & node, const rclcpp::QoS & qos = tf2_ros::StaticBroadcasterQoS())
+  : impl_(&node, qos)
+  {
+  }
+
+  StaticTransformBroadcaster(
+    Node & node, const rclcpp::QoS & qos, const rclcpp::PublisherOptions & options)
+  : impl_(&node, qos, options)
+  {
+  }
+
+  StaticTransformBroadcaster(const StaticTransformBroadcaster &) = delete;
+  StaticTransformBroadcaster & operator=(const StaticTransformBroadcaster &) = delete;
+  StaticTransformBroadcaster(StaticTransformBroadcaster &&) = delete;
+  StaticTransformBroadcaster & operator=(StaticTransformBroadcaster &&) = delete;
+
+  void sendTransform(const geometry_msgs::msg::TransformStamped & transform)
+  {
+    impl_.sendTransform(transform);
+  }
+
+  void sendTransform(const std::vector<geometry_msgs::msg::TransformStamped> & transforms)
+  {
+    impl_.sendTransform(transforms);
+  }
+
+private:
+  tf2_ros::StaticTransformBroadcaster impl_;
+};
+
+}  // namespace autoware::agnocast_wrapper
+
+#endif

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
@@ -85,9 +85,11 @@ public:
             rclcpp::SubscriptionOptions ros2_options;
             ros2_options.callback_group = options.callback_group;
             ros2_options.qos_overriding_options = options.qos_overriding_options;
+            ros2_options.ignore_local_publications = options.ignore_local_publications;
             rclcpp::SubscriptionOptions ros2_static_options;
             ros2_static_options.callback_group = static_options.callback_group;
             ros2_static_options.qos_overriding_options = static_options.qos_overriding_options;
+            ros2_static_options.ignore_local_publications = static_options.ignore_local_publications;
             return decltype(impl_)(
               std::in_place_index<0>, std::make_unique<tf2_ros::TransformListener>(
                                         buffer, node.get_rclcpp_node().get(), spin_thread, qos,

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
@@ -61,15 +61,14 @@ public:
     const rclcpp::QoS & qos = tf2_ros::DynamicListenerQoS(),
     const rclcpp::QoS & static_qos = tf2_ros::StaticListenerQoS())
   : impl_(
-      use_agnocast()
-        ? decltype(impl_)(
-            std::in_place_type<AgnocastImpl>, std::make_unique<agnocast::TransformListener>(
-                                                buffer, *node.get_agnocast_node(), spin_thread,
-                                                qos, static_qos))
-        : decltype(impl_)(
-            std::in_place_type<RclcppImpl>, std::make_unique<tf2_ros::TransformListener>(
-                                              buffer, node.get_rclcpp_node().get(), spin_thread,
-                                              qos, static_qos)))
+      use_agnocast() ? decltype(impl_)(
+                         std::in_place_type<AgnocastImpl>,
+                         std::make_unique<agnocast::TransformListener>(
+                           buffer, *node.get_agnocast_node(), spin_thread, qos, static_qos))
+                     : decltype(impl_)(
+                         std::in_place_type<RclcppImpl>,
+                         std::make_unique<tf2_ros::TransformListener>(
+                           buffer, node.get_rclcpp_node().get(), spin_thread, qos, static_qos)))
   {
   }
 
@@ -83,8 +82,8 @@ public:
       use_agnocast()
         ? decltype(impl_)(
             std::in_place_type<AgnocastImpl>, std::make_unique<agnocast::TransformListener>(
-                                                buffer, *node.get_agnocast_node(), spin_thread,
-                                                qos, static_qos, options, static_options))
+                                                buffer, *node.get_agnocast_node(), spin_thread, qos,
+                                                static_qos, options, static_options))
         : [&] {
             rclcpp::SubscriptionOptions ros2_options;
             ros2_options.callback_group = options.callback_group;
@@ -93,10 +92,10 @@ public:
             ros2_static_options.callback_group = static_options.callback_group;
             ros2_static_options.qos_overriding_options = static_options.qos_overriding_options;
             return decltype(impl_)(
-              std::in_place_type<RclcppImpl>, std::make_unique<tf2_ros::TransformListener>(
-                                                buffer, node.get_rclcpp_node().get(), spin_thread,
-                                                qos, static_qos, ros2_options,
-                                                ros2_static_options));
+              std::in_place_type<RclcppImpl>,
+              std::make_unique<tf2_ros::TransformListener>(
+                buffer, node.get_rclcpp_node().get(), spin_thread, qos, static_qos, ros2_options,
+                ros2_static_options));
           }())
   {
   }
@@ -104,13 +103,12 @@ public:
   /// @brief Buffer-only constructor; the underlying listener creates its own node internally.
   explicit TransformListener(tf2::BufferCore & buffer, bool spin_thread = true)
   : impl_(
-      use_agnocast()
-        ? decltype(impl_)(
-            std::in_place_type<AgnocastImpl>,
-            std::make_unique<agnocast::TransformListener>(buffer, spin_thread))
-        : decltype(impl_)(
-            std::in_place_type<RclcppImpl>,
-            std::make_unique<tf2_ros::TransformListener>(buffer, spin_thread)))
+      use_agnocast() ? decltype(impl_)(
+                         std::in_place_type<AgnocastImpl>,
+                         std::make_unique<agnocast::TransformListener>(buffer, spin_thread))
+                     : decltype(impl_)(
+                         std::in_place_type<RclcppImpl>,
+                         std::make_unique<tf2_ros::TransformListener>(buffer, spin_thread)))
   {
   }
 
@@ -190,14 +188,13 @@ public:
   explicit StaticTransformBroadcaster(
     Node & node, const rclcpp::QoS & qos = tf2_ros::StaticBroadcasterQoS())
   : impl_(
-      use_agnocast() ? decltype(impl_)(
-                         std::in_place_type<AgnocastImpl>,
-                         std::make_unique<agnocast::StaticTransformBroadcaster>(
-                           *node.get_agnocast_node(), qos))
-                     : decltype(impl_)(
-                         std::in_place_type<RclcppImpl>,
-                         std::make_unique<tf2_ros::StaticTransformBroadcaster>(
-                           node.get_rclcpp_node().get(), qos)))
+      use_agnocast()
+        ? decltype(impl_)(
+            std::in_place_type<AgnocastImpl>,
+            std::make_unique<agnocast::StaticTransformBroadcaster>(*node.get_agnocast_node(), qos))
+        : decltype(impl_)(
+            std::in_place_type<RclcppImpl>, std::make_unique<tf2_ros::StaticTransformBroadcaster>(
+                                              node.get_rclcpp_node().get(), qos)))
   {
   }
 
@@ -206,8 +203,9 @@ public:
   : impl_(
       use_agnocast()
         ? decltype(impl_)(
-            std::in_place_type<AgnocastImpl>, std::make_unique<agnocast::StaticTransformBroadcaster>(
-                                                *node.get_agnocast_node(), qos, options))
+            std::in_place_type<AgnocastImpl>,
+            std::make_unique<agnocast::StaticTransformBroadcaster>(
+              *node.get_agnocast_node(), qos, options))
         : [&] {
             rclcpp::PublisherOptions ros2_options;
             ros2_options.qos_overriding_options = options.qos_overriding_options;
@@ -218,9 +216,8 @@ public:
             ros2_options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
 #endif
             return decltype(impl_)(
-              std::in_place_type<RclcppImpl>,
-              std::make_unique<tf2_ros::StaticTransformBroadcaster>(
-                node.get_rclcpp_node().get(), qos, ros2_options));
+              std::in_place_type<RclcppImpl>, std::make_unique<tf2_ros::StaticTransformBroadcaster>(
+                                                node.get_rclcpp_node().get(), qos, ros2_options));
           }())
   {
   }

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
@@ -58,15 +58,14 @@ public:
     const rclcpp::QoS & qos = tf2_ros::DynamicListenerQoS(),
     const rclcpp::QoS & static_qos = tf2_ros::StaticListenerQoS())
   : impl_(
-      use_agnocast()
-        ? decltype(impl_)(
-            std::in_place_index<1>, std::make_unique<agnocast::TransformListener>(
-                                      buffer, *node.get_agnocast_node(), spin_thread, qos,
-                                      static_qos))
-        : decltype(impl_)(
-            std::in_place_index<0>, std::make_unique<tf2_ros::TransformListener>(
-                                      buffer, node.get_rclcpp_node().get(), spin_thread, qos,
-                                      static_qos)))
+      use_agnocast() ? decltype(impl_)(
+                         std::in_place_index<1>,
+                         std::make_unique<agnocast::TransformListener>(
+                           buffer, *node.get_agnocast_node(), spin_thread, qos, static_qos))
+                     : decltype(impl_)(
+                         std::in_place_index<0>,
+                         std::make_unique<tf2_ros::TransformListener>(
+                           buffer, node.get_rclcpp_node().get(), spin_thread, qos, static_qos)))
   {
   }
 
@@ -90,10 +89,9 @@ public:
             ros2_static_options.callback_group = static_options.callback_group;
             ros2_static_options.qos_overriding_options = static_options.qos_overriding_options;
             return decltype(impl_)(
-              std::in_place_index<0>,
-              std::make_unique<tf2_ros::TransformListener>(
-                buffer, node.get_rclcpp_node().get(), spin_thread, qos, static_qos, ros2_options,
-                ros2_static_options));
+              std::in_place_index<0>, std::make_unique<tf2_ros::TransformListener>(
+                                        buffer, node.get_rclcpp_node().get(), spin_thread, qos,
+                                        static_qos, ros2_options, ros2_static_options));
           }())
   {
   }
@@ -101,13 +99,12 @@ public:
   /// @brief Buffer-only constructor; the underlying listener creates its own node internally.
   explicit TransformListener(tf2::BufferCore & buffer, bool spin_thread = true)
   : impl_(
-      use_agnocast()
-        ? decltype(impl_)(
-            std::in_place_index<1>,
-            std::make_unique<agnocast::TransformListener>(buffer, spin_thread))
-        : decltype(impl_)(
-            std::in_place_index<0>,
-            std::make_unique<tf2_ros::TransformListener>(buffer, spin_thread)))
+      use_agnocast() ? decltype(impl_)(
+                         std::in_place_index<1>,
+                         std::make_unique<agnocast::TransformListener>(buffer, spin_thread))
+                     : decltype(impl_)(
+                         std::in_place_index<0>,
+                         std::make_unique<tf2_ros::TransformListener>(buffer, spin_thread)))
   {
   }
 
@@ -130,13 +127,12 @@ public:
   explicit TransformBroadcaster(
     Node & node, const rclcpp::QoS & qos = tf2_ros::DynamicBroadcasterQoS())
   : impl_(
-      use_agnocast()
-        ? decltype(impl_)(
-            std::in_place_index<1>,
-            std::make_unique<agnocast::TransformBroadcaster>(*node.get_agnocast_node(), qos))
-        : decltype(impl_)(
-            std::in_place_index<0>,
-            std::make_unique<tf2_ros::TransformBroadcaster>(node.get_rclcpp_node().get(), qos)))
+      use_agnocast() ? decltype(impl_)(
+                         std::in_place_index<1>, std::make_unique<agnocast::TransformBroadcaster>(
+                                                   *node.get_agnocast_node(), qos))
+                     : decltype(impl_)(
+                         std::in_place_index<0>, std::make_unique<tf2_ros::TransformBroadcaster>(
+                                                   node.get_rclcpp_node().get(), qos)))
   {
   }
 
@@ -174,8 +170,7 @@ public:
 
 private:
   std::variant<
-    std::unique_ptr<tf2_ros::TransformBroadcaster>,
-    std::unique_ptr<agnocast::TransformBroadcaster>>
+    std::unique_ptr<tf2_ros::TransformBroadcaster>, std::unique_ptr<agnocast::TransformBroadcaster>>
     impl_;
 };
 
@@ -189,8 +184,7 @@ public:
       use_agnocast()
         ? decltype(impl_)(
             std::in_place_index<1>,
-            std::make_unique<agnocast::StaticTransformBroadcaster>(
-              *node.get_agnocast_node(), qos))
+            std::make_unique<agnocast::StaticTransformBroadcaster>(*node.get_agnocast_node(), qos))
         : decltype(impl_)(
             std::in_place_index<0>, std::make_unique<tf2_ros::StaticTransformBroadcaster>(
                                       node.get_rclcpp_node().get(), qos)))

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/tf2.hpp
@@ -53,19 +53,23 @@ using Buffer = agnocast::Buffer;
 class TransformListener
 {
 public:
+  using RclcppImpl = std::unique_ptr<tf2_ros::TransformListener>;
+  using AgnocastImpl = std::unique_ptr<agnocast::TransformListener>;
+
   TransformListener(
     tf2::BufferCore & buffer, Node & node, bool spin_thread = true,
     const rclcpp::QoS & qos = tf2_ros::DynamicListenerQoS(),
     const rclcpp::QoS & static_qos = tf2_ros::StaticListenerQoS())
   : impl_(
-      use_agnocast() ? decltype(impl_)(
-                         std::in_place_index<1>,
-                         std::make_unique<agnocast::TransformListener>(
-                           buffer, *node.get_agnocast_node(), spin_thread, qos, static_qos))
-                     : decltype(impl_)(
-                         std::in_place_index<0>,
-                         std::make_unique<tf2_ros::TransformListener>(
-                           buffer, node.get_rclcpp_node().get(), spin_thread, qos, static_qos)))
+      use_agnocast()
+        ? decltype(impl_)(
+            std::in_place_type<AgnocastImpl>, std::make_unique<agnocast::TransformListener>(
+                                                buffer, *node.get_agnocast_node(), spin_thread,
+                                                qos, static_qos))
+        : decltype(impl_)(
+            std::in_place_type<RclcppImpl>, std::make_unique<tf2_ros::TransformListener>(
+                                              buffer, node.get_rclcpp_node().get(), spin_thread,
+                                              qos, static_qos)))
   {
   }
 
@@ -78,9 +82,9 @@ public:
   : impl_(
       use_agnocast()
         ? decltype(impl_)(
-            std::in_place_index<1>, std::make_unique<agnocast::TransformListener>(
-                                      buffer, *node.get_agnocast_node(), spin_thread, qos,
-                                      static_qos, options, static_options))
+            std::in_place_type<AgnocastImpl>, std::make_unique<agnocast::TransformListener>(
+                                                buffer, *node.get_agnocast_node(), spin_thread,
+                                                qos, static_qos, options, static_options))
         : [&] {
             rclcpp::SubscriptionOptions ros2_options;
             ros2_options.callback_group = options.callback_group;
@@ -89,9 +93,10 @@ public:
             ros2_static_options.callback_group = static_options.callback_group;
             ros2_static_options.qos_overriding_options = static_options.qos_overriding_options;
             return decltype(impl_)(
-              std::in_place_index<0>, std::make_unique<tf2_ros::TransformListener>(
-                                        buffer, node.get_rclcpp_node().get(), spin_thread, qos,
-                                        static_qos, ros2_options, ros2_static_options));
+              std::in_place_type<RclcppImpl>, std::make_unique<tf2_ros::TransformListener>(
+                                                buffer, node.get_rclcpp_node().get(), spin_thread,
+                                                qos, static_qos, ros2_options,
+                                                ros2_static_options));
           }())
   {
   }
@@ -99,12 +104,13 @@ public:
   /// @brief Buffer-only constructor; the underlying listener creates its own node internally.
   explicit TransformListener(tf2::BufferCore & buffer, bool spin_thread = true)
   : impl_(
-      use_agnocast() ? decltype(impl_)(
-                         std::in_place_index<1>,
-                         std::make_unique<agnocast::TransformListener>(buffer, spin_thread))
-                     : decltype(impl_)(
-                         std::in_place_index<0>,
-                         std::make_unique<tf2_ros::TransformListener>(buffer, spin_thread)))
+      use_agnocast()
+        ? decltype(impl_)(
+            std::in_place_type<AgnocastImpl>,
+            std::make_unique<agnocast::TransformListener>(buffer, spin_thread))
+        : decltype(impl_)(
+            std::in_place_type<RclcppImpl>,
+            std::make_unique<tf2_ros::TransformListener>(buffer, spin_thread)))
   {
   }
 
@@ -114,9 +120,7 @@ public:
   TransformListener & operator=(TransformListener &&) = delete;
 
 private:
-  std::variant<
-    std::unique_ptr<tf2_ros::TransformListener>, std::unique_ptr<agnocast::TransformListener>>
-    impl_;
+  std::variant<RclcppImpl, AgnocastImpl> impl_;
 };
 
 /// @brief TransformBroadcaster wrapper; requires a Method 2 node
@@ -124,15 +128,19 @@ private:
 class TransformBroadcaster
 {
 public:
+  using RclcppImpl = std::unique_ptr<tf2_ros::TransformBroadcaster>;
+  using AgnocastImpl = std::unique_ptr<agnocast::TransformBroadcaster>;
+
   explicit TransformBroadcaster(
     Node & node, const rclcpp::QoS & qos = tf2_ros::DynamicBroadcasterQoS())
   : impl_(
-      use_agnocast() ? decltype(impl_)(
-                         std::in_place_index<1>, std::make_unique<agnocast::TransformBroadcaster>(
-                                                   *node.get_agnocast_node(), qos))
-                     : decltype(impl_)(
-                         std::in_place_index<0>, std::make_unique<tf2_ros::TransformBroadcaster>(
-                                                   node.get_rclcpp_node().get(), qos)))
+      use_agnocast()
+        ? decltype(impl_)(
+            std::in_place_type<AgnocastImpl>,
+            std::make_unique<agnocast::TransformBroadcaster>(*node.get_agnocast_node(), qos))
+        : decltype(impl_)(
+            std::in_place_type<RclcppImpl>,
+            std::make_unique<tf2_ros::TransformBroadcaster>(node.get_rclcpp_node().get(), qos)))
   {
   }
 
@@ -141,14 +149,14 @@ public:
   : impl_(
       use_agnocast()
         ? decltype(impl_)(
-            std::in_place_index<1>, std::make_unique<agnocast::TransformBroadcaster>(
-                                      *node.get_agnocast_node(), qos, options))
+            std::in_place_type<AgnocastImpl>, std::make_unique<agnocast::TransformBroadcaster>(
+                                                *node.get_agnocast_node(), qos, options))
         : [&] {
             rclcpp::PublisherOptions ros2_options;
             ros2_options.qos_overriding_options = options.qos_overriding_options;
             return decltype(impl_)(
-              std::in_place_index<0>, std::make_unique<tf2_ros::TransformBroadcaster>(
-                                        node.get_rclcpp_node().get(), qos, ros2_options));
+              std::in_place_type<RclcppImpl>, std::make_unique<tf2_ros::TransformBroadcaster>(
+                                                node.get_rclcpp_node().get(), qos, ros2_options));
           }())
   {
   }
@@ -169,25 +177,27 @@ public:
   }
 
 private:
-  std::variant<
-    std::unique_ptr<tf2_ros::TransformBroadcaster>, std::unique_ptr<agnocast::TransformBroadcaster>>
-    impl_;
+  std::variant<RclcppImpl, AgnocastImpl> impl_;
 };
 
 /// @brief StaticTransformBroadcaster wrapper; requires a Method 2 node.
 class StaticTransformBroadcaster
 {
 public:
+  using RclcppImpl = std::unique_ptr<tf2_ros::StaticTransformBroadcaster>;
+  using AgnocastImpl = std::unique_ptr<agnocast::StaticTransformBroadcaster>;
+
   explicit StaticTransformBroadcaster(
     Node & node, const rclcpp::QoS & qos = tf2_ros::StaticBroadcasterQoS())
   : impl_(
-      use_agnocast()
-        ? decltype(impl_)(
-            std::in_place_index<1>,
-            std::make_unique<agnocast::StaticTransformBroadcaster>(*node.get_agnocast_node(), qos))
-        : decltype(impl_)(
-            std::in_place_index<0>, std::make_unique<tf2_ros::StaticTransformBroadcaster>(
-                                      node.get_rclcpp_node().get(), qos)))
+      use_agnocast() ? decltype(impl_)(
+                         std::in_place_type<AgnocastImpl>,
+                         std::make_unique<agnocast::StaticTransformBroadcaster>(
+                           *node.get_agnocast_node(), qos))
+                     : decltype(impl_)(
+                         std::in_place_type<RclcppImpl>,
+                         std::make_unique<tf2_ros::StaticTransformBroadcaster>(
+                           node.get_rclcpp_node().get(), qos)))
   {
   }
 
@@ -196,8 +206,8 @@ public:
   : impl_(
       use_agnocast()
         ? decltype(impl_)(
-            std::in_place_index<1>, std::make_unique<agnocast::StaticTransformBroadcaster>(
-                                      *node.get_agnocast_node(), qos, options))
+            std::in_place_type<AgnocastImpl>, std::make_unique<agnocast::StaticTransformBroadcaster>(
+                                                *node.get_agnocast_node(), qos, options))
         : [&] {
             rclcpp::PublisherOptions ros2_options;
             ros2_options.qos_overriding_options = options.qos_overriding_options;
@@ -208,8 +218,9 @@ public:
             ros2_options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
 #endif
             return decltype(impl_)(
-              std::in_place_index<0>, std::make_unique<tf2_ros::StaticTransformBroadcaster>(
-                                        node.get_rclcpp_node().get(), qos, ros2_options));
+              std::in_place_type<RclcppImpl>,
+              std::make_unique<tf2_ros::StaticTransformBroadcaster>(
+                node.get_rclcpp_node().get(), qos, ros2_options));
           }())
   {
   }
@@ -230,10 +241,7 @@ public:
   }
 
 private:
-  std::variant<
-    std::unique_ptr<tf2_ros::StaticTransformBroadcaster>,
-    std::unique_ptr<agnocast::StaticTransformBroadcaster>>
-    impl_;
+  std::variant<RclcppImpl, AgnocastImpl> impl_;
 };
 
 }  // namespace autoware::agnocast_wrapper

--- a/common/autoware_agnocast_wrapper/package.xml
+++ b/common/autoware_agnocast_wrapper/package.xml
@@ -18,9 +18,12 @@
   <depend condition="$ENABLE_AGNOCAST == 1">agnocastlib</depend>
   <depend>autoware_utils_rclcpp</depend>
   <depend>class_loader</depend>
+  <depend>geometry_msgs</depend>
   <depend>message_filters</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
 
   <exec_depend condition="$ENABLE_AGNOCAST == 1">agnocast_components</exec_depend>
 


### PR DESCRIPTION
## Description
Adds tf2 support to `autoware_agnocast_wrapper`, letting nodes use tf2 while transparently switching between the `tf2_ros` and `agnocast` backends at runtime.

### Changes
  - Add `tf2.hpp` with `autoware::agnocast_wrapper` wrappers: `TransformListener`, `TransformBroadcaster`, `StaticTransformBroadcaster`, and `Buffer`.
  - The listener and broadcasters dispatch at runtime between their `tf2_ros` and `agnocast` implementations depending on whether Agnocast is enabled (`std::variant` based).
  - `Buffer` aliases to `agnocast::Buffer` in Agnocast-enabled builds and `tf2_ros::Buffer` otherwise. The agnocast variant intentionally omits APIs that would silently break under an AgnocastOnly executor (`waitForTransform` / the `/tf2_frames` service), so misuse is caught at compile time.
  - `StaticTransformBroadcaster` forces `use_intra_process_comm = Disable` on the ROS 2 path only on Humble (`#if RCLCPP_VERSION_MAJOR < 28`). Pre-Jazzy `tf2_ros::StaticTransformBroadcaster` set this in its default options as a workaround for rclcpp intra-process not supporting transient_local QoS ([humble 
  L77](https://github.com/ros2/geometry2/blob/humble/tf2_ros/include/tf2_ros/static_transform_broadcaster.hpp#L77)); Jazzy (rclcpp 28+) removed the workaround ([jazzy L62-L78](https://github.com/ros2/geometry2/blob/jazzy/tf2_ros/include/tf2_ros/static_transform_broadcaster.hpp#L62-L78)). The wrapper mirrors that distro split (same gating pattern as `node.hpp` uses elsewhere).
  - Add `tf2`, `tf2_ros`, and `geometry_msgs` dependencies to `CMakeLists.txt` and `package.xml`.
  - Add a "tf2 Support" section to `README.md` covering usage and a migration guide.
  - 
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers
Options are exposed only via the unified `AUTOWARE_SUBSCRIPTION_OPTIONS` / `AUTOWARE_PUBLISHER_OPTIONS` abstraction (not the per-backend `rclcpp` / `agnocast` option types), and `callback_group` / `qos_overriding_options` are forwarded to both backends.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
