### PR TITLE
feat(autoware_agnocast_wrapper): align message_filters `registerCallback` with upstream API

### DIFF
--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -183,7 +183,7 @@ autoware_agnocast_wrapper_setup(target)
 
 ## Message Filters Support
 
-This package provides wrapper types for `message_filters` (`Subscriber`, `Synchronizer`, `ApproximateTimeSynchronizer`, `ExactTimeSynchronizer`) in the `autoware::agnocast_wrapper::message_filters` namespace. These wrappers transparently switch between `::message_filters` and `agnocast::message_filters` at runtime.
+This package provides wrapper types for `message_filters` (`Subscriber`, `Synchronizer`) in the `autoware::agnocast_wrapper::message_filters` namespace. These wrappers transparently switch between `::message_filters` and `agnocast::message_filters` at runtime.
 
 ### Current limitations
 
@@ -209,9 +209,15 @@ using Policy = sync_policies::ApproximateTime<
     sensor_msgs::msg::Image, sensor_msgs::msg::CameraInfo>;
 Synchronizer<Policy> sync(Policy(10), image_sub, info_sub);
 
-// 3. Register callback (use std::bind, not a lambda — see migration note below)
-sync.registerCallback(
-  std::bind(&MyNode::onSynchronized, this, std::placeholders::_1, std::placeholders::_2));
+// 3. Register callback. Mirrors `::message_filters::Synchronizer::registerCallback` —
+//    pass a member-function pointer and `this`, or a `std::bind` result, or any other
+//    callable convertible to `void(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0) &,
+//                                    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1) &)`.
+//    Returns a `::message_filters::Connection` for later `.disconnect()`.
+auto conn = sync.registerCallback(&MyNode::onSynchronized, this);
+// Equivalent form (still supported):
+// sync.registerCallback(std::bind(
+//   &MyNode::onSynchronized, this, std::placeholders::_1, std::placeholders::_2));
 ```
 
 The callback method signature should use `const` references:

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -233,6 +233,8 @@ Synchronizer<Policy> sync(Policy(10), image_sub, info_sub);
 //                                    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1) &)`.
 //    Returns a `::message_filters::Connection` for later `.disconnect()`.
 auto conn = sync.registerCallback(&MyNode::onSynchronized, this);
+// Note: `conn` going out of scope does NOT unregister the callback.
+// Call conn.disconnect() explicitly if you need to remove it later.
 // Equivalent form (still supported):
 // sync.registerCallback(std::bind(
 //   &MyNode::onSynchronized, this, std::placeholders::_1, std::placeholders::_2));

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -219,15 +219,15 @@ private:
   using AgnocastSync = agnocast::message_filters::Synchronizer<AgnocastPolicy>;
 
   template <class C, typename T>
-  static Callback bindMemberCallback(C callback, T * t)
+  static Callback bindMemberCallback(C && callback, T * t)
   {
     return Callback{
-      [callback = std::move(callback), t](
+      [callback = std::forward<C>(callback), t](
         const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0) & m0,
         const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1) & m1) { (t->*callback)(m0, m1); }};
   }
 
-  ::message_filters::Connection registerCallbackInternal(Callback callback)
+  ::message_filters::Connection registerCallbackInternal(Callback && callback)
   {
     auto adapter = std::make_unique<CallbackAdapter>();
     adapter->fn = std::move(callback);

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -214,7 +214,7 @@ private:
     }
   };
 
-  using AdapterPtr = std::shared_ptr<CallbackAdapter>;
+  using AdapterPtr = std::unique_ptr<CallbackAdapter>;
   using RclcppSync = ::message_filters::Synchronizer<RclcppPolicy>;
   using AgnocastSync = agnocast::message_filters::Synchronizer<AgnocastPolicy>;
 
