### PR TITLE
refactor(autoware_agnocast_wrapper): to use `std::variant` in message_filter

### DIFF
--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -54,10 +54,10 @@ public:
   using AgnocastSubscriber = agnocast::message_filters::Subscriber<M, agnocast::Node>;
 
   Subscriber()
+  : sub_(
+      use_agnocast() ? decltype(sub_)(std::in_place_type<AgnocastSubscriber>)
+                     : decltype(sub_)(std::in_place_type<RclcppSubscriber>))
   {
-    if (use_agnocast()) {
-      sub_.template emplace<AgnocastSubscriber>();
-    }
   }
 
   Subscriber(

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -138,13 +138,12 @@ public:
 
   ApproximateTimeSynchronizer(uint32_t queue_size, Subscriber<M0> & sub0, Subscriber<M1> & sub1)
   : sync_(
-      use_agnocast()
-        ? decltype(sync_)(
-            std::in_place_type<AgnocastSync>, AgnocastPolicy(queue_size),
-            sub0.agnocast_subscriber(), sub1.agnocast_subscriber())
-        : decltype(sync_)(
-            std::in_place_type<RclcppSync>, RclcppPolicy(queue_size),
-            sub0.rclcpp_subscriber(), sub1.rclcpp_subscriber()))
+      use_agnocast() ? decltype(sync_)(
+                         std::in_place_type<AgnocastSync>, AgnocastPolicy(queue_size),
+                         sub0.agnocast_subscriber(), sub1.agnocast_subscriber())
+                     : decltype(sync_)(
+                         std::in_place_type<RclcppSync>, RclcppPolicy(queue_size),
+                         sub0.rclcpp_subscriber(), sub1.rclcpp_subscriber()))
   {
   }
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -137,14 +137,15 @@ public:
     const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0) &, const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1) &)>;
 
   ApproximateTimeSynchronizer(uint32_t queue_size, Subscriber<M0> & sub0, Subscriber<M1> & sub1)
+  : sync_(
+      use_agnocast()
+        ? decltype(sync_)(
+            std::in_place_type<AgnocastSync>, AgnocastPolicy(queue_size),
+            sub0.agnocast_subscriber(), sub1.agnocast_subscriber())
+        : decltype(sync_)(
+            std::in_place_type<RclcppSync>, RclcppPolicy(queue_size),
+            sub0.rclcpp_subscriber(), sub1.rclcpp_subscriber()))
   {
-    if (use_agnocast()) {
-      sync_.template emplace<std::unique_ptr<AgnocastSync>>(std::make_unique<AgnocastSync>(
-        AgnocastPolicy(queue_size), sub0.agnocast_subscriber(), sub1.agnocast_subscriber()));
-    } else {
-      sync_.template emplace<std::unique_ptr<RclcppSync>>(std::make_unique<RclcppSync>(
-        RclcppPolicy(queue_size), sub0.rclcpp_subscriber(), sub1.rclcpp_subscriber()));
-    }
   }
 
   void registerCallback(Callback callback)
@@ -152,11 +153,11 @@ public:
     stored_callback_ = std::move(callback);
     std::visit(
       [this](auto & sync) {
-        using SyncT = typename std::decay_t<decltype(sync)>::element_type;
+        using SyncT = std::decay_t<decltype(sync)>;
         if constexpr (std::is_same_v<SyncT, AgnocastSync>) {
-          sync->registerCallback(&ApproximateTimeSynchronizer::agnocastCallbackAdapter, this);
+          sync.registerCallback(&ApproximateTimeSynchronizer::agnocastCallbackAdapter, this);
         } else {
-          sync->registerCallback(&ApproximateTimeSynchronizer::rclcppCallbackAdapter, this);
+          sync.registerCallback(&ApproximateTimeSynchronizer::rclcppCallbackAdapter, this);
         }
       },
       sync_);
@@ -192,7 +193,7 @@ private:
   using AgnocastPolicy = agnocast::message_filters::sync_policies::ApproximateTime<M0, M1>;
   using AgnocastSync = agnocast::message_filters::Synchronizer<AgnocastPolicy>;
 
