### PR TITLE
perf(autoware_map_height_fitter): extract testable ground-height kernel and use a cached KdTree

### DIFF
--- a/map/autoware_map_height_fitter/CMakeLists.txt
+++ b/map/autoware_map_height_fitter/CMakeLists.txt
@@ -23,6 +23,8 @@ if(BUILD_TESTING)
     test/test_map_height_fitter_kernel.cpp
   )
   target_link_libraries(test_${PROJECT_NAME}_kernel ${PROJECT_NAME} ${PCL_LIBRARIES})
+  # map_height_fitter_kernel.hpp is an internal (non-installed) header under src/.
+  target_include_directories(test_${PROJECT_NAME}_kernel PRIVATE src)
 endif()
 
 autoware_ament_auto_package(

--- a/map/autoware_map_height_fitter/CMakeLists.txt
+++ b/map/autoware_map_height_fitter/CMakeLists.txt
@@ -6,6 +6,7 @@ autoware_package()
 find_package(PCL REQUIRED COMPONENTS common)
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/map_height_fitter_kernel.cpp
   src/map_height_fitter.cpp
   src/map_height_fitter_node.cpp
 )
@@ -16,6 +17,13 @@ rclcpp_components_register_node(${PROJECT_NAME}
   EXECUTABLE ${PROJECT_NAME}_node
   EXECUTOR MultiThreadedExecutor
 )
+
+if(BUILD_TESTING)
+  ament_auto_add_gtest(test_${PROJECT_NAME}_kernel
+    test/test_map_height_fitter_kernel.cpp
+  )
+  target_link_libraries(test_${PROJECT_NAME}_kernel ${PROJECT_NAME} ${PCL_LIBRARIES})
+endif()
 
 autoware_ament_auto_package(
   USE_SCOPED_HEADER_INSTALL_DIR

--- a/map/autoware_map_height_fitter/include/autoware/map_height_fitter/map_height_fitter_kernel.hpp
+++ b/map/autoware_map_height_fitter/include/autoware/map_height_fitter/map_height_fitter_kernel.hpp
@@ -1,0 +1,94 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MAP_HEIGHT_FITTER__MAP_HEIGHT_FITTER_KERNEL_HPP_
+#define AUTOWARE__MAP_HEIGHT_FITTER__MAP_HEIGHT_FITTER_KERNEL_HPP_
+
+#include <pcl/kdtree/kdtree_flann.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+#include <optional>
+
+namespace lanelet
+{
+class LaneletMap;
+}  // namespace lanelet
+
+namespace autoware::map_height_fitter
+{
+
+/// \brief Build a 2D (x, y) KdTree over the horizontal projection of a point cloud.
+///
+/// The map_height_fitter ground-height search uses a purely horizontal (2D) distance metric, so
+/// the cloud is projected onto the z = 0 plane before indexing. The returned tree is queried with
+/// the same projection and its point indices map one-to-one onto \p cloud, so the original (un
+/// projected) z values are recovered through those indices.
+///
+/// \param cloud the source point cloud (its x, y are used for indexing, z is ignored).
+/// \return a KdTree built over the (x, y, 0) projection of \p cloud.
+pcl::KdTreeFLANN<pcl::PointXYZ> build_pointcloud_xy_kdtree(
+  const pcl::PointCloud<pcl::PointXYZ> & cloud);
+
+/// \brief Find the ground height at (x, y) from a point-cloud map, using a prebuilt 2D KdTree.
+///
+/// Behavior matches the original two-pass linear scan exactly: it finds the minimum squared 2D
+/// distance d2 to any cloud point, then returns the lowest z among all points whose squared 2D
+/// distance is strictly less than (sqrt(d2) + 1.0)^2. The squared-distance comparison is performed
+/// in double precision against the original cloud points, so the selected set is identical to the
+/// original implementation. When no point qualifies (e.g. an empty cloud), \p fallback_z is
+/// returned.
+///
+/// \param cloud the source point cloud (the z values used for the lowest-height selection).
+/// \param kdtree a 2D KdTree built from the same \p cloud via build_pointcloud_xy_kdtree().
+/// \param x query x coordinate (map frame).
+/// \param y query y coordinate (map frame).
+/// \param fallback_z the value returned when no finite height is found.
+/// \return the fitted ground height, or \p fallback_z when none is found.
+double get_ground_height_from_pointcloud(
+  const pcl::PointCloud<pcl::PointXYZ> & cloud, const pcl::KdTreeFLANN<pcl::PointXYZ> & kdtree,
+  double x, double y, double fallback_z);
+
+/// \brief Find the ground height at (x, y) from a point-cloud map.
+///
+/// Convenience overload that builds the 2D KdTree from \p cloud and delegates to the prebuilt-tree
+/// overload. Prefer the prebuilt-tree overload on hot paths to avoid rebuilding the tree per call.
+///
+/// \param cloud the source point cloud.
+/// \param x query x coordinate (map frame).
+/// \param y query y coordinate (map frame).
+/// \param fallback_z the value returned when no finite height is found.
+/// \return the fitted ground height, or \p fallback_z when none is found.
+double get_ground_height_from_pointcloud(
+  const pcl::PointCloud<pcl::PointXYZ> & cloud, double x, double y, double fallback_z);
+
+/// \brief Find the ground height at (x, y) from a vector (lanelet) map.
+///
+/// Runs the nearest-point search on the map's point layer exactly once and returns the z value of
+/// that nearest point. Returns std::nullopt when the point layer has no nearest point (e.g. an
+/// empty map), letting the caller emit the "failed to get closest lanelet" warning and fall back.
+/// When a nearest point exists but its z is non-finite, \p fallback_z is returned (matching the
+/// original implementation, which silently fell back in that case).
+///
+/// \param map the lanelet map whose point layer is queried.
+/// \param x query x coordinate (map frame).
+/// \param y query y coordinate (map frame).
+/// \param fallback_z the value returned when the nearest point's height is non-finite.
+/// \return the fitted ground height, or std::nullopt when there is no nearest point.
+std::optional<double> get_ground_height_from_vector_map(
+  const lanelet::LaneletMap & map, double x, double y, double fallback_z);
+
+}  // namespace autoware::map_height_fitter
+
+#endif  // AUTOWARE__MAP_HEIGHT_FITTER__MAP_HEIGHT_FITTER_KERNEL_HPP_

--- a/map/autoware_map_height_fitter/src/map_height_fitter.cpp
+++ b/map/autoware_map_height_fitter/src/map_height_fitter.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/map_height_fitter/map_height_fitter.hpp"
 
+#include "autoware/map_height_fitter/map_height_fitter_kernel.hpp"
+
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware/qos_utils/qos_compatibility.hpp>
 #include <tf2_ros/transform_listener.hpp>
@@ -29,7 +31,7 @@
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
 
-#include <algorithm>
+#include <cstddef>
 #include <memory>
 #include <string>
 
@@ -57,6 +59,7 @@ struct MapHeightFitter::Impl
   // for fitting by pointcloud_map_loader
   rclcpp::CallbackGroup::SharedPtr group_;
   pcl::PointCloud<pcl::PointXYZ>::Ptr map_cloud_;
+  pcl::KdTreeFLANN<pcl::PointXYZ> map_cloud_kdtree_;
   rclcpp::Client<autoware_map_msgs::srv::GetPartialPointCloudMap>::SharedPtr cli_pcd_map_;
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_pcd_map_;
   rclcpp::AsyncParametersClient::SharedPtr params_pcd_map_loader_;
@@ -113,6 +116,7 @@ void MapHeightFitter::Impl::on_pcd_map(const sensor_msgs::msg::PointCloud2::Cons
   map_frame_ = msg->header.frame_id;
   map_cloud_ = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
   pcl::fromROSMsg(*msg, *map_cloud_);
+  map_cloud_kdtree_ = build_pointcloud_xy_kdtree(*map_cloud_);
 }
 
 bool MapHeightFitter::Impl::get_partial_point_cloud_map(const Point & point)
@@ -150,6 +154,11 @@ bool MapHeightFitter::Impl::get_partial_point_cloud_map(const Point & point)
     res->new_pointcloud_with_ids.size());
 
   sensor_msgs::msg::PointCloud2 pcd_msg;
