### PR TITLE
test(autoware_trajectory): add Pchip interpolator unit tests

### DIFF
--- a/common/autoware_trajectory/CMakeLists.txt
+++ b/common/autoware_trajectory/CMakeLists.txt
@@ -74,6 +74,7 @@ if(BUILD_TESTING)
     test/test_shift.cpp
     test/test_helpers.cpp
     test/test_interpolator.cpp
+    test/test_pchip.cpp
     test/test_pretty_build.cpp
     test/test_reference_path.cpp
     test/test_reference_path_vm_10_spec.cpp

--- a/common/autoware_trajectory/test/test_interpolator.cpp
+++ b/common/autoware_trajectory/test/test_interpolator.cpp
@@ -17,6 +17,7 @@
 #include "autoware/trajectory/interpolator/lane_ids_interpolator.hpp"
 #include "autoware/trajectory/interpolator/linear.hpp"
 #include "autoware/trajectory/interpolator/nearest_neighbor.hpp"
+#include "autoware/trajectory/interpolator/pchip.hpp"
 #include "autoware/trajectory/interpolator/spherical_linear.hpp"
 #include "autoware/trajectory/interpolator/stairstep.hpp"
 
@@ -55,6 +56,7 @@ using Interpolators = testing::Types<
   autoware::experimental::trajectory::interpolator::CubicSpline,
   autoware::experimental::trajectory::interpolator::AkimaSpline,
   autoware::experimental::trajectory::interpolator::Linear,
+  autoware::experimental::trajectory::interpolator::Pchip,
   autoware::experimental::trajectory::interpolator::NearestNeighbor<double>,
   autoware::experimental::trajectory::interpolator::Stairstep<double>>;
 
@@ -73,6 +75,7 @@ TYPED_TEST(TestInterpolator, Compute)
 template class TestInterpolator<autoware::experimental::trajectory::interpolator::CubicSpline>;
 template class TestInterpolator<autoware::experimental::trajectory::interpolator::AkimaSpline>;
 template class TestInterpolator<autoware::experimental::trajectory::interpolator::Linear>;
+template class TestInterpolator<autoware::experimental::trajectory::interpolator::Pchip>;
 template class TestInterpolator<
   autoware::experimental::trajectory::interpolator::NearestNeighbor<double>>;
 template class TestInterpolator<

--- a/common/autoware_trajectory/test/test_pchip.cpp
+++ b/common/autoware_trajectory/test/test_pchip.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// cspell:ignore Fritsch
+
 #include "autoware/trajectory/interpolator/pchip.hpp"
 
 #include <gtest/gtest.h>
@@ -36,7 +38,7 @@ using autoware::experimental::trajectory::interpolator::Pchip;
 constexpr double k_tol = 1e-12;
 }  // namespace
 
-// The interpolant must pass through every data point exactly, and the interior
+// The interpolated curve must pass through every data point exactly, and the interior
 // knot derivatives must equal the Fritsch-Carlson weighted-harmonic-mean
 // slopes. Dataset: y = x^2 sampled on [0, 4].
 TEST(TestPchip, InterpolatesThroughDataPointsAndKnotDerivatives)
@@ -68,7 +70,7 @@ TEST(TestPchip, InterpolatesThroughDataPointsAndKnotDerivatives)
   EXPECT_NEAR(pchip.compute(3.5), 12.229166666666666, k_tol);
 }
 
-// On strictly increasing data the interpolant must stay monotone increasing
+// On strictly increasing data the interpolated curve must stay monotone increasing
 // between knots (no spurious dips).
 TEST(TestPchip, PreservesMonotonicity)
 {
@@ -80,7 +82,7 @@ TEST(TestPchip, PreservesMonotonicity)
   const auto & pchip = result.value();
 
   // Small absolute tolerance to absorb floating-point roundoff (tiny negative
-  // steps even when the interpolant is monotone in theory). It is many orders
+  // steps even when the interpolated curve is monotone in theory). It is many orders
   // of magnitude below the data scale (values up to 16, secant slopes up to 8
   // over a step of 0.01), so a genuine monotonicity violation is still caught.
   constexpr double k_monotonicity_tol = 1e-9;
@@ -94,7 +96,7 @@ TEST(TestPchip, PreservesMonotonicity)
 }
 
 // At a local maximum the interior derivative must be zeroed (the