@@ -229,33 +229,37 @@ private:
 
   ::message_filters::Connection registerCallbackInternal(Callback callback)
   {
-    auto adapter = std::make_shared<CallbackAdapter>();
+    auto adapter = std::make_unique<CallbackAdapter>();
     adapter->fn = std::move(callback);
+    auto * const adapter_raw = adapter.get();
 
     auto upstream_conn = std::visit(
-      [&adapter](auto & sync) -> ::message_filters::Connection {
+      [adapter_raw](auto & sync) -> ::message_filters::Connection {
         using SyncT = std::decay_t<decltype(sync)>;
         if constexpr (std::is_same_v<SyncT, AgnocastSync>) {
-          return sync.registerCallback(&CallbackAdapter::agnocastInvoke, adapter.get());
+          return sync.registerCallback(&CallbackAdapter::agnocastInvoke, adapter_raw);
         } else {
-          return sync.registerCallback(&CallbackAdapter::rclcppInvoke, adapter.get());
+          return sync.registerCallback(&CallbackAdapter::rclcppInvoke, adapter_raw);
         }
       },
       sync_);
 
     {
       std::lock_guard<std::mutex> lock(adapters_mutex_);
-      adapters_.push_back(adapter);
+      adapters_.push_back(std::move(adapter));
     }
 
     // Wrap upstream's Connection so the user's disconnect also drops our adapter entry.
     return ::message_filters::Connection(
       ::message_filters::Connection::VoidDisconnectFunction(
-        [this, adapter = std::move(adapter), upstream_conn = std::move(upstream_conn)]() mutable {
+        [this, adapter_raw, upstream_conn = std::move(upstream_conn)]() mutable {
           upstream_conn.disconnect();
           std::lock_guard<std::mutex> lock(adapters_mutex_);
           adapters_.erase(
-            std::remove(adapters_.begin(), adapters_.end(), adapter), adapters_.end());
+            std::remove_if(
+              adapters_.begin(), adapters_.end(),
+              [adapter_raw](const AdapterPtr & p) { return p.get() == adapter_raw; }),
+            adapters_.end());
         }));
   }
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -160,7 +160,9 @@ public:
   ///       is delegated to the underlying rclcpp/agnocast signal9, so ordering and
   ///       concurrency semantics match upstream.
   /// @note The returned Connection captures `this`; do not invoke `.disconnect()` after
-  ///       this Synchronizer has been destroyed.
+  ///       this Synchronizer has been destroyed. Mirrors upstream
+  ///       `::message_filters::Synchronizer`, whose Connection also captures the inner
+  ///       `Signal9*` and has the same lifetime contract.
   template <class C>
   ::message_filters::Connection registerCallback(C & callback)
   {

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -259,8 +259,7 @@ private:
     // Wrap upstream's Connection so the user's disconnect also drops our adapter entry.
     return ::message_filters::Connection(
       ::message_filters::Connection::VoidDisconnectFunction(
-        [this, adapter = std::move(adapter),
-         upstream_conn = std::move(upstream_conn)]() mutable {
+        [this, adapter = std::move(adapter), upstream_conn = std::move(upstream_conn)]() mutable {
           upstream_conn.disconnect();
           std::lock_guard<std::mutex> lock(adapters_mutex_);
           adapters_.erase(

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -90,7 +90,7 @@ public:
     std::visit([](auto & sub) { sub.unsubscribe(); }, sub_);
   }
 
-  // Internal API: used by ApproximateTimeSynchronizer / ExactTimeSynchronizer.
+  // Internal API: used by PolicySynchronizer.
   // Not intended for downstream use.
   RclcppSubscriber & rclcpp_subscriber() { return std::get<RclcppSubscriber>(sub_); }
   AgnocastSubscriber & agnocast_subscriber() { return std::get<AgnocastSubscriber>(sub_); }
@@ -100,7 +100,8 @@ private:
 };
 
 /// @brief Common synchronizer wrapper parameterized by the underlying policy types.
-///        Use through ApproximateTimeSynchronizer or ExactTimeSynchronizer.
+///        Use through the user-facing Synchronizer<sync_policies::ApproximateTime<M0, M1>> /
+///        Synchronizer<sync_policies::ExactTime<M0, M1>>.
 ///
 /// At construction, use_agnocast() selects which backend synchronizer to instantiate
 /// inside the internal std::variant; the choice is fixed for the wrapper's lifetime
@@ -133,32 +134,97 @@ public:
   {
   }
 
-  // Non-movable: registerCallback() passes `this` to the internal synchronizer, so the
-  // wrapper's address must remain stable for the lifetime of the internal synchronizer.
+  // Non-copyable and non-movable: the internal synchronizer holds `this` (registered
+  // via the adapter callback), so the wrapper's address must remain stable for the
+  // lifetime of the internal synchronizer. Spelled out (Rule of 5) for readability and
+  // future-proofing — declaring just the move ops implicitly deletes the copy ops, but
+  // that fact is non-obvious to readers and brittle under later edits.
+  ~PolicySynchronizer() = default;
+  PolicySynchronizer(const PolicySynchronizer &) = delete;
+  PolicySynchronizer & operator=(const PolicySynchronizer &) = delete;
   PolicySynchronizer(PolicySynchronizer &&) = delete;
   PolicySynchronizer & operator=(PolicySynchronizer &&) = delete;
 
-  void registerCallback(Callback callback)
+  /// @brief Register a callable invoked on each matching tuple. Mirrors the four
+  ///        `::message_filters::Synchronizer::registerCallback` overloads (free callable
+  ///        or member-function-pointer + instance; const and non-const reference).
+  ///
+  /// Callable signature: `void(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0) &,
+  ///                           const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1) &)`.
+  /// Returns a `::message_filters::Connection`; call `.disconnect()` to stop callbacks.
+  /// The returned Connection is NOT RAII — it must be explicitly disconnected; letting
+  /// it go out of scope does not unregister.
+  ///
+  /// @note Repeated calls overwrite the stored callable; the same Connection is returned
+  ///       each time (only one callable active at a time).
+  /// @note Not thread-safe: registerCallback assigns the stored callable without
+  ///       synchronization, so it must not race with callback invocation from the
+  ///       executor. Register before spinning, or hold an external lock if you need
+  ///       to swap callbacks at runtime.
+  template <class C>
+  ::message_filters::Connection registerCallback(C & callback)
   {
-    stored_callback_ = std::move(callback);
-    std::visit(
-      [this](auto & sync) {
-        using SyncT = std::decay_t<decltype(sync)>;
-        if constexpr (std::is_same_v<SyncT, AgnocastSync>) {
-          sync.registerCallback(&PolicySynchronizer::agnocastCallbackAdapter, this);
-        } else {
-          sync.registerCallback(&PolicySynchronizer::rclcppCallbackAdapter, this);
-        }
-      },
-      sync_);
+    return registerCallbackInternal(Callback(callback));
+  }
+
+  template <class C>
+  ::message_filters::Connection registerCallback(const C & callback)
+  {
+    return registerCallbackInternal(Callback(callback));
+  }
+
+  template <class C, typename T>
+  ::message_filters::Connection registerCallback(C & callback, T * t)
+  {
+    return registerCallbackInternal(bindMemberCallback(callback, t));
+  }
+
+  template <class C, typename T>
+  ::message_filters::Connection registerCallback(const C & callback, T * t)
+  {
+    return registerCallbackInternal(bindMemberCallback(callback, t));
   }
 
 private:
   Callback stored_callback_;
 
+  using RclcppSync = ::message_filters::Synchronizer<RclcppPolicy>;
+  using AgnocastSync = agnocast::message_filters::Synchronizer<AgnocastPolicy>;
+
+  template <class C, typename T>
+  static Callback bindMemberCallback(C callback, T * t)
+  {
+    return Callback{
+      [callback = std::move(callback), t](
+        const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0) & m0,
+        const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1) & m1) { (t->*callback)(m0, m1); }};
+  }
+
+  ::message_filters::Connection registerCallbackInternal(Callback callback)
+  {
+    stored_callback_ = std::move(callback);
+    if (!adapter_registered_) {
+      adapter_connection_ = std::visit(
+        [this](auto & sync) -> ::message_filters::Connection {
+          using SyncT = std::decay_t<decltype(sync)>;
+          if constexpr (std::is_same_v<SyncT, AgnocastSync>) {
+            return sync.registerCallback(&PolicySynchronizer::agnocastCallbackAdapter, this);
+          } else {
+            return sync.registerCallback(&PolicySynchronizer::rclcppCallbackAdapter, this);
+          }
+        },
+        sync_);
+      adapter_registered_ = true;
+    }
+    return adapter_connection_;
+  }
+
   using M0Event = agnocast::message_filters::MessageEvent<const M0>;
   using M1Event = agnocast::message_filters::MessageEvent<const M1>;
 
+  // stored_callback_ is guaranteed non-empty here: registerCallbackInternal assigns it
+  // before performing the (one-time) adapter registration on the underlying synchronizer,
+  // so this adapter cannot fire without a stored callable. No emptiness guard needed.
   void agnocastCallbackAdapter(const M0Event & e0, const M1Event & e1)
   {
     // Wrap ipc_shared_ptr in message_ptr (copies ipc_shared_ptr refcount, not data)
@@ -177,60 +243,10 @@ private:
     stored_callback_(p0, p1);
   }
 
-  using RclcppSync = ::message_filters::Synchronizer<RclcppPolicy>;
-  using AgnocastSync = agnocast::message_filters::Synchronizer<AgnocastPolicy>;
-
+  bool adapter_registered_ = false;
+  ::message_filters::Connection adapter_connection_;
   std::variant<RclcppSync, AgnocastSync> sync_;
 };
-
-/// @brief Wrapper ApproximateTime Synchronizer that switches between
-///        rclcpp and agnocast message_filters at runtime.
-///
-/// The callback receives `(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)&,
-///                         const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)&)`.
-/// In agnocast mode, message_ptrs are created from the ipc_shared_ptrs,
-/// preserving zero-copy semantics during the callback lifetime.
-///
-/// @note Current limitations:
-///   - Maximum 2 message types per Synchronizer.
-///   - connectInput() is not supported; pass Subscriber references at construction time.
-///
-/// @code
-/// using namespace autoware::agnocast_wrapper::message_filters;
-///
-/// Subscriber<sensor_msgs::msg::Image> image_sub;
-/// Subscriber<sensor_msgs::msg::CameraInfo> info_sub;
-/// image_sub.subscribe(node, "/camera/image", rmw_qos_profile_sensor_data);
-/// info_sub.subscribe(node, "/camera/info", rmw_qos_profile_sensor_data);
-///
-/// using Policy = sync_policies::ApproximateTime<
-///     sensor_msgs::msg::Image, sensor_msgs::msg::CameraInfo>;
-/// auto sync = std::make_shared<Synchronizer<Policy>>(Policy(10), image_sub, info_sub);
-///
-/// sync->registerCallback(
-///   std::bind(&MyNode::onSynchronized, this, std::placeholders::_1, std::placeholders::_2));
-///
-/// // Where the callback method signature is:
-/// // void onSynchronized(
-/// //   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::Image) & img,
-/// //   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::CameraInfo) & info);
-/// @endcode
-template <typename M0, typename M1>
-using ApproximateTimeSynchronizer = PolicySynchronizer<
-  ::message_filters::sync_policies::ApproximateTime<M0, M1>,
-  agnocast::message_filters::sync_policies::ApproximateTime<M0, M1>, M0, M1>;
-
-/// @brief Wrapper ExactTime Synchronizer mirroring ApproximateTimeSynchronizer.
-///
-/// Same callback signature and zero-copy semantics as ApproximateTimeSynchronizer;
-/// only the sync policy differs (messages must share identical timestamps).
-/// @note Subject to the same limitations as ApproximateTimeSynchronizer
-///       (max 2 message types, connectInput() not supported).
-/// @see ApproximateTimeSynchronizer for a usage example.
-template <typename M0, typename M1>
-using ExactTimeSynchronizer = PolicySynchronizer<
-  ::message_filters::sync_policies::ExactTime<M0, M1>,
-  agnocast::message_filters::sync_policies::ExactTime<M0, M1>, M0, M1>;
 
 /// @brief Policy and Synchronizer types that mirror the rclcpp message_filters API.
 ///        Allows node code to use the same pattern as rclcpp:
@@ -282,26 +298,75 @@ class Synchronizer
     "are supported. Policies with more than 2 message types are not implemented.");
 };
 
