### PR TITLE
feat(motion_velocity_planner): support ANIMAL and HAZARD labels

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/types.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/src/types.hpp
@@ -45,6 +45,8 @@ struct StopObstacleClassification
     MOTORCYCLE,
     BICYCLE,
     PEDESTRIAN,
+    ANIMAL,
+    HAZARD,
     POINTCLOUD
   };
 
@@ -53,6 +55,7 @@ struct StopObstacleClassification
     {Type::TRUCK, "truck"},          {Type::BUS, "bus"},
     {Type::TRAILER, "trailer"},      {Type::MOTORCYCLE, "motorcycle"},
     {Type::BICYCLE, "bicycle"},      {Type::PEDESTRIAN, "pedestrian"},
+    {Type::ANIMAL, "animal"},        {Type::HAZARD, "hazard"},
     {Type::POINTCLOUD, "pointcloud"}};
 
   explicit StopObstacleClassification(const ObjectClassification object_classification)
@@ -81,6 +84,12 @@ struct StopObstacleClassification
         break;
       case ObjectClassification::PEDESTRIAN:
         label = Type::PEDESTRIAN;
+        break;
+      case ObjectClassification::ANIMAL:
+        label = Type::ANIMAL;
+        break;
+      case ObjectClassification::HAZARD:
+        label = Type::HAZARD;
         break;
       default:
         throw std::invalid_argument("Undefined ObjectClassification label");

--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_types.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_stop_module/test/test_types.cpp
@@ -37,6 +37,16 @@ TEST(StopObstacleClassificationTest, InitializesFromPerceptionObjectClassificati
   ASSERT_EQ(
     StopObstacleClassification(perception_obj_classification).label,
     StopObstacleClassification::Type::PEDESTRIAN);
+
+  perception_obj_classification.label = ObjectClassification::ANIMAL;
+  ASSERT_EQ(
+    StopObstacleClassification(perception_obj_classification).label,
+    StopObstacleClassification::Type::ANIMAL);
+
+  perception_obj_classification.label = ObjectClassification::HAZARD;
+  ASSERT_EQ(
+    StopObstacleClassification(perception_obj_classification).label,
+    StopObstacleClassification::Type::HAZARD);
 }
 
 TEST(StopObstacleClassificationTest, InitializesFromPredictedObjectClassification)
@@ -61,6 +71,16 @@ TEST(StopObstacleClassificationTest, InitializesFromPredictedObjectClassificatio
     ASSERT_EQ(
       StopObstacleClassification(predicted_obj.classification).label,
       StopObstacleClassification::Type::PEDESTRIAN);
+
+    predicted_obj.classification.at(0).label = ObjectClassification::ANIMAL;
+    ASSERT_EQ(
+      StopObstacleClassification(predicted_obj.classification).label,
+      StopObstacleClassification::Type::ANIMAL);
+
+    predicted_obj.classification.at(0).label = ObjectClassification::HAZARD;
+    ASSERT_EQ(
+      StopObstacleClassification(predicted_obj.classification).label,
+      StopObstacleClassification::Type::HAZARD);
   }
 }
 
@@ -75,6 +95,12 @@ TEST(StopObstacleClassificationTest, InitializesFromStopObstacleClassification)
   ASSERT_EQ(
     StopObstacleClassification{StopObstacleClassification::Type::PEDESTRIAN}.label,
     StopObstacleClassification::Type::PEDESTRIAN);