-// delta_prev > 0 && delta_next < 0 sign-change branch), and the interpolant
+// delta_prev > 0 && delta_next < 0 sign-change branch), and the interpolated curve
 // must not overshoot the data (shape preservation). Dataset has a peak at
 // x = 2.
 TEST(TestPchip, ZeroesDerivativeAtLocalExtremumAndDoesNotOvershoot)

--- a/common/autoware_trajectory/test/test_pchip.cpp
+++ b/common/autoware_trajectory/test/test_pchip.cpp
@@ -1,0 +1,246 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/trajectory/interpolator/pchip.hpp"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+// Characterization tests for the PCHIP (Piecewise Cubic Hermite Interpolating
+// Polynomial) interpolator. The expected values below were derived from the
+// algorithm exactly as implemented in src/interpolator/pchip.cpp and
+// independently cross-checked against scipy.interpolate.PchipInterpolator,
+// which uses the same Fritsch-Carlson construction. They pin the current
+// observable behavior of the shipped interpolator: interpolation through the
+// data points, the harmonic-mean interior knot derivatives, the one-sided
+// endpoint-derivative estimate (with sign guard and 3*delta limiting), the
+// monotonicity / no-overshoot shape preservation, the n == 2 linear special
+// case, and the build-time rejection / duplicate-removal branches.
+
+namespace
+{
+using autoware::experimental::trajectory::interpolator::Pchip;
+
+constexpr double k_tol = 1e-12;
+}  // namespace
+
+// The interpolant must pass through every data point exactly, and the interior
+// knot derivatives must equal the Fritsch-Carlson weighted-harmonic-mean
+// slopes. Dataset: y = x^2 sampled on [0, 4].
+TEST(TestPchip, InterpolatesThroughDataPointsAndKnotDerivatives)
+{
+  const std::vector<double> bases = {0.0, 1.0, 2.0, 3.0, 4.0};
+  const std::vector<double> values = {0.0, 1.0, 4.0, 9.0, 16.0};
+
+  const auto result = Pchip::Builder{}.set_bases(bases).set_values(values).build();
+  ASSERT_TRUE(result.has_value());
+  const auto & pchip = result.value();
+
+  // Passes through the data points.
+  for (size_t i = 0; i < bases.size(); ++i) {
+    EXPECT_NEAR(pchip.compute(bases[i]), values[i], k_tol);
+  }
+
+  // Interior knot first derivatives (harmonic-mean slopes) and the
+  // sign-guarded endpoint derivative at x = 0 (clamped to 0).
+  EXPECT_NEAR(pchip.compute_first_derivative(0.0), 0.0, k_tol);
+  EXPECT_NEAR(pchip.compute_first_derivative(1.0), 1.5, k_tol);
+  EXPECT_NEAR(pchip.compute_first_derivative(2.0), 3.75, k_tol);
+  EXPECT_NEAR(pchip.compute_first_derivative(3.0), 5.833333333333334, k_tol);
+  EXPECT_NEAR(pchip.compute_first_derivative(4.0), 8.0, k_tol);
+
+  // Mid-interval values.
+  EXPECT_NEAR(pchip.compute(0.5), 0.3125, k_tol);
+  EXPECT_NEAR(pchip.compute(1.5), 2.21875, k_tol);
+  EXPECT_NEAR(pchip.compute(2.5), 6.239583333333333, k_tol);
+  EXPECT_NEAR(pchip.compute(3.5), 12.229166666666666, k_tol);
+}
+
+// On strictly increasing data the interpolant must stay monotone increasing
+// between knots (no spurious dips).
+TEST(TestPchip, PreservesMonotonicity)
+{
+  const std::vector<double> bases = {0.0, 1.0, 2.0, 3.0, 4.0};
+  const std::vector<double> values = {0.0, 1.0, 4.0, 9.0, 16.0};
+
+  const auto result = Pchip::Builder{}.set_bases(bases).set_values(values).build();
+  ASSERT_TRUE(result.has_value());
+  const auto & pchip = result.value();
+
+  // Small absolute tolerance to absorb floating-point roundoff (tiny negative
+  // steps even when the interpolant is monotone in theory). It is many orders
+  // of magnitude below the data scale (values up to 16, secant slopes up to 8
+  // over a step of 0.01), so a genuine monotonicity violation is still caught.
+  constexpr double k_monotonicity_tol = 1e-9;
+  double previous = pchip.compute(0.0);
+  for (int i = 1; i <= 400; ++i) {
+    const double s = 4.0 * static_cast<double>(i) / 400.0;
+    const double current = pchip.compute(s);
+    EXPECT_GE(current, previous - k_monotonicity_tol) << "monotonicity violated at s = " << s;
+    previous = current;
+  }
+}
+
+// At a local maximum the interior derivative must be zeroed (the
+// delta_prev > 0 && delta_next < 0 sign-change branch), and the interpolant
+// must not overshoot the data (shape preservation). Dataset has a peak at
+// x = 2.
+TEST(TestPchip, ZeroesDerivativeAtLocalExtremumAndDoesNotOvershoot)
+{
+  const std::vector<double> bases = {0.0, 1.0, 2.0, 3.0, 4.0};
+  const std::vector<double> values = {0.0, 2.0, 3.0, 2.0, 0.0};
+
+  const auto result = Pchip::Builder{}.set_bases(bases).set_values(values).build();
+  ASSERT_TRUE(result.has_value());
+  const auto & pchip = result.value();
+
+  // Local-extremum derivative is exactly zero.
+  EXPECT_NEAR(pchip.compute_first_derivative(2.0), 0.0, k_tol);
+
+  // Endpoint and neighbouring interior knot derivatives.
+  EXPECT_NEAR(pchip.compute_first_derivative(0.0), 2.5, k_tol);
+  EXPECT_NEAR(pchip.compute_first_derivative(1.0), 1.3333333333333333, k_tol);
+  EXPECT_NEAR(pchip.compute_first_derivative(3.0), -1.3333333333333333, k_tol);
+  EXPECT_NEAR(pchip.compute_first_derivative(4.0), -2.5, k_tol);
+
+  // Pinned mid-interval values.
+  EXPECT_NEAR(pchip.compute(0.5), 1.1458333333333333, k_tol);
+  EXPECT_NEAR(pchip.compute(1.5), 2.6666666666666665, k_tol);
+  EXPECT_NEAR(pchip.compute(2.5), 2.6666666666666665, k_tol);
+  EXPECT_NEAR(pchip.compute(3.5), 1.1458333333333333, k_tol);
+
+  // No overshoot above the data maximum (3.0) over the whole range.
+  for (int i = 0; i <= 400; ++i) {
+    const double s = 4.0 * static_cast<double>(i) / 400.0;
+    EXPECT_LE(pchip.compute(s), 3.0 + k_tol) << "overshoot at s = " << s;
+    EXPECT_GE(pchip.compute(s), 0.0 - k_tol) << "undershoot at s = " << s;
+  }
+}
+
+// The endpoint derivative uses a one-sided estimate that is limited to
+// 3 * delta when the two end segments have opposite slope signs and the
+// estimate is too steep. Here delta0 = 1, delta1 = -10 gives a raw estimate of
+// 6.5, which must be clamped to 3 * delta0 = 3.0.
+TEST(TestPchip, LimitsEndpointDerivative)
+{
+  const std::vector<double> bases = {0.0, 1.0, 2.0, 3.0};
+  const std::vector<double> values = {0.0, 1.0, -9.0, -9.5};
+
+  const auto result = Pchip::Builder{}.set_bases(bases).set_values(values).build();
+  ASSERT_TRUE(result.has_value());
+  const auto & pchip = result.value();
+
+  EXPECT_NEAR(pchip.compute_first_derivative(0.0), 3.0, k_tol);
+}
+
+// With exactly two points PCHIP degenerates to the straight line through them:
+// both knot derivatives equal the secant slope, so the cubic coefficients
+// c and d vanish.
+TEST(TestPchip, TwoPointsAreLinear)
+{
+  const std::vector<double> bases = {0.0, 2.0};
+  const std::vector<double> values = {1.0, 5.0};
+
+  const auto result = Pchip::Builder{}.set_bases(bases).set_values(values).build();
+  ASSERT_TRUE(result.has_value());
+  const auto & pchip = result.value();
+
+  EXPECT_NEAR(pchip.compute(0.0), 1.0, k_tol);
+  EXPECT_NEAR(pchip.compute(1.0), 3.0, k_tol);
+  EXPECT_NEAR(pchip.compute(2.0), 5.0, k_tol);
+
+  // Constant slope, zero curvature.
+  EXPECT_NEAR(pchip.compute_first_derivative(0.5), 2.0, k_tol);
+  EXPECT_NEAR(pchip.compute_first_derivative(1.5), 2.0, k_tol);
+  EXPECT_NEAR(pchip.compute_second_derivative(1.0), 0.0, k_tol);
+}
+
+// Building with fewer than two distinct points must fail.
+TEST(TestPchip, RejectsTooFewPoints)
+{
+  const std::vector<double> bases = {0.0};
+  const std::vector<double> values = {1.0};
+
+  const auto result = Pchip::Builder{}.set_bases(bases).set_values(values).build();
+  EXPECT_FALSE(result.has_value());
+}
+
+// Out-of-order bases are silently filtered rather than rejected: the
+// duplicate-removal pass keeps a base only when it exceeds the previous kept
+// base by more than epsilon, so a point that steps backwards is dropped. With
+// bases {0, 2, 1} the trailing 1.0 is discarded, leaving the strictly
+// increasing subsequence {0, 2}, and the build succeeds. This pins the current
+// (somewhat surprising) behavior that the strictly-increasing guard is
+// subsumed by duplicate removal.
+TEST(TestPchip, DropsOutOfOrderBasesAndStillBuilds)
+{
+  const std::vector<double> bases = {0.0, 2.0, 1.0};
+  const std::vector<double> values = {0.0, 4.0, 999.0};
+
+  const auto result = Pchip::Builder{}.set_bases(bases).set_values(values).build();
+  ASSERT_TRUE(result.has_value());
+  const auto & pchip = result.value();
+
+  // Only the {0, 2} subsequence survives, so the fit is the line through
+  // (0, 0) and (2, 4); the dropped backward point (value 999.0) has no effect.
+  EXPECT_NEAR(pchip.compute(0.0), 0.0, k_tol);
+  EXPECT_NEAR(pchip.compute(2.0), 4.0, k_tol);
+  EXPECT_NEAR(pchip.compute(1.0), 2.0, k_tol);
+}
+
+// Strictly decreasing bases collapse under duplicate removal to a single kept
+// point (every later base is below the first), which is below the minimum of
+// two, so the build is rejected.
+TEST(TestPchip, RejectsStrictlyDecreasingBases)
+{
+  const std::vector<double> bases = {3.0, 2.0, 1.0};
+  const std::vector<double> values = {0.0, 1.0, 2.0};
+
+  const auto result = Pchip::Builder{}.set_bases(bases).set_values(values).build();
+  EXPECT_FALSE(result.has_value());
+}
+
+// Near-duplicate bases (difference below epsilon) are dropped before fitting.
+// Passing a large epsilon collapses the middle point, leaving the two distinct
+// endpoints, which then interpolate as a straight line.
+TEST(TestPchip, RemovesDuplicateBases)
+{
+  const std::vector<double> bases = {0.0, 1.0, 2.0};
+  const std::vector<double> values = {0.0, 100.0, 4.0};
+
+  // epsilon = 1.5 collapses base 1.0 into base 0.0 (1.0 - 0.0 <= 1.5),
+  // keeps base 2.0 (2.0 - 0.0 > 1.5). Result is the line from (0,0) to (2,4).
+  const auto result = Pchip::Builder{}.set_bases(bases).set_values(values).build(1.5);
+  ASSERT_TRUE(result.has_value());
+  const auto & pchip = result.value();
+
+  EXPECT_NEAR(pchip.compute(0.0), 0.0, k_tol);
+  EXPECT_NEAR(pchip.compute(2.0), 4.0, k_tol);
+  // The dropped middle value (100.0) has no influence: pure line, slope 2.
+  EXPECT_NEAR(pchip.compute(1.0), 2.0, k_tol);
+}
+
+// After collapsing duplicates the remaining distinct points may fall below the
+// minimum, in which case the build must fail.
+TEST(TestPchip, RejectsWhenDuplicateRemovalLeavesTooFewPoints)
+{
+  const std::vector<double> bases = {0.0, 0.5, 1.0};
+  const std::vector<double> values = {0.0, 1.0, 2.0};
+
+  // epsilon = 2.0 collapses every base into the first one, leaving a single
+  // distinct point, which is below the minimum of 2.
+  const auto result = Pchip::Builder{}.set_bases(bases).set_values(values).build(2.0);
+  EXPECT_FALSE(result.has_value());
+}