+/// @brief Synchronizer specialization for the wrapper-layer ApproximateTime policy.
+///        Switches between rclcpp and agnocast message_filters at runtime.
+///
+/// The callback receives `(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)&,
+///                         const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)&)`.
+/// In agnocast mode, message_ptrs are created from the ipc_shared_ptrs, preserving
+/// zero-copy semantics during the callback lifetime.
+///
+/// @note Current limitations:
+///   - Maximum 2 message types per Synchronizer.
+///   - connectInput() is not supported; pass Subscriber references at construction time.
+///
+/// @code
+/// using namespace autoware::agnocast_wrapper::message_filters;
+///
+/// Subscriber<sensor_msgs::msg::Image> image_sub;
+/// Subscriber<sensor_msgs::msg::CameraInfo> info_sub;
+/// image_sub.subscribe(node, "/camera/image", rmw_qos_profile_sensor_data);
+/// info_sub.subscribe(node, "/camera/info", rmw_qos_profile_sensor_data);
+///
+/// using Policy = sync_policies::ApproximateTime<
+///     sensor_msgs::msg::Image, sensor_msgs::msg::CameraInfo>;
+/// auto sync = std::make_shared<Synchronizer<Policy>>(Policy(10), image_sub, info_sub);
+///
+/// // Pass a member-function pointer and `this` (mirrors upstream message_filters):
+/// sync->registerCallback(&MyNode::onSynchronized, this);
+/// // Equivalent form (still supported):
+/// // sync->registerCallback(std::bind(
+/// //   &MyNode::onSynchronized, this, std::placeholders::_1, std::placeholders::_2));
+/// @endcode
 template <typename M0, typename M1>
 class Synchronizer<sync_policies::ApproximateTime<M0, M1>>
