### PR TITLE
fix(autoware_core_localization): sync ekf_localizer param

### DIFF
--- a/localization/autoware_core_localization/config/ekf_localizer.param.yaml
+++ b/localization/autoware_core_localization/config/ekf_localizer.param.yaml
@@ -45,6 +45,8 @@
       warn_ellipse_size: 1.2
       error_ellipse_size_lateral_direction: 0.3
       warn_ellipse_size_lateral_direction: 0.25
+      # diagnostics publish frequency [Hz] (must be > 0)
+      diagnostics_publish_frequency: 10.0
 
     misc:
       # for velocity measurement limitation (Set 0.0 if you want to ignore)


### PR DESCRIPTION
## Description

Sync ekf_localizer.param.yaml to fix this error.
```
[autoware_ekf_localizer_node-9] terminate called after throwing an instance of 'rclcpp::exceptions::UninitializedStaticallyTypedParameterException'
[autoware_ekf_localizer_node-9]   what():  Statically typed parameter 'diagnostics.diagnostics_publish_frequency' must be initialized.
```

## Related links

None

## How was this PR tested?

Launch autoware_core.launch.xml

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