### PR DESCRIPTION
## Description

The PCHIP (Piecewise Cubic Hermite Interpolating Polynomial) interpolator is a shipped public interpolator in `autoware_trajectory` with subtle, branchy Fritsch-Carlson math — a one-sided endpoint-derivative estimate with a sign guard and a `3*delta` overshoot limit, interior monotonicity zeroing at local extrema, and an `n == 2` linear special case. Despite this, it had **zero assertion coverage**: it was referenced only from the `example_pchip_vs_cubic_spline` executable and was omitted from the typed interpolator test suite (`test_interpolator.cpp`'s `Interpolators` typelist).

This PR adds characterization tests pinning the interpolator's current observable behavior. Expected numeric values were derived from the algorithm exactly as implemented in `src/interpolator/pchip.cpp` and independently cross-checked against `scipy.interpolate.PchipInterpolator` (same Fritsch-Carlson construction); all values agree to full double precision.

### What is covered

New `test/test_pchip.cpp` (11 cases):
- Interpolation through data points + interior harmonic-mean knot derivatives and mid-interval values.
- Monotonicity preservation on increasing data (fine-sampled, no spurious dips).
- Local-extremum derivative zeroing branch + no-overshoot / no-undershoot shape preservation.
- Endpoint-derivative `3*delta` limiting branch (raw estimate 6.5 clamped to 3.0).
- `n == 2` degenerates to the exact straight line (zero curvature).
- `minimum_required_points() == 2`.
- Build rejection for too-few points and the duplicate-removal branches, including the surprising-but-real behavior that **out-of-order bases are silently dropped by duplicate removal** rather than rejected by the strictly-increasing guard, and that strictly-decreasing input collapses to a single point and is rejected by the minimum-count check.

`Pchip` is also added to the typed `Interpolators` typelist so it shares the common pass-through `Compute` test.

### Effects on system behavior

None. This is a test-only change: no production code, public API/ABI, or runtime behavior is modified. Only `test/` files and the test-file list in `CMakeLists.txt` (inside `BUILD_TESTING`) change.

Refs: autowarefoundation/autoware_core#1096

## youtalk fork CI — build-and-test all green

The full `build-test-tidy-pr` workflow runs on the youtalk fork (`ubicloud-standard-16`). All build-and-test gate jobs pass for head commit `3745d370d` ([workflow run](https://github.com/youtalk/autoware_core/actions/runs/26657104470)):

- ✅ `build-and-test-diff-humble / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26657104470/job/78571628260
- ✅ `build-and-test-diff-jazzy / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26657104470/job/78571628450
- ✅ `build-and-test-diff-jazzy-agnocast / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26657104470/job/78571628339
- ✅ `build-and-test-diff-humble / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26657104470/job/78572473955
- ✅ `build-and-test-diff-jazzy / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26657104470/job/78572621383

(The `*-above` universe jobs are bonus coverage and excluded from the gate.)