-: public ApproximateTimeSynchronizer<M0, M1>
+: public PolicySynchronizer<
+    ::message_filters::sync_policies::ApproximateTime<M0, M1>,
+    agnocast::message_filters::sync_policies::ApproximateTime<M0, M1>, M0, M1>
 {
+  using Base = PolicySynchronizer<
+    ::message_filters::sync_policies::ApproximateTime<M0, M1>,
+    agnocast::message_filters::sync_policies::ApproximateTime<M0, M1>, M0, M1>;
+
 public:
   Synchronizer(
     const sync_policies::ApproximateTime<M0, M1> & policy, Subscriber<M0> & sub0,
     Subscriber<M1> & sub1)
-  : ApproximateTimeSynchronizer<M0, M1>(policy.queue_size, sub0, sub1)
+  : Base(policy.queue_size, sub0, sub1)
   {
   }
 };
 
+/// @brief Synchronizer specialization for the wrapper-layer ExactTime policy.
+///
+/// Same callback signature and zero-copy semantics as the ApproximateTime specialization;
+/// only the sync policy differs (messages must share identical timestamps). Subject to the
+/// same limitations (max 2 message types, connectInput() not supported).
+/// @see Synchronizer<sync_policies::ApproximateTime<M0, M1>> for a usage example.
 template <typename M0, typename M1>
-class Synchronizer<sync_policies::ExactTime<M0, M1>> : public ExactTimeSynchronizer<M0, M1>
+class Synchronizer<sync_policies::ExactTime<M0, M1>>
+: public PolicySynchronizer<
+    ::message_filters::sync_policies::ExactTime<M0, M1>,
+    agnocast::message_filters::sync_policies::ExactTime<M0, M1>, M0, M1>
 {
+  using Base = PolicySynchronizer<
+    ::message_filters::sync_policies::ExactTime<M0, M1>,
+    agnocast::message_filters::sync_policies::ExactTime<M0, M1>, M0, M1>;
+
 public:
   Synchronizer(
     const sync_policies::ExactTime<M0, M1> & policy, Subscriber<M0> & sub0, Subscriber<M1> & sub1)
-  : ExactTimeSynchronizer<M0, M1>(policy.queue_size, sub0, sub1)
+  : Base(policy.queue_size, sub0, sub1)
   {
   }
 };
@@ -320,14 +385,6 @@ namespace message_filters
 
 template <class M>
 using Subscriber = ::message_filters::Subscriber<M>;
