### PR TITLE
feat(autoware_agnocast_wrapper): adopt glog

### DIFF
--- a/common/autoware_agnocast_wrapper/CMakeLists.txt
+++ b/common/autoware_agnocast_wrapper/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(diagnostic_updater REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(glog REQUIRED)
 
 if(DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
   find_package(agnocastlib REQUIRED)
@@ -37,6 +38,7 @@ if("$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
     geometry_msgs
     tf2
     tf2_ros
+    glog
   )
   target_compile_definitions(${PROJECT_NAME} PUBLIC USE_AGNOCAST_ENABLED)
 else()
@@ -48,6 +50,7 @@ else()
     geometry_msgs
     tf2
     tf2_ros
+    glog
   )
 endif()
 
@@ -65,6 +68,12 @@ ament_export_dependencies(
   diagnostic_updater
   tf2
   tf2_ros
+  glog
+)
+
+ament_export_libraries(
+  ${PROJECT_NAME}
+  glog
 )
 
 if(DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")

--- a/common/autoware_agnocast_wrapper/package.xml
+++ b/common/autoware_agnocast_wrapper/package.xml
@@ -20,6 +20,7 @@
   <depend>class_loader</depend>
   <depend>diagnostic_updater</depend>
   <depend>geometry_msgs</depend>
+  <depend>libgoogle-glog-dev</depend>
   <depend>message_filters</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/common/autoware_agnocast_wrapper/templates/node_main_switchable.cpp.in
+++ b/common/autoware_agnocast_wrapper/templates/node_main_switchable.cpp.in
@@ -18,6 +18,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <glog/logging.h>
 
 #include "agnocast/agnocast.hpp"
 #include "@_AWR_agnocast_executor_include@"
@@ -31,6 +32,9 @@
 
 int main(int argc, char * argv[])
 {
+  google::InitGoogleLogging(argv[0]);
+  google::InstallFailureSignalHandler();
+
   constexpr bool agnocast_only = @_AWR_agnocast_only@;
   const bool use_agnocast = autoware::agnocast_wrapper::use_agnocast();
   const bool is_agnocast_only_mode = use_agnocast && agnocast_only;


### PR DESCRIPTION
## Description
Integrate glog into the main function template managed by autoware_agnocast_wrapper.

This template allows each node to dynamically switch between the ROS 2 Executor and the Agnocast Executor. By embedding glog into this main function, we can now capture backtraces whenever a node process implementing this template is killed.あ

## Related links

**Parent Issue:**

- [discussion](https://github.com/orgs/autowarefoundation/discussions/6937)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
