### PR TITLE
feat(autoware_agnocast_wrapper): introduce diagnostic_updater API

### DIFF
--- a/common/autoware_agnocast_wrapper/CMakeLists.txt
+++ b/common/autoware_agnocast_wrapper/CMakeLists.txt
@@ -7,6 +7,7 @@ autoware_package()
 find_package(rclcpp REQUIRED)
 find_package(autoware_utils_rclcpp REQUIRED)
 find_package(message_filters REQUIRED)
+find_package(diagnostic_updater REQUIRED)
 
 if(DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
   find_package(agnocastlib REQUIRED)
@@ -29,6 +30,7 @@ if("$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
     agnocastlib
     autoware_utils_rclcpp
     message_filters
+    diagnostic_updater
   )
   target_compile_definitions(${PROJECT_NAME} PUBLIC USE_AGNOCAST_ENABLED)
 else()
@@ -36,6 +38,7 @@ else()
     rclcpp
     autoware_utils_rclcpp
     message_filters
+    diagnostic_updater
   )
 endif()
 
@@ -49,6 +52,7 @@ ament_export_dependencies(
   message_filters
   rclcpp
   rclcpp_components
+  diagnostic_updater
 )
 
 if(DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -231,6 +231,53 @@ void onSynchronized(
 | `message_filters::Synchronizer<Policy>`                   | `autoware::agnocast_wrapper::message_filters::Synchronizer<Policy>`                   |
 | `message_filters::sync_policies::ApproximateTime<M0, M1>` | `autoware::agnocast_wrapper::message_filters::sync_policies::ApproximateTime<M0, M1>` |
 
+## Diagnostic Updater Support
+
+This package provides a wrapper `autoware::agnocast_wrapper::diagnostic_updater::Updater` for `diagnostic_updater::Updater`. The wrapper transparently switches between `diagnostic_updater::Updater` and `agnocast::Updater` at runtime, so nodes inheriting from `autoware::agnocast_wrapper::Node` can use the same idiom in both modes.
+
+The `diagnostic_updater.period` and `diagnostic_updater.use_fqn` parameters are declared identically in both modes, so behavior remains consistent.
+
+### Current limitations
+
+- Only the `Updater(autoware::agnocast_wrapper::Node*, double)` constructor is supported. The upstream interface-pointer constructor and `Updater(NodeT, double)` template overload are intentionally hidden in both modes, so source code stays portable between agnocast-enabled and disabled builds.
+- The wrapper does **not** inherit from `DiagnosticTaskVector`, so `getTasks()` is not available.
+- The wrapper is non-copyable and non-movable; `verbose_` is bound by reference to the underlying impl.
+
+### Usage example
+
+```cpp
+#include <autoware/agnocast_wrapper/diagnostic_updater.hpp>
+
+class MyNode : public autoware::agnocast_wrapper::Node
+{
+public:
+  explicit MyNode(const rclcpp::NodeOptions & options)
+  : Node("my_node", options), updater_(this)
+  {
+    updater_.setHardwareID("my_hardware");
+    updater_.add("status", this, &MyNode::diagnose);
+  }
+
+private:
+  void diagnose(diagnostic_updater::DiagnosticStatusWrapper & stat) {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "running");
+  }
+
+  autoware::agnocast_wrapper::diagnostic_updater::Updater updater_;
+};
+```
+
+### Migration guide (from `diagnostic_updater::Updater`)
+
+| Before                                                 | After                                                                       |
+| ------------------------------------------------------ | --------------------------------------------------------------------------- |
+| `#include <diagnostic_updater/diagnostic_updater.hpp>` | `#include <autoware/agnocast_wrapper/diagnostic_updater.hpp>`               |
+| `diagnostic_updater::Updater updater_{this};`          | `autoware::agnocast_wrapper::diagnostic_updater::Updater updater_{this};`   |
+
+The `add()` / `removeByName()` / `setHardwareID()` / `setHardwareIDf()` / `broadcast()` / `force_update()` / `setPeriod()` / `getPeriod()` APIs and the `verbose_` field behave the same as the upstream `diagnostic_updater::Updater`.
+
+> **Note:** `DiagnosticTask` subclasses (e.g. `FrequencyStatus`, `TimeStampStatus`, `Heartbeat`) defined in `diagnostic_updater` can be added via `updater_.add(task)` unchanged.
+
 ## How to Enable/Disable Agnocast on Build
 
 To build Autoware **with** Agnocast:

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -269,10 +269,10 @@ private:
 
 ### Migration guide (from `diagnostic_updater::Updater`)
 
-| Before                                                 | After                                                                       |
-| ------------------------------------------------------ | --------------------------------------------------------------------------- |
-| `#include <diagnostic_updater/diagnostic_updater.hpp>` | `#include <autoware/agnocast_wrapper/diagnostic_updater.hpp>`               |
-| `diagnostic_updater::Updater updater_{this};`          | `autoware::agnocast_wrapper::diagnostic_updater::Updater updater_{this};`   |
+| Before                                                 | After                                                                     |
+| ------------------------------------------------------ | ------------------------------------------------------------------------- |
+| `#include <diagnostic_updater/diagnostic_updater.hpp>` | `#include <autoware/agnocast_wrapper/diagnostic_updater.hpp>`             |
+| `diagnostic_updater::Updater updater_{this};`          | `autoware::agnocast_wrapper::diagnostic_updater::Updater updater_{this};` |
 
 The `add()` / `removeByName()` / `setHardwareID()` / `setHardwareIDf()` / `broadcast()` / `force_update()` / `setPeriod()` / `getPeriod()` APIs and the `verbose_` field behave the same as the upstream `diagnostic_updater::Updater`.
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/diagnostic_updater.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/diagnostic_updater.hpp
@@ -1,0 +1,149 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// cspell:ignore hwid
+
+#pragma once
+
+#include "autoware/agnocast_wrapper/node.hpp"
+
+#include <diagnostic_updater/diagnostic_updater.hpp>
+
+#include <cstdarg>
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <variant>
+
+#ifdef USE_AGNOCAST_ENABLED
+
+#include <agnocast/node/diagnostic_updater/diagnostic_updater.hpp>
+
+namespace autoware::agnocast_wrapper
+{
+
+/// @brief Wrapper Updater that dispatches between diagnostic_updater::Updater (rclcpp mode)
+///        and agnocast::Updater (agnocast mode) at runtime, depending on whether the given
+///        autoware::agnocast_wrapper::Node is running in agnocast mode.
+///
+/// Constructor signature mirrors `diagnostic_updater::Updater updater_{this};` so nodes
+/// inheriting from autoware::agnocast_wrapper::Node can use the same idiom in both modes.
+class Updater
+{
+public:
+  explicit Updater(autoware::agnocast_wrapper::Node * node, double period = 1.0)
+  : logger_(node->get_logger()),
+    impl_(
+      node->is_using_agnocast()
+        ? decltype(impl_)(
+            std::in_place_index<1>,
+            std::make_unique<agnocast::Updater>(*node->get_agnocast_node(), period))
+        : decltype(impl_)(
+            std::in_place_index<0>,
+            std::make_unique<diagnostic_updater::Updater>(node->get_rclcpp_node(), period))),
+    verbose_(std::visit([](auto & impl) -> bool & { return impl->verbose_; }, impl_))
+  {
+  }
+
+  void add(const std::string & name, diagnostic_updater::TaskFunction f)
+  {
+    std::visit([&](auto & impl) { impl->add(name, f); }, impl_);
+  }
+
+  void add(diagnostic_updater::DiagnosticTask & task)
+  {
+    std::visit([&](auto & impl) { impl->add(task); }, impl_);
+  }
+
+  template <class T>
+  void add(
+    const std::string name, T * c, void (T::*f)(diagnostic_updater::DiagnosticStatusWrapper &))
+  {
+    std::visit([&](auto & impl) { impl->add(name, c, f); }, impl_);
+  }
+
+  bool removeByName(const std::string name)
+  {
+    return std::visit([&](auto & impl) { return impl->removeByName(name); }, impl_);
+  }
+
+  auto getPeriod() const
+  {
+    return std::visit([](const auto & impl) { return impl->getPeriod(); }, impl_);
+  }
+
+  void setPeriod(rclcpp::Duration period)
+  {
+    std::visit([&](auto & impl) { impl->setPeriod(period); }, impl_);
+  }
+
+  void setPeriod(double period)
+  {
+    std::visit([&](auto & impl) { impl->setPeriod(period); }, impl_);
+  }
+
+  void force_update()
+  {
+    std::visit([&](auto & impl) { impl->force_update(); }, impl_);
+  }
+
+  void broadcast(unsigned char lvl, const std::string msg)
+  {
+    std::visit([&](auto & impl) { impl->broadcast(lvl, msg); }, impl_);
+  }
+
+  void setHardwareID(const std::string & hwid)
+  {
+    std::visit([&](auto & impl) { impl->setHardwareID(hwid); }, impl_);
+  }
+
+  void setHardwareIDf(const char * format, ...)
+  {
+    va_list va;
+    constexpr int kBufferSize = 1000;
+    char buff[kBufferSize];
+    va_start(va, format);
+    if (vsnprintf(buff, kBufferSize, format, va) >= kBufferSize) {
+      RCLCPP_DEBUG(logger_, "Really long string in diagnostic_updater::setHardwareIDf.");
+    }
+    va_end(va);
+    setHardwareID(std::string(buff));
+  }
+
+  Updater(const Updater &) = delete;
+  Updater & operator=(const Updater &) = delete;
+  Updater(Updater &&) = delete;
+  Updater & operator=(Updater &&) = delete;
+
+private:
+  rclcpp::Logger logger_;
+  std::variant<std::unique_ptr<diagnostic_updater::Updater>, std::unique_ptr<agnocast::Updater>>
+    impl_;
+
+public:
+  // Mirrors `diagnostic_updater::Updater::verbose_` / `agnocast::Updater::verbose_`.
+  // Bound by reference so `updater.verbose_ = true;` writes through to the underlying impl.
+  bool & verbose_;
+};
+
+}  // namespace autoware::agnocast_wrapper
+
+#else
+
+namespace autoware::agnocast_wrapper
+{
+using Updater = diagnostic_updater::Updater;
+}  // namespace autoware::agnocast_wrapper
+
+#endif

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/diagnostic_updater.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/diagnostic_updater.hpp
@@ -35,25 +35,76 @@ namespace autoware::agnocast_wrapper
 namespace diagnostic_updater
 {
 
-/// @brief Wrapper Updater that dispatches between ::diagnostic_updater::Updater and
-///        ::agnocast::Updater at runtime, based on the wrapper Node's mode.
+/// @brief Wrapper Updater that dispatches between ::diagnostic_updater::Updater
+///        (rclcpp mode) and ::agnocast::Updater (agnocast mode) at runtime,
+///        depending on whether the given autoware::agnocast_wrapper::Node is
+///        running in agnocast mode.
 ///
-/// Constructor mirrors `::diagnostic_updater::Updater updater_{this};` so the same
-/// idiom works in both modes.
+/// Constructor signature mirrors `::diagnostic_updater::Updater updater_{this};`
+/// so nodes inheriting from autoware::agnocast_wrapper::Node can use the same
+/// idiom in both modes. The `diagnostic_updater.period` and
+/// `diagnostic_updater.use_fqn` ros2 parameters are declared by the underlying
+/// impl identically in both backends, so observed behavior is consistent.
+///
+/// @invariant The backend variant is selected from use_agnocast() at construction
+///            and never changes. impl_ holds the active backend through unique_ptr,
+///            so the underlying impl object's address stays stable for the
+///            wrapper's lifetime — `verbose_` is bound by reference to that
+///            stable address.
+///
+/// @code
+/// #include <autoware/agnocast_wrapper/diagnostic_updater.hpp>
+///
+/// class MyNode : public autoware::agnocast_wrapper::Node
+/// {
+/// public:
+///   explicit MyNode(const rclcpp::NodeOptions & options)
+///   : Node("my_node", options), updater_(this)
+///   {
+///     updater_.setHardwareID("my_hardware");
+///     updater_.add("status", this, &MyNode::diagnose);
+///   }
+///
+/// private:
+///   void diagnose(diagnostic_updater::DiagnosticStatusWrapper & stat) {
+///     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "running");
+///   }
+///
+///   autoware::agnocast_wrapper::diagnostic_updater::Updater updater_;
+/// };
+/// @endcode
 class Updater
 {
 public:
-  // unique_ptr indirection: both Updater impls are non-movable, but variant
-  // alternatives must be at least move-constructible.
+  /// @brief Heap-allocated rclcpp-backed implementation held inside impl_.
   using RclcppImpl = std::unique_ptr<::diagnostic_updater::Updater>;
+
+  /// @brief Heap-allocated agnocast-backed implementation held inside impl_.
   using AgnocastImpl = std::unique_ptr<::agnocast::Updater>;
 
+  /// @brief Construct an Updater bound to a wrapper Node.
+  ///
+  /// Selects the backend from use_agnocast() at construction; the choice is
+  /// fixed for the wrapper's lifetime.
+  ///
   /// @pre The given Node must outlive this Updater. ::agnocast::Updater stores
-  ///      `agnocast::Node &` by reference; ::diagnostic_updater::Updater holds
-  ///      interface pointers extracted from the rclcpp::Node.
+  ///      `agnocast::Node &` by reference (initialized from
+  ///      `*node->get_agnocast_node()`), and ::diagnostic_updater::Updater holds
+  ///      interface pointers extracted from the rclcpp::Node. Outliving the
+  ///      wrapper Node will dangle in both modes.
+  ///
+  /// @param node   Wrapper node providing access to either an agnocast::Node or
+  ///               an rclcpp::Node.
+  /// @param period Default update period in seconds; overridden by the
+  ///               `diagnostic_updater.period` ros2 parameter if set.
   explicit Updater(autoware::agnocast_wrapper::Node * node, double period = 1.0)
   : logger_(node->get_logger()),
     impl_(
+      // unique_ptr indirection is required because both ::diagnostic_updater::Updater
+      // and ::agnocast::Updater are non-movable (their constructors register internal
+      // callbacks that capture `this`). std::variant alternatives must be at least
+      // move-constructible, so we hold each impl through unique_ptr to satisfy that
+      // constraint while keeping the underlying impl's address stable.
       use_agnocast()
         ? decltype(impl_)(
             std::in_place_type<AgnocastImpl>,
@@ -65,16 +116,36 @@ public:
   {
   }
 
+  /// @brief Register a diagnostic task by name and callable.
+  ///
+  /// Dispatches to ::diagnostic_updater::Updater::add() or ::agnocast::Updater::add()
+  /// depending on the active backend.
+  ///
+  /// @param name Diagnostic task name surfaced in the published DiagnosticStatus.
+  /// @param f    Callable invoked each update cycle to fill in a DiagnosticStatusWrapper.
   void add(const std::string & name, ::diagnostic_updater::TaskFunction f)
   {
     std::visit([&](auto & impl) { impl->add(name, f); }, impl_);
   }
 
+  /// @brief Register a diagnostic task object by reference.
+  ///
+  /// The task is stored by reference inside the underlying Updater; the caller
+  /// must ensure the task outlives this Updater. Useful for adding pre-built
+  /// task types such as FrequencyStatus, TimeStampStatus, or Heartbeat.
+  ///
+  /// @param task DiagnosticTask subclass instance.
   void add(::diagnostic_updater::DiagnosticTask & task)
   {
     std::visit([&](auto & impl) { impl->add(task); }, impl_);
   }
 
+  /// @brief Register a diagnostic task by name and member function pointer.
+  ///
+  /// @tparam T   Class type owning the diagnostic method.
+  /// @param name Diagnostic task name.
+  /// @param c    Pointer to the owning instance; must outlive this Updater.
+  /// @param f    Member function called each update cycle.
   template <class T>
   void add(
     const std::string name, T * c,
@@ -83,44 +154,75 @@ public:
     std::visit([&](auto & impl) { impl->add(name, c, f); }, impl_);
   }
 
+  /// @brief Remove a previously added task by name.
+  /// @param name Task name passed to a prior add() call.
+  /// @return true if a task with that name was found and removed; false otherwise.
   bool removeByName(const std::string name)
   {
     return std::visit([&](auto & impl) { return impl->removeByName(name); }, impl_);
   }
 
+  /// @brief Get the current update period as rclcpp::Duration.
   auto getPeriod() const
   {
     return std::visit([](const auto & impl) { return impl->getPeriod(); }, impl_);
   }
 
+  /// @brief Set the update period from rclcpp::Duration.
+  ///
+  /// Resets the internal timer to the new period.
   void setPeriod(rclcpp::Duration period)
   {
     std::visit([&](auto & impl) { impl->setPeriod(period); }, impl_);
   }
 
+  /// @brief Set the update period in seconds.
+  ///
+  /// Convenience overload that converts to rclcpp::Duration internally.
   void setPeriod(double period)
   {
     std::visit([&](auto & impl) { impl->setPeriod(period); }, impl_);
   }
 
+  /// @brief Force an immediate update of all known DiagnosticStatus tasks,
+  ///        bypassing the period interval.
+  ///
+  /// Useful when something drastic happens (shutdown, self-test) and the latest
+  /// status must be published immediately rather than waiting for the next tick.
   void force_update()
   {
     std::visit([&](auto & impl) { impl->force_update(); }, impl_);
   }
 
+  /// @brief Publish a single status with the given level and message across all
+  ///        known DiagnosticStatus tasks.
+  ///
+  /// @param lvl Diagnostic level
+  ///            (diagnostic_msgs::msg::DiagnosticStatus::OK / WARN / ERROR / STALE).
+  /// @param msg Status message attached to every task in the broadcast.
   void broadcast(unsigned char lvl, const std::string msg)
   {
     std::visit([&](auto & impl) { impl->broadcast(lvl, msg); }, impl_);
   }
 
+  /// @brief Set the hardware ID embedded in every published DiagnosticStatus.
+  /// @param hwid Hardware identifier string (free-form).
   void setHardwareID(const std::string & hwid)
   {
     std::visit([&](auto & impl) { impl->setHardwareID(hwid); }, impl_);
   }
 
-  // Pre-format here (rather than forwarding to impl->setHardwareIDf) to warn on
-  // truncation; C-style varargs cannot be forwarded cleanly. Storage is still
-  // delegated to setHardwareID -> impl.
+  /// @brief printf-style variant of setHardwareID, with truncation reported via
+  ///        RCLCPP_DEBUG when the formatted string overflows the internal buffer.
+  ///
+  /// We pre-format here (rather than forwarding the varargs to impl->setHardwareIDf)
+  /// so we can warn on truncation; C-style varargs (`...`) cannot be forwarded
+  /// cleanly across a std::visit boundary, and neither upstream impl exposes a
+  /// `vsetHardwareID(va_list)` overload. After formatting, storage is delegated to
+  /// setHardwareID -> impl, so the underlying hwid_ field stays in sync with the
+  /// active backend.
+  ///
+  /// @param format printf-style format string.
   void setHardwareIDf(const char * format, ...)
   {
     va_list va;
@@ -134,7 +236,9 @@ public:
     setHardwareID(std::string(buff));
   }
 
-  // Move/copy deleted: verbose_ is a reference bound at construction and cannot be reseated.
+  // Non-copyable and non-movable: `verbose_` is a reference bound at construction
+  // to impl_'s active alternative's `verbose_` field. References cannot be reseated,
+  // so neither copy-assign nor move (which would require rebinding) is meaningful.
   Updater(const Updater &) = delete;
   Updater & operator=(const Updater &) = delete;
   Updater(Updater &&) = delete;
@@ -145,7 +249,9 @@ private:
   std::variant<RclcppImpl, AgnocastImpl> impl_;
 
 public:
-  // Reference-bound so `updater.verbose_ = true;` writes through to the underlying impl.
+  /// Mirrors ::diagnostic_updater::Updater::verbose_ / ::agnocast::Updater::verbose_.
+  /// Bound by reference so `updater.verbose_ = true;` writes through to the
+  /// underlying impl, matching the field-access idiom of both upstream Updaters.
   bool & verbose_;
 };
 
@@ -159,13 +265,24 @@ namespace autoware::agnocast_wrapper
 namespace diagnostic_updater
 {
 
-// Pass-through wrapper that re-declares only `Updater(Node*, double)`. In C++17, base
-// constructors are not implicitly inherited, so the upstream template and interface-
-// pointer constructors are hidden — keeping the supported signature consistent across
-// both modes at compile time.
+/// @brief Pass-through Updater for the non-Agnocast build.
+///
+/// Inherits from ::diagnostic_updater::Updater and re-declares only the
+/// `Updater(Node*, double)` constructor; base-class constructors are not
+/// implicitly inherited in C++, so the upstream template and interface-pointer
+/// constructors stay hidden. This keeps the supported signature identical to
+/// the agnocast-enabled build. All other public members are inherited as-is.
 class Updater : public ::diagnostic_updater::Updater
 {
 public:
+  /// @brief Construct from a wrapper Node and update period.
+  ///
+  /// In this build, autoware::agnocast_wrapper::Node is an alias for rclcpp::Node,
+  /// so the call forwards directly to ::diagnostic_updater::Updater(NodeT, double).
+  ///
+  /// @param node   Wrapper node (alias for rclcpp::Node in this build).
+  /// @param period Default update period in seconds; overridden by the
+  ///               `diagnostic_updater.period` ros2 parameter if set.
   explicit Updater(autoware::agnocast_wrapper::Node * node, double period = 1.0)
   : ::diagnostic_updater::Updater(node, period)
   {

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/diagnostic_updater.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/diagnostic_updater.hpp
@@ -20,58 +20,65 @@
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
 
+#ifdef USE_AGNOCAST_ENABLED
+
+#include <agnocast/node/diagnostic_updater/diagnostic_updater.hpp>
+
 #include <cstdarg>
 #include <cstdio>
 #include <memory>
 #include <string>
 #include <variant>
 
-#ifdef USE_AGNOCAST_ENABLED
-
-#include <agnocast/node/diagnostic_updater/diagnostic_updater.hpp>
-
 namespace autoware::agnocast_wrapper
 {
+namespace diagnostic_updater
+{
 
-/// @brief Wrapper Updater that dispatches between diagnostic_updater::Updater (rclcpp mode)
-///        and agnocast::Updater (agnocast mode) at runtime, depending on whether the given
-///        autoware::agnocast_wrapper::Node is running in agnocast mode.
+/// @brief Wrapper Updater that dispatches between ::diagnostic_updater::Updater and
+///        ::agnocast::Updater at runtime, based on the wrapper Node's mode.
 ///
-/// Constructor signature mirrors `diagnostic_updater::Updater updater_{this};` so nodes
-/// inheriting from autoware::agnocast_wrapper::Node can use the same idiom in both modes.
+/// Constructor mirrors `::diagnostic_updater::Updater updater_{this};` so the same
+/// idiom works in both modes.
 class Updater
 {
 public:
-  using RclcppImpl = std::unique_ptr<diagnostic_updater::Updater>;
-  using AgnocastImpl = std::unique_ptr<agnocast::Updater>;
+  // unique_ptr indirection: both Updater impls are non-movable, but variant
+  // alternatives must be at least move-constructible.
+  using RclcppImpl = std::unique_ptr<::diagnostic_updater::Updater>;
+  using AgnocastImpl = std::unique_ptr<::agnocast::Updater>;
 
+  /// @pre The given Node must outlive this Updater. ::agnocast::Updater stores
+  ///      `agnocast::Node &` by reference; ::diagnostic_updater::Updater holds
+  ///      interface pointers extracted from the rclcpp::Node.
   explicit Updater(autoware::agnocast_wrapper::Node * node, double period = 1.0)
   : logger_(node->get_logger()),
     impl_(
       use_agnocast()
         ? decltype(impl_)(
             std::in_place_type<AgnocastImpl>,
-            std::make_unique<agnocast::Updater>(*node->get_agnocast_node(), period))
+            std::make_unique<::agnocast::Updater>(*node->get_agnocast_node(), period))
         : decltype(impl_)(
             std::in_place_type<RclcppImpl>,
-            std::make_unique<diagnostic_updater::Updater>(node->get_rclcpp_node(), period))),
+            std::make_unique<::diagnostic_updater::Updater>(node->get_rclcpp_node(), period))),
     verbose_(std::visit([](auto & impl) -> bool & { return impl->verbose_; }, impl_))
   {
   }
 
-  void add(const std::string & name, diagnostic_updater::TaskFunction f)
+  void add(const std::string & name, ::diagnostic_updater::TaskFunction f)
   {
     std::visit([&](auto & impl) { impl->add(name, f); }, impl_);
   }
 
-  void add(diagnostic_updater::DiagnosticTask & task)
+  void add(::diagnostic_updater::DiagnosticTask & task)
   {
     std::visit([&](auto & impl) { impl->add(task); }, impl_);
   }
 
   template <class T>
   void add(
-    const std::string name, T * c, void (T::*f)(diagnostic_updater::DiagnosticStatusWrapper &))
+    const std::string name, T * c,
+    void (T::*f)(::diagnostic_updater::DiagnosticStatusWrapper &))
   {
     std::visit([&](auto & impl) { impl->add(name, c, f); }, impl_);
   }
@@ -111,6 +118,9 @@ public:
     std::visit([&](auto & impl) { impl->setHardwareID(hwid); }, impl_);
   }
 
+  // Pre-format here (rather than forwarding to impl->setHardwareIDf) to warn on
+  // truncation; C-style varargs cannot be forwarded cleanly. Storage is still
+  // delegated to setHardwareID -> impl.
   void setHardwareIDf(const char * format, ...)
   {
     va_list va;
@@ -124,6 +134,7 @@ public:
     setHardwareID(std::string(buff));
   }
 
+  // Move/copy deleted: verbose_ is a reference bound at construction and cannot be reseated.
   Updater(const Updater &) = delete;
   Updater & operator=(const Updater &) = delete;
   Updater(Updater &&) = delete;
@@ -134,18 +145,34 @@ private:
   std::variant<RclcppImpl, AgnocastImpl> impl_;
 
 public:
-  // Mirrors `diagnostic_updater::Updater::verbose_` / `agnocast::Updater::verbose_`.
-  // Bound by reference so `updater.verbose_ = true;` writes through to the underlying impl.
+  // Reference-bound so `updater.verbose_ = true;` writes through to the underlying impl.
   bool & verbose_;
 };
 
+}  // namespace diagnostic_updater
 }  // namespace autoware::agnocast_wrapper
 
-#else
+#else  // !USE_AGNOCAST_ENABLED
 
 namespace autoware::agnocast_wrapper
 {
-using Updater = diagnostic_updater::Updater;
+namespace diagnostic_updater
+{
+
+// Pass-through wrapper that re-declares only `Updater(Node*, double)`. In C++17, base
+// constructors are not implicitly inherited, so the upstream template and interface-
+// pointer constructors are hidden — keeping the supported signature consistent across
+// both modes at compile time.
+class Updater : public ::diagnostic_updater::Updater
+{
+public:
+  explicit Updater(autoware::agnocast_wrapper::Node * node, double period = 1.0)
+  : ::diagnostic_updater::Updater(node, period)
+  {
+  }
+};
+
+}  // namespace diagnostic_updater
 }  // namespace autoware::agnocast_wrapper
 
 #endif

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/diagnostic_updater.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/diagnostic_updater.hpp
@@ -97,6 +97,12 @@ public:
   ///               an rclcpp::Node.
   /// @param period Default update period in seconds; overridden by the
   ///               `diagnostic_updater.period` ros2 parameter if set.
+  ///
+  /// @note The upstream `::diagnostic_updater::Updater` exposes a third
+  ///       `starting_up_status` parameter (the DiagnosticStatus level sent as
+  ///       the first message). It is intentionally not surfaced here because
+  ///       `::agnocast::Updater` does not support it, and the wrapper keeps a
+  ///       single signature shared by both backends.
   explicit Updater(autoware::agnocast_wrapper::Node * node, double period = 1.0)
   : logger_(node->get_logger()),
     impl_(
@@ -282,6 +288,12 @@ public:
   /// @param node   Wrapper node (alias for rclcpp::Node in this build).
   /// @param period Default update period in seconds; overridden by the
   ///               `diagnostic_updater.period` ros2 parameter if set.
+  ///
+  /// @note The upstream `::diagnostic_updater::Updater` exposes a third
+  ///       `starting_up_status` parameter (the DiagnosticStatus level sent as
+  ///       the first message). It is intentionally not surfaced here because
+  ///       `::agnocast::Updater` does not support it, and the wrapper keeps a
+  ///       single signature shared by both backends.
   explicit Updater(autoware::agnocast_wrapper::Node * node, double period = 1.0)
   : ::diagnostic_updater::Updater(node, period)
   {

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/diagnostic_updater.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/diagnostic_updater.hpp
@@ -42,15 +42,18 @@ namespace autoware::agnocast_wrapper
 class Updater
 {
 public:
+  using RclcppImpl = std::unique_ptr<diagnostic_updater::Updater>;
+  using AgnocastImpl = std::unique_ptr<agnocast::Updater>;
+
   explicit Updater(autoware::agnocast_wrapper::Node * node, double period = 1.0)
   : logger_(node->get_logger()),
     impl_(
-      node->is_using_agnocast()
+      use_agnocast()
         ? decltype(impl_)(
-            std::in_place_index<1>,
+            std::in_place_type<AgnocastImpl>,
             std::make_unique<agnocast::Updater>(*node->get_agnocast_node(), period))
         : decltype(impl_)(
-            std::in_place_index<0>,
+            std::in_place_type<RclcppImpl>,
             std::make_unique<diagnostic_updater::Updater>(node->get_rclcpp_node(), period))),
     verbose_(std::visit([](auto & impl) -> bool & { return impl->verbose_; }, impl_))
   {
@@ -128,8 +131,7 @@ public:
 
 private:
   rclcpp::Logger logger_;
-  std::variant<std::unique_ptr<diagnostic_updater::Updater>, std::unique_ptr<agnocast::Updater>>
-    impl_;
+  std::variant<RclcppImpl, AgnocastImpl> impl_;
 
 public:
   // Mirrors `diagnostic_updater::Updater::verbose_` / `agnocast::Updater::verbose_`.

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/diagnostic_updater.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/diagnostic_updater.hpp
@@ -77,8 +77,7 @@ public:
 
   template <class T>
   void add(
-    const std::string name, T * c,
-    void (T::*f)(::diagnostic_updater::DiagnosticStatusWrapper &))
+    const std::string name, T * c, void (T::*f)(::diagnostic_updater::DiagnosticStatusWrapper &))
   {
     std::visit([&](auto & impl) { impl->add(name, c, f); }, impl_);
   }

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/diagnostic_updater.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/diagnostic_updater.hpp
@@ -20,15 +20,15 @@
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
 
-#ifdef USE_AGNOCAST_ENABLED
-
-#include <agnocast/node/diagnostic_updater/diagnostic_updater.hpp>
-
 #include <cstdarg>
 #include <cstdio>
 #include <memory>
 #include <string>
 #include <variant>
+
+#ifdef USE_AGNOCAST_ENABLED
+
+#include <agnocast/node/diagnostic_updater/diagnostic_updater.hpp>
 
 namespace autoware::agnocast_wrapper
 {

--- a/common/autoware_agnocast_wrapper/package.xml
+++ b/common/autoware_agnocast_wrapper/package.xml
@@ -15,6 +15,7 @@
   <depend condition="$ENABLE_AGNOCAST == 1">agnocastlib</depend>
   <depend>autoware_utils_rclcpp</depend>
   <depend>class_loader</depend>
+  <depend>diagnostic_updater</depend>
   <depend>message_filters</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>


### PR DESCRIPTION
## Description
Add a `diagnostic_updater` wrapper to `autoware_agnocast_wrapper` so nodes can use the same `diagnostic_updater::Updater` idiom in both rclcpp and Agnocast modes.

## Changes
- New `include/autoware/agnocast_wrapper/diagnostic_updater.hpp`: defines `autoware::agnocast_wrapper::Updater`, which holds the underlying impl in a `std::variant<unique_ptr<diagnostic_updater::Updater>, unique_ptr<agnocast::Updater>>` and dispatches every call via `std::visit`.
- When `USE_AGNOCAST_ENABLED` is off, the header degenerates to `using Updater = diagnostic_updater::Updater;` (zero overhead).
- `CMakeLists.txt` / `package.xml`: add `diagnostic_updater` dependency.

## API parity with upstream
- `setHardwareIDf` cannot forward `...` directly (no `vsetHardwareIDf` sibling upstream), so it is re-implemented locally with the same truncation behavior and `RCLCPP_DEBUG` warning as upstream.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
