### PR TITLE
feat(autoware_agnocast_wrapper): update `agnocast_env.launch` to enable override `use_agnocast`

### DIFF
--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -420,11 +420,11 @@ After including `agnocast_env.launch.xml` (or `agnocast_env.launch.py`), the fol
 
 ### Launch Arguments
 
-| Argument                 | Default                                       | Description                                                                                             |
-| ------------------------ | --------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Argument                 | Default                                                                     | Description                                                                                             |
+| ------------------------ | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `agnocast_heaphook_path` | `/opt/ros/$ROS_DISTRO/lib/libagnocast_heaphook.so` (falls back to `humble`) | Path to the heaphook shared library                                                                     |
-| `use_multithread`        | `false`                                       | Use the multi-threaded component container (`component_container_mt`)                                   |
-| `use_agnocast`           | `$(env ENABLE_AGNOCAST 0)`                    | Per-node override (`1`/`0`). Usually left unset; defaults to the `ENABLE_AGNOCAST` environment variable |
+| `use_multithread`        | `false`                                                                     | Use the multi-threaded component container (`component_container_mt`)                                   |
+| `use_agnocast`           | `$(env ENABLE_AGNOCAST 0)`                                                  | Per-node override (`1`/`0`). Usually left unset; defaults to the `ENABLE_AGNOCAST` environment variable |
 
 The `container_executable` is resolved as follows:
 

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -457,6 +457,20 @@ Using a component container with multi-threading:
 </node_container>
 ```
 
+Disabling Agnocast for a single include (debugging / emergency fallback):
+
+```xml
+<include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml">
+  <arg name="use_agnocast" value="0"/>
+</include>
+
+<node pkg="my_package" exec="my_node" name="my_node">
+  <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+</node>
+```
+
+Even when the workspace is built with `ENABLE_AGNOCAST=1`, passing `use_agnocast` to a single include forces that node (or container) back to the plain `rclcpp` path without touching the rest of the launch tree. Use it to temporarily disable Agnocast for one node while debugging, or as an emergency fallback when a specific node misbehaves under Agnocast.
+
 ### Examples (Python)
 
 A Python launch file (`agnocast_env.launch.py`) is also provided with the same functionality. It accepts the same `use_agnocast` argument and sets the same launch configurations (`ld_preload_value`, `container_package`, `container_executable`) that can be referenced via `LaunchConfiguration`.
@@ -527,5 +541,7 @@ def generate_launch_description():
 
     return LaunchDescription([agnocast_env, container])
 ```
+
+The same `use_agnocast` override works here too, via `launch_arguments={"use_agnocast": "0"}.items()`.
 
 This ensures that only the intended nodes receive the heaphook, rather than all nodes in the launch tree.

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -420,10 +420,11 @@ After including `agnocast_env.launch.xml` (or `agnocast_env.launch.py`), the fol
 
 ### Launch Arguments
 
-| Argument                 | Default                                       | Description                                                           |
-| ------------------------ | --------------------------------------------- | --------------------------------------------------------------------- |
-| `agnocast_heaphook_path` | `/opt/ros/humble/lib/libagnocast_heaphook.so` | Path to the heaphook shared library                                   |
-| `use_multithread`        | `false`                                       | Use the multi-threaded component container (`component_container_mt`) |
+| Argument                 | Default                                       | Description                                                                                             |
+| ------------------------ | --------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `agnocast_heaphook_path` | `/opt/ros/$ROS_DISTRO/lib/libagnocast_heaphook.so` (falls back to `humble`) | Path to the heaphook shared library                                                                     |
+| `use_multithread`        | `false`                                       | Use the multi-threaded component container (`component_container_mt`)                                   |
+| `use_agnocast`           | `$(env ENABLE_AGNOCAST 0)`                    | Per-node override (`1`/`0`). Usually left unset; defaults to the `ENABLE_AGNOCAST` environment variable |
 
 The `container_executable` is resolved as follows:
 
@@ -458,7 +459,7 @@ Using a component container with multi-threading:
 
 ### Examples (Python)
 
-A Python launch file (`agnocast_env.launch.py`) is also provided with the same functionality. It sets the same launch configurations (`ld_preload_value`, `container_package`, `container_executable`) that can be referenced via `LaunchConfiguration`.
+A Python launch file (`agnocast_env.launch.py`) is also provided with the same functionality. It accepts the same `use_agnocast` argument and sets the same launch configurations (`ld_preload_value`, `container_package`, `container_executable`) that can be referenced via `LaunchConfiguration`.
 
 Basic usage with a single node:
 

