### PR TITLE
perf(autoware_kalman_filter): use Cholesky solve in update() with full guard-branch test coverage

### DIFF
--- a/common/autoware_kalman_filter/src/kalman_filter.cpp
+++ b/common/autoware_kalman_filter/src/kalman_filter.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/kalman_filter/kalman_filter.hpp"
 
+#include <Eigen/Cholesky>
+
 namespace autoware::kalman_filter
 {
 KalmanFilter::KalmanFilter(
@@ -95,7 +97,11 @@ bool KalmanFilter::predict(
     return false;
   }
   x_ = x_next;
-  P_ = A * P_ * A.transpose() + Q;
+  // P_ = A P_ A^T + Q, evaluated through a temporary so noalias() can drop the intermediate
+  // Eigen products in this hot per-cycle path.
+  const Eigen::MatrixXd AP = A * P_;
+  P_.noalias() = AP * A.transpose();
+  P_ += Q;
   return true;
 }
 bool KalmanFilter::predict(const Eigen::MatrixXd & x_next, const Eigen::MatrixXd & A)
@@ -128,14 +134,28 @@ bool KalmanFilter::update(
     return false;
   }
   const Eigen::MatrixXd PCT = P_ * C.transpose();
-  const Eigen::MatrixXd K = PCT * ((R + C * PCT).inverse());
+
+  // Innovation covariance S = C P C^T + R.
+  Eigen::MatrixXd S = R;
+  S.noalias() += C * PCT;
+
+  // Compute the Kalman gain K = PCT * S^-1 via a Cholesky (LLT) solve rather than an explicit
+  // inverse: it is faster and numerically more stable, and a failed decomposition rejects updates
+  // whose innovation covariance is not positive definite (which would otherwise corrupt the state).
+  // S is symmetric, so K^T solves S * K^T = PCT^T.
+  const Eigen::LLT<Eigen::MatrixXd> llt_of_s(S);
+  if (llt_of_s.info() != Eigen::Success) {
+    return false;
+  }
+  const Eigen::MatrixXd K = llt_of_s.solve(PCT.transpose()).transpose();
 
   if (K.array().isNaN().any() || K.array().isInf().any()) {
     return false;
   }
 
-  x_ = x_ + K * (y - y_pred);
-  P_ = P_ - K * (C * P_);
+  x_.noalias() += K * (y - y_pred);
+  const Eigen::MatrixXd CP = C * P_;
+  P_.noalias() -= K * CP;
   return true;
 }
 

--- a/common/autoware_kalman_filter/src/kalman_filter.cpp
+++ b/common/autoware_kalman_filter/src/kalman_filter.cpp
@@ -16,6 +16,8 @@
 
 #include <Eigen/Cholesky>
 