-
-template <typename M0, typename M1>
-using ApproximateTimeSynchronizer =
-  ::message_filters::Synchronizer<::message_filters::sync_policies::ApproximateTime<M0, M1>>;
-
-template <typename M0, typename M1>
-using ExactTimeSynchronizer =
-  ::message_filters::Synchronizer<::message_filters::sync_policies::ExactTime<M0, M1>>;
 
 namespace sync_policies
 {

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -137,10 +137,8 @@ public:
   {
   }
 
-  // Non-copyable and non-movable: each CallbackAdapter we register with the underlying
-  // synchronizer is held by `adapters_`, and upstream stores raw pointers to those
-  // adapters, so this wrapper's address (which owns `adapters_` and `sync_`) must remain
-  // stable for the lifetime of the registrations.
+  // Non-copyable and non-movable: upstream holds raw pointers into this object
+  // (see CallbackAdapter), so its address must stay stable for the registrations' lifetime.
   ~PolicySynchronizer() = default;
   PolicySynchronizer(const PolicySynchronizer &) = delete;
   PolicySynchronizer & operator=(const PolicySynchronizer &) = delete;
@@ -157,12 +155,11 @@ public:
   /// only (not RAII — scope exit does NOT unregister).
   ///
   /// @note Multiple callables can be registered; all fire on each matching tuple. Dispatch
-  ///       is delegated to the underlying rclcpp/agnocast signal9, so ordering and
+  ///       is delegated to the underlying rclcpp/agnocast synchronizer, so ordering and
   ///       concurrency semantics match upstream.
   /// @note The returned Connection captures `this`; do not invoke `.disconnect()` after
   ///       this Synchronizer has been destroyed. Mirrors upstream
-  ///       `::message_filters::Synchronizer`, whose Connection also captures the inner
-  ///       `Signal9*` and has the same lifetime contract.
+  ///       `::message_filters::Synchronizer`, whose Connection has the same lifetime contract.
   template <class C>
   ::message_filters::Connection registerCallback(C & callback)
   {
@@ -188,11 +185,9 @@ public:
   }
 
 private:
-  // Per-registration adapter object. Each adapter is registered as its own slot in the
-  // underlying signal9 (one upstream slot per user callback). Owns the user-supplied
-  // callable and bridges upstream's MessageEvent / ConstSharedPtr arguments to the
-  // wrapper's message_ptr type. Stored in `adapters_` (shared_ptr) so the adapter
-  // outlives the raw pointer upstream's std::bind retains.
+  // Per-registration adapter: owns the user callable and bridges upstream's MessageEvent /
+  // ConstSharedPtr arguments to the wrapper's message_ptr type. Upstream keeps only a raw
+  // pointer (adapter.get()), so it is held in `adapters_` to keep it alive.
   struct CallbackAdapter
   {
     Callback fn;
@@ -237,9 +232,6 @@ private:
     auto adapter = std::make_shared<CallbackAdapter>();
     adapter->fn = std::move(callback);
 
-    // Register this adapter as its own slot on the underlying signal9. Dispatch is done
-    // by upstream — we never iterate here. Upstream stores `adapter.get()` as a raw
-    // pointer via std::bind, so we keep the adapter alive in `adapters_` below.
     auto upstream_conn = std::visit(
       [&adapter](auto & sync) -> ::message_filters::Connection {
         using SyncT = std::decay_t<decltype(sync)>;

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -244,23 +244,37 @@ private:
       },
       sync_);
 
-    {
-      std::lock_guard<std::mutex> lock(adapters_mutex_);
-      adapters_.push_back(std::move(adapter));
-    }
+    // Upstream now holds `adapter_raw`; any throw before return would leave it
+    // dangling (Connection's dtor does not auto-disconnect). `upstream_conn` is
+    // copy-captured (not moved) so the catch handler still has a live local if
+    // the closure / Connection construction throws.
+    try {
+      {
+        std::lock_guard<std::mutex> lock(adapters_mutex_);
+        adapters_.push_back(std::move(adapter));
+      }
 
-    // Wrap upstream's Connection so the user's disconnect also drops our adapter entry.
-    return ::message_filters::Connection(
-      ::message_filters::Connection::VoidDisconnectFunction(
-        [this, adapter_raw, upstream_conn = std::move(upstream_conn)]() mutable {
-          upstream_conn.disconnect();
-          std::lock_guard<std::mutex> lock(adapters_mutex_);
-          adapters_.erase(
-            std::remove_if(
-              adapters_.begin(), adapters_.end(),
-              [adapter_raw](const AdapterPtr & p) { return p.get() == adapter_raw; }),
-            adapters_.end());
-        }));
+      return ::message_filters::Connection(
+        ::message_filters::Connection::VoidDisconnectFunction(
+          [this, adapter_raw, upstream_conn]() mutable {
+            upstream_conn.disconnect();
+            std::lock_guard<std::mutex> lock(adapters_mutex_);
+            adapters_.erase(
+              std::remove_if(
+                adapters_.begin(), adapters_.end(),
+                [adapter_raw](const AdapterPtr & p) { return p.get() == adapter_raw; }),
+              adapters_.end());
+          }));
+    } catch (...) {
+      upstream_conn.disconnect();
+      std::lock_guard<std::mutex> lock(adapters_mutex_);
+      adapters_.erase(
+        std::remove_if(
+          adapters_.begin(), adapters_.end(),
+          [adapter_raw](const AdapterPtr & p) { return p.get() == adapter_raw; }),
+        adapters_.end());
+      throw;
+    }
   }
 
   std::mutex adapters_mutex_;

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -135,24 +135,12 @@ public:
                          std::in_place_type<RclcppSync>, RclcppPolicy(queue_size),
                          sub0.rclcpp_subscriber(), sub1.rclcpp_subscriber()))
   {
-    // Register the per-backend adapter exactly once on the underlying synchronizer.
-    // User-supplied callables are accumulated in callbacks_ and invoked from the adapter
-    // (see the agnocast/rclcpp adapters below).
-    std::visit(
-      [this](auto & sync) {
-        using SyncT = std::decay_t<decltype(sync)>;
-        if constexpr (std::is_same_v<SyncT, AgnocastSync>) {
-          sync.registerCallback(&PolicySynchronizer::agnocastCallbackAdapter, this);
-        } else {
-          sync.registerCallback(&PolicySynchronizer::rclcppCallbackAdapter, this);
-        }
-      },
-      sync_);
   }
 
-  // Non-copyable and non-movable: the internal synchronizer holds `this` (registered
-  // via the adapter callback), so the wrapper's address must remain stable for the
-  // lifetime of the internal synchronizer.
+  // Non-copyable and non-movable: each CallbackAdapter we register with the underlying
+  // synchronizer is held by `adapters_`, and upstream stores raw pointers to those
+  // adapters, so this wrapper's address (which owns `adapters_` and `sync_`) must remain
+  // stable for the lifetime of the registrations.
   ~PolicySynchronizer() = default;
   PolicySynchronizer(const PolicySynchronizer &) = delete;
   PolicySynchronizer & operator=(const PolicySynchronizer &) = delete;
@@ -168,8 +156,9 @@ public:
   /// Returns `::message_filters::Connection` whose `.disconnect()` removes THIS callable
   /// only (not RAII — scope exit does NOT unregister).
   ///