+  std::size_t total_data_size = 0;
+  for (const auto & pcd_with_id : res->new_pointcloud_with_ids) {
+    total_data_size += pcd_with_id.pointcloud.data.size();
+  }
+  pcd_msg.data.reserve(total_data_size);
   for (const auto & pcd_with_id : res->new_pointcloud_with_ids) {
     if (pcd_msg.width == 0) {
       pcd_msg = pcd_with_id.pointcloud;
@@ -163,6 +172,7 @@ bool MapHeightFitter::Impl::get_partial_point_cloud_map(const Point & point)
   map_frame_ = res->header.frame_id;
   map_cloud_ = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
   pcl::fromROSMsg(pcd_msg, *map_cloud_);
+  map_cloud_kdtree_ = build_pointcloud_xy_kdtree(*map_cloud_);
   return true;
 }
 
@@ -181,38 +191,21 @@ double MapHeightFitter::Impl::get_ground_height(const Point & point) const
   const double x = point.x;
   const double y = point.y;
 
-  double height = INFINITY;
   if (fit_target_ == "pointcloud_map") {
-    // find distance d to closest point
-    double min_dist2 = INFINITY;
-    for (const auto & p : map_cloud_->points) {
-      const double dx = x - p.x;
-      const double dy = y - p.y;
-      const double sd = (dx * dx) + (dy * dy);
-      min_dist2 = std::min(min_dist2, sd);
-    }
-
-    // find lowest height within radius (d+1.0)
-    const double radius2 = std::pow(std::sqrt(min_dist2) + 1.0, 2.0);
-
-    for (const auto & p : map_cloud_->points) {
-      const double dx = x - p.x;
-      const double dy = y - p.y;
-      const double sd = (dx * dx) + (dy * dy);
-      if (sd < radius2) {
-        height = std::min(height, static_cast<double>(p.z));
-      }
-    }
-  } else if (fit_target_ == "vector_map") {
-    const auto closest_points = vector_map_->pointLayer.nearest(lanelet::BasicPoint2d{x, y}, 1);
-    if (closest_points.empty()) {
+    return get_ground_height_from_pointcloud(*map_cloud_, map_cloud_kdtree_, x, y, point.z);
+  }
+  if (fit_target_ == "vector_map") {
+    // The kernel runs the nearest-point search once; std::nullopt means no closest lanelet, in
+    // which case we warn and fall back to the original point.z (matching the original behavior).
+    const auto height = get_ground_height_from_vector_map(*vector_map_, x, y, point.z);
+    if (!height) {
       RCLCPP_WARN_STREAM(logger, "failed to get closest lanelet");
       return point.z;
     }
-    height = closest_points.front().z();
+    return *height;
   }
 
-  return std::isfinite(height) ? height : point.z;
+  return point.z;  // unreachable: fit() validates fit_target_ before calling get_ground_height
 }
 
 std::optional<Point> MapHeightFitter::Impl::fit(const Point & position, const std::string & frame)

--- a/map/autoware_map_height_fitter/src/map_height_fitter.cpp
+++ b/map/autoware_map_height_fitter/src/map_height_fitter.cpp
@@ -14,7 +14,7 @@
 
 #include "autoware/map_height_fitter/map_height_fitter.hpp"
 
-#include "autoware/map_height_fitter/map_height_fitter_kernel.hpp"
+#include "map_height_fitter_kernel.hpp"
 
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware/qos_utils/qos_compatibility.hpp>

--- a/map/autoware_map_height_fitter/src/map_height_fitter_kernel.cpp
+++ b/map/autoware_map_height_fitter/src/map_height_fitter_kernel.cpp
@@ -58,6 +58,13 @@ double get_ground_height_from_pointcloud(
     return fallback_z;
   }
 
+  // A non-finite query makes every squared distance non-finite, so the original double-precision
+  // scan rejected every point and fell back. Guard here as well: pcl::KdTreeFLANN asserts on a
+  // NaN/Inf query point, so we must not hand one to the tree.
+  if (!std::isfinite(x) || !std::isfinite(y)) {
+    return fallback_z;
+  }
+
   pcl::PointXYZ query;
   query.x = static_cast<float>(x);
   query.y = static_cast<float>(y);

--- a/map/autoware_map_height_fitter/src/map_height_fitter_kernel.cpp
+++ b/map/autoware_map_height_fitter/src/map_height_fitter_kernel.cpp
@@ -1,0 +1,124 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/map_height_fitter/map_height_fitter_kernel.hpp"
+
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/Point.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <vector>
+
+namespace autoware::map_height_fitter
+{
+
+pcl::KdTreeFLANN<pcl::PointXYZ> build_pointcloud_xy_kdtree(
+  const pcl::PointCloud<pcl::PointXYZ> & cloud)
+{
+  pcl::KdTreeFLANN<pcl::PointXYZ> kdtree;
+  if (cloud.points.empty()) {
+    return kdtree;
+  }
+
+  // Project onto the z = 0 plane so the KdTree uses a purely horizontal (x, y) distance metric,
+  // matching the original 2D nearest-point search. Point indices are preserved one-to-one with the
+  // source cloud so the original z values can be recovered through them.
+  auto projected = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+  projected->points.reserve(cloud.points.size());
+  for (const auto & p : cloud.points) {
+    projected->points.emplace_back(p.x, p.y, 0.0F);
+  }
+  projected->width = static_cast<std::uint32_t>(projected->points.size());
+  projected->height = 1;
+  kdtree.setInputCloud(projected);
+  return kdtree;
+}
+
+double get_ground_height_from_pointcloud(
+  const pcl::PointCloud<pcl::PointXYZ> & cloud, const pcl::KdTreeFLANN<pcl::PointXYZ> & kdtree,
+  double x, double y, double fallback_z)
+{
+  if (cloud.points.empty()) {
+    return fallback_z;
+  }
+
+  pcl::PointXYZ query;
+  query.x = static_cast<float>(x);
+  query.y = static_cast<float>(y);
+  query.z = 0.0F;
+
+  // Find the closest point's squared 2D distance, then recompute it in double precision against the
+  // original point so the radius matches the original implementation bit-for-bit.
+  std::vector<int> nn_indices;
+  std::vector<float> nn_sqr_dists;
+  if (kdtree.nearestKSearch(query, 1, nn_indices, nn_sqr_dists) < 1) {
+    return fallback_z;
+  }
+  const auto & nearest = cloud.points[nn_indices.front()];
+  const double ndx = x - nearest.x;
+  const double ndy = y - nearest.y;
+  const double min_dist2 = (ndx * ndx) + (ndy * ndy);
+
+  // Lowest height within radius (sqrt(min_dist2) + 1.0).
+  const double radius = std::sqrt(min_dist2) + 1.0;
+  const double radius2 = radius * radius;
+
+  // Query a slightly enlarged radius so every point the double-precision strict test would accept
+  // is guaranteed to be in the candidate set despite the KdTree's internal float arithmetic; the
+  // double-precision filter below then reproduces the original membership exactly.
+  const double search_radius = radius + (1e-3 + (1e-6 * radius));
+  std::vector<int> radius_indices;
+  std::vector<float> radius_sqr_dists;
+  kdtree.radiusSearch(query, search_radius, radius_indices, radius_sqr_dists);
+
+  double height = std::numeric_limits<double>::infinity();
+  for (const int index : radius_indices) {
+    const auto & p = cloud.points[index];
+    const double dx = x - p.x;
+    const double dy = y - p.y;
+    const double sd = (dx * dx) + (dy * dy);
+    if (sd < radius2) {
+      height = std::min(height, static_cast<double>(p.z));
+    }
+  }
+
+  return std::isfinite(height) ? height : fallback_z;
+}
+
+double get_ground_height_from_pointcloud(
+  const pcl::PointCloud<pcl::PointXYZ> & cloud, double x, double y, double fallback_z)
+{
+  const auto kdtree = build_pointcloud_xy_kdtree(cloud);
+  return get_ground_height_from_pointcloud(cloud, kdtree, x, y, fallback_z);
+}
+
+std::optional<double> get_ground_height_from_vector_map(
+  const lanelet::LaneletMap & map, double x, double y, double fallback_z)
+{
+  // Run the nearest-point search exactly once. The empty case is reported as std::nullopt so the
+  // caller can emit the "failed to get closest lanelet" warning without a second lookup.
+  const auto closest_points = map.pointLayer.nearest(lanelet::BasicPoint2d{x, y}, 1);
+  if (closest_points.empty()) {
+    return std::nullopt;
+  }
+  const double height = closest_points.front().z();
+  return std::isfinite(height) ? height : fallback_z;
+}
+
+}  // namespace autoware::map_height_fitter

--- a/map/autoware_map_height_fitter/src/map_height_fitter_kernel.cpp
+++ b/map/autoware_map_height_fitter/src/map_height_fitter_kernel.cpp
@@ -63,26 +63,59 @@ double get_ground_height_from_pointcloud(
   query.y = static_cast<float>(y);
   query.z = 0.0F;
 
-  // Find the closest point's squared 2D distance, then recompute it in double precision against the
-  // original point so the radius matches the original implementation bit-for-bit.
+  // The original computed min_dist2 as the true double-precision minimum over all points. The
+  // KdTree, however, searches in float: both the query and the indexed coordinates are rounded to
+  // float, so nearestKSearch can return a point that is *not* the double-precision nearest when two
+  // points are near-tied or the coordinates are large (where the float grid is coarse). Trusting a
+  // single returned index would therefore over- or under-estimate min_dist2 and, through the
+  // radius, change the selected height. To stay bit-for-bit faithful to the original, we use the
+  // KdTree only to localize the search and then recompute everything in double precision.
+  //
+  // Float rounding of a coordinate of magnitude up to coord_max introduces an absolute error of at
+  // most coord_max * 2^-24 (round-to-nearest, half an ULP) per coordinate; the float distance
+  // evaluation adds further rounding of the same order. coord_margin bounds the resulting error in
+  // the (linear) distance domain with margin to spare, so any float-radius search enlarged by
+  // coord_margin is a guaranteed superset of the corresponding double-precision predicate.
   std::vector<int> nn_indices;
   std::vector<float> nn_sqr_dists;
   if (kdtree.nearestKSearch(query, 1, nn_indices, nn_sqr_dists) < 1) {
     return fallback_z;
   }
-  const auto & nearest = cloud.points[nn_indices.front()];
-  const double ndx = x - nearest.x;
-  const double ndy = y - nearest.y;
-  const double min_dist2 = (ndx * ndx) + (ndy * ndy);
+  const auto & nn = cloud.points[nn_indices.front()];
+  const double nn_dx = x - nn.x;
+  const double nn_dy = y - nn.y;
+  // Double-precision distance to the float-nearest point: an upper bound on the true min_dist2.
+  const double nn_dist = std::sqrt((nn_dx * nn_dx) + (nn_dy * nn_dy));
+
+  const double coord_max =
+    std::max(std::fabs(x), std::fabs(y)) +
+    std::max(std::fabs(static_cast<double>(nn.x)), std::fabs(static_cast<double>(nn.y))) + 1.0;
+  const double coord_margin = (2.0 * coord_max * std::ldexp(1.0, -23)) + 1e-3;
+
+  // Recompute the true double-precision min_dist2 over a candidate set guaranteed to contain the
+  // double-nearest point: every point whose float distance is within coord_margin of the
+  // float-nearest distance. This reproduces the original min_dist2 (and thus radius) exactly.
+  const double nearest_search_radius = nn_dist + coord_margin;
+  std::vector<int> nearest_indices;
+  std::vector<float> nearest_sqr_dists;
+  kdtree.radiusSearch(query, nearest_search_radius, nearest_indices, nearest_sqr_dists);
+
+  double min_dist2 = (nn_dx * nn_dx) + (nn_dy * nn_dy);
+  for (const int index : nearest_indices) {
+    const auto & p = cloud.points[index];
+    const double dx = x - p.x;
+    const double dy = y - p.y;
+    min_dist2 = std::min(min_dist2, (dx * dx) + (dy * dy));
+  }
 
   // Lowest height within radius (sqrt(min_dist2) + 1.0).
   const double radius = std::sqrt(min_dist2) + 1.0;
   const double radius2 = radius * radius;
 
-  // Query a slightly enlarged radius so every point the double-precision strict test would accept
-  // is guaranteed to be in the candidate set despite the KdTree's internal float arithmetic; the
+  // Query a margin-enlarged radius so every point the double-precision strict test would accept is
+  // guaranteed to be in the candidate set despite the KdTree's internal float arithmetic; the
   // double-precision filter below then reproduces the original membership exactly.
-  const double search_radius = radius + (1e-3 + (1e-6 * radius));
+  const double search_radius = radius + coord_margin;
   std::vector<int> radius_indices;
   std::vector<float> radius_sqr_dists;
   kdtree.radiusSearch(query, search_radius, radius_indices, radius_sqr_dists);

--- a/map/autoware_map_height_fitter/src/map_height_fitter_kernel.cpp
+++ b/map/autoware_map_height_fitter/src/map_height_fitter_kernel.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// cspell:ignore dists
+
 #include "autoware/map_height_fitter/map_height_fitter_kernel.hpp"
 
 #include <lanelet2_core/LaneletMap.h>

--- a/map/autoware_map_height_fitter/src/map_height_fitter_kernel.cpp
+++ b/map/autoware_map_height_fitter/src/map_height_fitter_kernel.cpp
@@ -14,7 +14,7 @@
 
 // cspell:ignore dists
 
-#include "autoware/map_height_fitter/map_height_fitter_kernel.hpp"
+#include "map_height_fitter_kernel.hpp"
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/primitives/Point.h>

--- a/map/autoware_map_height_fitter/src/map_height_fitter_kernel.hpp
+++ b/map/autoware_map_height_fitter/src/map_height_fitter_kernel.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__MAP_HEIGHT_FITTER__MAP_HEIGHT_FITTER_KERNEL_HPP_
-#define AUTOWARE__MAP_HEIGHT_FITTER__MAP_HEIGHT_FITTER_KERNEL_HPP_
+#ifndef MAP_HEIGHT_FITTER_KERNEL_HPP_
+#define MAP_HEIGHT_FITTER_KERNEL_HPP_
 
 #include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/point_cloud.h>
@@ -91,4 +91,4 @@ std::optional<double> get_ground_height_from_vector_map(
 
 }  // namespace autoware::map_height_fitter
 
-#endif  // AUTOWARE__MAP_HEIGHT_FITTER__MAP_HEIGHT_FITTER_KERNEL_HPP_
+#endif  // MAP_HEIGHT_FITTER_KERNEL_HPP_

--- a/map/autoware_map_height_fitter/test/test_map_height_fitter_kernel.cpp
+++ b/map/autoware_map_height_fitter/test/test_map_height_fitter_kernel.cpp
@@ -14,7 +14,7 @@
 
 // cspell:ignore npts qdist zdist
 
-#include "autoware/map_height_fitter/map_height_fitter_kernel.hpp"
+#include "map_height_fitter_kernel.hpp"
 
 #include <gtest/gtest.h>
 #include <lanelet2_core/LaneletMap.h>

--- a/map/autoware_map_height_fitter/test/test_map_height_fitter_kernel.cpp
+++ b/map/autoware_map_height_fitter/test/test_map_height_fitter_kernel.cpp
@@ -194,6 +194,45 @@ TEST(MapHeightFitterKernel, MatchesReferenceOverRandomClouds)
   }
 }
 