--- a/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.py
+++ b/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.py
@@ -15,7 +15,9 @@
 """Python equivalent of agnocast_env.launch.xml.
 
 Configuration:
-- Checks ENABLE_AGNOCAST environment variable (set to "1" to enable)
+- use_agnocast arg overrides the ENABLE_AGNOCAST environment variable per include
+  (set to "1" to enable). When not passed by the including launch file, it defaults to the
+  ENABLE_AGNOCAST environment variable (which itself defaults to "0").
 - Heaphook path is configurable via the agnocast_heaphook_path arg
   (default: /opt/ros/$ROS_DISTRO/lib/libagnocast_heaphook.so, falls back to humble)
 
@@ -36,7 +38,7 @@ from launch.substitutions import LaunchConfiguration
 
 
 def _resolve_agnocast_env(context):
-    use_agnocast = context.launch_configurations.get("use_agnocast", "0")
+    use_agnocast = context.perform_substitution(LaunchConfiguration("use_agnocast"))
     use_multithread = context.perform_substitution(LaunchConfiguration("use_multithread"))
     heaphook_path = context.perform_substitution(LaunchConfiguration("agnocast_heaphook_path"))
     existing_ld_preload = context.perform_substitution(
@@ -76,9 +78,9 @@ def generate_launch_description():
                 "use_multithread",
                 default_value="false",
             ),
-            SetLaunchConfiguration(
+            DeclareLaunchArgument(
                 "use_agnocast",
-                EnvironmentVariable("ENABLE_AGNOCAST", default_value="0"),
+                default_value=EnvironmentVariable("ENABLE_AGNOCAST", default_value="0"),
             ),
             OpaqueFunction(function=_resolve_agnocast_env),
         ]

--- a/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.xml
+++ b/common/autoware_agnocast_wrapper/launch/agnocast_env.launch.xml
@@ -2,7 +2,9 @@
 <launch>
   <!--
     Configuration:
-    - Checks ENABLE_AGNOCAST environment variable (set to "1" to enable)
+    - use_agnocast arg overrides the ENABLE_AGNOCAST environment variable per include
+      (set to "1" to enable). When not passed by the including launch file, it defaults to the
+      ENABLE_AGNOCAST environment variable (which itself defaults to "0").
     - Heaphook path is configurable via the agnocast_heaphook_path arg
       (default: /opt/ros/$ROS_DISTRO/lib/libagnocast_heaphook.so, falls back to humble)
 
@@ -14,7 +16,7 @@
 
   <arg name="agnocast_heaphook_path" default="/opt/ros/$(env ROS_DISTRO humble)/lib/libagnocast_heaphook.so"/>
   <arg name="use_multithread" default="false"/>
-  <let name="use_agnocast" value="$(env ENABLE_AGNOCAST 0)"/>
+  <arg name="use_agnocast" default="$(env ENABLE_AGNOCAST 0)"/>
 
   <!-- LD_PRELOAD -->
   <let name="ld_preload_value" value="$(var agnocast_heaphook_path):$(env LD_PRELOAD '')" if="$(eval &quot;'$(var use_agnocast)' == '1'&quot;)"/>


### PR DESCRIPTION
## Description
Make `use_agnocast` an overridable launch argument in `agnocast_env.launch`.

Previously `use_agnocast` was an internal launch configuration derived solely from the `ENABLE_AGNOCAST` environment variable, so it could not be overridden per include. This changes it to a declared launch argument (`arg` / `DeclareLaunchArgument`) that an including launch file can set per-node, while still defaulting to the　`ENABLE_AGNOCAST` environment variable (which defaults to `0`). This preserves existing behavior when the argument is not passed.

In short, `ENABLE_AGNOCAST` remains the single switch that toggles Agnocast globally for all nodes, and the new `use_agnocast` argument lets an including launch file override that decision only where needed, without affecting the rest.

## Changes

  - `agnocast_env.launch.xml`: `<let name="use_agnocast">` → `<arg name="use_agnocast" default="$(env ENABLE_AGNOCAST 0)">`
  - `agnocast_env.launch.py`: `SetLaunchConfiguration` → `DeclareLaunchArgument`; resolve via `LaunchConfiguration` substitution
  - `README.md`: document the new `use_agnocast` argument
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

With `ENABLE_AGNOCAST=1`, I confirmed that the `shape_estimation` node launches via Agnocast when nothing is specified, and falls back to a plain `rclcpp::Node` when overridden with `use_agnocast:=false`.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
