### PR TITLE
feat: add visualization support for area primitives (part of reverse maneuver feature)

### DIFF
--- a/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization_node.cpp
+++ b/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization_node.cpp
@@ -345,7 +345,7 @@ void Lanelet2MapVisualizationNode::on_map_bin(
                          obstacle_removal_areas, cl_obstacle_removal_area));
   insert_marker_array(
     &map_marker_array, lanelet::visualization::laneletAreasAsMarkerArray(
-                        lanelet_areas, cl_lanelet_routing_area, cl_lanelet_routing_area_outline));         
+                         lanelet_areas, cl_lanelet_routing_area, cl_lanelet_routing_area_outline));
 
   pub_marker_->publish(map_marker_array);
 }

--- a/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization_node.cpp
+++ b/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization_node.cpp
@@ -138,6 +138,12 @@ void Lanelet2MapVisualizationNode::on_map_bin(
   lanelet::ConstPolygons3d obstacle_removal_areas =
     lanelet::utils::query::getAllPolygonsByType(viz_lanelet_map, "obstacle_removal_area");
 
+  std::vector<lanelet::ConstArea> lanelet_areas;
+  lanelet_areas.reserve(viz_lanelet_map->areaLayer.size());
+  for (const auto & area : viz_lanelet_map->areaLayer) {
+    lanelet_areas.push_back(area);
+  }
+
   std_msgs::msg::ColorRGBA cl_road;
   std_msgs::msg::ColorRGBA cl_shoulder;
   std_msgs::msg::ColorRGBA cl_cross;
@@ -167,6 +173,9 @@ void Lanelet2MapVisualizationNode::on_map_bin(
   std_msgs::msg::ColorRGBA cl_bicycle_lane;
   std_msgs::msg::ColorRGBA cl_waypoints;
   std_msgs::msg::ColorRGBA cl_obstacle_removal_area;
+  std_msgs::msg::ColorRGBA cl_lanelet_routing_area;
+  std_msgs::msg::ColorRGBA cl_lanelet_routing_area_outline;
+
   set_color(&cl_road, 0.27, 0.27, 0.27, 0.999);
   set_color(&cl_shoulder, 0.15, 0.15, 0.15, 0.999);
   set_color(&cl_cross, 0.27, 0.3, 0.27, 0.5);
@@ -196,6 +205,10 @@ void Lanelet2MapVisualizationNode::on_map_bin(
   set_color(&cl_bicycle_lane, 0.0, 0.3843, 0.6274, 0.5);
   set_color(&cl_waypoints, 0.6, 0.4, 0.3, 0.999);
   set_color(&cl_obstacle_removal_area, 0.2, 0.2, 0.5, 0.5);
+  // Static map fill for areaLayer namespace lanelet_routing_area; darker edge in
+  // lanelet_routing_area_outline
+  set_color(&cl_lanelet_routing_area, 0.8, 0.53, 0.25, 0.35);
+  set_color(&cl_lanelet_routing_area_outline, 0.45, 0.28, 0.12, 0.95);
 
   visualization_msgs::msg::MarkerArray map_marker_array;
 
@@ -330,6 +343,9 @@ void Lanelet2MapVisualizationNode::on_map_bin(
   insert_marker_array(
     &map_marker_array, lanelet::visualization::obstacleRemovalAreaAsMarkerArray(
                          obstacle_removal_areas, cl_obstacle_removal_area));
+  insert_marker_array(
+    &map_marker_array, lanelet::visualization::laneletAreasAsMarkerArray(
+                        lanelet_areas, cl_lanelet_routing_area, cl_lanelet_routing_area_outline));         
 
   pub_marker_->publish(map_marker_array);
 }


### PR DESCRIPTION
## Description

This PR include changes related to the visualization of area primitives. Current `autoware`, do not visualize the area primitives that join the lanes.  Currently, brown color is used to visualize the areas.

## Related links

**Parent Issue:**

- [Tier IV Internal Link](https://tier4.atlassian.net/browse/T4DEV-2508)

**Design Documents**

- [Map Requirements Doc 2](https://tier4.atlassian.net/wiki/spaces/SI/pages/5152014822/Map+Requirements)
- [Detailed Design Doc 1](https://tier4.atlassian.net/wiki/spaces/SI/pages/5077074153/Detailed+Design+Document+Lanelet2+Area+Support+for+Route+Finding)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- colcon build worked as expected.
- PSim Tests, no regression issues noticed.
<img width="564" height="513" alt="image" src="https://github.com/user-attachments/assets/5b86892c-8c8a-4251-86df-988a5a7e60de" />


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

- The area primitive will be displayed in brown color.