+// --- Characterization at large coordinates / near-ties (float-vs-double divergence regime) -------
+
+TEST(MapHeightFitterKernel, MatchesReferenceAtLargeCoordinates)
+{
+  // Autoware map frames can place points at large coordinates (MGRS/UTM-derived, up to ~1e6) where
+  // the float grid spacing the KdTree searches on is coarse (sub-decimeter). Combined with
+  // near-tied candidate points this is exactly where a naive float nearest/radius search diverges
+  // from the original double-precision two-pass scan. The kernel must still match bit-for-bit.
+  std::mt19937 rng(20260602);
+  std::uniform_real_distribution<double> center(-2.0e6, 2.0e6);
+  std::uniform_real_distribution<double> offset(-30.0, 30.0);
+  std::uniform_real_distribution<float> zdist(-50.0F, 50.0F);
+  std::uniform_int_distribution<int> npts(1, 24);
+
+  for (int trial = 0; trial < 5000; ++trial) {
+    const double cx = center(rng);
+    const double cy = center(rng);
+    const int n = npts(rng);
+    pcl::PointCloud<pcl::PointXYZ> cloud;
+    cloud.points.reserve(n);
+    for (int i = 0; i < n; ++i) {
+      cloud.points.emplace_back(
+        static_cast<float>(cx + offset(rng)), static_cast<float>(cy + offset(rng)), zdist(rng));
+    }
+    cloud.width = static_cast<std::uint32_t>(cloud.points.size());
+    cloud.height = 1;
+
+    const double qx = cx + offset(rng);
+    const double qy = cy + offset(rng);
+    const double fallback = 12345.0;
+
+    const double expected = reference_ground_height_from_pointcloud(cloud, qx, qy, fallback);
+    const auto kdtree = autoware::map_height_fitter::build_pointcloud_xy_kdtree(cloud);
+    const double actual = get_ground_height_from_pointcloud(cloud, kdtree, qx, qy, fallback);
+    EXPECT_DOUBLE_EQ(actual, expected) << "large-coord trial " << trial << " n=" << n << " center=("
+                                       << cx << "," << cy << ") q=(" << qx << "," << qy << ")";
+  }
+}
+
 // --- Vector-map branch --------------------------------------------------------------------------
 
 TEST(MapHeightFitterKernel, VectorMapReturnsNearestPointHeight)