-  std::variant<std::unique_ptr<RclcppSync>, std::unique_ptr<AgnocastSync>> sync_;
+  std::variant<RclcppSync, AgnocastSync> sync_;
 };
 
 /// @brief Policy and Synchronizer types that mirror the rclcpp message_filters API.

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -41,6 +41,11 @@ namespace message_filters
 
 /// @brief Wrapper message_filters Subscriber that switches between
 ///        rclcpp and agnocast message_filters at runtime.
+///
+/// @invariant The backend is selected from use_agnocast() at construction and never
+///            changes, so the held subscriber object keeps a stable identity for the
+///            Subscriber's lifetime. subscribe() may therefore be called repeatedly
+///            without invalidating a Synchronizer already wired to this Subscriber.
 template <class M>
 class Subscriber
 {
@@ -48,11 +53,17 @@ public:
   using RclcppSubscriber = ::message_filters::Subscriber<M, rclcpp::Node>;
   using AgnocastSubscriber = agnocast::message_filters::Subscriber<M, agnocast::Node>;
 
-  Subscriber() = default;
+  Subscriber()
+  {
+    if (use_agnocast()) {
+      sub_.template emplace<AgnocastSubscriber>();
+    }
+  }
 
   Subscriber(
     autoware::agnocast_wrapper::Node * node, const std::string & topic,
     const rmw_qos_profile_t qos = rmw_qos_profile_default)
+  : Subscriber()
   {
     subscribe(node, topic, qos);
   }
@@ -61,21 +72,21 @@ public:
     autoware::agnocast_wrapper::Node * node, const std::string & topic,
     const rmw_qos_profile_t qos = rmw_qos_profile_default)
   {
-    if (node->is_using_agnocast()) {
-      sub_.template emplace<AgnocastSubscriber>().subscribe(
-        node->get_agnocast_node().get(), topic, qos);
-    } else {
-      sub_.template emplace<RclcppSubscriber>().subscribe(
-        node->get_rclcpp_node().get(), topic, qos);
-    }
+    std::visit(
+      [&](auto & sub) {
+        if constexpr (std::is_same_v<std::decay_t<decltype(sub)>, AgnocastSubscriber>) {
+          sub.subscribe(node->get_agnocast_node().get(), topic, qos);
+        } else {
+          sub.subscribe(node->get_rclcpp_node().get(), topic, qos);
+        }
+      },
+      sub_);
   }
 
   void unsubscribe()
   {
     std::visit([](auto & sub) { sub.unsubscribe(); }, sub_);
   }
-
-  bool is_using_agnocast() const { return std::holds_alternative<AgnocastSubscriber>(sub_); }
 
   // Internal API: used by ApproximateTimeSynchronizer. Not intended for downstream use.
   RclcppSubscriber & rclcpp_subscriber() { return std::get<RclcppSubscriber>(sub_); }