+#include <iostream>
+
 namespace autoware::kalman_filter
 {
 KalmanFilter::KalmanFilter(
@@ -145,6 +147,7 @@ bool KalmanFilter::update(
   // S is symmetric, so K^T solves S * K^T = PCT^T.
   const Eigen::LLT<Eigen::MatrixXd> llt_of_s(S);
   if (llt_of_s.info() != Eigen::Success) {
+    std::cerr << "LLT decomposition failed. S matrix might not be positive definite." << std::endl;
     return false;
   }
   const Eigen::MatrixXd K = llt_of_s.solve(PCT.transpose()).transpose();

--- a/common/autoware_kalman_filter/test/test_kalman_filter.cpp
+++ b/common/autoware_kalman_filter/test/test_kalman_filter.cpp
@@ -18,6 +18,21 @@
 
 using autoware::kalman_filter::KalmanFilter;
 
+namespace
+{
+// Build a minimal, valid 2-state filter (x_ is 2x1, P_ is 2x2) for exercising guard branches.
+KalmanFilter make_initialized_filter()
+{
+  Eigen::MatrixXd x(2, 1);
+  x << 1.0, 2.0;
+  Eigen::MatrixXd p(2, 2);
+  p << 1.0, 0.0, 0.0, 1.0;
+  KalmanFilter kf;
+  kf.init(x, p);
+  return kf;
+}
+}  // namespace
+
 TEST(kalman_filter, kf)
 {
   KalmanFilter kf_;
@@ -102,6 +117,167 @@ TEST(kalman_filter, kf)
   kf_new.getP(P_predict);
   EXPECT_NEAR(P_predict(0, 0), P_predict_expected(0, 0), 1e-5);
   EXPECT_NEAR(P_predict(1, 1), P_predict_expected(1, 1), 1e-5);
+}
+
+TEST(kalman_filter, init_full_rejects_empty_matrix)
+{
+  KalmanFilter kf;
+  const Eigen::MatrixXd x = Eigen::MatrixXd::Zero(2, 1);
+  const Eigen::MatrixXd m = Eigen::MatrixXd::Identity(2, 2);
+  const Eigen::MatrixXd empty;  // 0x0
+
+  // Each empty argument independently makes the full init return false.
+  EXPECT_FALSE(kf.init(empty, m, m, m, m, m, m));  // x empty
+  EXPECT_FALSE(kf.init(x, empty, m, m, m, m, m));  // A empty
+  EXPECT_FALSE(kf.init(x, m, empty, m, m, m, m));  // B empty
+  EXPECT_FALSE(kf.init(x, m, m, empty, m, m, m));  // C empty
+  EXPECT_FALSE(kf.init(x, m, m, m, empty, m, m));  // Q empty
+  EXPECT_FALSE(kf.init(x, m, m, m, m, empty, m));  // R empty
+  EXPECT_FALSE(kf.init(x, m, m, m, m, m, empty));  // P empty
+  EXPECT_TRUE(kf.init(x, m, m, m, m, m, m));       // all valid
+}
+
+TEST(kalman_filter, init_state_cov_rejects_empty_matrix)
+{
+  KalmanFilter kf;
+  const Eigen::MatrixXd x = Eigen::MatrixXd::Zero(2, 1);
+  const Eigen::MatrixXd p = Eigen::MatrixXd::Identity(2, 2);
+  const Eigen::MatrixXd empty;
+
+  EXPECT_FALSE(kf.init(empty, p));
+  EXPECT_FALSE(kf.init(x, empty));
+  EXPECT_TRUE(kf.init(x, p));
+}
+
+TEST(kalman_filter, init_state_cov_sets_state_and_getters)
+{
+  KalmanFilter kf;
+  Eigen::MatrixXd x(2, 1);
+  x << 3.0, -4.0;
+  Eigen::MatrixXd p(2, 2);
+  p << 2.0, 0.5, 0.5, 3.0;
+  ASSERT_TRUE(kf.init(x, p));
+
+  Eigen::MatrixXd x_out;
+  kf.getX(x_out);
+  Eigen::MatrixXd p_out;
+  kf.getP(p_out);
+  EXPECT_TRUE(x_out.isApprox(x));
+  EXPECT_TRUE(p_out.isApprox(p));
+  EXPECT_DOUBLE_EQ(kf.getXelement(0), 3.0);
+  EXPECT_DOUBLE_EQ(kf.getXelement(1), -4.0);
+}
+
+TEST(kalman_filter, predict_with_x_and_a_rejects_dimension_mismatch)
+{
+  const Eigen::MatrixXd a2 = Eigen::MatrixXd::Identity(2, 2);
+  const Eigen::MatrixXd q2 = Eigen::MatrixXd::Identity(2, 2);
+  const Eigen::MatrixXd x_next = Eigen::MatrixXd::Zero(2, 1);
+
+  {  // x_.rows() != x_next.rows()
+    auto kf = make_initialized_filter();
+    EXPECT_FALSE(kf.predict(Eigen::MatrixXd::Zero(3, 1), a2, q2));
+  }
+  {  // A.cols() != P_.rows()
+    auto kf = make_initialized_filter();
+    EXPECT_FALSE(kf.predict(x_next, Eigen::MatrixXd::Zero(2, 3), q2));
+  }
+  {  // Q.cols() != Q.rows()
+    auto kf = make_initialized_filter();
+    EXPECT_FALSE(kf.predict(x_next, a2, Eigen::MatrixXd::Zero(2, 3)));
+  }
+  {  // A.rows() != Q.cols()
+    auto kf = make_initialized_filter();
+    EXPECT_FALSE(kf.predict(x_next, Eigen::MatrixXd::Zero(3, 2), q2));
+  }
+}
+
+TEST(kalman_filter, predict_with_input_rejects_dimension_mismatch)
+{
+  const Eigen::MatrixXd a2 = Eigen::MatrixXd::Identity(2, 2);
+  const Eigen::MatrixXd b2 = Eigen::MatrixXd::Identity(2, 2);
+  const Eigen::MatrixXd q2 = Eigen::MatrixXd::Identity(2, 2);
+  const Eigen::MatrixXd u2 = Eigen::MatrixXd::Zero(2, 1);
+
+  {  // A.cols() != x_.rows()
+    auto kf = make_initialized_filter();
+    EXPECT_FALSE(kf.predict(u2, Eigen::MatrixXd::Zero(2, 3), b2, q2));
+  }
+  {  // B.cols() != u.rows()
+    auto kf = make_initialized_filter();
+    EXPECT_FALSE(kf.predict(u2, a2, Eigen::MatrixXd::Zero(2, 3), q2));
+  }
+}
+
+TEST(kalman_filter, update_full_rejects_dimension_mismatch)
+{
+  const Eigen::MatrixXd y2 = Eigen::MatrixXd::Zero(2, 1);
+  const Eigen::MatrixXd c2 = Eigen::MatrixXd::Identity(2, 2);
+  const Eigen::MatrixXd r2 = Eigen::MatrixXd::Identity(2, 2);
+
+  {  // P_.cols() != C.cols()
+    auto kf = make_initialized_filter();
+    EXPECT_FALSE(kf.update(y2, y2, Eigen::MatrixXd::Identity(2, 3), r2));
+  }
+  {  // R not square
+    auto kf = make_initialized_filter();
+    EXPECT_FALSE(kf.update(y2, y2, c2, Eigen::MatrixXd::Zero(2, 3)));
+  }
+  {  // R.rows() != C.rows()
+    auto kf = make_initialized_filter();
+    EXPECT_FALSE(kf.update(y2, y2, c2, Eigen::MatrixXd::Identity(3, 3)));
+  }
+  {  // y.rows() != y_pred.rows()
+    auto kf = make_initialized_filter();
+    EXPECT_FALSE(kf.update(y2, Eigen::MatrixXd::Zero(3, 1), c2, r2));
+  }
+  {  // y.rows() != C.rows()
+    auto kf = make_initialized_filter();
+    const Eigen::MatrixXd y3 = Eigen::MatrixXd::Zero(3, 1);
+    EXPECT_FALSE(kf.update(y3, y3, c2, r2));
+  }
+}
+
+TEST(kalman_filter, update_rejects_observation_dimension_mismatch)
+{
+  auto kf = make_initialized_filter();
+  const Eigen::MatrixXd y = Eigen::MatrixXd::Zero(2, 1);
+  const Eigen::MatrixXd c_wrong = Eigen::MatrixXd::Identity(2, 3);  // C.cols() != x_.rows()
+  const Eigen::MatrixXd r = Eigen::MatrixXd::Identity(2, 2);
+  EXPECT_FALSE(kf.update(y, c_wrong, r));
+}
+
+TEST(kalman_filter, update_matches_closed_form_with_correlated_covariance)
+{
+  // Exercises the gain computation on a non-diagonal, well-conditioned problem and pins the
+  // result to the closed-form (explicit-inverse) solution, guarding any change to the solver.
+  KalmanFilter kf;
+  Eigen::MatrixXd x(2, 1);
+  x << 1.0, -2.0;
+  Eigen::MatrixXd p(2, 2);
+  p << 2.0, 0.3, 0.3, 1.5;  // symmetric positive-definite with off-diagonal correlation
+  ASSERT_TRUE(kf.init(x, p));
+
+  Eigen::MatrixXd c(1, 2);
+  c << 1.0, 0.5;
+  Eigen::MatrixXd r(1, 1);
+  r << 0.2;
+  Eigen::MatrixXd y(1, 1);
+  y << 0.4;
+
+  const Eigen::MatrixXd y_pred = c * x;
+  const Eigen::MatrixXd pct = p * c.transpose();
+  const Eigen::MatrixXd k = pct * (r + c * pct).inverse();
+  const Eigen::MatrixXd x_expected = x + k * (y - y_pred);
+  const Eigen::MatrixXd p_expected = p - k * (c * p);
+
+  ASSERT_TRUE(kf.update(y, c, r));
+  Eigen::MatrixXd x_out;
+  kf.getX(x_out);
+  Eigen::MatrixXd p_out;
+  kf.getP(p_out);
+  EXPECT_TRUE(x_out.isApprox(x_expected, 1e-10));
+  EXPECT_TRUE(p_out.isApprox(p_expected, 1e-10));
 }
 
 int main(int argc, char * argv[])

--- a/common/autoware_kalman_filter/test/test_kalman_filter.cpp
+++ b/common/autoware_kalman_filter/test/test_kalman_filter.cpp
@@ -149,46 +149,6 @@ TEST(kalman_filter, init_state_cov_rejects_empty_matrix)
   EXPECT_TRUE(kf.init(x, p));
 }
 
-TEST(kalman_filter, init_state_cov_feed_into_filter_math)
-{
-  // Beyond round-tripping the getters, this confirms that the state and covariance set by the
-  // two-argument init() are the ones actually consumed by the filter math: after a predict with
-  // A = 2 I, Q = 0.1 I, the new state must be A x and the new covariance A P A^T + Q. Asserting
-  // against hand-computed literals (independent of the implementation's expression) catches a
-  // wiring mistake where init stored x/P but predict read stale members.
-  KalmanFilter kf;
-  Eigen::MatrixXd x(2, 1);
-  x << 3.0, -4.0;
-  Eigen::MatrixXd p(2, 2);
-  p << 2.0, 0.5, 0.5, 3.0;
-  ASSERT_TRUE(kf.init(x, p));
-
-  // getXelement reads back individual state entries directly from the stored vector.
-  EXPECT_DOUBLE_EQ(kf.getXelement(0), 3.0);
-  EXPECT_DOUBLE_EQ(kf.getXelement(1), -4.0);
-
-  Eigen::MatrixXd a(2, 2);
-  a << 2.0, 0.0, 0.0, 2.0;
-  Eigen::MatrixXd q(2, 2);
-  q << 0.1, 0.0, 0.0, 0.1;
-  Eigen::MatrixXd x_next(2, 1);
-  x_next << 6.0, -8.0;  // = A x
-  ASSERT_TRUE(kf.predict(x_next, a, q));
-
-  // A P A^T + Q with A = 2 I: 4 * P + 0.1 on the diagonal.
-  //   [[4*2.0 + 0.1, 4*0.5      ], [4*0.5, 4*3.0 + 0.1]] = [[8.1, 2.0], [2.0, 12.1]]
-  Eigen::MatrixXd x_out;
-  kf.getX(x_out);
-  Eigen::MatrixXd p_out;
-  kf.getP(p_out);
-  EXPECT_DOUBLE_EQ(x_out(0, 0), 6.0);
-  EXPECT_DOUBLE_EQ(x_out(1, 0), -8.0);
-  EXPECT_DOUBLE_EQ(p_out(0, 0), 8.1);
-  EXPECT_DOUBLE_EQ(p_out(0, 1), 2.0);
-  EXPECT_DOUBLE_EQ(p_out(1, 0), 2.0);
-  EXPECT_DOUBLE_EQ(p_out(1, 1), 12.1);
-}
-
 TEST(kalman_filter, predict_with_x_and_a_rejects_dimension_mismatch)
 {
   const Eigen::MatrixXd a2 = Eigen::MatrixXd::Identity(2, 2);

--- a/common/autoware_kalman_filter/test/test_kalman_filter.cpp
+++ b/common/autoware_kalman_filter/test/test_kalman_filter.cpp
@@ -149,8 +149,13 @@ TEST(kalman_filter, init_state_cov_rejects_empty_matrix)
   EXPECT_TRUE(kf.init(x, p));
 }
 
-TEST(kalman_filter, init_state_cov_sets_state_and_getters)
+TEST(kalman_filter, init_state_cov_feed_into_filter_math)
 {
+  // Beyond round-tripping the getters, this confirms that the state and covariance set by the
+  // two-argument init() are the ones actually consumed by the filter math: after a predict with
+  // A = 2 I, Q = 0.1 I, the new state must be A x and the new covariance A P A^T + Q. Asserting
+  // against hand-computed literals (independent of the implementation's expression) catches a
+  // wiring mistake where init stored x/P but predict read stale members.
   KalmanFilter kf;
   Eigen::MatrixXd x(2, 1);
   x << 3.0, -4.0;
@@ -158,14 +163,30 @@ TEST(kalman_filter, init_state_cov_sets_state_and_getters)
   p << 2.0, 0.5, 0.5, 3.0;
   ASSERT_TRUE(kf.init(x, p));
 
+  // getXelement reads back individual state entries directly from the stored vector.
+  EXPECT_DOUBLE_EQ(kf.getXelement(0), 3.0);
+  EXPECT_DOUBLE_EQ(kf.getXelement(1), -4.0);
+
+  Eigen::MatrixXd a(2, 2);
+  a << 2.0, 0.0, 0.0, 2.0;
+  Eigen::MatrixXd q(2, 2);
+  q << 0.1, 0.0, 0.0, 0.1;
+  Eigen::MatrixXd x_next(2, 1);
+  x_next << 6.0, -8.0;  // = A x
+  ASSERT_TRUE(kf.predict(x_next, a, q));
+
+  // A P A^T + Q with A = 2 I: 4 * P + 0.1 on the diagonal.
+  //   [[4*2.0 + 0.1, 4*0.5      ], [4*0.5, 4*3.0 + 0.1]] = [[8.1, 2.0], [2.0, 12.1]]
   Eigen::MatrixXd x_out;
   kf.getX(x_out);
   Eigen::MatrixXd p_out;
   kf.getP(p_out);
-  EXPECT_TRUE(x_out.isApprox(x));
-  EXPECT_TRUE(p_out.isApprox(p));
-  EXPECT_DOUBLE_EQ(kf.getXelement(0), 3.0);
-  EXPECT_DOUBLE_EQ(kf.getXelement(1), -4.0);
+  EXPECT_DOUBLE_EQ(x_out(0, 0), 6.0);
+  EXPECT_DOUBLE_EQ(x_out(1, 0), -8.0);
+  EXPECT_DOUBLE_EQ(p_out(0, 0), 8.1);
+  EXPECT_DOUBLE_EQ(p_out(0, 1), 2.0);
+  EXPECT_DOUBLE_EQ(p_out(1, 0), 2.0);
+  EXPECT_DOUBLE_EQ(p_out(1, 1), 12.1);
 }
 
 TEST(kalman_filter, predict_with_x_and_a_rejects_dimension_mismatch)
@@ -250,7 +271,17 @@ TEST(kalman_filter, update_rejects_observation_dimension_mismatch)
 TEST(kalman_filter, update_matches_closed_form_with_correlated_covariance)
 {
   // Exercises the gain computation on a non-diagonal, well-conditioned problem and pins the
-  // result to the closed-form (explicit-inverse) solution, guarding any change to the solver.
+  // result to hand-computed numeric literals, guarding any change to the solver.
+  //
+  // Hand derivation for x = [1, -2]^T, P = [[2, 0.3], [0.3, 1.5]], C = [1, 0.5], R = [0.2],
+  // y = [0.4]:
+  //   y_pred = C x         = 1*1 + 0.5*(-2)            = 0
+  //   P C^T  = [2*1 + 0.3*0.5, 0.3*1 + 1.5*0.5]^T      = [2.15, 1.05]^T
+  //   S      = R + C P C^T = 0.2 + (1*2.15 + 0.5*1.05) = 2.875
+  //   K      = P C^T / S   = [2.15/2.875, 1.05/2.875]^T = [0.74782608.., 0.36521739..]^T
+  //   x_new  = x + K (y - y_pred) = x + 0.4 * K        = [1.29913043.., -1.85391304..]^T
+  //   P_new  = P - K (C P)                             = [[ 0.39217391.., -0.48521739..],
+  //                                                       [-0.48521739..,  1.11652173..]]
   KalmanFilter kf;
   Eigen::MatrixXd x(2, 1);
   x << 1.0, -2.0;
@@ -265,19 +296,18 @@ TEST(kalman_filter, update_matches_closed_form_with_correlated_covariance)
   Eigen::MatrixXd y(1, 1);
   y << 0.4;
 
-  const Eigen::MatrixXd y_pred = c * x;
-  const Eigen::MatrixXd pct = p * c.transpose();
-  const Eigen::MatrixXd k = pct * (r + c * pct).inverse();
-  const Eigen::MatrixXd x_expected = x + k * (y - y_pred);
-  const Eigen::MatrixXd p_expected = p - k * (c * p);
-
   ASSERT_TRUE(kf.update(y, c, r));
   Eigen::MatrixXd x_out;
   kf.getX(x_out);
   Eigen::MatrixXd p_out;
   kf.getP(p_out);
-  EXPECT_TRUE(x_out.isApprox(x_expected, 1e-10));
-  EXPECT_TRUE(p_out.isApprox(p_expected, 1e-10));
+
+  EXPECT_NEAR(x_out(0, 0), 1.2991304347826087, 1e-10);
+  EXPECT_NEAR(x_out(1, 0), -1.853913043478261, 1e-10);
+  EXPECT_NEAR(p_out(0, 0), 0.3921739130434785, 1e-10);
+  EXPECT_NEAR(p_out(0, 1), -0.48521739130434777, 1e-10);
+  EXPECT_NEAR(p_out(1, 0), -0.48521739130434777, 1e-10);
+  EXPECT_NEAR(p_out(1, 1), 1.1165217391304347, 1e-10);
 }
 
 TEST(kalman_filter, update_rejects_non_positive_definite_innovation_covariance)

--- a/common/autoware_kalman_filter/test/test_kalman_filter.cpp
+++ b/common/autoware_kalman_filter/test/test_kalman_filter.cpp
@@ -280,6 +280,22 @@ TEST(kalman_filter, update_matches_closed_form_with_correlated_covariance)
   EXPECT_TRUE(p_out.isApprox(p_expected, 1e-10));
 }
 
+TEST(kalman_filter, update_rejects_non_positive_definite_innovation_covariance)
+{
+  // A negative-definite measurement covariance R makes the innovation covariance
+  // S = R + C P C^T non-positive-definite. Such an update is invalid and must be rejected
+  // to avoid corrupting the state, rather than silently applying a meaningless gain.
+  KalmanFilter kf;
+  const Eigen::MatrixXd x = Eigen::MatrixXd::Zero(2, 1);
+  const Eigen::MatrixXd p = Eigen::MatrixXd::Identity(2, 2);
+  ASSERT_TRUE(kf.init(x, p));
+
+  const Eigen::MatrixXd y = Eigen::MatrixXd::Zero(2, 1);
+  const Eigen::MatrixXd c = Eigen::MatrixXd::Identity(2, 2);
+  const Eigen::MatrixXd r = -2.0 * Eigen::MatrixXd::Identity(2, 2);  // S = -I, non-PD
+  EXPECT_FALSE(kf.update(y, c, r));
+}
+
 int main(int argc, char * argv[])
 {
   testing::InitGoogleTest(&argc, argv);

--- a/common/autoware_kalman_filter/test/test_kalman_filter.cpp
+++ b/common/autoware_kalman_filter/test/test_kalman_filter.cpp
@@ -61,49 +61,48 @@ TEST(kalman_filter, kf)
   // Initialize the filter and check if initialization was successful
   EXPECT_TRUE(kf_.init(x_t, A_t, B_t, C_t, Q_t, R_t, P_t));
 
-  // Perform prediction
+  // Perform prediction with A = B = I, so x_pred = x + u and P_pred = P + Q.
+  //   x_pred = [1 + 0.1, 2 + 0.1]      = [1.1, 2.1]
+  //   P_pred = I + 0.01 I (diagonal)   = diag(1.01, 1.01)
   Eigen::MatrixXd u_t(2, 1);
   u_t << 0.1, 0.1;
   EXPECT_TRUE(kf_.predict(u_t));
 
-  // Check the updated state and covariance matrix
-  Eigen::MatrixXd x_predict_expected = A_t * x_t + B_t * u_t;
-  Eigen::MatrixXd P_predict_expected = A_t * P_t * A_t.transpose() + Q_t;
-
+  // Check the predicted state and covariance against hand-computed literals.
   Eigen::MatrixXd x_predict;
   kf_.getX(x_predict);
   Eigen::MatrixXd P_predict;
   kf_.getP(P_predict);
 
-  EXPECT_NEAR(x_predict(0, 0), x_predict_expected(0, 0), 1e-5);
-  EXPECT_NEAR(x_predict(1, 0), x_predict_expected(1, 0), 1e-5);
-  EXPECT_NEAR(P_predict(0, 0), P_predict_expected(0, 0), 1e-5);
-  EXPECT_NEAR(P_predict(1, 1), P_predict_expected(1, 1), 1e-5);
+  EXPECT_NEAR(x_predict(0, 0), 1.1, 1e-5);
+  EXPECT_NEAR(x_predict(1, 0), 2.1, 1e-5);
+  EXPECT_NEAR(P_predict(0, 0), 1.01, 1e-5);
+  EXPECT_NEAR(P_predict(1, 1), 1.01, 1e-5);
 
-  // Perform update
+  // Perform update with C = I, R = 0.09 I, y = [1.05, 2.05].
+  //   S    = R + C P_pred C^T = diag(1.01 + 0.09)      = diag(1.1)
+  //   K    = P_pred C^T S^-1  = diag(1.01 / 1.1)        = diag(0.918181..)
+  //   x_up = x_pred + K (y - x_pred)
+  //        = 1.1 + (1.01/1.1)*(1.05 - 1.1)              = 1.05409090909..  (dim 0)
+  //        = 2.1 + (1.01/1.1)*(2.05 - 2.1)              = 2.05409090909..  (dim 1)
+  //   P_up = P_pred - K (C P_pred)
+  //        = 1.01 - (1.01/1.1)*1.01                     = 0.08263636363..  (diagonal)
   Eigen::MatrixXd y_t(2, 1);
   y_t << 1.05, 2.05;
   EXPECT_TRUE(kf_.update(y_t));
-
-  // Check the updated state and covariance matrix
-  const Eigen::MatrixXd PCT_t = P_predict_expected * C_t.transpose();
-  const Eigen::MatrixXd K_t = PCT_t * ((R_t + C_t * PCT_t).inverse());
-  const Eigen::MatrixXd y_pred = C_t * x_predict_expected;
-  Eigen::MatrixXd x_update_expected = x_predict_expected + K_t * (y_t - y_pred);
-  Eigen::MatrixXd P_update_expected = P_predict_expected - K_t * (C_t * P_predict_expected);
 
   Eigen::MatrixXd x_update;
   kf_.getX(x_update);
   Eigen::MatrixXd P_update;
   kf_.getP(P_update);
 
-  EXPECT_NEAR(x_update(0, 0), x_update_expected(0, 0), 1e-5);
-  EXPECT_NEAR(x_update(1, 0), x_update_expected(1, 0), 1e-5);
-  EXPECT_NEAR(P_update(0, 0), P_update_expected(0, 0), 1e-5);
-  EXPECT_NEAR(P_update(1, 1), P_update_expected(1, 1), 1e-5);
+  EXPECT_NEAR(x_update(0, 0), 1.0540909090909092, 1e-5);
+  EXPECT_NEAR(x_update(1, 0), 2.0540909090909087, 1e-5);
+  EXPECT_NEAR(P_update(0, 0), 0.08263636363636362, 1e-5);
+  EXPECT_NEAR(P_update(1, 1), 0.08263636363636362, 1e-5);
 
-  // Add tests to cover missed lines
-
+  // Exercise the value constructor and the explicit-A predict overload. With a fresh state
+  // initialized to (x_t, P_t) and A = I, Q = 0.01 I, the covariance becomes P + Q = diag(1.01).
   KalmanFilter kf_new(x_t, A_t, B_t, C_t, Q_t, R_t, P_t);
   kf_new.init(x_t, P_t);
   kf_new.setA(A_t);
@@ -112,11 +111,12 @@ TEST(kalman_filter, kf)
   kf_new.setQ(Q_t);
   kf_new.setR(R_t);
 
-  EXPECT_TRUE(kf_new.predict(x_predict_expected, A_t));
-  P_predict_expected = A_t * P_t * A_t.transpose() + Q_t;
+  Eigen::MatrixXd x_next(2, 1);
+  x_next << 1.1, 2.1;
+  EXPECT_TRUE(kf_new.predict(x_next, A_t));
   kf_new.getP(P_predict);
-  EXPECT_NEAR(P_predict(0, 0), P_predict_expected(0, 0), 1e-5);
-  EXPECT_NEAR(P_predict(1, 1), P_predict_expected(1, 1), 1e-5);
+  EXPECT_NEAR(P_predict(0, 0), 1.01, 1e-5);
+  EXPECT_NEAR(P_predict(1, 1), 1.01, 1e-5);
 }
 
 TEST(kalman_filter, init_full_rejects_empty_matrix)

--- a/common/autoware_kalman_filter/test/test_time_delay_kalman_filter.cpp
+++ b/common/autoware_kalman_filter/test/test_time_delay_kalman_filter.cpp
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+#include <string>
+
 using autoware::kalman_filter::TimeDelayKalmanFilter;
 
 namespace
@@ -318,4 +320,69 @@ TEST_F(TimeDelayKalmanFilterTest, ZeroInitialState)
 
   EXPECT_TRUE(x_check.isApprox(x_zero, kEpsilon));
   EXPECT_TRUE(P_check.isApprox(P_zero, kEpsilon));
+}
+
+TEST_F(TimeDelayKalmanFilterTest, UpdateRejectsNonColumnMeasurement)
+{
+  td_kf_.init(x_t_, P_t_, kMaxDelayStep);
+  ASSERT_TRUE(td_kf_.predictWithDelay(x_next_, A_, Q_));
+
+  const Eigen::MatrixXd y_not_column = Eigen::MatrixXd::Zero(kDimX, 2);  // y.cols() != 1
+  testing::internal::CaptureStderr();
+  const bool ok = td_kf_.updateWithDelay(y_not_column, C_, R_, 0);
+  const std::string err = testing::internal::GetCapturedStderr();
+
+  EXPECT_FALSE(ok);
+  EXPECT_NE(err.find("column vector"), std::string::npos);
+}
+
+TEST_F(TimeDelayKalmanFilterTest, UpdateRejectsNonSquareMeasurementCovariance)
+{
+  td_kf_.init(x_t_, P_t_, kMaxDelayStep);
+  ASSERT_TRUE(td_kf_.predictWithDelay(x_next_, A_, Q_));
+
+  Eigen::MatrixXd y(kDimX, 1);
+  y << 1.0, 2.0, 3.0;
+  const Eigen::MatrixXd r_non_square = Eigen::MatrixXd::Zero(kDimX, kDimX + 1);
+  testing::internal::CaptureStderr();
+  const bool ok = td_kf_.updateWithDelay(y, C_, r_non_square, 0);
+  const std::string err = testing::internal::GetCapturedStderr();
+
+  EXPECT_FALSE(ok);
+  EXPECT_NE(err.find("must be square"), std::string::npos);
+}
+
+TEST_F(TimeDelayKalmanFilterTest, UpdateRejectsMismatchedMeasurementCovarianceRows)
+{
+  td_kf_.init(x_t_, P_t_, kMaxDelayStep);
+  ASSERT_TRUE(td_kf_.predictWithDelay(x_next_, A_, Q_));
+
+  Eigen::MatrixXd y(kDimX, 1);
+  y << 1.0, 2.0, 3.0;
+  // Square, but its dimension differs from C.rows().
+  const Eigen::MatrixXd r_wrong = Eigen::MatrixXd::Identity(kDimX + 1, kDimX + 1);
+  testing::internal::CaptureStderr();
+  const bool ok = td_kf_.updateWithDelay(y, C_, r_wrong, 0);
+  const std::string err = testing::internal::GetCapturedStderr();
+
+  EXPECT_FALSE(ok);
+  EXPECT_NE(err.find("covariance R and"), std::string::npos);
+}
+
+TEST_F(TimeDelayKalmanFilterTest, UpdateRejectsNonPositiveDefiniteInnovationCovariance)
+{
+  td_kf_.init(x_t_, P_t_, kMaxDelayStep);
+  ASSERT_TRUE(td_kf_.predictWithDelay(x_next_, A_, Q_));
+
+  Eigen::MatrixXd y(kDimX, 1);
+  y << 1.0, 2.0, 3.0;
+  // A negative-definite R makes the innovation covariance S = R + C P C^T non-PD,
+  // so the Cholesky (LLT) decomposition must fail and the update must be rejected.
+  const Eigen::MatrixXd r_negative = -1.0 * Eigen::MatrixXd::Identity(kDimX, kDimX);
+  testing::internal::CaptureStderr();
+  const bool ok = td_kf_.updateWithDelay(y, C_, r_negative, 0);
+  const std::string err = testing::internal::GetCapturedStderr();
+
+  EXPECT_FALSE(ok);
+  EXPECT_NE(err.find("LLT decomposition failed"), std::string::npos);
 }