-  /// @note Multiple callables can be registered; all fire on each matching tuple, in
-  ///       registration order. Mirrors upstream signal9 semantics.
+  /// @note Multiple callables can be registered; all fire on each matching tuple. Dispatch
+  ///       is delegated to the underlying rclcpp/agnocast signal9, so ordering and
+  ///       concurrency semantics match upstream.
   /// @note The returned Connection captures `this`; do not invoke `.disconnect()` after
   ///       this Synchronizer has been destroyed.
   template <class C>
@@ -197,8 +186,38 @@ public:
   }
 
 private:
-  using CallbackEntry = std::shared_ptr<Callback>;
+  // Per-registration adapter object. Each adapter is registered as its own slot in the
+  // underlying signal9 (one upstream slot per user callback). Owns the user-supplied
+  // callable and bridges upstream's MessageEvent / ConstSharedPtr arguments to the
+  // wrapper's message_ptr type. Stored in `adapters_` (shared_ptr) so the adapter
+  // outlives the raw pointer upstream's std::bind retains.
+  struct CallbackAdapter
+  {
+    Callback fn;
 
+    using M0Event = agnocast::message_filters::MessageEvent<const M0>;
+    using M1Event = agnocast::message_filters::MessageEvent<const M1>;
+
+    void agnocastInvoke(const M0Event & e0, const M1Event & e1)
+    {
+      // Wrap ipc_shared_ptr in message_ptr (copies ipc_shared_ptr refcount, not data)
+      const auto p0 =
+        AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)(agnocast::ipc_shared_ptr<const M0>(e0.getMessage()));
+      const auto p1 =
+        AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)(agnocast::ipc_shared_ptr<const M1>(e1.getMessage()));
+      fn(p0, p1);
+    }
+
+    void rclcppInvoke(
+      const typename M0::ConstSharedPtr & m0, const typename M1::ConstSharedPtr & m1)
+    {
+      const auto p0 = AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)(std::shared_ptr<const M0>(m0));
+      const auto p1 = AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)(std::shared_ptr<const M1>(m1));
+      fn(p0, p1);
+    }
+  };
+
+  using AdapterPtr = std::shared_ptr<CallbackAdapter>;
   using RclcppSync = ::message_filters::Synchronizer<RclcppPolicy>;
   using AgnocastSync = agnocast::message_filters::Synchronizer<AgnocastPolicy>;
 
@@ -213,63 +232,41 @@ private:
 
   ::message_filters::Connection registerCallbackInternal(Callback callback)
   {
-    auto entry = std::make_shared<Callback>(std::move(callback));
+    auto adapter = std::make_shared<CallbackAdapter>();
+    adapter->fn = std::move(callback);
+
+    // Register this adapter as its own slot on the underlying signal9. Dispatch is done
+    // by upstream — we never iterate here. Upstream stores `adapter.get()` as a raw
+    // pointer via std::bind, so we keep the adapter alive in `adapters_` below.
+    auto upstream_conn = std::visit(
+      [&adapter](auto & sync) -> ::message_filters::Connection {
+        using SyncT = std::decay_t<decltype(sync)>;
+        if constexpr (std::is_same_v<SyncT, AgnocastSync>) {
+          return sync.registerCallback(&CallbackAdapter::agnocastInvoke, adapter.get());
+        } else {
+          return sync.registerCallback(&CallbackAdapter::rclcppInvoke, adapter.get());
+        }
+      },
+      sync_);
+
     {
-      std::lock_guard<std::mutex> lock(callbacks_mutex_);
-      callbacks_.push_back(entry);
+      std::lock_guard<std::mutex> lock(adapters_mutex_);
+      adapters_.push_back(adapter);
     }
-    // Bind a remove function tied to this specific entry. `this` is captured; the
-    // Connection must not outlive the Synchronizer (mirrors upstream signal9 semantics).
+
+    // Wrap upstream's Connection so the user's disconnect also drops our adapter entry.
     return ::message_filters::Connection(
       ::message_filters::Connection::VoidDisconnectFunction(
-        [this, entry]() { this->removeCallback(entry); }));
+        [this, adapter, upstream_conn]() mutable {
+          upstream_conn.disconnect();
+          std::lock_guard<std::mutex> lock(adapters_mutex_);
+          adapters_.erase(
+            std::remove(adapters_.begin(), adapters_.end(), adapter), adapters_.end());
+        }));
   }
 
