### PR TITLE
fix(autoware_core_control): fix unknown substitution

### DIFF
--- a/control/autoware_core_control/launch/autoware_core_control.launch.xml
+++ b/control/autoware_core_control/launch/autoware_core_control.launch.xml
@@ -13,7 +13,7 @@
       <remap from="~/output/control_command" to="/control/command/control_cmd"/>
     </node>
 
-    <group if="$(arg launch_command_gate)">
+    <group if="$(var launch_command_gate)">
       <node pkg="autoware_command_gate" exec="autoware_command_gate_exe" name="autoware_command_gate" output="screen"/>
     </group>
   </group>


### PR DESCRIPTION
## Description

Fix this error.
```
[ERROR] [launch]: Caught exception in launch (see debug for traceback): Caught multiple exceptions when trying to load file of format [xml]:
 - VisitError: Error trying to process rule "substitution":

Unknown substitution: arg
 - SyntaxError: invalid syntax (autoware_core_control.launch.xml, line 1)
```

## Related links

None

## How was this PR tested?

Launch autoware_core.launch.xml

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