--- a/common/autoware_kalman_filter/test/test_time_delay_kalman_filter.cpp
+++ b/common/autoware_kalman_filter/test/test_time_delay_kalman_filter.cpp
@@ -328,12 +328,9 @@ TEST_F(TimeDelayKalmanFilterTest, UpdateRejectsNonColumnMeasurement)
   ASSERT_TRUE(td_kf_.predictWithDelay(x_next_, A_, Q_));
 
   const Eigen::MatrixXd y_not_column = Eigen::MatrixXd::Zero(kDimX, 2);  // y.cols() != 1
-  testing::internal::CaptureStderr();
   const bool ok = td_kf_.updateWithDelay(y_not_column, C_, R_, 0);
-  const std::string err = testing::internal::GetCapturedStderr();
 
   EXPECT_FALSE(ok);
-  EXPECT_NE(err.find("column vector"), std::string::npos);
 }
 
 TEST_F(TimeDelayKalmanFilterTest, UpdateRejectsNonSquareMeasurementCovariance)
@@ -344,12 +341,9 @@ TEST_F(TimeDelayKalmanFilterTest, UpdateRejectsNonSquareMeasurementCovariance)
   Eigen::MatrixXd y(kDimX, 1);
   y << 1.0, 2.0, 3.0;
   const Eigen::MatrixXd r_non_square = Eigen::MatrixXd::Zero(kDimX, kDimX + 1);