-  void removeCallback(const CallbackEntry & entry)
-  {
-    std::lock_guard<std::mutex> lock(callbacks_mutex_);
-    auto it = std::find(callbacks_.begin(), callbacks_.end(), entry);
-    if (it != callbacks_.end()) {
-      callbacks_.erase(it);
-    }
-  }
-
-  // Snapshot the current callback list under lock, then invoke outside the lock so that
-  // user callbacks may freely call registerCallback / disconnect without deadlocking on
-  // callbacks_mutex_.
-  std::vector<CallbackEntry> snapshotCallbacks()
-  {
-    std::lock_guard<std::mutex> lock(callbacks_mutex_);
-    return callbacks_;
-  }
-
-  using M0Event = agnocast::message_filters::MessageEvent<const M0>;
-  using M1Event = agnocast::message_filters::MessageEvent<const M1>;
-
-  void agnocastCallbackAdapter(const M0Event & e0, const M1Event & e1)
-  {
-    // Wrap ipc_shared_ptr in message_ptr (copies ipc_shared_ptr refcount, not data)
-    const auto p0 =
-      AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)(agnocast::ipc_shared_ptr<const M0>(e0.getMessage()));
-    const auto p1 =
-      AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)(agnocast::ipc_shared_ptr<const M1>(e1.getMessage()));
-    for (const auto & entry : snapshotCallbacks()) {
-      (*entry)(p0, p1);
-    }
-  }
-
-  void rclcppCallbackAdapter(
-    const typename M0::ConstSharedPtr & m0, const typename M1::ConstSharedPtr & m1)
-  {
-    const auto p0 = AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)(std::shared_ptr<const M0>(m0));
-    const auto p1 = AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)(std::shared_ptr<const M1>(m1));
-    for (const auto & entry : snapshotCallbacks()) {
-      (*entry)(p0, p1);
-    }
-  }
-
-  std::mutex callbacks_mutex_;
-  std::vector<CallbackEntry> callbacks_;
+  std::mutex adapters_mutex_;
+  std::vector<AdapterPtr> adapters_;
   std::variant<RclcppSync, AgnocastSync> sync_;
 };
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -256,13 +256,12 @@ private:
 
     // Wrap upstream's Connection so the user's disconnect also drops our adapter entry.
     return ::message_filters::Connection(
-      ::message_filters::Connection::VoidDisconnectFunction(
-        [this, adapter, upstream_conn]() mutable {
-          upstream_conn.disconnect();
-          std::lock_guard<std::mutex> lock(adapters_mutex_);
-          adapters_.erase(
-            std::remove(adapters_.begin(), adapters_.end(), adapter), adapters_.end());
-        }));
+      ::message_filters::Connection::VoidDisconnectFunction([this, adapter,
+                                                             upstream_conn]() mutable {
+        upstream_conn.disconnect();
+        std::lock_guard<std::mutex> lock(adapters_mutex_);
+        adapters_.erase(std::remove(adapters_.begin(), adapters_.end(), adapter), adapters_.end());
+      }));
   }
 
   std::mutex adapters_mutex_;

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -258,12 +258,14 @@ private:
 
     // Wrap upstream's Connection so the user's disconnect also drops our adapter entry.
     return ::message_filters::Connection(
-      ::message_filters::Connection::VoidDisconnectFunction([this, adapter,
-                                                             upstream_conn]() mutable {
-        upstream_conn.disconnect();
-        std::lock_guard<std::mutex> lock(adapters_mutex_);
-        adapters_.erase(std::remove(adapters_.begin(), adapters_.end(), adapter), adapters_.end());
-      }));
+      ::message_filters::Connection::VoidDisconnectFunction(
+        [this, adapter = std::move(adapter),
+         upstream_conn = std::move(upstream_conn)]() mutable {
+          upstream_conn.disconnect();
+          std::lock_guard<std::mutex> lock(adapters_mutex_);
+          adapters_.erase(
+            std::remove(adapters_.begin(), adapters_.end(), adapter), adapters_.end());
+        }));
   }
 
   std::mutex adapters_mutex_;

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -22,12 +22,15 @@
 #include <message_filters/sync_policies/exact_time.h>
 #include <message_filters/synchronizer.h>
 
+#include <algorithm>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <type_traits>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #ifdef USE_AGNOCAST_ENABLED
 
@@ -132,35 +135,43 @@ public:
                          std::in_place_type<RclcppSync>, RclcppPolicy(queue_size),
                          sub0.rclcpp_subscriber(), sub1.rclcpp_subscriber()))
   {
+    // Register the per-backend adapter exactly once on the underlying synchronizer.
+    // User-supplied callables are accumulated in callbacks_ and invoked from the adapter
+    // (see the agnocast/rclcpp adapters below).
+    std::visit(
+      [this](auto & sync) {
+        using SyncT = std::decay_t<decltype(sync)>;
+        if constexpr (std::is_same_v<SyncT, AgnocastSync>) {
+          sync.registerCallback(&PolicySynchronizer::agnocastCallbackAdapter, this);
+        } else {
+          sync.registerCallback(&PolicySynchronizer::rclcppCallbackAdapter, this);
+        }
+      },
+      sync_);
   }
 
   // Non-copyable and non-movable: the internal synchronizer holds `this` (registered
   // via the adapter callback), so the wrapper's address must remain stable for the
-  // lifetime of the internal synchronizer. Spelled out (Rule of 5) for readability and
-  // future-proofing — declaring just the move ops implicitly deletes the copy ops, but
-  // that fact is non-obvious to readers and brittle under later edits.
+  // lifetime of the internal synchronizer.
   ~PolicySynchronizer() = default;
   PolicySynchronizer(const PolicySynchronizer &) = delete;
   PolicySynchronizer & operator=(const PolicySynchronizer &) = delete;
   PolicySynchronizer(PolicySynchronizer &&) = delete;
   PolicySynchronizer & operator=(PolicySynchronizer &&) = delete;
 
-  /// @brief Register a callable invoked on each matching tuple. Mirrors the four
+  /// @brief Register a callable for each matching tuple. Mirrors the four upstream
   ///        `::message_filters::Synchronizer::registerCallback` overloads (free callable
-  ///        or member-function-pointer + instance; const and non-const reference).
+  ///        or member-fn-ptr + instance; const and non-const).
   ///
-  /// Callable signature: `void(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0) &,
-  ///                           const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1) &)`.
-  /// Returns a `::message_filters::Connection`; call `.disconnect()` to stop callbacks.
-  /// The returned Connection is NOT RAII — it must be explicitly disconnected; letting
-  /// it go out of scope does not unregister.
+  /// Signature: `void(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0) &,
+  ///                  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1) &)`.
+  /// Returns `::message_filters::Connection` whose `.disconnect()` removes THIS callable
+  /// only (not RAII — scope exit does NOT unregister).
   ///
