### PR TITLE
feat(object_recognition_utils): templatize `object_recognition_utils` buffer

### DIFF
--- a/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/transform.hpp
+++ b/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/transform.hpp
@@ -19,12 +19,12 @@
 #include <rclcpp/duration.hpp>
 #include <rclcpp/logging.hpp>
 #include <rclcpp/time.hpp>
+#include <tf2/exceptions.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <geometry_msgs/msg/transform.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/msg/point_field.hpp>
-#include <tf2/exceptions.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <boost/optional.hpp>

--- a/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/transform.hpp
+++ b/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/transform.hpp
@@ -16,13 +16,15 @@
 #define AUTOWARE__OBJECT_RECOGNITION_UTILS__TRANSFORM_HPP_
 
 #include <pcl_ros/transforms.hpp>
+#include <rclcpp/duration.hpp>
+#include <rclcpp/logging.hpp>
+#include <rclcpp/time.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
-#include <tf2_ros/buffer.hpp>
-#include <tf2_ros/transform_listener.hpp>
 
 #include <geometry_msgs/msg/transform.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/msg/point_field.hpp>
+#include <tf2/exceptions.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <boost/optional.hpp>

--- a/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/transform.hpp
+++ b/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/transform.hpp
@@ -31,8 +31,9 @@
 
 namespace detail
 {
-[[maybe_unused]] inline boost::optional<geometry_msgs::msg::Transform> getTransform(
-  const tf2_ros::Buffer & tf_buffer, const std::string & source_frame_id,
+template <class BufferT>
+[[maybe_unused]] boost::optional<geometry_msgs::msg::Transform> getTransform(
+  const BufferT & tf_buffer, const std::string & source_frame_id,
   const std::string & target_frame_id, const rclcpp::Time & time)
 {
   try {
@@ -46,9 +47,10 @@ namespace detail
   }
 }
 
-[[maybe_unused]] inline boost::optional<Eigen::Matrix4f> getTransformMatrix(
+template <class BufferT>
+[[maybe_unused]] boost::optional<Eigen::Matrix4f> getTransformMatrix(
   const std::string & in_target_frame, const std_msgs::msg::Header & in_cloud_header,
-  const tf2_ros::Buffer & tf_buffer)
+  const BufferT & tf_buffer)
 {
   try {
     geometry_msgs::msg::TransformStamped transform_stamped;
@@ -66,9 +68,9 @@ namespace detail
 
 namespace autoware::object_recognition_utils
 {
-template <class T>
+template <class T, class BufferT>
 bool transformObjects(
-  const T & input_msg, const std::string & target_frame_id, const tf2_ros::Buffer & tf_buffer,
+  const T & input_msg, const std::string & target_frame_id, const BufferT & tf_buffer,
   T & output_msg)
 {
   output_msg = input_msg;
@@ -99,9 +101,9 @@ bool transformObjects(
   }
   return true;
 }
-template <class T>
+template <class T, class BufferT>
 bool transformObjectsWithFeature(
-  const T & input_msg, const std::string & target_frame_id, const tf2_ros::Buffer & tf_buffer,
+  const T & input_msg, const std::string & target_frame_id, const BufferT & tf_buffer,
   T & output_msg)
 {
   output_msg = input_msg;


### PR DESCRIPTION
## Description
Templatize the TF buffer parameter of the transform helpers in `object_recognition_utils/transform.hpp` so they accept any tf2 buffer type, not only `tf2_ros::Buffer`.

Affected functions:
  - `transformObjects()`
  - `transformObjectsWithFeature()`
  - `detail::getTransform()`
  - `detail::getTransformMatrix()`

### Motivation
When a node runs as `agnocast_wrapper::Node` under an Agnocast `AgnocastOnly*` executor, its TF buffer is an `agnocast::Buffer` instead of a `tf2_ros::Buffer`. An `agnocast::Buffer` cannot be passed to a function that takes const `tf2_ros::Buffer &`. Templatizing the parameter lets both concrete types be used without changing the function bodies.

### Backward compatibility
Fully backward compatible. BufferT is deduced at each call site, so existing callers passing `tf2_ros::Buffer` compile and behave exactly as before (the function bodies are unchanged). No new dependency is added to this package.

## Related links
This change is required by autowarefoundation/autoware_universe#12665, which migrates `autoware_detection_by_tracker` to an `agnocast_wrapper::Node` and therefore passes an `agnocast::Buffer` to `object_recognition_utils::transformObjects()`.

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- `colcon build` succeeds with both ENABLE_AGNOCAST=1 and ENABLE_AGNOCAST=0.
- Confirmed a non-converted consumer of transformObjects (autoware_object_merger) still builds after the util change.
- Ran Autoware with this change applied and confirmed it operates without any regression.



## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior
Existing behavior is unchanged: this is a non-functional generalization — for callers passing `tf2_ros::Buffer`, `BufferT` is deduced to `tf2_ros::Buffer` and the function bodies are untouched, so the generated code (and runtime behavior) is identical to before. Existing consumers therefore continue to work without modification.