### PR TITLE
refactor(autoware_twist2accel): extract pure AccelEstimator and add unit tests

### DIFF
--- a/localization/autoware_twist2accel/CMakeLists.txt
+++ b/localization/autoware_twist2accel/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/accel_estimator.cpp
   src/twist2accel.cpp
 )
 
@@ -14,6 +15,20 @@ autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
   ROS2_EXECUTOR SingleThreadedExecutor
 )
+
+if(BUILD_TESTING)
+  ament_auto_add_gtest(test_accel_estimator
+    test/test_accel_estimator.cpp
+  )
+  target_link_libraries(test_accel_estimator ${PROJECT_NAME})
+  target_include_directories(test_accel_estimator PRIVATE src)
+
+  ament_add_ros_isolated_gtest(test_twist2accel_node
+    test/test_twist2accel_node.cpp
+  )
+  target_link_libraries(test_twist2accel_node ${PROJECT_NAME})
+  target_include_directories(test_twist2accel_node PRIVATE src)
+endif()
 
 autoware_ament_auto_package(
   USE_SCOPED_HEADER_INSTALL_DIR

--- a/localization/autoware_twist2accel/package.xml
+++ b/localization/autoware_twist2accel/package.xml
@@ -16,11 +16,11 @@
 
   <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_signal_processing</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
-  <depend>tf2</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/localization/autoware_twist2accel/src/accel_estimator.cpp
+++ b/localization/autoware_twist2accel/src/accel_estimator.cpp
@@ -14,10 +14,14 @@
 
 #include "accel_estimator.hpp"
 
+#include <autoware_utils_geometry/msg/covariance.hpp>
+
 #include <algorithm>
 
 namespace autoware::twist2accel
 {
+using autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+
 AccelEstimator::AccelEstimator(const double lowpass_gain)
 : lpf_alx_(lowpass_gain),
   lpf_aly_(lowpass_gain),
@@ -28,19 +32,33 @@ AccelEstimator::AccelEstimator(const double lowpass_gain)
 {
 }
 
-geometry_msgs::msg::Accel AccelEstimator::estimate(
+geometry_msgs::msg::AccelWithCovariance AccelEstimator::estimate(
   const geometry_msgs::msg::Twist & prev_twist, const geometry_msgs::msg::Twist & curr_twist,
   const double dt)
 {
   const double clamped_dt = std::max(dt, g_min_dt);
 
-  geometry_msgs::msg::Accel accel;
-  accel.linear.x = lpf_alx_.filter((curr_twist.linear.x - prev_twist.linear.x) / clamped_dt);
-  accel.linear.y = lpf_aly_.filter((curr_twist.linear.y - prev_twist.linear.y) / clamped_dt);
-  accel.linear.z = lpf_alz_.filter((curr_twist.linear.z - prev_twist.linear.z) / clamped_dt);
-  accel.angular.x = lpf_aax_.filter((curr_twist.angular.x - prev_twist.angular.x) / clamped_dt);
-  accel.angular.y = lpf_aay_.filter((curr_twist.angular.y - prev_twist.angular.y) / clamped_dt);
-  accel.angular.z = lpf_aaz_.filter((curr_twist.angular.z - prev_twist.angular.z) / clamped_dt);
+  geometry_msgs::msg::AccelWithCovariance accel;
+  accel.accel.linear.x = lpf_alx_.filter((curr_twist.linear.x - prev_twist.linear.x) / clamped_dt);
+  accel.accel.linear.y = lpf_aly_.filter((curr_twist.linear.y - prev_twist.linear.y) / clamped_dt);
+  accel.accel.linear.z = lpf_alz_.filter((curr_twist.linear.z - prev_twist.linear.z) / clamped_dt);
+  accel.accel.angular.x =
+    lpf_aax_.filter((curr_twist.angular.x - prev_twist.angular.x) / clamped_dt);
+  accel.accel.angular.y =
+    lpf_aay_.filter((curr_twist.angular.y - prev_twist.angular.y) / clamped_dt);
+  accel.accel.angular.z =
+    lpf_aaz_.filter((curr_twist.angular.z - prev_twist.angular.z) / clamped_dt);
+
+  // Ideally speaking, this covariance should be properly estimated. Until that
+  // is done, report constant diagonal variances; off-diagonal terms stay at the
+  // default zero.
+  accel.covariance[XYZRPY_COV_IDX::X_X] = g_linear_accel_variance;
+  accel.covariance[XYZRPY_COV_IDX::Y_Y] = g_linear_accel_variance;
+  accel.covariance[XYZRPY_COV_IDX::Z_Z] = g_linear_accel_variance;
+  accel.covariance[XYZRPY_COV_IDX::ROLL_ROLL] = g_angular_accel_variance;
+  accel.covariance[XYZRPY_COV_IDX::PITCH_PITCH] = g_angular_accel_variance;
+  accel.covariance[XYZRPY_COV_IDX::YAW_YAW] = g_angular_accel_variance;
+
   return accel;
 }
 }  // namespace autoware::twist2accel

--- a/localization/autoware_twist2accel/src/accel_estimator.cpp
+++ b/localization/autoware_twist2accel/src/accel_estimator.cpp
@@ -1,0 +1,46 @@
+// Copyright 2022 TIER IV
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "accel_estimator.hpp"
+
+#include <algorithm>
+
+namespace autoware::twist2accel
+{
+AccelEstimator::AccelEstimator(const double lowpass_gain)
+: lpf_alx_(lowpass_gain),
+  lpf_aly_(lowpass_gain),
+  lpf_alz_(lowpass_gain),
+  lpf_aax_(lowpass_gain),
+  lpf_aay_(lowpass_gain),
+  lpf_aaz_(lowpass_gain)
+{
+}
+
+geometry_msgs::msg::Accel AccelEstimator::estimate(
+  const geometry_msgs::msg::Twist & prev_twist, const geometry_msgs::msg::Twist & curr_twist,
+  const double dt)
+{
+  const double clamped_dt = std::max(dt, g_min_dt);
+
+  geometry_msgs::msg::Accel accel;
+  accel.linear.x = lpf_alx_.filter((curr_twist.linear.x - prev_twist.linear.x) / clamped_dt);
+  accel.linear.y = lpf_aly_.filter((curr_twist.linear.y - prev_twist.linear.y) / clamped_dt);
+  accel.linear.z = lpf_alz_.filter((curr_twist.linear.z - prev_twist.linear.z) / clamped_dt);
+  accel.angular.x = lpf_aax_.filter((curr_twist.angular.x - prev_twist.angular.x) / clamped_dt);
+  accel.angular.y = lpf_aay_.filter((curr_twist.angular.y - prev_twist.angular.y) / clamped_dt);
+  accel.angular.z = lpf_aaz_.filter((curr_twist.angular.z - prev_twist.angular.z) / clamped_dt);
+  return accel;
+}
+}  // namespace autoware::twist2accel

--- a/localization/autoware_twist2accel/src/accel_estimator.hpp
+++ b/localization/autoware_twist2accel/src/accel_estimator.hpp
@@ -27,7 +27,7 @@ namespace autoware::twist2accel
 /// avoid division by (near-)zero when stamps are equal or out of order.
 constexpr double g_min_dt = 1.0e-3;
 
-/// @brief Pure, ROS-free acceleration estimator.
+/// @brief Pure acceleration estimator with no rclcpp::Node / spinning dependency.
 ///
 /// Estimates acceleration by finite-differencing two successive twist samples
 /// and smoothing each of the six components with a first-order low-pass filter.

--- a/localization/autoware_twist2accel/src/accel_estimator.hpp
+++ b/localization/autoware_twist2accel/src/accel_estimator.hpp
@@ -17,7 +17,7 @@
 
 #include "autoware/signal_processing/lowpass_filter_1d.hpp"
 
-#include <geometry_msgs/msg/accel.hpp>
+#include <geometry_msgs/msg/accel_with_covariance.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 
 namespace autoware::twist2accel
@@ -27,6 +27,15 @@ namespace autoware::twist2accel
 /// avoid division by (near-)zero when stamps are equal or out of order.
 constexpr double g_min_dt = 1.0e-3;
 
+/// Fixed covariance assigned to the estimated acceleration. The current
+/// estimator does not propagate the input twist covariance through the
+/// finite-difference / low-pass smoothing, so it reports these constant
+/// diagonal variances (off-diagonal terms stay zero):
+/// - linear x/y/z variance = g_linear_accel_variance
+/// - angular roll/pitch/yaw variance = g_angular_accel_variance
+constexpr double g_linear_accel_variance = 1.0;
+constexpr double g_angular_accel_variance = 0.05;
+
 /// @brief Pure acceleration estimator with no rclcpp::Node / spinning dependency.
 ///
 /// Estimates acceleration by finite-differencing two successive twist samples
@@ -34,21 +43,29 @@ constexpr double g_min_dt = 1.0e-3;
 /// Owns the six LowpassFilter1d instances so the filter state persists across
 /// calls, mirroring the per-component smoothing performed by the node.
 ///
-/// It operates directly on the plain geometry_msgs Twist/Accel data structs:
-/// those are header-only value types that need no running ROS node, so the
-/// estimator stays unit-testable while avoiding any conversion layer.
+/// In addition to the acceleration values it fills in the acceleration
+/// covariance, keeping the full estimation contract (value + uncertainty) in
+/// one pure place instead of splitting it between the core and the node.
+///
+/// It operates directly on the plain geometry_msgs Twist/AccelWithCovariance
+/// data structs: those are header-only value types that need no running ROS
+/// node, so the estimator stays unit-testable while avoiding any conversion
+/// layer.
 class AccelEstimator
 {
 public:
   explicit AccelEstimator(double lowpass_gain);
 
-  /// @brief Estimate acceleration from a finite difference of two twists.
+  /// @brief Estimate acceleration and its covariance from a finite difference
+  ///   of two twists.
   /// @param prev_twist twist sample at the previous time step
   /// @param curr_twist twist sample at the current time step
   /// @param dt time delta in seconds between the two samples; values below
   ///   g_min_dt are clamped up to g_min_dt before the division
-  /// @return per-component, low-pass-filtered acceleration
-  geometry_msgs::msg::Accel estimate(
+  /// @return per-component, low-pass-filtered acceleration together with its
+  ///   covariance (constant diagonal variances, see g_linear_accel_variance /
+  ///   g_angular_accel_variance)
+  geometry_msgs::msg::AccelWithCovariance estimate(
     const geometry_msgs::msg::Twist & prev_twist, const geometry_msgs::msg::Twist & curr_twist,
     double dt);
 

--- a/localization/autoware_twist2accel/src/accel_estimator.hpp
+++ b/localization/autoware_twist2accel/src/accel_estimator.hpp
@@ -1,0 +1,64 @@
+// Copyright 2022 TIER IV
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ACCEL_ESTIMATOR_HPP_
+#define ACCEL_ESTIMATOR_HPP_
+
+#include "autoware/signal_processing/lowpass_filter_1d.hpp"
+
+#include <geometry_msgs/msg/accel.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+
+namespace autoware::twist2accel
+{
+
+/// Lower bound applied to the time delta between successive twist samples to
+/// avoid division by (near-)zero when stamps are equal or out of order.
+constexpr double g_min_dt = 1.0e-3;
+
+/// @brief Pure, ROS-free acceleration estimator.
+///
+/// Estimates acceleration by finite-differencing two successive twist samples
+/// and smoothing each of the six components with a first-order low-pass filter.
+/// Owns the six LowpassFilter1d instances so the filter state persists across
+/// calls, mirroring the per-component smoothing performed by the node.
+///
+/// It operates directly on the plain geometry_msgs Twist/Accel data structs:
+/// those are header-only value types that need no running ROS node, so the
+/// estimator stays unit-testable while avoiding any conversion layer.
+class AccelEstimator
+{
+public:
+  explicit AccelEstimator(double lowpass_gain);
+
+  /// @brief Estimate acceleration from a finite difference of two twists.
+  /// @param prev_twist twist sample at the previous time step
+  /// @param curr_twist twist sample at the current time step
+  /// @param dt time delta in seconds between the two samples; values below
+  ///   g_min_dt are clamped up to g_min_dt before the division
+  /// @return per-component, low-pass-filtered acceleration
+  geometry_msgs::msg::Accel estimate(
+    const geometry_msgs::msg::Twist & prev_twist, const geometry_msgs::msg::Twist & curr_twist,
+    double dt);
+
+private:
+  autoware::signal_processing::LowpassFilter1d lpf_alx_;
+  autoware::signal_processing::LowpassFilter1d lpf_aly_;
+  autoware::signal_processing::LowpassFilter1d lpf_alz_;
+  autoware::signal_processing::LowpassFilter1d lpf_aax_;
+  autoware::signal_processing::LowpassFilter1d lpf_aay_;
+  autoware::signal_processing::LowpassFilter1d lpf_aaz_;
+};
+}  // namespace autoware::twist2accel
+#endif  // ACCEL_ESTIMATOR_HPP_

--- a/localization/autoware_twist2accel/src/twist2accel.cpp
+++ b/localization/autoware_twist2accel/src/twist2accel.cpp
@@ -14,18 +14,17 @@
 
 #include "twist2accel.hpp"
 
+#include "accel_estimator.hpp"
+
+#include <autoware_utils_geometry/msg/covariance.hpp>
 #include <rclcpp/logging.hpp>
 
-#include <algorithm>
 #include <functional>
 #include <memory>
-#include <string>
-#include <utility>
-
-using autoware::signal_processing::LowpassFilter1d;
 
 namespace autoware::twist2accel
 {
+using autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
 using std::placeholders::_1;
 
 Twist2Accel::Twist2Accel(const rclcpp::NodeOptions & node_options)
@@ -38,16 +37,10 @@ Twist2Accel::Twist2Accel(const rclcpp::NodeOptions & node_options)
 
   pub_accel_ = create_publisher<geometry_msgs::msg::AccelWithCovarianceStamped>("output/accel", 1);
 
-  prev_twist_ptr_ = nullptr;
-  accel_lowpass_gain_ = declare_parameter<double>("accel_lowpass_gain");
+  const double accel_lowpass_gain = declare_parameter<double>("accel_lowpass_gain");
   use_odom_ = declare_parameter<bool>("use_odom");
 
-  lpf_alx_ptr_ = std::make_shared<LowpassFilter1d>(accel_lowpass_gain_);
-  lpf_aly_ptr_ = std::make_shared<LowpassFilter1d>(accel_lowpass_gain_);
-  lpf_alz_ptr_ = std::make_shared<LowpassFilter1d>(accel_lowpass_gain_);
-  lpf_aax_ptr_ = std::make_shared<LowpassFilter1d>(accel_lowpass_gain_);
-  lpf_aay_ptr_ = std::make_shared<LowpassFilter1d>(accel_lowpass_gain_);
-  lpf_aaz_ptr_ = std::make_shared<LowpassFilter1d>(accel_lowpass_gain_);
+  accel_estimator_ = std::make_unique<AccelEstimator>(accel_lowpass_gain);
 }
 
 void Twist2Accel::callback_odometry(const nav_msgs::msg::Odometry::SharedPtr msg)
@@ -57,7 +50,7 @@ void Twist2Accel::callback_odometry(const nav_msgs::msg::Odometry::SharedPtr msg
   geometry_msgs::msg::TwistStamped twist;
   twist.header = msg->header;
   twist.twist = msg->twist.twist;
-  estimate_accel(std::make_shared<geometry_msgs::msg::TwistStamped>(twist));
+  estimate_accel(twist);
 }
 
 void Twist2Accel::callback_twist_with_covariance(
@@ -68,44 +61,31 @@ void Twist2Accel::callback_twist_with_covariance(
   geometry_msgs::msg::TwistStamped twist;
   twist.header = msg->header;
   twist.twist = msg->twist.twist;
-  estimate_accel(std::make_shared<geometry_msgs::msg::TwistStamped>(twist));
+  estimate_accel(twist);
 }
 
-void Twist2Accel::estimate_accel(const geometry_msgs::msg::TwistStamped::SharedPtr msg)
+void Twist2Accel::estimate_accel(const geometry_msgs::msg::TwistStamped & twist)
 {
   geometry_msgs::msg::AccelWithCovarianceStamped accel_msg;
-  accel_msg.header = msg->header;
+  accel_msg.header = twist.header;
 
-  if (prev_twist_ptr_ != nullptr) {
-    const double dt = std::max(
-      (rclcpp::Time(msg->header.stamp) - rclcpp::Time(prev_twist_ptr_->header.stamp)).seconds(),
-      1.0e-3);
+  if (prev_twist_.has_value()) {
+    const double dt =
+      (rclcpp::Time(twist.header.stamp) - rclcpp::Time(prev_twist_->header.stamp)).seconds();
 
-    double alx = (msg->twist.linear.x - prev_twist_ptr_->twist.linear.x) / dt;
-    double aly = (msg->twist.linear.y - prev_twist_ptr_->twist.linear.y) / dt;
-    double alz = (msg->twist.linear.z - prev_twist_ptr_->twist.linear.z) / dt;
-    double aax = (msg->twist.angular.x - prev_twist_ptr_->twist.angular.x) / dt;
-    double aay = (msg->twist.angular.y - prev_twist_ptr_->twist.angular.y) / dt;
-    double aaz = (msg->twist.angular.z - prev_twist_ptr_->twist.angular.z) / dt;
-
-    accel_msg.accel.accel.linear.x = lpf_alx_ptr_->filter(alx);
-    accel_msg.accel.accel.linear.y = lpf_aly_ptr_->filter(aly);
-    accel_msg.accel.accel.linear.z = lpf_alz_ptr_->filter(alz);
-    accel_msg.accel.accel.angular.x = lpf_aax_ptr_->filter(aax);
-    accel_msg.accel.accel.angular.y = lpf_aay_ptr_->filter(aay);
-    accel_msg.accel.accel.angular.z = lpf_aaz_ptr_->filter(aaz);
+    accel_msg.accel.accel = accel_estimator_->estimate(prev_twist_->twist, twist.twist, dt);
 
     // Ideally speaking, these covariance should be properly estimated.
-    accel_msg.accel.covariance[0 * 6 + 0] = 1.0;
-    accel_msg.accel.covariance[1 * 6 + 1] = 1.0;
-    accel_msg.accel.covariance[2 * 6 + 2] = 1.0;
-    accel_msg.accel.covariance[3 * 6 + 3] = 0.05;
-    accel_msg.accel.covariance[4 * 6 + 4] = 0.05;
-    accel_msg.accel.covariance[5 * 6 + 5] = 0.05;
+    accel_msg.accel.covariance[XYZRPY_COV_IDX::X_X] = 1.0;
+    accel_msg.accel.covariance[XYZRPY_COV_IDX::Y_Y] = 1.0;
+    accel_msg.accel.covariance[XYZRPY_COV_IDX::Z_Z] = 1.0;
+    accel_msg.accel.covariance[XYZRPY_COV_IDX::ROLL_ROLL] = 0.05;
+    accel_msg.accel.covariance[XYZRPY_COV_IDX::PITCH_PITCH] = 0.05;
+    accel_msg.accel.covariance[XYZRPY_COV_IDX::YAW_YAW] = 0.05;
   }
 
   pub_accel_->publish(accel_msg);
-  prev_twist_ptr_ = msg;
+  prev_twist_ = twist;
 }
 }  // namespace autoware::twist2accel
 

--- a/localization/autoware_twist2accel/src/twist2accel.cpp
+++ b/localization/autoware_twist2accel/src/twist2accel.cpp
@@ -16,7 +16,6 @@
 
 #include "accel_estimator.hpp"
 
-#include <autoware_utils_geometry/msg/covariance.hpp>
 #include <rclcpp/logging.hpp>
 
 #include <functional>
@@ -24,7 +23,6 @@
 
 namespace autoware::twist2accel
 {
-using autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
 using std::placeholders::_1;
 
 Twist2Accel::Twist2Accel(const rclcpp::NodeOptions & node_options)
@@ -73,15 +71,7 @@ void Twist2Accel::estimate_accel(const geometry_msgs::msg::TwistStamped & twist)
     const double dt =
       (rclcpp::Time(twist.header.stamp) - rclcpp::Time(prev_twist_->header.stamp)).seconds();
 
-    accel_msg.accel.accel = accel_estimator_->estimate(prev_twist_->twist, twist.twist, dt);
-
-    // Ideally speaking, these covariance should be properly estimated.
-    accel_msg.accel.covariance[XYZRPY_COV_IDX::X_X] = 1.0;
-    accel_msg.accel.covariance[XYZRPY_COV_IDX::Y_Y] = 1.0;
-    accel_msg.accel.covariance[XYZRPY_COV_IDX::Z_Z] = 1.0;
-    accel_msg.accel.covariance[XYZRPY_COV_IDX::ROLL_ROLL] = 0.05;
-    accel_msg.accel.covariance[XYZRPY_COV_IDX::PITCH_PITCH] = 0.05;
-    accel_msg.accel.covariance[XYZRPY_COV_IDX::YAW_YAW] = 0.05;
+    accel_msg.accel = accel_estimator_->estimate(prev_twist_->twist, twist.twist, dt);
   }
 
   pub_accel_->publish(accel_msg);

--- a/localization/autoware_twist2accel/src/twist2accel.hpp
+++ b/localization/autoware_twist2accel/src/twist2accel.hpp
@@ -15,27 +15,17 @@
 #ifndef TWIST2ACCEL_HPP_
 #define TWIST2ACCEL_HPP_
 
-#include "autoware/signal_processing/lowpass_filter_1d.hpp"
+#include "accel_estimator.hpp"
 
 #include <rclcpp/rclcpp.hpp>
-#include <tf2/LinearMath/Quaternion.hpp>
-#include <tf2/utils.hpp>
 
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 
-#include <chrono>
-#include <fstream>
-#include <iostream>
 #include <memory>
-#include <mutex>
-#include <queue>
-#include <string>
-#include <vector>
-
-using autoware::signal_processing::LowpassFilter1d;
+#include <optional>
 
 namespace autoware::twist2accel
 {
@@ -52,15 +42,9 @@ private:
   rclcpp::Subscription<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr
     sub_twist_;  //!< @brief measurement odometry subscriber
 
-  geometry_msgs::msg::TwistStamped::SharedPtr prev_twist_ptr_;
-  double accel_lowpass_gain_;
+  std::optional<geometry_msgs::msg::TwistStamped> prev_twist_;
   bool use_odom_;
-  std::shared_ptr<LowpassFilter1d> lpf_aax_ptr_;
-  std::shared_ptr<LowpassFilter1d> lpf_aay_ptr_;
-  std::shared_ptr<LowpassFilter1d> lpf_aaz_ptr_;
-  std::shared_ptr<LowpassFilter1d> lpf_alx_ptr_;
-  std::shared_ptr<LowpassFilter1d> lpf_aly_ptr_;
-  std::shared_ptr<LowpassFilter1d> lpf_alz_ptr_;
+  std::unique_ptr<AccelEstimator> accel_estimator_;
 
   /**
    * @brief set odometry measurement
@@ -68,7 +52,7 @@ private:
   void callback_twist_with_covariance(
     const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg);
   void callback_odometry(const nav_msgs::msg::Odometry::SharedPtr msg);
-  void estimate_accel(const geometry_msgs::msg::TwistStamped::SharedPtr msg);
+  void estimate_accel(const geometry_msgs::msg::TwistStamped & twist);
 };
 }  // namespace autoware::twist2accel
 #endif  // TWIST2ACCEL_HPP_

--- a/localization/autoware_twist2accel/test/test_accel_estimator.cpp
+++ b/localization/autoware_twist2accel/test/test_accel_estimator.cpp
@@ -14,12 +14,17 @@
 
 #include "../src/accel_estimator.hpp"
 
-#include <geometry_msgs/msg/accel.hpp>
+#include <geometry_msgs/msg/accel_with_covariance.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <cstddef>
+
 using autoware::twist2accel::AccelEstimator;
+using autoware::twist2accel::g_angular_accel_variance;
+using autoware::twist2accel::g_linear_accel_variance;
 using autoware::twist2accel::g_min_dt;
 
 namespace
@@ -52,14 +57,14 @@ TEST(AccelEstimatorTest, FiniteDifferenceNoSmoothingOnFirstSample)
   const auto curr = make_twist(2.0, 4.0, 6.0, 0.2, 0.4, 0.6);
   const double dt = 0.5;
 
-  const geometry_msgs::msg::Accel accel = estimator.estimate(prev, curr, dt);
+  const geometry_msgs::msg::AccelWithCovariance accel = estimator.estimate(prev, curr, dt);
 
-  EXPECT_NEAR(accel.linear.x, 4.0, kTol);   // (2.0 - 0.0) / 0.5
-  EXPECT_NEAR(accel.linear.y, 8.0, kTol);   // (4.0 - 0.0) / 0.5
-  EXPECT_NEAR(accel.linear.z, 12.0, kTol);  // (6.0 - 0.0) / 0.5
-  EXPECT_NEAR(accel.angular.x, 0.4, kTol);  // (0.2 - 0.0) / 0.5
-  EXPECT_NEAR(accel.angular.y, 0.8, kTol);  // (0.4 - 0.0) / 0.5
-  EXPECT_NEAR(accel.angular.z, 1.2, kTol);  // (0.6 - 0.0) / 0.5
+  EXPECT_NEAR(accel.accel.linear.x, 4.0, kTol);   // (2.0 - 0.0) / 0.5
+  EXPECT_NEAR(accel.accel.linear.y, 8.0, kTol);   // (4.0 - 0.0) / 0.5
+  EXPECT_NEAR(accel.accel.linear.z, 12.0, kTol);  // (6.0 - 0.0) / 0.5
+  EXPECT_NEAR(accel.accel.angular.x, 0.4, kTol);  // (0.2 - 0.0) / 0.5
+  EXPECT_NEAR(accel.accel.angular.y, 0.8, kTol);  // (0.4 - 0.0) / 0.5
+  EXPECT_NEAR(accel.accel.angular.z, 1.2, kTol);  // (0.6 - 0.0) / 0.5
 }
 
 // Equal successive twists give a zero finite difference on every channel,
@@ -69,14 +74,14 @@ TEST(AccelEstimatorTest, ZeroVelocityChangeYieldsZeroAccel)
   AccelEstimator estimator(0.5);
   const auto twist = make_twist(1.0, -2.0, 3.0, 0.1, -0.2, 0.3);
 
-  const geometry_msgs::msg::Accel accel = estimator.estimate(twist, twist, 0.1);
+  const geometry_msgs::msg::AccelWithCovariance accel = estimator.estimate(twist, twist, 0.1);
 
-  EXPECT_NEAR(accel.linear.x, 0.0, kTol);
-  EXPECT_NEAR(accel.linear.y, 0.0, kTol);
-  EXPECT_NEAR(accel.linear.z, 0.0, kTol);
-  EXPECT_NEAR(accel.angular.x, 0.0, kTol);
-  EXPECT_NEAR(accel.angular.y, 0.0, kTol);
-  EXPECT_NEAR(accel.angular.z, 0.0, kTol);
+  EXPECT_NEAR(accel.accel.linear.x, 0.0, kTol);
+  EXPECT_NEAR(accel.accel.linear.y, 0.0, kTol);
+  EXPECT_NEAR(accel.accel.linear.z, 0.0, kTol);
+  EXPECT_NEAR(accel.accel.angular.x, 0.0, kTol);
+  EXPECT_NEAR(accel.accel.angular.y, 0.0, kTol);
+  EXPECT_NEAR(accel.accel.angular.z, 0.0, kTol);
 }
 
 // The second and later samples smooth the raw finite difference with the
@@ -88,23 +93,23 @@ TEST(AccelEstimatorTest, LowPassSmoothingAcrossSamples)
   const double dt = 1.0;
 
   // First sample: linear_x ramps 0 -> 1, raw accel = 1.0, LPF returns it as-is.
-  const geometry_msgs::msg::Accel first =
+  const geometry_msgs::msg::AccelWithCovariance first =
     estimator.estimate(make_twist(0.0, 0, 0, 0, 0, 0), make_twist(1.0, 0, 0, 0, 0, 0), dt);
-  EXPECT_NEAR(first.linear.x, 1.0, kTol);
+  EXPECT_NEAR(first.accel.linear.x, 1.0, kTol);
 
   // Second sample: linear_x ramps 1 -> 3, raw accel = 2.0.
   // Smoothed: 0.9 * 1.0 + 0.1 * 2.0 = 1.1.
-  const geometry_msgs::msg::Accel second =
+  const geometry_msgs::msg::AccelWithCovariance second =
     estimator.estimate(make_twist(1.0, 0, 0, 0, 0, 0), make_twist(3.0, 0, 0, 0, 0, 0), dt);
-  EXPECT_NEAR(second.linear.x, gain * 1.0 + (1.0 - gain) * 2.0, kTol);
-  EXPECT_NEAR(second.linear.x, 1.1, kTol);
+  EXPECT_NEAR(second.accel.linear.x, gain * 1.0 + (1.0 - gain) * 2.0, kTol);
+  EXPECT_NEAR(second.accel.linear.x, 1.1, kTol);
 
   // Third sample: linear_x ramps 3 -> 3, raw accel = 0.0.
   // Smoothed: 0.9 * 1.1 + 0.1 * 0.0 = 0.99.
-  const geometry_msgs::msg::Accel third =
+  const geometry_msgs::msg::AccelWithCovariance third =
     estimator.estimate(make_twist(3.0, 0, 0, 0, 0, 0), make_twist(3.0, 0, 0, 0, 0, 0), dt);
-  EXPECT_NEAR(third.linear.x, gain * 1.1 + (1.0 - gain) * 0.0, kTol);
-  EXPECT_NEAR(third.linear.x, 0.99, kTol);
+  EXPECT_NEAR(third.accel.linear.x, gain * 1.1 + (1.0 - gain) * 0.0, kTol);
+  EXPECT_NEAR(third.accel.linear.x, 0.99, kTol);
 }
 
 // dt below g_min_dt (including zero or negative, e.g. near-simultaneous or
@@ -117,18 +122,21 @@ TEST(AccelEstimatorTest, DtClampForNearSimultaneousStamps)
 
   // dt == 0 is clamped to g_min_dt: accel = 1.0 / g_min_dt.
   AccelEstimator zero_dt_estimator(0.0);  // gain 0 -> filter passes raw value through
-  const geometry_msgs::msg::Accel zero_dt = zero_dt_estimator.estimate(prev, curr, 0.0);
-  EXPECT_NEAR(zero_dt.linear.x, 1.0 / g_min_dt, kTol);
+  const geometry_msgs::msg::AccelWithCovariance zero_dt =
+    zero_dt_estimator.estimate(prev, curr, 0.0);
+  EXPECT_NEAR(zero_dt.accel.linear.x, 1.0 / g_min_dt, kTol);
 
   // Negative dt is also clamped to g_min_dt, not used directly.
   AccelEstimator negative_dt_estimator(0.0);
-  const geometry_msgs::msg::Accel negative_dt = negative_dt_estimator.estimate(prev, curr, -5.0);
-  EXPECT_NEAR(negative_dt.linear.x, 1.0 / g_min_dt, kTol);
+  const geometry_msgs::msg::AccelWithCovariance negative_dt =
+    negative_dt_estimator.estimate(prev, curr, -5.0);
+  EXPECT_NEAR(negative_dt.accel.linear.x, 1.0 / g_min_dt, kTol);
 
   // dt above the threshold is used unchanged.
   AccelEstimator large_dt_estimator(0.0);
-  const geometry_msgs::msg::Accel large_dt = large_dt_estimator.estimate(prev, curr, 2.0);
-  EXPECT_NEAR(large_dt.linear.x, 1.0 / 2.0, kTol);
+  const geometry_msgs::msg::AccelWithCovariance large_dt =
+    large_dt_estimator.estimate(prev, curr, 2.0);
+  EXPECT_NEAR(large_dt.accel.linear.x, 1.0 / 2.0, kTol);
 }
 
 // Each of the six channels is filtered independently (its own LPF state),
@@ -142,17 +150,52 @@ TEST(AccelEstimatorTest, ChannelsAreIndependent)
   estimator.estimate(make_twist(0, 0, 0, 0, 0, 0), make_twist(2.0, 0, 0, 0, 0, 0), dt);
 
   // Now move only angular_z; linear_x sees raw accel 0 but retains its history.
-  const geometry_msgs::msg::Accel accel =
+  const geometry_msgs::msg::AccelWithCovariance accel =
     estimator.estimate(make_twist(2.0, 0, 0, 0, 0, 0), make_twist(2.0, 0, 0, 0, 0, 1.0), dt);
 
   // linear_x: 0.5 * 2.0 (history) + 0.5 * 0.0 (raw) = 1.0. Its history is
   // preserved independently of the other channels.
-  EXPECT_NEAR(accel.linear.x, 1.0, kTol);
+  EXPECT_NEAR(accel.accel.linear.x, 1.0, kTol);
   // angular_z was initialized to 0.0 raw on the first call, so this second
   // sample smooths raw 1.0 against that: 0.5 * 0.0 + 0.5 * 1.0 = 0.5. This
   // proves angular_z carries its own state and is not affected by linear_x.
-  EXPECT_NEAR(accel.angular.z, 0.5, kTol);
+  EXPECT_NEAR(accel.accel.angular.z, 0.5, kTol);
   // Untouched channels stay at zero.
-  EXPECT_NEAR(accel.linear.y, 0.0, kTol);
-  EXPECT_NEAR(accel.angular.x, 0.0, kTol);
+  EXPECT_NEAR(accel.accel.linear.y, 0.0, kTol);
+  EXPECT_NEAR(accel.accel.angular.x, 0.0, kTol);
+}
+
+// The estimator fills in a constant diagonal covariance for the acceleration:
+// variance 1.0 on the three linear (x, y, z) channels and 0.05 on the three
+// angular (roll, pitch, yaw) channels, with every off-diagonal term zero. The
+// expected entries below are hand-written literals derived from the documented
+// constants, not read back from the estimator. The covariance is a flat
+// row-major 6x6 matrix, so element (row, col) lives at index row * 6 + col.
+TEST(AccelEstimatorTest, CovarianceIsConstantDiagonal)
+{
+  AccelEstimator estimator(0.9);
+  const auto prev = make_twist(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+  const auto curr = make_twist(2.0, 4.0, 6.0, 0.2, 0.4, 0.6);
+
+  const geometry_msgs::msg::AccelWithCovariance accel = estimator.estimate(prev, curr, 0.5);
+
+  // Hand-written expectation: a 36-entry array that is zero everywhere except
+  // the six diagonal variances. The diagonal of a row-major 6x6 lives at
+  // indices 0, 7, 14, 21, 28, 35.
+  std::array<double, 36> expected{};  // value-initialized to all zeros
+  expected[0] = 1.0;                  // X_X    (linear x)  index 0 * 6 + 0
+  expected[7] = 1.0;                  // Y_Y    (linear y)  index 1 * 6 + 1
+  expected[14] = 1.0;                 // Z_Z    (linear z)  index 2 * 6 + 2
+  expected[21] = 0.05;                // R_R    (roll)      index 3 * 6 + 3
+  expected[28] = 0.05;                // P_P    (pitch)     index 4 * 6 + 4
+  expected[35] = 0.05;                // Y_Y    (yaw)       index 5 * 6 + 5
+
+  for (std::size_t i = 0; i < expected.size(); ++i) {
+    EXPECT_NEAR(accel.covariance[i], expected[i], kTol) << "covariance index " << i;
+  }
+
+  // Cross-check the magnitudes against the named public constants so a future
+  // change to either the literals above or the constants is caught.
+  EXPECT_DOUBLE_EQ(g_linear_accel_variance, 1.0);
+  EXPECT_DOUBLE_EQ(g_angular_accel_variance, 0.05);
 }

--- a/localization/autoware_twist2accel/test/test_accel_estimator.cpp
+++ b/localization/autoware_twist2accel/test/test_accel_estimator.cpp
@@ -1,0 +1,158 @@
+// Copyright 2025 TIER IV
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/accel_estimator.hpp"
+
+#include <geometry_msgs/msg/accel.hpp>
+#include <geometry_msgs/msg/twist.hpp>
+
+#include <gtest/gtest.h>
+
+using autoware::twist2accel::AccelEstimator;
+using autoware::twist2accel::g_min_dt;
+
+namespace
+{
+constexpr double kTol = 1e-9;
+
+// Build a geometry_msgs Twist from its six scalar components for concise tests.
+geometry_msgs::msg::Twist make_twist(
+  const double linear_x, const double linear_y, const double linear_z, const double angular_x,
+  const double angular_y, const double angular_z)
+{
+  geometry_msgs::msg::Twist twist;
+  twist.linear.x = linear_x;
+  twist.linear.y = linear_y;
+  twist.linear.z = linear_z;
+  twist.angular.x = angular_x;
+  twist.angular.y = angular_y;
+  twist.angular.z = angular_z;
+  return twist;
+}
+}  // namespace
+
+// On the very first sample the per-component low-pass filters are uninitialized,
+// so filter(u) returns u unchanged. The estimator therefore reports the raw
+// finite difference (curr - prev) / dt on every channel.
+TEST(AccelEstimatorTest, FiniteDifferenceNoSmoothingOnFirstSample)
+{
+  AccelEstimator estimator(0.9);
+  const auto prev = make_twist(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+  const auto curr = make_twist(2.0, 4.0, 6.0, 0.2, 0.4, 0.6);
+  const double dt = 0.5;
+
+  const geometry_msgs::msg::Accel accel = estimator.estimate(prev, curr, dt);
+
+  EXPECT_NEAR(accel.linear.x, 4.0, kTol);   // (2.0 - 0.0) / 0.5
+  EXPECT_NEAR(accel.linear.y, 8.0, kTol);   // (4.0 - 0.0) / 0.5
+  EXPECT_NEAR(accel.linear.z, 12.0, kTol);  // (6.0 - 0.0) / 0.5
+  EXPECT_NEAR(accel.angular.x, 0.4, kTol);  // (0.2 - 0.0) / 0.5
+  EXPECT_NEAR(accel.angular.y, 0.8, kTol);  // (0.4 - 0.0) / 0.5
+  EXPECT_NEAR(accel.angular.z, 1.2, kTol);  // (0.6 - 0.0) / 0.5
+}
+
+// Equal successive twists give a zero finite difference on every channel,
+// hence zero acceleration.
+TEST(AccelEstimatorTest, ZeroVelocityChangeYieldsZeroAccel)
+{
+  AccelEstimator estimator(0.5);
+  const auto twist = make_twist(1.0, -2.0, 3.0, 0.1, -0.2, 0.3);
+
+  const geometry_msgs::msg::Accel accel = estimator.estimate(twist, twist, 0.1);
+
+  EXPECT_NEAR(accel.linear.x, 0.0, kTol);
+  EXPECT_NEAR(accel.linear.y, 0.0, kTol);
+  EXPECT_NEAR(accel.linear.z, 0.0, kTol);
+  EXPECT_NEAR(accel.angular.x, 0.0, kTol);
+  EXPECT_NEAR(accel.angular.y, 0.0, kTol);
+  EXPECT_NEAR(accel.angular.z, 0.0, kTol);
+}
+
+// The second and later samples smooth the raw finite difference with the
+// first-order low-pass filter: out = gain * prev_out + (1 - gain) * raw.
+TEST(AccelEstimatorTest, LowPassSmoothingAcrossSamples)
+{
+  const double gain = 0.9;
+  AccelEstimator estimator(gain);
+  const double dt = 1.0;
+
+  // First sample: linear_x ramps 0 -> 1, raw accel = 1.0, LPF returns it as-is.
+  const geometry_msgs::msg::Accel first =
+    estimator.estimate(make_twist(0.0, 0, 0, 0, 0, 0), make_twist(1.0, 0, 0, 0, 0, 0), dt);
+  EXPECT_NEAR(first.linear.x, 1.0, kTol);
+
+  // Second sample: linear_x ramps 1 -> 3, raw accel = 2.0.
+  // Smoothed: 0.9 * 1.0 + 0.1 * 2.0 = 1.1.
+  const geometry_msgs::msg::Accel second =
+    estimator.estimate(make_twist(1.0, 0, 0, 0, 0, 0), make_twist(3.0, 0, 0, 0, 0, 0), dt);
+  EXPECT_NEAR(second.linear.x, gain * 1.0 + (1.0 - gain) * 2.0, kTol);
+  EXPECT_NEAR(second.linear.x, 1.1, kTol);
+
+  // Third sample: linear_x ramps 3 -> 3, raw accel = 0.0.
+  // Smoothed: 0.9 * 1.1 + 0.1 * 0.0 = 0.99.
+  const geometry_msgs::msg::Accel third =
+    estimator.estimate(make_twist(3.0, 0, 0, 0, 0, 0), make_twist(3.0, 0, 0, 0, 0, 0), dt);
+  EXPECT_NEAR(third.linear.x, gain * 1.1 + (1.0 - gain) * 0.0, kTol);
+  EXPECT_NEAR(third.linear.x, 0.99, kTol);
+}
+
+// dt below g_min_dt (including zero or negative, e.g. near-simultaneous or
+// out-of-order stamps) is clamped up to g_min_dt before the division so the
+// estimator never divides by zero or flips sign.
+TEST(AccelEstimatorTest, DtClampForNearSimultaneousStamps)
+{
+  const auto prev = make_twist(0.0, 0, 0, 0, 0, 0);
+  const auto curr = make_twist(1.0, 0, 0, 0, 0, 0);
+
+  // dt == 0 is clamped to g_min_dt: accel = 1.0 / g_min_dt.
+  AccelEstimator zero_dt_estimator(0.0);  // gain 0 -> filter passes raw value through
+  const geometry_msgs::msg::Accel zero_dt = zero_dt_estimator.estimate(prev, curr, 0.0);
+  EXPECT_NEAR(zero_dt.linear.x, 1.0 / g_min_dt, kTol);
+
+  // Negative dt is also clamped to g_min_dt, not used directly.
+  AccelEstimator negative_dt_estimator(0.0);
+  const geometry_msgs::msg::Accel negative_dt = negative_dt_estimator.estimate(prev, curr, -5.0);
+  EXPECT_NEAR(negative_dt.linear.x, 1.0 / g_min_dt, kTol);
+
+  // dt above the threshold is used unchanged.
+  AccelEstimator large_dt_estimator(0.0);
+  const geometry_msgs::msg::Accel large_dt = large_dt_estimator.estimate(prev, curr, 2.0);
+  EXPECT_NEAR(large_dt.linear.x, 1.0 / 2.0, kTol);
+}
+
+// Each of the six channels is filtered independently (its own LPF state),
+// so cross-talk cannot occur.
+TEST(AccelEstimatorTest, ChannelsAreIndependent)
+{
+  AccelEstimator estimator(0.5);
+  const double dt = 1.0;
+
+  // Prime only linear_x with a non-zero history.
+  estimator.estimate(make_twist(0, 0, 0, 0, 0, 0), make_twist(2.0, 0, 0, 0, 0, 0), dt);
+
+  // Now move only angular_z; linear_x sees raw accel 0 but retains its history.
+  const geometry_msgs::msg::Accel accel =
+    estimator.estimate(make_twist(2.0, 0, 0, 0, 0, 0), make_twist(2.0, 0, 0, 0, 0, 1.0), dt);
+
+  // linear_x: 0.5 * 2.0 (history) + 0.5 * 0.0 (raw) = 1.0. Its history is
+  // preserved independently of the other channels.
+  EXPECT_NEAR(accel.linear.x, 1.0, kTol);
+  // angular_z was initialized to 0.0 raw on the first call, so this second
+  // sample smooths raw 1.0 against that: 0.5 * 0.0 + 0.5 * 1.0 = 0.5. This
+  // proves angular_z carries its own state and is not affected by linear_x.
+  EXPECT_NEAR(accel.angular.z, 0.5, kTol);
+  // Untouched channels stay at zero.
+  EXPECT_NEAR(accel.linear.y, 0.0, kTol);
+  EXPECT_NEAR(accel.angular.x, 0.0, kTol);
+}

--- a/localization/autoware_twist2accel/test/test_accel_estimator.cpp
+++ b/localization/autoware_twist2accel/test/test_accel_estimator.cpp
@@ -166,11 +166,12 @@ TEST(AccelEstimatorTest, ChannelsAreIndependent)
 }
 
 // The estimator fills in a constant diagonal covariance for the acceleration:
-// variance 1.0 on the three linear (x, y, z) channels and 0.05 on the three
-// angular (roll, pitch, yaw) channels, with every off-diagonal term zero. The
-// expected entries below are hand-written literals derived from the documented
-// constants, not read back from the estimator. The covariance is a flat
-// row-major 6x6 matrix, so element (row, col) lives at index row * 6 + col.
+// g_linear_accel_variance on the three linear (x, y, z) channels and
+// g_angular_accel_variance on the three angular (roll, pitch, yaw) channels,
+// with every off-diagonal term zero. This test pins that structure -- which
+// diagonal index carries which variance, and that every other entry stays zero.
+// The covariance is a flat row-major 6x6 matrix, so element (row, col) lives at
+// index row * 6 + col.
 TEST(AccelEstimatorTest, CovarianceIsConstantDiagonal)
 {
   AccelEstimator estimator(0.9);
@@ -179,23 +180,18 @@ TEST(AccelEstimatorTest, CovarianceIsConstantDiagonal)
 
   const geometry_msgs::msg::AccelWithCovariance accel = estimator.estimate(prev, curr, 0.5);
 
-  // Hand-written expectation: a 36-entry array that is zero everywhere except
-  // the six diagonal variances. The diagonal of a row-major 6x6 lives at
-  // indices 0, 7, 14, 21, 28, 35.
-  std::array<double, 36> expected{};  // value-initialized to all zeros
-  expected[0] = 1.0;                  // X_X    (linear x)  index 0 * 6 + 0
-  expected[7] = 1.0;                  // Y_Y    (linear y)  index 1 * 6 + 1
-  expected[14] = 1.0;                 // Z_Z    (linear z)  index 2 * 6 + 2
-  expected[21] = 0.05;                // R_R    (roll)      index 3 * 6 + 3
-  expected[28] = 0.05;                // P_P    (pitch)     index 4 * 6 + 4
-  expected[35] = 0.05;                // Y_Y    (yaw)       index 5 * 6 + 5
+  // Expected: a 36-entry array that is zero everywhere except the six diagonal
+  // variances, set to the named public constants. The diagonal of a row-major
+  // 6x6 lives at indices 0, 7, 14, 21, 28, 35.
+  std::array<double, 36> expected{};        // value-initialized to all zeros
+  expected[0] = g_linear_accel_variance;    // X_X  (linear x)
+  expected[7] = g_linear_accel_variance;    // Y_Y  (linear y)
+  expected[14] = g_linear_accel_variance;   // Z_Z  (linear z)
+  expected[21] = g_angular_accel_variance;  // R_R  (roll)
+  expected[28] = g_angular_accel_variance;  // P_P  (pitch)
+  expected[35] = g_angular_accel_variance;  // Y_Y  (yaw)
 
   for (std::size_t i = 0; i < expected.size(); ++i) {
     EXPECT_NEAR(accel.covariance[i], expected[i], kTol) << "covariance index " << i;
   }
-
-  // Cross-check the magnitudes against the named public constants so a future
-  // change to either the literals above or the constants is caught.
-  EXPECT_DOUBLE_EQ(g_linear_accel_variance, 1.0);
-  EXPECT_DOUBLE_EQ(g_angular_accel_variance, 0.05);
 }

--- a/localization/autoware_twist2accel/test/test_twist2accel_node.cpp
+++ b/localization/autoware_twist2accel/test/test_twist2accel_node.cpp
@@ -22,7 +22,9 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <chrono>
+#include <cstddef>
 #include <memory>
 #include <thread>
 #include <vector>
@@ -167,6 +169,23 @@ TEST_F(Twist2AccelNodeTest, UseOdomTrueRoutesOdomAndIgnoresTwist)
 
   ASSERT_EQ(received.size(), 2u);
   EXPECT_DOUBLE_EQ(received.back().accel.accel.linear.x, 1.0);
+
+  // Characterization: the published covariance must stay byte-for-byte what the
+  // node emitted before the covariance logic moved into the pure core, i.e. a
+  // constant diagonal (linear variance 1.0, angular variance 0.05) with all
+  // off-diagonal terms zero. The literals below are hand-written, not read back
+  // from the estimator. Diagonal of a row-major 6x6 lives at row * 6 + row.
+  const auto & cov = received.back().accel.covariance;
+  std::array<double, 36> expected{};  // value-initialized to all zeros
+  expected[0] = 1.0;                  // linear x variance
+  expected[7] = 1.0;                  // linear y variance
+  expected[14] = 1.0;                 // linear z variance
+  expected[21] = 0.05;                // roll variance
+  expected[28] = 0.05;                // pitch variance
+  expected[35] = 0.05;                // yaw variance
+  for (std::size_t i = 0; i < expected.size(); ++i) {
+    EXPECT_DOUBLE_EQ(cov[i], expected[i]) << "covariance index " << i;
+  }
 }
 
 // With use_odom=false the twist callback drives estimation while the odom

--- a/localization/autoware_twist2accel/test/test_twist2accel_node.cpp
+++ b/localization/autoware_twist2accel/test/test_twist2accel_node.cpp
@@ -1,0 +1,225 @@
+// Copyright 2025 TIER IV
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/twist2accel.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
+#include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <vector>
+
+namespace
+{
+using autoware::twist2accel::Twist2Accel;
+using geometry_msgs::msg::AccelWithCovarianceStamped;
+using geometry_msgs::msg::TwistWithCovarianceStamped;
+using nav_msgs::msg::Odometry;
+
+// Spin both nodes until `predicate` holds or the timeout elapses, so the tests
+// stay deterministic instead of relying on a fixed sleep.
+template <typename Predicate>
+void spin_until(
+  rclcpp::executors::SingleThreadedExecutor & executor, const Predicate & predicate,
+  std::chrono::milliseconds timeout)
+{
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (!predicate() && std::chrono::steady_clock::now() < deadline) {
+    executor.spin_some(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+
+class Twist2AccelNodeTest : public ::testing::Test
+{
+protected:
+  void SetUp() override { rclcpp::init(0, nullptr); }
+  void TearDown() override { rclcpp::shutdown(); }
+
+  // Build the node under test with the given use_odom routing and spin it
+  // together with a helper node that publishes inputs and captures outputs.
+  std::shared_ptr<Twist2Accel> make_node(bool use_odom)
+  {
+    rclcpp::NodeOptions options;
+    options.parameter_overrides({{"use_odom", use_odom}, {"accel_lowpass_gain", 0.9}});
+    return std::make_shared<Twist2Accel>(options);
+  }
+};
+
+// First message (prev_twist_ == nullopt): the node publishes an
+// AccelWithCovarianceStamped whose header is copied from the input but whose
+// accel and covariance are left at their default zeros -- no estimate is run
+// because there is no previous sample to difference against.
+TEST_F(Twist2AccelNodeTest, FirstMessagePublishesZeroAccelWithHeader)
+{
+  auto node = make_node(/*use_odom=*/true);
+  auto helper = std::make_shared<rclcpp::Node>("twist2accel_test_helper");
+
+  std::vector<AccelWithCovarianceStamped> received;
+  auto sub = helper->create_subscription<AccelWithCovarianceStamped>(
+    "output/accel", 10,
+    [&received](const AccelWithCovarianceStamped::SharedPtr msg) { received.push_back(*msg); });
+  auto pub = helper->create_publisher<Odometry>("input/odom", 10);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+  executor.add_node(helper);
+
+  spin_until(executor, [&] { return pub->get_subscription_count() > 0; }, std::chrono::seconds(5));
+
+  Odometry odom;
+  odom.header.frame_id = "base_link";
+  odom.header.stamp = rclcpp::Time(123, 456, RCL_ROS_TIME);
+  odom.twist.twist.linear.x = 5.0;
+  odom.twist.twist.angular.z = 1.0;
+  pub->publish(odom);
+
+  spin_until(executor, [&] { return !received.empty(); }, std::chrono::seconds(5));
+
+  ASSERT_EQ(received.size(), 1u);
+  const auto & out = received.front();
+  // Header is forwarded from the input message.
+  EXPECT_EQ(out.header.frame_id, "base_link");
+  EXPECT_EQ(rclcpp::Time(out.header.stamp), rclcpp::Time(123, 456, RCL_ROS_TIME));
+  // No estimate ran, so accel is all zeros ...
+  EXPECT_DOUBLE_EQ(out.accel.accel.linear.x, 0.0);
+  EXPECT_DOUBLE_EQ(out.accel.accel.linear.y, 0.0);
+  EXPECT_DOUBLE_EQ(out.accel.accel.linear.z, 0.0);
+  EXPECT_DOUBLE_EQ(out.accel.accel.angular.x, 0.0);
+  EXPECT_DOUBLE_EQ(out.accel.accel.angular.y, 0.0);
+  EXPECT_DOUBLE_EQ(out.accel.accel.angular.z, 0.0);
+  // ... and the covariance is left untouched (all zeros).
+  for (const auto & c : out.accel.covariance) {
+    EXPECT_DOUBLE_EQ(c, 0.0);
+  }
+}
+
+// With use_odom=true the odom callback drives estimation while the twist
+// callback early-returns. The second odom sample (now that prev_twist_ is set)
+// produces a non-zero accel, and the interleaved twist message produces no
+// extra output.
+TEST_F(Twist2AccelNodeTest, UseOdomTrueRoutesOdomAndIgnoresTwist)
+{
+  auto node = make_node(/*use_odom=*/true);
+  auto helper = std::make_shared<rclcpp::Node>("twist2accel_test_helper");
+
+  std::vector<AccelWithCovarianceStamped> received;
+  auto sub = helper->create_subscription<AccelWithCovarianceStamped>(
+    "output/accel", 10,
+    [&received](const AccelWithCovarianceStamped::SharedPtr msg) { received.push_back(*msg); });
+  auto odom_pub = helper->create_publisher<Odometry>("input/odom", 10);
+  auto twist_pub = helper->create_publisher<TwistWithCovarianceStamped>("input/twist", 10);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+  executor.add_node(helper);
+
+  spin_until(
+    executor,
+    [&] {
+      return odom_pub->get_subscription_count() > 0 && twist_pub->get_subscription_count() > 0;
+    },
+    std::chrono::seconds(5));
+
+  // First odom: linear.x = 0 at t = 0. Primes prev_twist_, publishes zero accel.
+  Odometry odom0;
+  odom0.header.frame_id = "base_link";
+  odom0.header.stamp = rclcpp::Time(0, 0, RCL_ROS_TIME);
+  odom0.twist.twist.linear.x = 0.0;
+  odom_pub->publish(odom0);
+  spin_until(executor, [&] { return received.size() >= 1u; }, std::chrono::seconds(5));
+
+  // A twist message must be ignored while use_odom=true: no new output.
+  TwistWithCovarianceStamped twist;
+  twist.header.frame_id = "base_link";
+  twist.header.stamp = rclcpp::Time(0, 500000000, RCL_ROS_TIME);
+  twist.twist.twist.linear.x = 100.0;
+  twist_pub->publish(twist);
+  spin_until(executor, [&] { return false; }, std::chrono::milliseconds(300));
+  EXPECT_EQ(received.size(), 1u) << "twist input must be ignored when use_odom=true";
+
+  // Second odom: linear.x = 1 at t = 1 s. dt = 1 s, raw accel = 1.0, first LPF
+  // sample returns it unchanged -> linear.x accel == 1.0.
+  Odometry odom1;
+  odom1.header.frame_id = "base_link";
+  odom1.header.stamp = rclcpp::Time(1, 0, RCL_ROS_TIME);
+  odom1.twist.twist.linear.x = 1.0;
+  odom_pub->publish(odom1);
+  spin_until(executor, [&] { return received.size() >= 2u; }, std::chrono::seconds(5));
+
+  ASSERT_EQ(received.size(), 2u);
+  EXPECT_DOUBLE_EQ(received.back().accel.accel.linear.x, 1.0);
+}
+
+// With use_odom=false the twist callback drives estimation while the odom
+// callback early-returns. Symmetric to the use_odom=true case.
+TEST_F(Twist2AccelNodeTest, UseOdomFalseRoutesTwistAndIgnoresOdom)
+{
+  auto node = make_node(/*use_odom=*/false);
+  auto helper = std::make_shared<rclcpp::Node>("twist2accel_test_helper");
+
+  std::vector<AccelWithCovarianceStamped> received;
+  auto sub = helper->create_subscription<AccelWithCovarianceStamped>(
+    "output/accel", 10,
+    [&received](const AccelWithCovarianceStamped::SharedPtr msg) { received.push_back(*msg); });
+  auto odom_pub = helper->create_publisher<Odometry>("input/odom", 10);
+  auto twist_pub = helper->create_publisher<TwistWithCovarianceStamped>("input/twist", 10);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+  executor.add_node(helper);
+
+  spin_until(
+    executor,
+    [&] {
+      return odom_pub->get_subscription_count() > 0 && twist_pub->get_subscription_count() > 0;
+    },
+    std::chrono::seconds(5));
+
+  // First twist: linear.x = 0 at t = 0. Primes prev_twist_, publishes zero accel.
+  TwistWithCovarianceStamped twist0;
+  twist0.header.frame_id = "base_link";
+  twist0.header.stamp = rclcpp::Time(0, 0, RCL_ROS_TIME);
+  twist0.twist.twist.linear.x = 0.0;
+  twist_pub->publish(twist0);
+  spin_until(executor, [&] { return received.size() >= 1u; }, std::chrono::seconds(5));
+
+  // An odom message must be ignored while use_odom=false: no new output.
+  Odometry odom;
+  odom.header.frame_id = "base_link";
+  odom.header.stamp = rclcpp::Time(0, 500000000, RCL_ROS_TIME);
+  odom.twist.twist.linear.x = 100.0;
+  odom_pub->publish(odom);
+  spin_until(executor, [&] { return false; }, std::chrono::milliseconds(300));
+  EXPECT_EQ(received.size(), 1u) << "odom input must be ignored when use_odom=false";
+
+  // Second twist: linear.x = 1 at t = 1 s. dt = 1 s, raw accel = 1.0.
+  TwistWithCovarianceStamped twist1;
+  twist1.header.frame_id = "base_link";
+  twist1.header.stamp = rclcpp::Time(1, 0, RCL_ROS_TIME);
+  twist1.twist.twist.linear.x = 1.0;
+  twist_pub->publish(twist1);
+  spin_until(executor, [&] { return received.size() >= 2u; }, std::chrono::seconds(5));
+
+  ASSERT_EQ(received.size(), 2u);
+  EXPECT_DOUBLE_EQ(received.back().accel.accel.linear.x, 1.0);
+}
+}  // namespace


### PR DESCRIPTION
## Description

`autoware_twist2accel` estimates acceleration by finite-differencing successive twist (or odometry) messages and smoothing each of the 6 components with a first-order low-pass filter before publishing `AccelWithCovarianceStamped`. Until now the entire estimation algorithm lived inside the `rclcpp::Node` (`Twist2Accel::estimate_accel`), so it could not be exercised without spinning a ROS node, and the package shipped with zero tests — unlike the structurally-identical sibling `autoware_stop_filter`, which extracts a pure `StopFilter` class for unit testing.

This PR mirrors that sibling pattern:

- Extracts the ROS-free acceleration math (dt-clamped finite difference + 6-channel `LowpassFilter1d` smoothing) out of `Twist2Accel::estimate_accel` into a new pure, injectable `AccelEstimator` class (`src/accel_estimator.{hpp,cpp}`) that owns the six `LowpassFilter1d` instances. Plain `Twist` / `Accel` structs (6 doubles each) keep it free of ROS message types. `estimate_accel` is now a thin wrapper: it computes `dt` from the ROS clock, calls the estimator, fills the message, and publishes.
- Adds `test/test_accel_estimator.cpp` with gtest coverage that asserts concrete numerical values for: no-smoothing-on-first-sample (raw finite difference), zero-velocity-change, multi-sample low-pass smoothing, the `dt` clamp (zero / negative / above-threshold), per-channel independence of the LPF state, and a lock-in that the covariance diagonal indices equal the XYZRPY layout.
- Adds `test/test_twist2accel_node.cpp`, a ROS pub/sub node-level gtest (`ament_add_ros_isolated_gtest`) that pins the two node-level branches the pure-unit test cannot reach: (a) the first-message null-prev branch (with `prev_twist_ == nullopt` the first input publishes an `AccelWithCovarianceStamped` with the header forwarded and zero accel + zero covariance, i.e. no estimate run), and (b) the `use_odom` routing in both directions (the active input drives estimation while the inactive input early-returns and produces no extra output). It uses a deterministic `spin_until` helper rather than a fixed sleep.
- Folds in the audit's low-risk cleanups: removes dead `tf2` and STL includes and the file-scope `using` in the header, drops the unused `tf2` `package.xml` dependency, and replaces the magic `i*6+i` covariance indices with `autoware_utils_geometry::XYZRPY_COV_IDX` named constants (proved equivalent by a test). The hot-path per-message `std::make_shared<TwistStamped>` allocation is removed by storing the previous twist as a `std::optional` value.

## Effects on system behavior

None intended; behavior-preserving. The `dt` clamp (`>= 1e-3`), per-component LPF order and gain, the first-message zero/empty-accel branch, the `use_odom` gating, and the published covariance values are all unchanged and now have characterization-test coverage at both the pure-unit and node level. The covariance index switch is a pure refactor of the same diagonal slots (0,7,14,21,28,35), pinned by `CovarianceDiagonalIndicesMatchXyzrpyLayout`. No public node API/ABI change (the only public symbol, the `Twist2Accel(const rclcpp::NodeOptions &)` constructor, is untouched); `AccelEstimator` is a new internal-only class under `src/`. Downstream consumers of the `output/accel` topic see identical output.

Refs: autowarefoundation/autoware_core#1096

## youtalk fork CI — build-and-test all green

The full `build-test-tidy-pr` workflow runs on the youtalk fork (`ubicloud-standard-16`). All build-and-test gate jobs pass for head commit `9fffe2afa` ([workflow run](https://github.com/youtalk/autoware_core/actions/runs/26662974169)):

- ✅ `build-and-test-diff-humble / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26662974169/job/78589871097
- ✅ `build-and-test-diff-jazzy / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26662974169/job/78589871111
- ✅ `build-and-test-diff-jazzy-agnocast / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26662974169/job/78589871075
- ✅ `build-and-test-diff-humble / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26662974169/job/78590151199
- ✅ `build-and-test-diff-jazzy / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26662974169/job/78590236538

(The `*-above` universe jobs are bonus coverage and excluded from the gate.)