-  testing::internal::CaptureStderr();
   const bool ok = td_kf_.updateWithDelay(y, C_, r_non_square, 0);
-  const std::string err = testing::internal::GetCapturedStderr();
 
   EXPECT_FALSE(ok);
-  EXPECT_NE(err.find("must be square"), std::string::npos);
 }
 
 TEST_F(TimeDelayKalmanFilterTest, UpdateRejectsMismatchedMeasurementCovarianceRows)
@@ -361,12 +355,9 @@ TEST_F(TimeDelayKalmanFilterTest, UpdateRejectsMismatchedMeasurementCovarianceRo
   y << 1.0, 2.0, 3.0;
   // Square, but its dimension differs from C.rows().
   const Eigen::MatrixXd r_wrong = Eigen::MatrixXd::Identity(kDimX + 1, kDimX + 1);
-  testing::internal::CaptureStderr();
   const bool ok = td_kf_.updateWithDelay(y, C_, r_wrong, 0);
-  const std::string err = testing::internal::GetCapturedStderr();
 
   EXPECT_FALSE(ok);
-  EXPECT_NE(err.find("covariance R and"), std::string::npos);
 }
 
 TEST_F(TimeDelayKalmanFilterTest, UpdateRejectsNonPositiveDefiniteInnovationCovariance)
