### PR TITLE
feat(object_recognition_utils): support ANIMAL and HAZARD labels

### DIFF
--- a/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/object_classification.hpp
+++ b/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/object_classification.hpp
@@ -109,6 +109,10 @@ inline uint8_t toLabel(const std::string & class_name)
     return ObjectClassification::BICYCLE;
   } else if (class_name == "PEDESTRIAN") {
     return ObjectClassification::PEDESTRIAN;
+  } else if (class_name == "ANIMAL") {
+    return ObjectClassification::ANIMAL;
+  } else if (class_name == "HAZARD") {
+    return ObjectClassification::HAZARD;
   } else {
     throw std::runtime_error("Invalid Classification label.");
   }
@@ -147,6 +151,10 @@ inline std::string convertLabelToString(const uint8_t label)
     return "BICYCLE";
   } else if (label == ObjectClassification::PEDESTRIAN) {
     return "PEDESTRIAN";
+  } else if (label == ObjectClassification::ANIMAL) {
+    return "ANIMAL";
+  } else if (label == ObjectClassification::HAZARD) {
+    return "HAZARD";
   } else {
     return "UNKNOWN";
   }

--- a/common/autoware_object_recognition_utils/test/src/test_object_classification.cpp
+++ b/common/autoware_object_recognition_utils/test/src/test_object_classification.cpp
@@ -250,6 +250,8 @@ TEST(object_classification, test_fromString)
     EXPECT_EQ(toLabel("MOTORCYCLE"), ObjectClassification::MOTORCYCLE);
     EXPECT_EQ(toLabel("BICYCLE"), ObjectClassification::BICYCLE);
     EXPECT_EQ(toLabel("PEDESTRIAN"), ObjectClassification::PEDESTRIAN);
+    EXPECT_EQ(toLabel("ANIMAL"), ObjectClassification::ANIMAL);
+    EXPECT_EQ(toLabel("HAZARD"), ObjectClassification::HAZARD);
     EXPECT_THROW(toLabel(""), std::runtime_error);
   }
 
@@ -258,6 +260,16 @@ TEST(object_classification, test_fromString)
     auto classification = toObjectClassification("CAR", 0.7);
     EXPECT_EQ(classification.label, ObjectClassification::CAR);
     EXPECT_NEAR(classification.probability, 0.7, epsilon);
+  }
+  {
+    auto classification = toObjectClassification("ANIMAL", 0.6);
+    EXPECT_EQ(classification.label, ObjectClassification::ANIMAL);
+    EXPECT_NEAR(classification.probability, 0.6, epsilon);
+  }
+  {
+    auto classification = toObjectClassification("HAZARD", 0.5);
+    EXPECT_EQ(classification.label, ObjectClassification::HAZARD);
+    EXPECT_NEAR(classification.probability, 0.5, epsilon);
   }
   // Classifications
   {
@@ -282,6 +294,8 @@ TEST(object_classification, test_convertLabelToString)
     EXPECT_EQ(convertLabelToString(ObjectClassification::MOTORCYCLE), "MOTORCYCLE");
     EXPECT_EQ(convertLabelToString(ObjectClassification::BICYCLE), "BICYCLE");
     EXPECT_EQ(convertLabelToString(ObjectClassification::PEDESTRIAN), "PEDESTRIAN");
+    EXPECT_EQ(convertLabelToString(ObjectClassification::ANIMAL), "ANIMAL");
+    EXPECT_EQ(convertLabelToString(ObjectClassification::HAZARD), "HAZARD");
   }
 
   // from ObjectClassification


### PR DESCRIPTION
## Description
This PR adds `ANIMAL` and `HAZARD` support to the common object classification conversion utilities in `autoware_object_recognition_utils`.


## Changes
- add `ANIMAL` / `HAZARD` handling to `toLabel()`
- add `ANIMAL` / `HAZARD` handling to `convertLabelToString()`
- extend unit tests for string-to-label and label-to-string conversion

## API parity with upstream
- `setHardwareIDf` cannot forward `...` directly (no `vsetHardwareIDf` sibling upstream), so it is re-implemented locally with the same truncation behavior and `RCLCPP_DEBUG` warning as upstream.

## Related links

**Parent Issue:**
https://github.com/orgs/autowarefoundation/discussions/7127

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- `colcon build --packages-select autoware_object_recognition_utils --base-paths /tmp/autoware_core-object-classification --build-base /tmp/autoware_core-object-classification/build --install-base /tmp/autoware_core-object-classification/install --test-result-base /tmp/autoware_core-object-classification/test_results --event-handlers console_direct+`
- `colcon test --packages-select autoware_object_recognition_utils --base-paths /tmp/autoware_core-object-classification --build-base /tmp/autoware_core-object-classification/build --install-base /tmp/autoware_core-object-classification/install --test-result-base /tmp/autoware_core-object-classification/test_results --event-handlers console_direct+ --return-code-on-test-failure`

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes


### ROS Parameter Changes



🔴⬆️ -->

## Effects on system behavior

None.