+  ASSERT_EQ(
+    StopObstacleClassification{StopObstacleClassification::Type::ANIMAL}.label,
+    StopObstacleClassification::Type::ANIMAL);
+  ASSERT_EQ(
+    StopObstacleClassification{StopObstacleClassification::Type::HAZARD}.label,
+    StopObstacleClassification::Type::HAZARD);
   ASSERT_EQ(
     StopObstacleClassification{StopObstacleClassification::Type::POINTCLOUD}.label,
     StopObstacleClassification::Type::POINTCLOUD);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/CMakeLists.txt
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/CMakeLists.txt
@@ -13,6 +13,7 @@ if(BUILD_TESTING)
   ament_add_ros_isolated_gtest(test_${PROJECT_NAME}
     test/test_collision_checker.cpp
     test/test_polygon_utils.cpp
+    test/test_utils.cpp
   )
   target_link_libraries(test_${PROJECT_NAME}
     gtest_main

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/src/utils.cpp
@@ -146,11 +146,16 @@ std::vector<uint8_t> get_target_object_type(rclcpp::Node & node, const std::stri
     {"unknown", ObjectClassification::UNKNOWN}, {"car", ObjectClassification::CAR},
     {"truck", ObjectClassification::TRUCK},     {"bus", ObjectClassification::BUS},
     {"trailer", ObjectClassification::TRAILER}, {"motorcycle", ObjectClassification::MOTORCYCLE},
-    {"bicycle", ObjectClassification::BICYCLE}, {"pedestrian", ObjectClassification::PEDESTRIAN}};
+    {"bicycle", ObjectClassification::BICYCLE}, {"pedestrian", ObjectClassification::PEDESTRIAN},
+    {"animal", ObjectClassification::ANIMAL},   {"hazard", ObjectClassification::HAZARD}};
 
   std::vector<uint8_t> types;
   for (const auto & type : types_map) {
-    if (node.declare_parameter<bool>(param_prefix + type.first)) {
+    const auto param_name = param_prefix + type.first;
+    const bool is_target_object = node.has_parameter(param_name)
+                                    ? node.get_parameter(param_name).as_bool()
+                                    : node.declare_parameter<bool>(param_name, false);
+    if (is_target_object) {
       types.push_back(type.second);
     }
   }

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/test/test_utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_common/test/test_utils.cpp
@@ -1,0 +1,82 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/motion_velocity_planner_common/utils.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <memory>
+
+namespace autoware::motion_velocity_planner::utils
+{
+
+class MotionVelocityPlannerCommonUtilsTest : public ::testing::Test
+{
+protected:
+  static void SetUpTestSuite()
+  {
+    if (!rclcpp::ok()) {
+      rclcpp::init(0, nullptr);
+    }
+  }
+
+  static void TearDownTestSuite() { rclcpp::shutdown(); }
+};
+
+TEST_F(MotionVelocityPlannerCommonUtilsTest, GetTargetObjectTypeSupportsAnimalAndHazard)
+{
+  auto options = rclcpp::NodeOptions{};
+  options.append_parameter_override("target.unknown", false);
+  options.append_parameter_override("target.car", false);
+  options.append_parameter_override("target.truck", false);
+  options.append_parameter_override("target.bus", false);
+  options.append_parameter_override("target.trailer", false);
+  options.append_parameter_override("target.motorcycle", false);
+  options.append_parameter_override("target.bicycle", false);
+  options.append_parameter_override("target.pedestrian", false);
+  options.append_parameter_override("target.animal", true);
+  options.append_parameter_override("target.hazard", true);
+
+  auto node = std::make_shared<rclcpp::Node>("test_get_target_object_type", options);
+  const auto types = get_target_object_type(*node, "target.");
+
+  EXPECT_NE(std::find(types.begin(), types.end(), ObjectClassification::ANIMAL), types.end());
+  EXPECT_NE(std::find(types.begin(), types.end(), ObjectClassification::HAZARD), types.end());
+  EXPECT_EQ(std::find(types.begin(), types.end(), ObjectClassification::UNKNOWN), types.end());
+}
+
+TEST_F(MotionVelocityPlannerCommonUtilsTest, GetTargetObjectTypeDefaultsMissingLabelsToFalse)
+{
+  auto options = rclcpp::NodeOptions{};
+  options.append_parameter_override("target.unknown", true);
+  options.append_parameter_override("target.car", false);
+  options.append_parameter_override("target.truck", false);
+  options.append_parameter_override("target.bus", false);
+  options.append_parameter_override("target.trailer", false);
+  options.append_parameter_override("target.motorcycle", false);
+  options.append_parameter_override("target.bicycle", false);
+  options.append_parameter_override("target.pedestrian", false);
+
+  auto node = std::make_shared<rclcpp::Node>("test_get_target_object_type_defaults", options);
+
+  EXPECT_NO_THROW({
+    const auto types = get_target_object_type(*node, "target.");
+    EXPECT_NE(std::find(types.begin(), types.end(), ObjectClassification::UNKNOWN), types.end());
+    EXPECT_EQ(std::find(types.begin(), types.end(), ObjectClassification::ANIMAL), types.end());
+    EXPECT_EQ(std::find(types.begin(), types.end(), ObjectClassification::HAZARD), types.end());
+  });
+}
+
+}  // namespace autoware::motion_velocity_planner::utils


### PR DESCRIPTION
## Description
Add `ANIMAL` and `HAZARD` support to `motion_velocity_planner` utilities and obstacle stop classification so the planner-side core code can accept the new `ObjectClassification` labels without falling back to `UNKNOWN`-only assumptions.


### Changes

- Add `animal` and `hazard` entries to `get_target_object_type()` in `autoware_motion_velocity_planner_common`, so planner parameters can explicitly target `ObjectClassification::ANIMAL` and `ObjectClassification::HAZARD`.
- Extend `StopObstacleClassification::Type` with `ANIMAL` and `HAZARD`.
- Update the planner-side classification conversion logic to map `ObjectClassification::ANIMAL` and `ObjectClassification::HAZARD` into the corresponding stop obstacle types.
- Extend the string conversion map for stop obstacle classifications with `animal` and `hazard`.
- Add unit tests for:
  - planner target object parameter parsing for `animal` and `hazard`
  - `StopObstacleClassification` construction from perception classifications
  - `StopObstacleClassification` construction from predicted object classifications
  - `StopObstacleClassification` string conversion for the new labels


## Related links

**Parent Issue:**
https://github.com/orgs/autowarefoundation/discussions/7127
- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- Built `autoware_motion_velocity_planner_common` with testing disabled:
  - `colcon build --packages-select autoware_motion_velocity_planner_common ... --cmake-args -DBUILD_TESTING=OFF`
- Confirmed the planning branch is rebased onto `origin/main` and contains a single signed-off commit.
- Attempted isolated test-enabled verification for `autoware_motion_velocity_planner_common`, but the test build hit an existing unresolved reference around `autoware::motion_utils::isDrivingForward(...)` in the isolated overlay environment.
- Started verification for `autoware_motion_velocity_obstacle_stop_module` with the updated tests, but did not complete end-to-end test confirmation before pausing.


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