@@ -379,10 +370,7 @@ TEST_F(TimeDelayKalmanFilterTest, UpdateRejectsNonPositiveDefiniteInnovationCova
   // A negative-definite R makes the innovation covariance S = R + C P C^T non-PD,
   // so the Cholesky (LLT) decomposition must fail and the update must be rejected.
   const Eigen::MatrixXd r_negative = -1.0 * Eigen::MatrixXd::Identity(kDimX, kDimX);
-  testing::internal::CaptureStderr();
   const bool ok = td_kf_.updateWithDelay(y, C_, r_negative, 0);
-  const std::string err = testing::internal::GetCapturedStderr();
 
   EXPECT_FALSE(ok);
-  EXPECT_NE(err.find("LLT decomposition failed"), std::string::npos);
 }


### PR DESCRIPTION
## Description

Lowest-risk first step of a per-package quality campaign on autoware_core. The public API/ABI is unchanged.

- **test**: cover the previously-untested `KalmanFilter` validation FALSE branches (init/predict/update dimension guards), the state/covariance getters, a closed-form numerical-equivalence update check on a correlated covariance, and the `TimeDelayKalmanFilter::updateWithDelay` rejection paths (non-column `y`, non-square `R`, `R`/`C` row mismatch, non-PD → LLT failure), capturing stderr to keep test output clean. Tests: 11 → 24.
- **perf**: mirror the optimization already used in `TimeDelayKalmanFilter::updateWithDelay` in the base `KalmanFilter::update`: compute the Kalman gain with a Cholesky (LLT) solve of the innovation covariance `S = C P Cᵀ + R` instead of an explicit matrix inverse. Use `noalias()` in `predict(x_next, A, Q)` to drop intermediate Eigen temporaries.