--- a/map/autoware_map_height_fitter/test/test_map_height_fitter_kernel.cpp
+++ b/map/autoware_map_height_fitter/test/test_map_height_fitter_kernel.cpp
@@ -1,0 +1,237 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/map_height_fitter/map_height_fitter_kernel.hpp"
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/Point.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <random>
+#include <vector>
+
+namespace
+{
+using autoware::map_height_fitter::get_ground_height_from_pointcloud;
+using autoware::map_height_fitter::get_ground_height_from_vector_map;
+
+/// \brief Faithful re-implementation of the original (pre-KdTree) two-pass linear scan.
+///
+/// This is the characterization oracle: the new kernel must reproduce its output exactly. It
+/// mirrors the historical src/map_height_fitter.cpp get_ground_height pointcloud branch line for
+/// line.
+double reference_ground_height_from_pointcloud(
+  const pcl::PointCloud<pcl::PointXYZ> & cloud, double x, double y, double fallback_z)
+{
+  double height = std::numeric_limits<double>::infinity();
+
+  double min_dist2 = std::numeric_limits<double>::infinity();
+  for (const auto & p : cloud.points) {
+    const double dx = x - p.x;
+    const double dy = y - p.y;
+    const double sd = (dx * dx) + (dy * dy);
+    min_dist2 = std::min(min_dist2, sd);
+  }
+
+  const double radius2 = std::pow(std::sqrt(min_dist2) + 1.0, 2.0);
+
+  for (const auto & p : cloud.points) {
+    const double dx = x - p.x;
+    const double dy = y - p.y;
+    const double sd = (dx * dx) + (dy * dy);
+    if (sd < radius2) {
+      height = std::min(height, static_cast<double>(p.z));
+    }
+  }
+
+  return std::isfinite(height) ? height : fallback_z;
+}
+
+pcl::PointCloud<pcl::PointXYZ> make_cloud(const std::vector<std::array<float, 3>> & pts)
+{
+  pcl::PointCloud<pcl::PointXYZ> cloud;
+  cloud.points.reserve(pts.size());
+  for (const auto & p : pts) {
+    cloud.points.emplace_back(p[0], p[1], p[2]);
+  }
+  cloud.width = static_cast<std::uint32_t>(cloud.points.size());
+  cloud.height = 1;
+  return cloud;
+}
+}  // namespace
+
+// --- Empty-cloud fallback -----------------------------------------------------------------------
+
+TEST(MapHeightFitterKernel, EmptyCloudReturnsFallback)
+{
+  const pcl::PointCloud<pcl::PointXYZ> cloud;  // empty
+  EXPECT_DOUBLE_EQ(get_ground_height_from_pointcloud(cloud, 1.0, 2.0, 42.0), 42.0);
+}
+
+// --- Single-point cloud -------------------------------------------------------------------------
+
+TEST(MapHeightFitterKernel, SinglePointReturnsThatPointHeight)
+{
+  // The only point is the closest; radius = sqrt(min_dist2) + 1.0 always includes it, so its z is
+  // returned regardless of the query offset.
+  const auto cloud = make_cloud({{{10.0F, 20.0F, 7.5F}}});
+  EXPECT_DOUBLE_EQ(get_ground_height_from_pointcloud(cloud, 10.0, 20.0, -100.0), 7.5);
+  EXPECT_DOUBLE_EQ(get_ground_height_from_pointcloud(cloud, 13.0, 24.0, -100.0), 7.5);
+}
+
+// --- Lowest-z-within-radius selection -----------------------------------------------------------
+
+TEST(MapHeightFitterKernel, SelectsLowestZWithinRadius)
+{
+  // Query at origin. Closest point is at distance 1 (min_dist2 = 1), so radius = 2, radius2 = 4.
+  //  - A: (1, 0, 5.0)   sd = 1   < 4  -> candidate, z = 5.0
+  //  - B: (0, 1.5, 2.0) sd = 2.25 < 4 -> candidate, z = 2.0  (lowest within radius)
+  //  - C: (3, 0, -9.0)  sd = 9   >= 4 -> excluded even though its z is far lower
+  const auto cloud = make_cloud({
+    {{1.0F, 0.0F, 5.0F}},
+    {{0.0F, 1.5F, 2.0F}},
+    {{3.0F, 0.0F, -9.0F}},
+  });
+  EXPECT_DOUBLE_EQ(get_ground_height_from_pointcloud(cloud, 0.0, 0.0, 100.0), 2.0);
+}
+
+TEST(MapHeightFitterKernel, FarPointOutsideRadiusIsIgnored)
+{
+  // Closest point at distance 10 (min_dist2 = 100), radius = 11, radius2 = 121.
+  //  - near: (10, 0, 3.0)  sd = 100 < 121 -> candidate
+  //  - far : (0, 12, -50)  sd = 144 >= 121 -> excluded
+  const auto cloud = make_cloud({
+    {{10.0F, 0.0F, 3.0F}},
+    {{0.0F, 12.0F, -50.0F}},
+  });
+  EXPECT_DOUBLE_EQ(get_ground_height_from_pointcloud(cloud, 0.0, 0.0, 0.0), 3.0);
+}
+
+TEST(MapHeightFitterKernel, DistanceMetricIsHorizontalOnly)
+{
+  // z must NOT influence the nearest-point / radius computation. Point A is horizontally closest
+  // (dx = 1) but high up; B is horizontally farther (dx = 1.8) but its z is lower and still inside
+  // the radius. min_dist2 = 1 -> radius2 = 4; B sd = 3.24 < 4 -> included, z = -1.0 wins.
+  const auto cloud = make_cloud({
+    {{1.0F, 0.0F, 100.0F}},
+    {{1.8F, 0.0F, -1.0F}},
+  });
+  EXPECT_DOUBLE_EQ(get_ground_height_from_pointcloud(cloud, 0.0, 0.0, 0.0), -1.0);
+}
+
+// --- Prebuilt-KdTree overload matches the convenience overload ----------------------------------
+
+TEST(MapHeightFitterKernel, PrebuiltKdtreeMatchesConvenienceOverload)
+{
+  const auto cloud = make_cloud({
+    {{1.0F, 0.0F, 5.0F}},
+    {{0.0F, 1.5F, 2.0F}},
+    {{3.0F, 0.0F, -9.0F}},
+  });
+  const auto kdtree = autoware::map_height_fitter::build_pointcloud_xy_kdtree(cloud);
+  EXPECT_DOUBLE_EQ(
+    get_ground_height_from_pointcloud(cloud, kdtree, 0.0, 0.0, 100.0),
+    get_ground_height_from_pointcloud(cloud, 0.0, 0.0, 100.0));
+}
+
+// --- Characterization: kernel == original two-pass scan over randomized inputs -------------------
+
+TEST(MapHeightFitterKernel, MatchesReferenceOverRandomClouds)
+{
+  std::mt19937 rng(20260529);
+  std::uniform_real_distribution<float> coord(-50.0F, 50.0F);
+  std::uniform_real_distribution<float> zdist(-20.0F, 20.0F);
+  std::uniform_real_distribution<double> qdist(-60.0, 60.0);
+  std::uniform_int_distribution<int> npts(1, 200);
+
+  for (int trial = 0; trial < 300; ++trial) {
+    const int n = npts(rng);
+    pcl::PointCloud<pcl::PointXYZ> cloud;
+    cloud.points.reserve(n);
+    for (int i = 0; i < n; ++i) {
+      cloud.points.emplace_back(coord(rng), coord(rng), zdist(rng));
+    }
+    cloud.width = static_cast<std::uint32_t>(cloud.points.size());
+    cloud.height = 1;
+
+    const double qx = qdist(rng);
+    const double qy = qdist(rng);
+    const double fallback = 12345.0;
+
+    const double expected = reference_ground_height_from_pointcloud(cloud, qx, qy, fallback);
+
+    // Exercise the production path: Impl::get_ground_height calls the prebuilt-KdTree overload, so
+    // build the tree once (as the node does) and query that overload.
+    const auto kdtree = autoware::map_height_fitter::build_pointcloud_xy_kdtree(cloud);
+    const double actual_prebuilt =
+      get_ground_height_from_pointcloud(cloud, kdtree, qx, qy, fallback);
+    EXPECT_DOUBLE_EQ(actual_prebuilt, expected)
+      << "prebuilt overload, trial " << trial << " n=" << n << " q=(" << qx << "," << qy << ")";
+
+    // The convenience overload must agree as well.
+    const double actual_convenience = get_ground_height_from_pointcloud(cloud, qx, qy, fallback);
+    EXPECT_DOUBLE_EQ(actual_convenience, expected)
+      << "convenience overload, trial " << trial << " n=" << n << " q=(" << qx << "," << qy << ")";
+  }
+}
+
+// --- Vector-map branch --------------------------------------------------------------------------
+
+TEST(MapHeightFitterKernel, VectorMapReturnsNearestPointHeight)
+{
+  lanelet::LaneletMap map;
+  map.add(lanelet::Point3d(1, lanelet::BasicPoint3d(0.0, 0.0, 1.0)));
+  map.add(lanelet::Point3d(2, lanelet::BasicPoint3d(10.0, 0.0, 5.0)));
+  map.add(lanelet::Point3d(3, lanelet::BasicPoint3d(0.0, 10.0, 9.0)));
+
+  // Closest to (1, 0) is point 1 (z = 1.0).
+  const auto h1 = get_ground_height_from_vector_map(map, 1.0, 0.0, -1.0);
+  ASSERT_TRUE(h1.has_value());
+  EXPECT_DOUBLE_EQ(*h1, 1.0);
+  // Closest to (9, 0) is point 2 (z = 5.0).
+  const auto h2 = get_ground_height_from_vector_map(map, 9.0, 0.0, -1.0);
+  ASSERT_TRUE(h2.has_value());
+  EXPECT_DOUBLE_EQ(*h2, 5.0);
+  // Closest to (0, 9) is point 3 (z = 9.0).
+  const auto h3 = get_ground_height_from_vector_map(map, 0.0, 9.0, -1.0);
+  ASSERT_TRUE(h3.has_value());
+  EXPECT_DOUBLE_EQ(*h3, 9.0);
+}
+
+TEST(MapHeightFitterKernel, VectorMapEmptyReturnsNullopt)
+{
+  const lanelet::LaneletMap map;  // no points
+  // No nearest point: the kernel reports std::nullopt so the caller can warn and fall back.
+  EXPECT_FALSE(get_ground_height_from_vector_map(map, 1.0, 2.0, 77.0).has_value());
+}
+
+TEST(MapHeightFitterKernel, VectorMapNonFiniteHeightFallsBack)
+{
+  lanelet::LaneletMap map;
+  const double inf = std::numeric_limits<double>::infinity();
+  map.add(lanelet::Point3d(1, lanelet::BasicPoint3d(0.0, 0.0, inf)));
+  // A nearest point exists but its z is non-finite, so the original fallback (query z) is returned
+  // as a value (not std::nullopt, so the caller does not warn).
+  const auto height = get_ground_height_from_vector_map(map, 0.0, 0.0, 3.0);
+  ASSERT_TRUE(height.has_value());
+  EXPECT_DOUBLE_EQ(*height, 3.0);
+}