-  /// @note Repeated calls overwrite the stored callable; the same Connection is returned
-  ///       each time (only one callable active at a time).
-  /// @note Not thread-safe: registerCallback assigns the stored callable without
-  ///       synchronization, so it must not race with callback invocation from the
-  ///       executor. Register before spinning, or hold an external lock if you need
-  ///       to swap callbacks at runtime.
+  /// @note Multiple callables can be registered; all fire on each matching tuple, in
+  ///       registration order. Mirrors upstream signal9 semantics.
+  /// @note The returned Connection captures `this`; do not invoke `.disconnect()` after
+  ///       this Synchronizer has been destroyed.
   template <class C>
   ::message_filters::Connection registerCallback(C & callback)
   {
@@ -186,7 +197,7 @@ public:
   }
 
 private:
-  Callback stored_callback_;
+  using CallbackEntry = std::shared_ptr<Callback>;
 
   using RclcppSync = ::message_filters::Synchronizer<RclcppPolicy>;
   using AgnocastSync = agnocast::message_filters::Synchronizer<AgnocastPolicy>;
@@ -202,29 +213,39 @@ private:
 
   ::message_filters::Connection registerCallbackInternal(Callback callback)
   {
-    stored_callback_ = std::move(callback);
-    if (!adapter_registered_) {
-      adapter_connection_ = std::visit(
-        [this](auto & sync) -> ::message_filters::Connection {
-          using SyncT = std::decay_t<decltype(sync)>;
-          if constexpr (std::is_same_v<SyncT, AgnocastSync>) {
-            return sync.registerCallback(&PolicySynchronizer::agnocastCallbackAdapter, this);
-          } else {
-            return sync.registerCallback(&PolicySynchronizer::rclcppCallbackAdapter, this);
-          }
-        },
-        sync_);
-      adapter_registered_ = true;
+    auto entry = std::make_shared<Callback>(std::move(callback));
+    {
+      std::lock_guard<std::mutex> lock(callbacks_mutex_);
+      callbacks_.push_back(entry);
     }
-    return adapter_connection_;
+    // Bind a remove function tied to this specific entry. `this` is captured; the
+    // Connection must not outlive the Synchronizer (mirrors upstream signal9 semantics).
+    return ::message_filters::Connection(
+      ::message_filters::Connection::VoidDisconnectFunction(
+        [this, entry]() { this->removeCallback(entry); }));
+  }
+
+  void removeCallback(const CallbackEntry & entry)
+  {
+    std::lock_guard<std::mutex> lock(callbacks_mutex_);
+    auto it = std::find(callbacks_.begin(), callbacks_.end(), entry);
+    if (it != callbacks_.end()) {
+      callbacks_.erase(it);
+    }
+  }
+
+  // Snapshot the current callback list under lock, then invoke outside the lock so that
+  // user callbacks may freely call registerCallback / disconnect without deadlocking on
+  // callbacks_mutex_.
+  std::vector<CallbackEntry> snapshotCallbacks()
+  {
+    std::lock_guard<std::mutex> lock(callbacks_mutex_);
+    return callbacks_;
   }
 
   using M0Event = agnocast::message_filters::MessageEvent<const M0>;
   using M1Event = agnocast::message_filters::MessageEvent<const M1>;
 
-  // stored_callback_ is guaranteed non-empty here: registerCallbackInternal assigns it
-  // before performing the (one-time) adapter registration on the underlying synchronizer,
-  // so this adapter cannot fire without a stored callable. No emptiness guard needed.
   void agnocastCallbackAdapter(const M0Event & e0, const M1Event & e1)
   {
     // Wrap ipc_shared_ptr in message_ptr (copies ipc_shared_ptr refcount, not data)
@@ -232,7 +253,9 @@ private:
       AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)(agnocast::ipc_shared_ptr<const M0>(e0.getMessage()));
     const auto p1 =
       AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)(agnocast::ipc_shared_ptr<const M1>(e1.getMessage()));
-    stored_callback_(p0, p1);
+    for (const auto & entry : snapshotCallbacks()) {
+      (*entry)(p0, p1);
+    }
   }
 
   void rclcppCallbackAdapter(
@@ -240,11 +263,13 @@ private:
   {
     const auto p0 = AUTOWARE_MESSAGE_CONST_SHARED_PTR(M0)(std::shared_ptr<const M0>(m0));
     const auto p1 = AUTOWARE_MESSAGE_CONST_SHARED_PTR(M1)(std::shared_ptr<const M1>(m1));
-    stored_callback_(p0, p1);
+    for (const auto & entry : snapshotCallbacks()) {
+      (*entry)(p0, p1);
+    }
   }
 
-  bool adapter_registered_ = false;
-  ::message_filters::Connection adapter_connection_;
+  std::mutex callbacks_mutex_;
+  std::vector<CallbackEntry> callbacks_;
   std::variant<RclcppSync, AgnocastSync> sync_;
 };
 


### PR DESCRIPTION
## Description
This PR is to align message_filters `registerCallback` with upstream API

  - Support all four upstream `registerCallback` overloads (free callable, member-function-pointer + instance; const and non-const). Previously only a single `std::function`-style overload was supported.
  - Allow multiple `registerCallback` calls on the same `Synchronizer`. Each registration returns a `::message_filters::Connection` for individual `.disconnect()`.
  - Drop the public `ApproximateTimeSynchronizer` / `ExactTimeSynchronizer` aliases; use `Synchronizer<sync_policies::ApproximateTime<...>>` / `<ExactTime<...>>` instead.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