@@ -127,7 +138,7 @@ public:
 
   ApproximateTimeSynchronizer(uint32_t queue_size, Subscriber<M0> & sub0, Subscriber<M1> & sub1)
   {
-    if (sub0.is_using_agnocast()) {
+    if (use_agnocast()) {
       sync_.template emplace<std::unique_ptr<AgnocastSync>>(
         std::make_unique<AgnocastSync>(
           AgnocastPolicy(queue_size), sub0.agnocast_subscriber(), sub1.agnocast_subscriber()));

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -147,6 +147,11 @@ public:
   {
   }
 
+  // Non-movable: registerCallback() passes `this` to the internal synchronizer, so the
+  // wrapper's address must remain stable for the lifetime of the internal synchronizer.
+  ApproximateTimeSynchronizer(ApproximateTimeSynchronizer &&) = delete;
+  ApproximateTimeSynchronizer & operator=(ApproximateTimeSynchronizer &&) = delete;
+
   void registerCallback(Callback callback)
   {
     stored_callback_ = std::move(callback);

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -128,13 +128,11 @@ public:
   ApproximateTimeSynchronizer(uint32_t queue_size, Subscriber<M0> & sub0, Subscriber<M1> & sub1)
   {
     if (sub0.is_using_agnocast()) {
-      sync_.template emplace<std::unique_ptr<AgnocastSync>>(
-        std::make_unique<AgnocastSync>(
-          AgnocastPolicy(queue_size), sub0.agnocast_subscriber(), sub1.agnocast_subscriber()));
+      sync_.template emplace<std::unique_ptr<AgnocastSync>>(std::make_unique<AgnocastSync>(
+        AgnocastPolicy(queue_size), sub0.agnocast_subscriber(), sub1.agnocast_subscriber()));
     } else {
-      sync_.template emplace<std::unique_ptr<RclcppSync>>(
-        std::make_unique<RclcppSync>(
-          RclcppPolicy(queue_size), sub0.rclcpp_subscriber(), sub1.rclcpp_subscriber()));
+      sync_.template emplace<std::unique_ptr<RclcppSync>>(std::make_unique<RclcppSync>(
+        RclcppPolicy(queue_size), sub0.rclcpp_subscriber(), sub1.rclcpp_subscriber()));
     }
   }
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -24,7 +24,9 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <utility>
+#include <variant>
 
 #ifdef USE_AGNOCAST_ENABLED
 
@@ -43,6 +45,9 @@ template <class M>
 class Subscriber
 {
 public:
+  using RclcppSubscriber = ::message_filters::Subscriber<M, rclcpp::Node>;
+  using AgnocastSubscriber = agnocast::message_filters::Subscriber<M, agnocast::Node>;
+
   Subscriber() = default;
 
   Subscriber(
@@ -52,44 +57,32 @@ public:
     subscribe(node, topic, qos);
   }
 
-  /// @note The backend mode is captured here and reused by unsubscribe().
-  ///       The wrapper Node's backend mode is fixed at construction and does not
-  ///       change for the lifetime of the Node, so the captured value remains valid.
   void subscribe(
     autoware::agnocast_wrapper::Node * node, const std::string & topic,
     const rmw_qos_profile_t qos = rmw_qos_profile_default)
   {
-    const bool tmp_agnocast = node->is_using_agnocast();
-    if (tmp_agnocast) {
-      agnocast_sub_.subscribe(node->get_agnocast_node().get(), topic, qos);
+    if (node->is_using_agnocast()) {
+      sub_.template emplace<AgnocastSubscriber>().subscribe(
+        node->get_agnocast_node().get(), topic, qos);
     } else {
-      rclcpp_sub_.subscribe(node->get_rclcpp_node().get(), topic, qos);
+      sub_.template emplace<RclcppSubscriber>().subscribe(
+        node->get_rclcpp_node().get(), topic, qos);
     }
-    using_agnocast_ = tmp_agnocast;
   }
 
-  /// @note Uses the backend mode captured during the preceding subscribe() call.
-  ///       Calling this before subscribe() is a harmless no-op.
   void unsubscribe()
   {
-    if (using_agnocast_) {
-      agnocast_sub_.unsubscribe();
-    } else {
-      rclcpp_sub_.unsubscribe();
-    }
+    std::visit([](auto & sub) { sub.unsubscribe(); }, sub_);
   }
+
+  bool is_using_agnocast() const { return std::holds_alternative<AgnocastSubscriber>(sub_); }
 
   // Internal API: used by ApproximateTimeSynchronizer. Not intended for downstream use.
-  ::message_filters::Subscriber<M, rclcpp::Node> & rclcpp_subscriber() { return rclcpp_sub_; }
-  agnocast::message_filters::Subscriber<M, agnocast::Node> & agnocast_subscriber()
-  {
-    return agnocast_sub_;
-  }
+  RclcppSubscriber & rclcpp_subscriber() { return std::get<RclcppSubscriber>(sub_); }
+  AgnocastSubscriber & agnocast_subscriber() { return std::get<AgnocastSubscriber>(sub_); }
 
 private:
-  bool using_agnocast_ = false;
-  ::message_filters::Subscriber<M, rclcpp::Node> rclcpp_sub_;
-  agnocast::message_filters::Subscriber<M, agnocast::Node> agnocast_sub_;
+  std::variant<RclcppSubscriber, AgnocastSubscriber> sub_;
 };
 
 /// @brief Wrapper ApproximateTime Synchronizer that switches between
@@ -134,23 +127,30 @@ public:
 
   ApproximateTimeSynchronizer(uint32_t queue_size, Subscriber<M0> & sub0, Subscriber<M1> & sub1)
   {
-    if (use_agnocast()) {
-      agnocast_sync_ = std::make_unique<AgnocastSync>(
-        AgnocastPolicy(queue_size), sub0.agnocast_subscriber(), sub1.agnocast_subscriber());
+    if (sub0.is_using_agnocast()) {
+      sync_.template emplace<std::unique_ptr<AgnocastSync>>(
+        std::make_unique<AgnocastSync>(
+          AgnocastPolicy(queue_size), sub0.agnocast_subscriber(), sub1.agnocast_subscriber()));
     } else {
-      rclcpp_sync_ = std::make_unique<RclcppSync>(
-        RclcppPolicy(queue_size), sub0.rclcpp_subscriber(), sub1.rclcpp_subscriber());
+      sync_.template emplace<std::unique_ptr<RclcppSync>>(
+        std::make_unique<RclcppSync>(
+          RclcppPolicy(queue_size), sub0.rclcpp_subscriber(), sub1.rclcpp_subscriber()));
     }
   }
 
   void registerCallback(Callback callback)
   {
     stored_callback_ = std::move(callback);
-    if (use_agnocast()) {
-      agnocast_sync_->registerCallback(&ApproximateTimeSynchronizer::agnocastCallbackAdapter, this);
-    } else {
-      rclcpp_sync_->registerCallback(&ApproximateTimeSynchronizer::rclcppCallbackAdapter, this);
-    }
+    std::visit(
+      [this](auto & sync) {
+        using SyncT = typename std::decay_t<decltype(sync)>::element_type;
+        if constexpr (std::is_same_v<SyncT, AgnocastSync>) {
+          sync->registerCallback(&ApproximateTimeSynchronizer::agnocastCallbackAdapter, this);
+        } else {
+          sync->registerCallback(&ApproximateTimeSynchronizer::rclcppCallbackAdapter, this);
+        }
+      },
+      sync_);
   }
 
 private:
@@ -179,11 +179,11 @@ private:
 
   using RclcppPolicy = ::message_filters::sync_policies::ApproximateTime<M0, M1>;
   using RclcppSync = ::message_filters::Synchronizer<RclcppPolicy>;
-  std::unique_ptr<RclcppSync> rclcpp_sync_;
 
   using AgnocastPolicy = agnocast::message_filters::sync_policies::ApproximateTime<M0, M1>;
   using AgnocastSync = agnocast::message_filters::Synchronizer<AgnocastPolicy>;
-  std::unique_ptr<AgnocastSync> agnocast_sync_;
+
+  std::variant<std::unique_ptr<RclcppSync>, std::unique_ptr<AgnocastSync>> sync_;
 };
 
 /// @brief Policy and Synchronizer types that mirror the rclcpp message_filters API.

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -50,10 +50,10 @@ using OnSetParametersCallbackType =
 /// based on the ENABLE_AGNOCAST environment variable.
 ///
 /// @invariant The backend variant (rclcpp::Node or agnocast::Node) is chosen at construction
-///            and never mutates for the lifetime of the Node.
-/// @invariant `is_using_agnocast() == true`  iff `get_agnocast_node()` returns a valid
+///            based on use_agnocast() and never mutates for the lifetime of the Node.
+/// @invariant `use_agnocast() == true`  iff `get_agnocast_node()` returns a valid
 ///            shared_ptr without throwing.
-/// @invariant `is_using_agnocast() == false` iff `get_rclcpp_node()`   returns a valid
+/// @invariant `use_agnocast() == false` iff `get_rclcpp_node()`   returns a valid
 ///            shared_ptr without throwing.
 class Node
 {
@@ -256,17 +256,13 @@ public:
   }
 
   // ===== Internal node access (for Executor) =====
-  // Callers must check is_using_agnocast() before calling get_agnocast_node()/get_rclcpp_node().
+  // Callers must check use_agnocast() before calling get_agnocast_node()/get_rclcpp_node().
   // Accessing the inactive variant will throw std::runtime_error.
   // The return value is fixed for the lifetime of the Node (see class-level @invariant).
-  bool is_using_agnocast() const
-  {
-    return std::holds_alternative<std::shared_ptr<agnocast::Node>>(node_);
-  }
 
-  /// @pre `is_using_agnocast() == true`. Under this precondition, this method is guaranteed
+  /// @pre `use_agnocast() == true`. Under this precondition, this method is guaranteed
   ///      to return a valid non-null shared_ptr without throwing.
-  /// @throws std::runtime_error if Agnocast is not enabled (check is_using_agnocast() first)
+  /// @throws std::runtime_error if Agnocast is not enabled (check use_agnocast() first)
   std::shared_ptr<agnocast::Node> get_agnocast_node() const
   {
     if (auto * p = std::get_if<std::shared_ptr<agnocast::Node>>(&node_)) {
@@ -274,12 +270,12 @@ public:
     }
     throw std::runtime_error(
       "get_agnocast_node() called but Agnocast is not enabled. "
-      "Check is_using_agnocast() before calling this method.");
+      "Check use_agnocast() before calling this method.");
   }
 
-  /// @pre `is_using_agnocast() == false`. Under this precondition, this method is guaranteed
+  /// @pre `use_agnocast() == false`. Under this precondition, this method is guaranteed
   ///      to return a valid non-null shared_ptr without throwing.
-  /// @throws std::runtime_error if the node is in agnocast mode (check !is_using_agnocast() first)
+  /// @throws std::runtime_error if the node is in agnocast mode (check !use_agnocast() first)
   std::shared_ptr<rclcpp::Node> get_rclcpp_node() const
   {
     if (auto * p = std::get_if<std::shared_ptr<rclcpp::Node>>(&node_)) {
@@ -287,7 +283,7 @@ public:
     }
     throw std::runtime_error(
       "get_rclcpp_node() called but the node is in agnocast mode. "
-      "Check !is_using_agnocast() before calling this method.");
+      "Check !use_agnocast() before calling this method.");
   }
 
 private:
@@ -308,7 +304,7 @@ private:
 };
 
 /// @brief Get the underlying rclcpp::Node from a node that inherits agnocast_wrapper::Node.
-/// @throws std::runtime_error if the node is in agnocast mode (check is_using_agnocast() first)
+/// @throws std::runtime_error if the node is in agnocast mode (check !use_agnocast() first)
 template <typename T>
 std::shared_ptr<rclcpp::Node> to_rclcpp_node(const std::shared_ptr<T> & node)
 {


### PR DESCRIPTION
## Description
Refactor the `message_filters` wrapper so that `Subscriber` and `ApproximateTimeSynchronizer` hold their rclcpp / agnocast backend in a `std::variant`, instead of keeping both backends as members. This aligns `message_filters` with the `std::variant` design already used by `agnocast_wrapper::Node`.

### Changes
  - `Subscriber<M>`: replace the two always-constructed backend members and the mutable `using_agnocast_` flag with a single `std::variant<RclcppSubscriber, AgnocastSubscriber>`.
  - `ApproximateTimeSynchronizer<M0, M1>`: replace the two `std::unique_ptr` members with a single `std::variant`.
  - The backend is selected once from `use_agnocast()` at construction and stays fixed for the object's lifetime (documented as an `@invariant`); `subscribe()` delegates to the held backend.

### Notes
  - No public API change.
  - Only the active backend is held at a time; previously both were always constructed.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