--- a/map/autoware_map_height_fitter/test/test_map_height_fitter_kernel.cpp
+++ b/map/autoware_map_height_fitter/test/test_map_height_fitter_kernel.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// cspell:ignore npts qdist zdist
+
 #include "autoware/map_height_fitter/map_height_fitter_kernel.hpp"
 
 #include <gtest/gtest.h>

--- a/map/autoware_map_height_fitter/test/test_map_height_fitter_kernel.cpp
+++ b/map/autoware_map_height_fitter/test/test_map_height_fitter_kernel.cpp
@@ -233,6 +233,97 @@ TEST(MapHeightFitterKernel, MatchesReferenceAtLargeCoordinates)
   }
 }
 
+// --- Non-finite degenerate inputs (must still match the original double-precision scan) ----------
+
+TEST(MapHeightFitterKernel, NonFiniteCloudCoordinatesAreIgnored)
+{
+  // A realistic degenerate map cloud: some points carry NaN/Inf x or y (e.g. from a corrupt sensor
+  // frame). The original two-pass scan tolerated such points: a NaN squared distance is dropped by
+  // std::min (which keeps its first argument) and fails the strict sd < radius2 test, so the
+  // non-finite points never participate in the nearest-point or lowest-z selection. The KdTree path
+  // must stay bit-for-bit faithful to that behavior and still return the lowest z among the finite
+  // points within the radius (here z = -3.0 at the finite point closest to the origin).
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  const double inf = std::numeric_limits<double>::infinity();
+  const auto cloud = make_cloud({
+    {{static_cast<float>(nan), 0.0F, 99.0F}},   // NaN x: must be ignored
+    {{0.0F, static_cast<float>(inf), 88.0F}},   // Inf y: must be ignored
+    {{static_cast<float>(-inf), 0.0F, 77.0F}},  // -Inf x: must be ignored
+    {{1.0F, 0.0F, -3.0F}},                      // finite, nearest to origin
+    {{0.0F, 1.5F, 4.0F}},                       // finite, within radius
+  });
+  const double fallback = 12345.0;
+  const double expected = reference_ground_height_from_pointcloud(cloud, 0.0, 0.0, fallback);
+  const auto kdtree = autoware::map_height_fitter::build_pointcloud_xy_kdtree(cloud);
+  EXPECT_DOUBLE_EQ(get_ground_height_from_pointcloud(cloud, kdtree, 0.0, 0.0, fallback), expected);
+  EXPECT_DOUBLE_EQ(get_ground_height_from_pointcloud(cloud, 0.0, 0.0, fallback), expected);
+}
+
+TEST(MapHeightFitterKernel, AllNonFiniteCloudCoordinatesReturnFallback)
+{
+  // When EVERY point has a non-finite coordinate, no point participates in the scan: min_dist2
+  // stays +inf, radius2 is +inf, and the strict sd < radius2 test still rejects every NaN/Inf sd,
+  // so the lowest-z stays +inf and the fallback is returned. The KdTree path must agree.
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  const double inf = std::numeric_limits<double>::infinity();
+  const auto cloud = make_cloud({
+    {{static_cast<float>(nan), 0.0F, 1.0F}},
+    {{0.0F, static_cast<float>(inf), 2.0F}},
+  });
+  const double fallback = 55.5;
+  const double expected = reference_ground_height_from_pointcloud(cloud, 0.0, 0.0, fallback);
+  EXPECT_DOUBLE_EQ(expected, fallback);  // pin the oracle's fallback decision
+  const auto kdtree = autoware::map_height_fitter::build_pointcloud_xy_kdtree(cloud);
+  EXPECT_DOUBLE_EQ(get_ground_height_from_pointcloud(cloud, kdtree, 0.0, 0.0, fallback), expected);
+  EXPECT_DOUBLE_EQ(get_ground_height_from_pointcloud(cloud, 0.0, 0.0, fallback), expected);
+}
+
+TEST(MapHeightFitterKernel, NonFiniteQueryReturnsFallback)
+{
+  // A non-finite QUERY (x or y is NaN/Inf) makes every squared distance non-finite, so the original
+  // scan rejects every point and falls back. The KdTree path (whose FLANN search over a NaN/Inf
+  // query is otherwise unspecified) must reproduce that fallback.
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  const double inf = std::numeric_limits<double>::infinity();
+  const auto cloud = make_cloud({
+    {{1.0F, 0.0F, 5.0F}},
+    {{0.0F, 1.5F, 2.0F}},
+    {{3.0F, 0.0F, -9.0F}},
+  });
+  const double fallback = 678.0;
+  for (const auto & q : std::vector<std::array<double, 2>>{
+         {nan, 0.0}, {0.0, nan}, {inf, 0.0}, {0.0, -inf}, {nan, nan}}) {
+    const double expected = reference_ground_height_from_pointcloud(cloud, q[0], q[1], fallback);
+    EXPECT_DOUBLE_EQ(expected, fallback);  // pin the oracle's fallback decision
+    const auto kdtree = autoware::map_height_fitter::build_pointcloud_xy_kdtree(cloud);
+    EXPECT_DOUBLE_EQ(
+      get_ground_height_from_pointcloud(cloud, kdtree, q[0], q[1], fallback), expected)
+      << "query=(" << q[0] << "," << q[1] << ")";
+    EXPECT_DOUBLE_EQ(get_ground_height_from_pointcloud(cloud, q[0], q[1], fallback), expected)
+      << "query=(" << q[0] << "," << q[1] << ")";
+  }
+}
+
+TEST(MapHeightFitterKernel, FiniteCoordinateNonFiniteHeightFallsBack)
+{
+  // Mirrors VectorMapNonFiniteHeightFallsBack for the pointcloud branch: the nearest point has
+  // finite (x, y) but a non-finite z. The original scan sets height = min(+inf, -inf) = -inf inside
+  // the radius, then the final std::isfinite(height) guard returns fallback_z. The KdTree path must
+  // reproduce that guard return for both -Inf and NaN z.
+  const double inf = std::numeric_limits<double>::infinity();
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  for (const float bad_z : {static_cast<float>(-inf), static_cast<float>(nan)}) {
+    const auto cloud = make_cloud({{{0.0F, 0.0F, bad_z}}});
+    const double fallback = -100.0;
+    const double expected = reference_ground_height_from_pointcloud(cloud, 0.0, 0.0, fallback);
+    EXPECT_DOUBLE_EQ(expected, fallback);  // pin the oracle's guard return
+    const auto kdtree = autoware::map_height_fitter::build_pointcloud_xy_kdtree(cloud);
+    EXPECT_DOUBLE_EQ(
+      get_ground_height_from_pointcloud(cloud, kdtree, 0.0, 0.0, fallback), expected);
+    EXPECT_DOUBLE_EQ(get_ground_height_from_pointcloud(cloud, 0.0, 0.0, fallback), expected);
+  }
+}
+
 // --- Vector-map branch --------------------------------------------------------------------------
 
 TEST(MapHeightFitterKernel, VectorMapReturnsNearestPointHeight)