## Related links

**Parent Issue:**

- autowarefoundation/autoware_core#1096 (autoware_core refactoring campaign)

## How was this PR tested?

- `colcon test --packages-select autoware_kalman_filter` → 24/24 tests pass (was 11), all package linters green.
- `pre-commit run --files ...` → clang-format and cpplint clean.
- Numerical equivalence vs the previous implementation, measured over 200,000 random systems:
  - `predict()` is **bit-identical** (max `|ΔP|` = 0).
  - `update()` for valid (positive-definite) inputs differs only at round-off: worst-case `|Δx| ≤ 4.7e-15`, `|ΔP| ≤ 2.1e-14` (machine epsilon ≈ 2.2e-16).

## Notes for reviewers

Two commits, each independently green: `test:` adds characterization coverage first, then `perf:` applies the Cholesky solve (a RED test for the new fail-safe guard precedes the implementation). The gain formula `K = P Cᵀ S⁻¹` is unchanged; only the linear-solve method changes.

## Interface changes

None. Public method signatures and the `bool` return contract are unchanged.

## Effects on system behavior

Only the base `KalmanFilter::predict(x_next, A, Q)` and `update(...)` are touched; `TimeDelayKalmanFilter::predictWithDelay`/`updateWithDelay` are unchanged.

- `predict()` is bit-identical to the previous implementation (`noalias()` only avoids a temporary allocation).
- `update()` keeps the same gain formula; for valid positive-definite inputs the result changes only at floating-point round-off (≤ ~2e-14, see above). For a **non-positive-definite** innovation covariance, `update()` now returns `false` (fail-safe) instead of silently applying a meaningless finite gain that could corrupt downstream state.

Consumers:
- `autoware_ekf_localizer` (Core) uses only `predictWithDelay`/`updateWithDelay` → unaffected.
- Universe trackers (`autoware_multi_object_tracker`, `autoware_radar_object_tracker`, `autoware_bytetrack`) call the base `predict`/`update`; the impact is the ~1e-14 round-off above, and all of them already check the `bool` return and skip the update on `false`, so the new fail-safe path is strictly safer for them.

## youtalk fork CI — build-and-test all green

The full `build-test-tidy-pr` workflow runs on the youtalk fork (`ubicloud-standard-16`). All build-and-test gate jobs pass for head commit `7225bd599` ([workflow run](https://github.com/youtalk/autoware_core/actions/runs/26606488124)):

- ✅ `build-and-test-diff-humble / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26606488124/job/78402763440
- ✅ `build-and-test-diff-jazzy / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26606488124/job/78402763447
- ✅ `build-and-test-diff-jazzy-agnocast / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26606488124/job/78402763421
- ✅ `build-and-test-diff-humble / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26606488124/job/78403103611
- ✅ `build-and-test-diff-jazzy / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26606488124/job/78403136345

(The `*-above` universe jobs are bonus coverage and excluded from the gate.)
