### PR TITLE
test(autoware_ndt_scan_matcher): unit-test covariance/oscillation math and fix no-ground hot loop

### DIFF
--- a/localization/autoware_ndt_scan_matcher/CMakeLists.txt
+++ b/localization/autoware_ndt_scan_matcher/CMakeLists.txt
@@ -45,6 +45,7 @@ endif()
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/map_update_module.cpp
   src/ndt_scan_matcher_core.cpp
+  src/ndt_scan_matcher_helper.cpp
   src/particle.cpp
 )
 
@@ -77,6 +78,17 @@ if(BUILD_TESTING)
     test/test_cases/particles_num_less_than_publish_num.cpp
     TIMEOUT "300"
   )
+
+  # Fast, dependency-light unit tests for the pure covariance / oscillation math.
+  ament_auto_add_gtest(test_estimate_covariance
+    test/test_estimate_covariance.cpp
+  )
+  target_link_libraries(test_estimate_covariance multigrid_ndt_omp ${PCL_LIBRARIES})
+
+  ament_auto_add_gtest(test_ndt_scan_matcher_helper
+    test/test_ndt_scan_matcher_helper.cpp
+  )
+  target_link_libraries(test_ndt_scan_matcher_helper ${PROJECT_NAME})
 endif()
 
 autoware_ament_auto_package(

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp
@@ -204,8 +204,6 @@ private:
 
   pcl::shared_ptr<pcl::PointCloud<PointSource>> sensor_points_in_baselink_frame_;
 
-  Eigen::Matrix4f base_to_sensor_matrix_;
-
   std::unique_ptr<autoware::localization_util::SmartPoseBuffer> initial_pose_buffer_;
 
   // Keep latest position for dynamic map loading

--- a/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_helper.hpp
+++ b/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_helper.hpp
@@ -1,0 +1,41 @@
+// Copyright 2024 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__NDT_SCAN_MATCHER__NDT_SCAN_MATCHER_HELPER_HPP_
+#define AUTOWARE__NDT_SCAN_MATCHER__NDT_SCAN_MATCHER_HELPER_HPP_
+
+#include <Eigen/Core>
+
+#include <geometry_msgs/msg/pose.hpp>
+
+#include <array>
+#include <vector>
+
+namespace autoware::ndt_scan_matcher
+{
+
+/** \brief Rotate the 3x3 position block of a 6x6 (row-major, 36-element) pose covariance by the
+ * given rotation matrix, i.e. compute R * C * R^T for the upper-left 3x3 block while leaving the
+ * remaining entries untouched. */
+std::array<double, 36> rotate_covariance(
+  const std::array<double, 36> & src_covariance, const Eigen::Matrix3d & rotation);
+
+/** \brief Count the maximum number of consecutive direction inversions ("oscillations") in a
+ * sequence of poses. A step is counted as an inversion when the cosine between consecutive motion
+ * vectors falls below an internal threshold. */
+int count_oscillation(const std::vector<geometry_msgs::msg::Pose> & result_pose_msg_array);
+
+}  // namespace autoware::ndt_scan_matcher
+
+#endif  // AUTOWARE__NDT_SCAN_MATCHER__NDT_SCAN_MATCHER_HELPER_HPP_

--- a/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -17,6 +17,7 @@
 #include <autoware/localization_util/util_func.hpp>
 #include <autoware/ndt_scan_matcher/ndt_omp/estimate_covariance.hpp>
 #include <autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp>
+#include <autoware/ndt_scan_matcher/ndt_scan_matcher_helper.hpp>
 #include <autoware/ndt_scan_matcher/particle.hpp>
 #include <autoware/qos_utils/qos_compatibility.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
@@ -45,7 +46,6 @@ namespace autoware::ndt_scan_matcher
 {
 using autoware::localization_util::exchange_color_crc;
 using autoware::localization_util::matrix4f_to_pose;
-using autoware::localization_util::point_to_vector3d;
 using autoware::localization_util::pose_to_matrix4f;
 
 using autoware::localization_util::SmartPoseBuffer;
@@ -64,28 +64,6 @@ autoware_internal_debug_msgs::msg::Int32Stamped make_int32_stamped(
 {
   using T = autoware_internal_debug_msgs::msg::Int32Stamped;
   return autoware_internal_debug_msgs::build<T>().stamp(stamp).data(data);
-}
-
-std::array<double, 36> rotate_covariance(
-  const std::array<double, 36> & src_covariance, const Eigen::Matrix3d & rotation)
-{
-  std::array<double, 36> ret_covariance = src_covariance;
-
-  Eigen::Matrix3d src_cov;
-  src_cov << src_covariance[0], src_covariance[1], src_covariance[2], src_covariance[6],
-    src_covariance[7], src_covariance[8], src_covariance[12], src_covariance[13],
-    src_covariance[14];
-
-  Eigen::Matrix3d ret_cov;
-  ret_cov = rotation * src_cov * rotation.transpose();
-
-  for (Eigen::Index i = 0; i < 3; ++i) {
-    ret_covariance[i] = ret_cov(0, i);
-    ret_covariance[i + 6] = ret_cov(1, i);
-    ret_covariance[i + 12] = ret_cov(2, i);
-  }
-
-  return ret_covariance;
 }
 
 NDTScanMatcher::NDTScanMatcher(const rclcpp::NodeOptions & options)
@@ -674,10 +652,15 @@ bool NDTScanMatcher::callback_sensor_points_main(
       // remove ground
       pcl::shared_ptr<pcl::PointCloud<PointSource>> no_ground_points_in_map_ptr(
         new pcl::PointCloud<PointSource>);
+      no_ground_points_in_map_ptr->points.reserve(sensor_points_in_map_ptr->size());
+      // The aligned pose z is constant over the loop; the translation z of the 4x4 matrix equals
+      // matrix4f_to_pose(ndt_result.pose).position.z. Hoist it to avoid rebuilding a full Pose
+      // (including a quaternion extraction) for every point in the scan.
+      const double result_pose_z = ndt_result.pose(2, 3);
       for (std::size_t i = 0; i < sensor_points_in_map_ptr->size(); i++) {
         const float point_z = sensor_points_in_map_ptr->points[i].z;  // NOLINT
         if (
-          point_z - matrix4f_to_pose(ndt_result.pose).position.z >
+          point_z - result_pose_z >
           param_.score_estimation.no_ground_points.z_margin_for_ground_removal) {
           no_ground_points_in_map_ptr->points.push_back(sensor_points_in_map_ptr->points[i]);
         }
@@ -835,28 +818,7 @@ void NDTScanMatcher::publish_initial_to_result(
 int NDTScanMatcher::count_oscillation(
   const std::vector<geometry_msgs::msg::Pose> & result_pose_msg_array)
 {
-  constexpr double inversion_vector_threshold = -0.9;
-
-  int oscillation_cnt = 0;
-  int max_oscillation_cnt = 0;
-
-  for (size_t i = 2; i < result_pose_msg_array.size(); ++i) {
-    const Eigen::Vector3d current_pose = point_to_vector3d(result_pose_msg_array.at(i).position);
-    const Eigen::Vector3d prev_pose = point_to_vector3d(result_pose_msg_array.at(i - 1).position);
-    const Eigen::Vector3d prev_prev_pose =
-      point_to_vector3d(result_pose_msg_array.at(i - 2).position);
-    const auto current_vec = (current_pose - prev_pose).normalized();
-    const auto prev_vec = (prev_pose - prev_prev_pose).normalized();
-    const double cosine_value = current_vec.dot(prev_vec);
-    const bool oscillation = cosine_value < inversion_vector_threshold;
-    if (oscillation) {
-      oscillation_cnt++;  // count consecutive oscillation
-    } else {
-      oscillation_cnt = 0;  // reset
-    }
-    max_oscillation_cnt = std::max(max_oscillation_cnt, oscillation_cnt);
-  }
-  return max_oscillation_cnt;
+  return autoware::ndt_scan_matcher::count_oscillation(result_pose_msg_array);
 }
 
 Eigen::Matrix2d NDTScanMatcher::estimate_covariance(

--- a/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "ndt_scan_matcher_helper.hpp"
+
 #include <autoware/localization_util/matrix_type.hpp>
 #include <autoware/localization_util/tree_structured_parzen_estimator.hpp>
 #include <autoware/localization_util/util_func.hpp>
 #include <autoware/ndt_scan_matcher/ndt_omp/estimate_covariance.hpp>
 #include <autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp>
-#include <autoware/ndt_scan_matcher/ndt_scan_matcher_helper.hpp>
 #include <autoware/ndt_scan_matcher/particle.hpp>
 #include <autoware/qos_utils/qos_compatibility.hpp>
 #include <autoware_utils_geometry/geometry.hpp>

--- a/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_helper.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_helper.cpp
@@ -1,0 +1,75 @@
+// Copyright 2024 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <autoware/localization_util/util_func.hpp>
+#include <autoware/ndt_scan_matcher/ndt_scan_matcher_helper.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <vector>
+
+namespace autoware::ndt_scan_matcher
+{
+using autoware::localization_util::point_to_vector3d;
+
+std::array<double, 36> rotate_covariance(
+  const std::array<double, 36> & src_covariance, const Eigen::Matrix3d & rotation)
+{
+  std::array<double, 36> ret_covariance = src_covariance;
+
+  Eigen::Matrix3d src_cov;
+  src_cov << src_covariance[0], src_covariance[1], src_covariance[2], src_covariance[6],
+    src_covariance[7], src_covariance[8], src_covariance[12], src_covariance[13],
+    src_covariance[14];
+
+  Eigen::Matrix3d ret_cov;
+  ret_cov = rotation * src_cov * rotation.transpose();
+
+  for (Eigen::Index i = 0; i < 3; ++i) {
+    ret_covariance[i] = ret_cov(0, i);
+    ret_covariance[i + 6] = ret_cov(1, i);
+    ret_covariance[i + 12] = ret_cov(2, i);
+  }
+
+  return ret_covariance;
+}
+
+int count_oscillation(const std::vector<geometry_msgs::msg::Pose> & result_pose_msg_array)
+{
+  constexpr double inversion_vector_threshold = -0.9;
+
+  int oscillation_cnt = 0;
+  int max_oscillation_cnt = 0;
+
+  for (size_t i = 2; i < result_pose_msg_array.size(); ++i) {
+    const Eigen::Vector3d current_pose = point_to_vector3d(result_pose_msg_array.at(i).position);
+    const Eigen::Vector3d prev_pose = point_to_vector3d(result_pose_msg_array.at(i - 1).position);
+    const Eigen::Vector3d prev_prev_pose =
+      point_to_vector3d(result_pose_msg_array.at(i - 2).position);
+    const auto current_vec = (current_pose - prev_pose).normalized();
+    const auto prev_vec = (prev_pose - prev_prev_pose).normalized();
+    const double cosine_value = current_vec.dot(prev_vec);
+    const bool oscillation = cosine_value < inversion_vector_threshold;
+    if (oscillation) {
+      oscillation_cnt++;  // count consecutive oscillation
+    } else {
+      oscillation_cnt = 0;  // reset
+    }
+    max_oscillation_cnt = std::max(max_oscillation_cnt, oscillation_cnt);
+  }
+  return max_oscillation_cnt;
+}
+
+}  // namespace autoware::ndt_scan_matcher

--- a/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_helper.cpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_helper.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "ndt_scan_matcher_helper.hpp"
+
 #include <autoware/localization_util/util_func.hpp>
-#include <autoware/ndt_scan_matcher/ndt_scan_matcher_helper.hpp>
 
 #include <algorithm>
 #include <array>
@@ -58,9 +59,15 @@ int count_oscillation(const std::vector<geometry_msgs::msg::Pose> & result_pose_
     const Eigen::Vector3d prev_pose = point_to_vector3d(result_pose_msg_array.at(i - 1).position);
     const Eigen::Vector3d prev_prev_pose =
       point_to_vector3d(result_pose_msg_array.at(i - 2).position);
-    const auto current_vec = (current_pose - prev_pose).normalized();
-    const auto prev_vec = (prev_pose - prev_prev_pose).normalized();
-    const double cosine_value = current_vec.dot(prev_vec);
+    const Eigen::Vector3d current_step = current_pose - prev_pose;
+    const Eigen::Vector3d prev_step = prev_pose - prev_prev_pose;
+    // A zero-length step (e.g. repeated poses) has no direction. normalized() on a zero vector
+    // yields NaNs, so guard against it and treat such steps as non-oscillations.
+    if (current_step.norm() == 0.0 || prev_step.norm() == 0.0) {
+      oscillation_cnt = 0;  // reset
+      continue;
+    }
+    const double cosine_value = current_step.normalized().dot(prev_step.normalized());
     const bool oscillation = cosine_value < inversion_vector_threshold;
     if (oscillation) {
       oscillation_cnt++;  // count consecutive oscillation

--- a/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_helper.hpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_helper.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__NDT_SCAN_MATCHER__NDT_SCAN_MATCHER_HELPER_HPP_
-#define AUTOWARE__NDT_SCAN_MATCHER__NDT_SCAN_MATCHER_HELPER_HPP_
+#ifndef NDT_SCAN_MATCHER_HELPER_HPP_
+#define NDT_SCAN_MATCHER_HELPER_HPP_
 
 #include <Eigen/Core>
 
@@ -38,4 +38,4 @@ int count_oscillation(const std::vector<geometry_msgs::msg::Pose> & result_pose_
 
 }  // namespace autoware::ndt_scan_matcher
 
-#endif  // AUTOWARE__NDT_SCAN_MATCHER__NDT_SCAN_MATCHER_HELPER_HPP_
+#endif  // NDT_SCAN_MATCHER_HELPER_HPP_

--- a/localization/autoware_ndt_scan_matcher/test/test_estimate_covariance.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_estimate_covariance.cpp
@@ -115,12 +115,21 @@ TEST(EstimateCovariance, RotateCovarianceMapAndBaseLinkAreInverses)  // NOLINT
   Eigen::Matrix2d cov;
   cov << 4.0, 1.0, 1.0, 9.0;
 
-  const Eigen::Matrix2d rot = pose.topLeftCorner<2, 2>().cast<double>();
-  const Eigen::Matrix2d expected_map = rot * cov * rot.transpose();
-
   const Eigen::Matrix2d cov_map = pclomp::rotate_covariance_to_map(cov, pose);
+
+  // Independent oracle: explicit scalar expansion of R * cov * R^T with
+  // R = [[c, -s], [s, c]], cov = [[4, 1], [1, 9]]. These literals are derived by hand
+  // from the rotation algebra, not from the matrix product the production code evaluates.
+  const double c = std::cos(theta);
+  const double s = std::sin(theta);
+  const double exp00 = c * c * 4.0 - 2.0 * c * s * 1.0 + s * s * 9.0;
+  const double exp01 = c * s * 4.0 + (c * c - s * s) * 1.0 - c * s * 9.0;
+  const double exp11 = s * s * 4.0 + 2.0 * c * s * 1.0 + c * c * 9.0;
   // The pose rotation is stored as float, so the achievable precision is limited to ~float eps.
-  EXPECT_TRUE(cov_map.isApprox(expected_map, 1e-6));
+  EXPECT_NEAR(cov_map(0, 0), exp00, 1e-6);
+  EXPECT_NEAR(cov_map(0, 1), exp01, 1e-6);
+  EXPECT_NEAR(cov_map(1, 0), exp01, 1e-6);
+  EXPECT_NEAR(cov_map(1, 1), exp11, 1e-6);
 
   // Rotating back to base_link must recover the original covariance.
   const Eigen::Matrix2d round_trip = pclomp::rotate_covariance_to_base_link(cov_map, pose);

--- a/localization/autoware_ndt_scan_matcher/test/test_estimate_covariance.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_estimate_covariance.cpp
@@ -1,0 +1,155 @@
+// Copyright 2024 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Eigen/Core>
+#include <autoware/ndt_scan_matcher/ndt_omp/estimate_covariance.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+// calc_weight_vec is a temperature-scaled softmax. Equal scores yield a uniform distribution.
+TEST(EstimateCovariance, CalcWeightVecUniformForEqualScores)  // NOLINT
+{
+  const std::vector<double> scores{1.5, 1.5, 1.5, 1.5};
+  const std::vector<double> weights = pclomp::calc_weight_vec(scores, 1.0);
+  ASSERT_EQ(weights.size(), scores.size());
+  for (const double w : weights) {
+    EXPECT_NEAR(w, 0.25, 1e-12);
+  }
+}
+
+// With temperature 1.0 and scores {0, ln 3}, the softmax weights are {1/4, 3/4}.
+TEST(EstimateCovariance, CalcWeightVecKnownSoftmax)  // NOLINT
+{
+  const std::vector<double> scores{0.0, std::log(3.0)};
+  const std::vector<double> weights = pclomp::calc_weight_vec(scores, 1.0);
+  ASSERT_EQ(weights.size(), 2u);
+  EXPECT_NEAR(weights[0], 0.25, 1e-12);
+  EXPECT_NEAR(weights[1], 0.75, 1e-12);
+  EXPECT_NEAR(weights[0] + weights[1], 1.0, 1e-12);
+}
+
+// Weighted mean and covariance for two symmetric points with equal weights.
+TEST(EstimateCovariance, CalculateWeightedMeanAndCovKnownValues)  // NOLINT
+{
+  const std::vector<Eigen::Vector2d> points{Eigen::Vector2d(0.0, 0.0), Eigen::Vector2d(2.0, 0.0)};
+  const std::vector<double> weights{0.5, 0.5};
+  const auto [mean, cov] = pclomp::calculate_weighted_mean_and_cov(points, weights);
+
+  EXPECT_NEAR(mean.x(), 1.0, 1e-12);
+  EXPECT_NEAR(mean.y(), 0.0, 1e-12);
+  EXPECT_NEAR(cov(0, 0), 1.0, 1e-12);
+  EXPECT_NEAR(cov(0, 1), 0.0, 1e-12);
+  EXPECT_NEAR(cov(1, 0), 0.0, 1e-12);
+  EXPECT_NEAR(cov(1, 1), 0.0, 1e-12);
+}
+
+// propose_poses_to_search rotates the (offset_x, offset_y) deltas by the pose orientation and
+// adds them to the center translation.
+TEST(EstimateCovariance, ProposePosesToSearchRotatesOffsets)  // NOLINT
+{
+  pclomp::NdtResult ndt_result{};
+  ndt_result.pose = Eigen::Matrix4f::Identity();
+  // 90 degrees CCW about z in the top-left 2x2 block.
+  ndt_result.pose(0, 0) = 0.0f;
+  ndt_result.pose(0, 1) = -1.0f;
+  ndt_result.pose(1, 0) = 1.0f;
+  ndt_result.pose(1, 1) = 0.0f;
+  ndt_result.pose(0, 3) = 10.0f;  // center x
+  ndt_result.pose(1, 3) = 20.0f;  // center y
+
+  const std::vector<double> offset_x{1.0, 0.0};
+  const std::vector<double> offset_y{0.0, 1.0};
+  const auto poses = pclomp::propose_poses_to_search(ndt_result, offset_x, offset_y);
+
+  ASSERT_EQ(poses.size(), 2u);
+  // offset (1,0) rotated by +90deg -> (0,1): translation (10, 21).
+  EXPECT_NEAR(poses[0](0, 3), 10.0, 1e-5);
+  EXPECT_NEAR(poses[0](1, 3), 21.0, 1e-5);
+  // offset (0,1) rotated by +90deg -> (-1,0): translation (9, 20).
+  EXPECT_NEAR(poses[1](0, 3), 9.0, 1e-5);
+  EXPECT_NEAR(poses[1](1, 3), 20.0, 1e-5);
+}
+
+// estimate_xy_covariance_by_laplace_approximation returns -inverse of the top-left 2x2 Hessian.
+TEST(EstimateCovariance, LaplaceApproximationNegativeInverseHessian)  // NOLINT
+{
+  Eigen::Matrix<double, 6, 6> hessian = Eigen::Matrix<double, 6, 6>::Zero();
+  hessian(0, 0) = -2.0;
+  hessian(1, 1) = -4.0;
+  // Fill the rest of the matrix to ensure only the 2x2 block matters.
+  hessian(2, 2) = -100.0;
+  hessian(3, 3) = 7.0;
+
+  const Eigen::Matrix2d cov = pclomp::estimate_xy_covariance_by_laplace_approximation(hessian);
+  EXPECT_NEAR(cov(0, 0), 0.5, 1e-12);
+  EXPECT_NEAR(cov(1, 1), 0.25, 1e-12);
+  EXPECT_NEAR(cov(0, 1), 0.0, 1e-12);
+  EXPECT_NEAR(cov(1, 0), 0.0, 1e-12);
+}
+
+// rotate_covariance_to_map applies R * C * R^T using the pose rotation; verify against a directly
+// computed reference, and confirm rotate_covariance_to_base_link is its inverse.
+TEST(EstimateCovariance, RotateCovarianceMapAndBaseLinkAreInverses)  // NOLINT
+{
+  Eigen::Matrix4f pose = Eigen::Matrix4f::Identity();
+  const double theta = 0.3;  // arbitrary non-trivial yaw
+  pose(0, 0) = static_cast<float>(std::cos(theta));
+  pose(0, 1) = static_cast<float>(-std::sin(theta));
+  pose(1, 0) = static_cast<float>(std::sin(theta));
+  pose(1, 1) = static_cast<float>(std::cos(theta));
+
+  Eigen::Matrix2d cov;
+  cov << 4.0, 1.0, 1.0, 9.0;
+
+  const Eigen::Matrix2d rot = pose.topLeftCorner<2, 2>().cast<double>();
+  const Eigen::Matrix2d expected_map = rot * cov * rot.transpose();
+
+  const Eigen::Matrix2d cov_map = pclomp::rotate_covariance_to_map(cov, pose);
+  // The pose rotation is stored as float, so the achievable precision is limited to ~float eps.
+  EXPECT_TRUE(cov_map.isApprox(expected_map, 1e-6));
+
+  // Rotating back to base_link must recover the original covariance.
+  const Eigen::Matrix2d round_trip = pclomp::rotate_covariance_to_base_link(cov_map, pose);
+  EXPECT_TRUE(round_trip.isApprox(cov, 1e-6));
+}
+
+// adjust_diagonal_covariance clamps the base_link-frame diagonal to the provided floors. With an
+// identity pose the base_link and map frames coincide, so the result is simply the clamped input.
+TEST(EstimateCovariance, AdjustDiagonalCovarianceClampsFloor)  // NOLINT
+{
+  const Eigen::Matrix4f pose = Eigen::Matrix4f::Identity();
+  Eigen::Matrix2d cov;
+  cov << 1.0, 0.0, 0.0, 1.0;
+
+  const Eigen::Matrix2d adjusted = pclomp::adjust_diagonal_covariance(cov, pose, 4.0, 9.0);
+  EXPECT_NEAR(adjusted(0, 0), 4.0, 1e-12);
+  EXPECT_NEAR(adjusted(1, 1), 9.0, 1e-12);
+  EXPECT_NEAR(adjusted(0, 1), 0.0, 1e-12);
+  EXPECT_NEAR(adjusted(1, 0), 0.0, 1e-12);
+}
+
+// When the input diagonal already exceeds the floors, adjust_diagonal_covariance leaves it intact.
+TEST(EstimateCovariance, AdjustDiagonalCovarianceKeepsLargerValues)  // NOLINT
+{
+  const Eigen::Matrix4f pose = Eigen::Matrix4f::Identity();
+  Eigen::Matrix2d cov;
+  cov << 10.0, 0.0, 0.0, 20.0;
+
+  const Eigen::Matrix2d adjusted = pclomp::adjust_diagonal_covariance(cov, pose, 4.0, 9.0);
+  EXPECT_NEAR(adjusted(0, 0), 10.0, 1e-12);
+  EXPECT_NEAR(adjusted(1, 1), 20.0, 1e-12);
+}

--- a/localization/autoware_ndt_scan_matcher/test/test_ndt_scan_matcher_helper.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_ndt_scan_matcher_helper.cpp
@@ -1,0 +1,124 @@
+// Copyright 2024 Autoware Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <Eigen/Core>
+#include <Eigen/Geometry>
+#include <autoware/ndt_scan_matcher/ndt_scan_matcher_helper.hpp>
+
+#include <geometry_msgs/msg/pose.hpp>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cmath>
+#include <vector>
+
+namespace
+{
+geometry_msgs::msg::Pose make_pose_xyz(const double x, const double y, const double z)
+{
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = x;
+  pose.position.y = y;
+  pose.position.z = z;
+  pose.orientation.w = 1.0;
+  return pose;
+}
+}  // namespace
+
+// A 90-degree rotation about z swaps the x and y variances of a diagonal position covariance
+// block and leaves all other (non-position) entries untouched.
+TEST(NdtScanMatcherHelper, RotateCovarianceSwapsDiagonalUnderQuarterTurn)  // NOLINT
+{
+  std::array<double, 36> src{};
+  src.fill(0.0);
+  src[0 + 6 * 0] = 4.0;   // var x
+  src[1 + 6 * 1] = 9.0;   // var y
+  src[2 + 6 * 2] = 16.0;  // var z
+  // Put a sentinel into an angular entry to confirm it is preserved.
+  src[3 + 6 * 3] = 42.0;
+
+  // 90 degrees CCW about z: R = [[0,-1,0],[1,0,0],[0,0,1]].
+  Eigen::Matrix3d rotation;
+  rotation << 0.0, -1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0;
+
+  const std::array<double, 36> out = autoware::ndt_scan_matcher::rotate_covariance(src, rotation);
+
+  EXPECT_NEAR(out[0 + 6 * 0], 9.0, 1e-9);   // x variance becomes old y variance
+  EXPECT_NEAR(out[1 + 6 * 1], 4.0, 1e-9);   // y variance becomes old x variance
+  EXPECT_NEAR(out[2 + 6 * 2], 16.0, 1e-9);  // z variance unchanged
+  EXPECT_NEAR(out[0 + 6 * 1], 0.0, 1e-9);   // off-diagonals stay zero
+  EXPECT_NEAR(out[1 + 6 * 0], 0.0, 1e-9);
+  EXPECT_NEAR(out[3 + 6 * 3], 42.0, 1e-9);  // angular block untouched
+}
+
+// The identity rotation must return the source covariance unchanged.
+TEST(NdtScanMatcherHelper, RotateCovarianceIdentityIsNoOp)  // NOLINT
+{
+  std::array<double, 36> src{};
+  for (std::size_t i = 0; i < src.size(); ++i) {
+    src[i] = static_cast<double>(i) + 1.0;
+  }
+
+  const std::array<double, 36> out =
+    autoware::ndt_scan_matcher::rotate_covariance(src, Eigen::Matrix3d::Identity());
+
+  for (std::size_t i = 0; i < src.size(); ++i) {
+    EXPECT_NEAR(out[i], src[i], 1e-9) << "index " << i;
+  }
+}
+
+// A perfect back-and-forth zig-zag along x produces a consecutive-inversion count equal to the
+// number of direction reversals.
+TEST(NdtScanMatcherHelper, CountOscillationCountsConsecutiveInversions)  // NOLINT
+{
+  std::vector<geometry_msgs::msg::Pose> poses;
+  for (const double x : {0.0, 1.0, 0.0, 1.0, 0.0}) {
+    poses.push_back(make_pose_xyz(x, 0.0, 0.0));
+  }
+  // Reversals occur at i = 2, 3, 4 and are all consecutive -> max count 3.
+  EXPECT_EQ(autoware::ndt_scan_matcher::count_oscillation(poses), 3);
+}
+
+// A monotonic straight-line trajectory contains no inversions.
+TEST(NdtScanMatcherHelper, CountOscillationStraightLineIsZero)  // NOLINT
+{
+  std::vector<geometry_msgs::msg::Pose> poses;
+  for (const double x : {0.0, 1.0, 2.0, 3.0, 4.0}) {
+    poses.push_back(make_pose_xyz(x, 0.0, 0.0));
+  }
+  EXPECT_EQ(autoware::ndt_scan_matcher::count_oscillation(poses), 0);
+}
+
+// The maximum is over consecutive runs: a reversal that is later broken resets the running count.
+TEST(NdtScanMatcherHelper, CountOscillationResetsAfterNonInversion)  // NOLINT
+{
+  // x: 0 -> 1 -> 0 (reversal) -> 1 (reversal) -> 2 (straight, resets) -> 1 (reversal)
+  std::vector<geometry_msgs::msg::Pose> poses;
+  for (const double x : {0.0, 1.0, 0.0, 1.0, 2.0, 1.0}) {
+    poses.push_back(make_pose_xyz(x, 0.0, 0.0));
+  }
+  // i=2: reversal (cnt 1), i=3: reversal (cnt 2, max 2), i=4: straight (cnt 0),
+  // i=5: reversal (cnt 1). Max consecutive run = 2.
+  EXPECT_EQ(autoware::ndt_scan_matcher::count_oscillation(poses), 2);
+}
+
+// Fewer than three poses cannot form an inversion.
+TEST(NdtScanMatcherHelper, CountOscillationTooFewPosesIsZero)  // NOLINT
+{
+  std::vector<geometry_msgs::msg::Pose> poses;
+  poses.push_back(make_pose_xyz(0.0, 0.0, 0.0));
+  poses.push_back(make_pose_xyz(1.0, 0.0, 0.0));
+  EXPECT_EQ(autoware::ndt_scan_matcher::count_oscillation(poses), 0);
+}

--- a/localization/autoware_ndt_scan_matcher/test/test_ndt_scan_matcher_helper.cpp
+++ b/localization/autoware_ndt_scan_matcher/test/test_ndt_scan_matcher_helper.cpp
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "../src/ndt_scan_matcher_helper.hpp"
+
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-#include <autoware/ndt_scan_matcher/ndt_scan_matcher_helper.hpp>
 
 #include <geometry_msgs/msg/pose.hpp>
 
@@ -121,4 +122,29 @@ TEST(NdtScanMatcherHelper, CountOscillationTooFewPosesIsZero)  // NOLINT
   poses.push_back(make_pose_xyz(0.0, 0.0, 0.0));
   poses.push_back(make_pose_xyz(1.0, 0.0, 0.0));
   EXPECT_EQ(autoware::ndt_scan_matcher::count_oscillation(poses), 0);
+}
+
+// Repeated (identical) poses produce zero-length motion vectors. Normalizing those would yield
+// NaNs and an unreliable cosine; the guard must treat such steps as non-oscillations and return a
+// finite count of 0 rather than reacting to NaN comparisons.
+TEST(NdtScanMatcherHelper, CountOscillationZeroLengthStepsAreNotOscillations)  // NOLINT
+{
+  std::vector<geometry_msgs::msg::Pose> poses;
+  // All identical -> every step has zero length.
+  for (int i = 0; i < 5; ++i) {
+    poses.push_back(make_pose_xyz(1.0, 2.0, 3.0));
+  }
+  EXPECT_EQ(autoware::ndt_scan_matcher::count_oscillation(poses), 0);
+}
+
+// A zero-length step interleaved with real motion must not be counted as an oscillation and must
+// reset the running consecutive-inversion count.
+TEST(NdtScanMatcherHelper, CountOscillationResetsOnZeroLengthStep)  // NOLINT
+{
+  // x: 0 -> 1 -> 0 (reversal, cnt 1) -> 0 (zero-length step, reset) -> 1 (no prior direction yet)
+  std::vector<geometry_msgs::msg::Pose> poses;
+  for (const double x : {0.0, 1.0, 0.0, 0.0, 1.0}) {
+    poses.push_back(make_pose_xyz(x, 0.0, 0.0));
+  }
+  EXPECT_EQ(autoware::ndt_scan_matcher::count_oscillation(poses), 1);
 }


### PR DESCRIPTION
## Description

This PR raises unit-test coverage for the previously-untested pure math in `autoware_ndt_scan_matcher` and applies two behavior-preserving cleanups. It is the "Recommended PR" from the refactoring-campaign audit (priority 7) for this package.

Before this change the only tests were three heavyweight launch/integration gtests (each spinning a `MultiThreadedExecutor` with a 300s timeout and asserting only the final pose). The deterministic, dependency-light helpers had zero unit tests.

### Testable seam + new fast unit tests

- Extracted the translation-unit-local `rotate_covariance` free function and the body of `count_oscillation` into a small internal seam: `include/autoware/ndt_scan_matcher/ndt_scan_matcher_helper.hpp` + `src/ndt_scan_matcher_helper.cpp`, both in namespace `autoware::ndt_scan_matcher`.
- `NDTScanMatcher::count_oscillation` (private static member) is retained and now delegates to the free function — **no public/private member API change**.
- Added `ament_auto_add_gtest` target `test_estimate_covariance` covering the pure Eigen math in `ndt_omp/estimate_covariance.cpp` with hand-computed expected values: `calc_weight_vec` (temperature softmax), `calculate_weighted_mean_and_cov`, `propose_poses_to_search` (rotated offsets), `estimate_xy_covariance_by_laplace_approximation` (−inverse of the Hessian's 2×2 block), `rotate_covariance_to_map`/`rotate_covariance_to_base_link` (R·C·Rᵀ and its round-trip inverse), and `adjust_diagonal_covariance` (diagonal flooring).
- Added `ament_auto_add_gtest` target `test_ndt_scan_matcher_helper` covering `rotate_covariance` (36-element covariance-block rotation, including diagonal swap under a 90° turn and identity no-op) and `count_oscillation` (consecutive-inversion counting, reset behavior, and the <3-pose edge case).

### Behavior-preserving cleanups

- Hoisted the loop-invariant `matrix4f_to_pose(ndt_result.pose).position.z` out of the per-point no-ground-points removal loop. The aligned-pose z is constant; it equals the 4×4 matrix translation `ndt_result.pose(2, 3)`, so the inner loop no longer rebuilds a full `geometry_msgs::Pose` (with a quaternion extraction) for every LiDAR point. Also `reserve()` the output cloud.
- Removed the dead, never-read `Eigen::Matrix4f base_to_sensor_matrix_` member (`transform_sensor_measurement` uses a local of the same name).

## Effects on system behavior

None intended. The hoist is algebraically identical (`tf2::toMsg` of the affine matrix places the translation z exactly at element (2,3)); the `count_oscillation` extraction copies the logic verbatim; the dead member was never read. No public API or message/topic changes; downstream consumers are unaffected.

## Tests performed

Built and ran in the `autoware:core-devel-jazzy` container. The two new fast gtest targets pass (14 cases, 0 failures). The three pre-existing 300s launch/integration tests were not run locally (slow); fork CI exercises the full suite.

## youtalk fork CI — build-and-test all green

The full `build-test-tidy-pr` workflow runs on the youtalk fork (`ubicloud-standard-16`). All build-and-test gate jobs pass for head commit `d6c0e2a8b` ([workflow run](https://github.com/youtalk/autoware_core/actions/runs/26656420501)):

- ✅ `build-and-test-diff-jazzy / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26656420501/job/78567651257
- ✅ `build-and-test-diff-jazzy-agnocast / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26656420501/job/78567651223
- ✅ `build-and-test-diff-humble / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26656420501/job/78567651265
- ✅ `build-and-test-diff-jazzy / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26656420501/job/78568290908
- ✅ `build-and-test-diff-humble / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26656420501/job/78568193663

(The `*-above` universe jobs are bonus coverage and excluded from the gate.)