### PR DESCRIPTION
## Description

The `autoware_map_height_fitter` ground-height search lived entirely inside a `rclcpp::Node`-bound pimpl `Impl`, was unreachable for unit testing, and ran two full O(N) linear passes over the point cloud per `fit()` request. This PR makes the core algorithm testable, adds the package's first test suite, and replaces the linear scan with a cached KdTree, while keeping the public `MapHeightFitter` API unchanged.

## What changed

- **Extracted the pure search into free functions** in a new internal header `map_height_fitter_kernel.hpp` (no `Node`/TF dependency, plain data in):
  - `get_ground_height_from_pointcloud(cloud[, kdtree], x, y, fallback_z)`
  - `get_ground_height_from_vector_map(map, x, y, fallback_z)`
  - `build_pointcloud_xy_kdtree(cloud)`
  `Impl::get_ground_height` now delegates to these.
- **Performance:** the two full O(N) scans per request are replaced by a `pcl::KdTreeFLANN` built once when the cloud is set (`on_pcd_map` / `get_partial_point_cloud_map`) and reused — `nearestKSearch` for the closest distance, `radiusSearch` to restrict the lowest-z scan to a local candidate set. Per-call cost drops from O(N) to ~O(log N + k).
- **Two cheap audit micro-opts:** `radius2 = r*r` instead of `std::pow(..., 2.0)`; the partial-map merge loop reserves total data size before concatenating grids.
- **Tests:** new `test/test_map_height_fitter_kernel.cpp` (10 gtest cases) covering empty-cloud / single-point fallbacks, lowest-z-within-radius selection, the horizontal-only distance metric, prebuilt-vs-convenience overload equivalence, the vector-map nearest height and its non-finite/empty fallbacks, plus a 300-trial randomized characterization test asserting the new kernel matches the original two-pass scan exactly. The package previously had zero tests.

## Effects on system behavior

Behavior-preserving. The KdTree indexes the horizontal (z = 0) projection so the 2D distance metric is unchanged, and membership is recomputed in double precision with the original strict `sd < (sqrt(min_dist2) + 1.0)^2` test over the candidate set, so the selected point set (and thus the returned height) is identical to the original implementation. The vector-map nearest lookup, the "failed to get closest lanelet" warning, and all non-finite / empty / missing-map fallbacks are unchanged. A 300-trial randomized characterization test confirms bit-equality (`EXPECT_DOUBLE_EQ`) against a line-for-line re-implementation of the old two-pass scan (continuous-uniform inputs; it does not specifically target the sub-micrometer float/double near-tie corner described below).

Downstream consumers: only the public `MapHeightFitter` class is used externally; its constructor and `fit()` signatures are unchanged. The new free functions are additive.

Refs: autowarefoundation/autoware_core#1096

## youtalk fork CI — build-and-test all green

The full `build-test-tidy-pr` workflow runs on the youtalk fork (`ubicloud-standard-16`). All build-and-test gate jobs pass for head commit `e0a1642f4` ([workflow run](https://github.com/youtalk/autoware_core/actions/runs/26657092061)):

- ✅ `build-and-test-diff-humble / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26657092061/job/78571639690
- ✅ `build-and-test-diff-jazzy / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26657092061/job/78571639856
- ✅ `build-and-test-diff-jazzy-agnocast / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26657092061/job/78571639666
- ✅ `build-and-test-diff-humble / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26657092061/job/78572117789
- ✅ `build-and-test-diff-jazzy / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26657092061/job/78572195566

(The `*-above` universe jobs are bonus coverage and excluded from the gate.)
