### PR TITLE
refactor(autoware_lanelet2_utils): reuse geometry helpers, fix int-narrowing, dedup offset-bound builders

### DIFF
--- a/common/autoware_lanelet2_utils/src/geometry.cpp
+++ b/common/autoware_lanelet2_utils/src/geometry.cpp
@@ -29,8 +29,10 @@
 #include <lanelet2_core/primitives/Point.h>
 
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 #include <limits>
+#include <string>
 #include <vector>
 
 namespace autoware::experimental::lanelet2_utils
@@ -45,7 +47,8 @@ size_t compute_num_segments(const lanelet::ConstLanelet & lanelet, const double 
   const double left_length = static_cast<double>(lanelet::geometry::length(lanelet.leftBound()));
   const double right_length = static_cast<double>(lanelet::geometry::length(lanelet.rightBound()));
   const double longer_distance = (left_length > right_length) ? left_length : right_length;
-  const size_t num_segments = std::max(static_cast<int>(ceil(longer_distance / resolution)), 1);
+  const size_t num_segments =
+    static_cast<size_t>(std::max(std::ceil(longer_distance / resolution), 1.0));
   return num_segments;
 }
 
@@ -100,6 +103,55 @@ lanelet::BasicPoints3d resample_points(
     resampled_points.push_back(target_point);
   }
   return resampled_points;
+}
+
+/**
+ * @brief Build an offset linestring by resampling a lanelet's left/right bounds and applying a
+ * per-point formula.
+ *
+ * This factors out the shared scaffolding of get_fine_centerline / get_centerline_with_offset /
+ * get_right_bound_with_offset / get_left_bound_with_offset, which only differ in the per-point
+ * formula, the id assigned to each generated point, and the diagnostic message on failure.
+ *
+ * @param lanelet_obj Source lanelet whose bounds are resampled.
+ * @param resolution Resampling resolution forwarded to compute_num_segments.
+ * @param use_unique_id If true, each generated point gets a fresh id via lanelet::utils::getId();
+ * otherwise lanelet::InvalId is used.
+ * @param error_context Substring inserted into the diagnostic message when fewer than two points
+ * are produced.
+ * @param point_fn Formula mapping the resampled left/right points at an index to a 3d point.
+ * @return The assembled linestring, or an empty linestring if fewer than two points are produced.
+ */
+template <typename PointFn>
+lanelet::ConstLineString3d build_offset_linestring(
+  const lanelet::ConstLanelet & lanelet_obj, const double resolution, const bool use_unique_id,
+  const std::string & error_context, PointFn && point_fn)
+{
+  // get number of segments from resolution and longer bound
+  const auto num_segments = compute_num_segments(lanelet_obj, resolution);
+
+  // Resample points
+  const auto left_points = resample_points(lanelet_obj.leftBound().basicLineString(), num_segments);
+  const auto right_points =
+    resample_points(lanelet_obj.rightBound().basicLineString(), num_segments);
+
+  lanelet::ConstPoints3d points;
+  points.reserve(num_segments + 1);
+  for (size_t i = 0; i < num_segments + 1; i++) {
+    const lanelet::BasicPoint3d basic_point = point_fn(left_points.at(i), right_points.at(i));
+    const lanelet::Id id = use_unique_id ? lanelet::utils::getId() : lanelet::InvalId;
+    points.emplace_back(id, basic_point.x(), basic_point.y(), basic_point.z());
+  }
+
+  const auto linestring_opt = create_safe_linestring(points);
+  if (!linestring_opt.has_value()) {
+    RCLCPP_ERROR(
+      rclcpp::get_logger("autoware_lanelet2_utility"),
+      "%s has less than two points. Returning empty linestring.", error_context.c_str());
+    return lanelet::ConstLineString3d();
+  }
+
+  return *linestring_opt;
 }
 }  // namespace
 
@@ -268,18 +320,13 @@ std::optional<geometry_msgs::msg::Pose> get_pose_from_2d_arc_length(
         if (!const_pt.has_value()) {
           return std::nullopt;
         }
-        auto P = const_pt.value().basicPoint();
+        const auto P = const_pt.value().basicPoint();
 
-        double half_yaw = std::atan2(next_pt.y() - pt.y(), next_pt.x() - pt.x()) * 0.5;
+        const double yaw = std::atan2(next_pt.y() - pt.y(), next_pt.x() - pt.x());
 
         geometry_msgs::msg::Pose pose;
-        pose.position.x = P.x();
-        pose.position.y = P.y();
-        pose.position.z = P.z();
-        pose.orientation.x = 0.0;
-        pose.orientation.y = 0.0;
-        pose.orientation.z = std::sin(half_yaw);
-        pose.orientation.w = std::cos(half_yaw);
+        pose.position = autoware_utils_geometry::create_point(P.x(), P.y(), P.z());
+        pose.orientation = autoware_utils_geometry::create_quaternion_from_yaw(yaw);
 
         return pose;
       }
@@ -370,10 +417,7 @@ geometry_msgs::msg::Pose get_closest_center_pose(
   if (segment.empty()) {
     geometry_msgs::msg::Pose closest_pose;
     closest_pose.position = to_ros(lanelet.centerline().front(), search_pt.z());
-    closest_pose.orientation.x = 0.0;
-    closest_pose.orientation.y = 0.0;
-    closest_pose.orientation.z = 0.0;
-    closest_pose.orientation.w = 1.0;
+    closest_pose.orientation = autoware_utils_geometry::create_quaternion(0.0, 0.0, 0.0, 1.0);
     return closest_pose;
   }
 
@@ -626,136 +670,47 @@ std::optional<lanelet::ConstLanelets> get_dirty_expanded_lanelets(
 lanelet::ConstLineString3d get_fine_centerline(
   const lanelet::ConstLanelet & lanelet_obj, const double resolution)
 {
-  // get number of segments from resolution and longer bound
-  const auto num_segments = compute_num_segments(lanelet_obj, resolution);
-
-  // Resample points
-  const auto left_points = resample_points(lanelet_obj.leftBound().basicLineString(), num_segments);
-  const auto right_points =
-    resample_points(lanelet_obj.rightBound().basicLineString(), num_segments);
-
-  lanelet::ConstPoints3d center_points;
-  for (size_t i = 0; i < num_segments + 1; i++) {
-    const auto center_basic_point = (right_points.at(i) + left_points.at(i)) / 2;
-
-    const lanelet::ConstPoint3d center_point(
-      lanelet::InvalId, center_basic_point.x(), center_basic_point.y(), center_basic_point.z());
-    center_points.push_back(center_point);
-  }
-
-  const auto centerline_opt = create_safe_linestring(center_points);
-  if (!centerline_opt.has_value()) {
-    RCLCPP_ERROR(
-      rclcpp::get_logger("autoware_lanelet2_utility"),
-      "center_points has less than two points. Returning empty linestring.");
-    return lanelet::ConstLineString3d();
-  }
-
-  return *centerline_opt;
+  return build_offset_linestring(
+    lanelet_obj, resolution, /*use_unique_id=*/false, "center_points",
+    [](const lanelet::BasicPoint3d & left, const lanelet::BasicPoint3d & right)
+      -> lanelet::BasicPoint3d { return (right + left) / 2; });
 }
 
 lanelet::ConstLineString3d get_centerline_with_offset(
   const lanelet::ConstLanelet & lanelet_obj, const double offset, const double resolution)
 {
-  // get number of segments from resolution and longer bound
-  const auto num_segments = compute_num_segments(lanelet_obj, resolution);
-
-  // Resample points
-  const auto left_points = resample_points(lanelet_obj.leftBound().basicLineString(), num_segments);
-  const auto right_points =
-    resample_points(lanelet_obj.rightBound().basicLineString(), num_segments);
-
-  lanelet::ConstPoints3d center_points;
-  for (size_t i = 0; i < num_segments + 1; i++) {
-    const auto center_basic_point = (right_points.at(i) + left_points.at(i)) / 2;
-
-    const auto vec_right_2_left = (left_points.at(i) - right_points.at(i)).normalized();
-
-    const auto offset_center_basic_point = center_basic_point + vec_right_2_left * offset;
-
-    const lanelet::ConstPoint3d center_point(
-      lanelet::InvalId, offset_center_basic_point.x(), offset_center_basic_point.y(),
-      offset_center_basic_point.z());
-    center_points.push_back(center_point);
-  }
-
-  const auto centerline_opt = create_safe_linestring(center_points);
-  if (!centerline_opt.has_value()) {
-    RCLCPP_ERROR(
-      rclcpp::get_logger("autoware_lanelet2_utility"),
-      "center_points has less than two points in get_centerline_with_offset. "
-      "Returning empty linestring.");
-    return lanelet::ConstLineString3d();
-  }
-
-  return *centerline_opt;
+  return build_offset_linestring(
+    lanelet_obj, resolution, /*use_unique_id=*/false, "center_points",
+    [offset](const lanelet::BasicPoint3d & left, const lanelet::BasicPoint3d & right)
+      -> lanelet::BasicPoint3d {
+      const auto center_basic_point = (right + left) / 2;
+      const auto vec_right_2_left = (left - right).normalized();
+      return center_basic_point + vec_right_2_left * offset;
+    });
 }
 
 lanelet::ConstLineString3d get_right_bound_with_offset(
   const lanelet::ConstLanelet & lanelet_obj, const double offset, const double resolution)
 {
-  // get number of segments from resolution and longer bound
-  const auto num_segments = compute_num_segments(lanelet_obj, resolution);
-
-  // Resample points
-  const auto left_points = resample_points(lanelet_obj.leftBound().basicLineString(), num_segments);
-  const auto right_points =
-    resample_points(lanelet_obj.rightBound().basicLineString(), num_segments);
-
-  lanelet::ConstPoints3d right_bound_points;
-  for (size_t i = 0; i < num_segments + 1; i++) {
-    const auto vec_left_2_right = (right_points.at(i) - left_points.at(i)).normalized();
-
-    const auto offset_right_basic_point = right_points.at(i) + vec_left_2_right * offset;
-
-    const lanelet::ConstPoint3d right_bound_point(
-      lanelet::InvalId, offset_right_basic_point.x(), offset_right_basic_point.y(),
-      offset_right_basic_point.z());
-    right_bound_points.push_back(right_bound_point);
-  }
-  const auto right_bound_opt = create_safe_linestring(right_bound_points);
-  if (!right_bound_opt.has_value()) {
-    RCLCPP_ERROR(
-      rclcpp::get_logger("autoware_lanelet2_utility"),
-      "right_bound_points has less than two points. Returning empty linestring.");
-    return lanelet::ConstLineString3d();
-  }
-
-  return *right_bound_opt;
+  return build_offset_linestring(
+    lanelet_obj, resolution, /*use_unique_id=*/false, "right_bound_points",
+    [offset](const lanelet::BasicPoint3d & left, const lanelet::BasicPoint3d & right)
+      -> lanelet::BasicPoint3d {
+      const auto vec_left_2_right = (right - left).normalized();
+      return right + vec_left_2_right * offset;
+    });
 }
 
 lanelet::ConstLineString3d get_left_bound_with_offset(
   const lanelet::ConstLanelet & lanelet_obj, const double offset, const double resolution)
 {
-  // get number of segments from resolution and longer bound
-  const auto num_segments = compute_num_segments(lanelet_obj, resolution);
-
-  // Resample points
-  const auto left_points = resample_points(lanelet_obj.leftBound().basicLineString(), num_segments);
-  const auto right_points =
-    resample_points(lanelet_obj.rightBound().basicLineString(), num_segments);
-
-  lanelet::ConstPoints3d left_bound_points;
-  for (size_t i = 0; i < num_segments + 1; i++) {
-    const auto vec_right_2_left = (left_points.at(i) - right_points.at(i)).normalized();
-
-    const auto offset_left_basic_point = left_points.at(i) + vec_right_2_left * offset;
-
-    const lanelet::ConstPoint3d left_bound_point(
-      lanelet::utils::getId(), offset_left_basic_point.x(), offset_left_basic_point.y(),
-      offset_left_basic_point.z());
-    left_bound_points.push_back(left_bound_point);
-  }
-
-  const auto left_bound_opt = create_safe_linestring(left_bound_points);
-  if (!left_bound_opt.has_value()) {
-    RCLCPP_ERROR(
-      rclcpp::get_logger("autoware_lanelet2_utility"),
-      "left_bound_points has less than two points. Returning empty linestring.");
-    return lanelet::ConstLineString3d();
-  }
-
-  return *left_bound_opt;
+  return build_offset_linestring(
+    lanelet_obj, resolution, /*use_unique_id=*/true, "left_bound_points",
+    [offset](const lanelet::BasicPoint3d & left, const lanelet::BasicPoint3d & right)
+      -> lanelet::BasicPoint3d {
+      const auto vec_right_2_left = (left - right).normalized();
+      return left + vec_right_2_left * offset;
+    });
 }
 
 bool is_in_lanelet(

--- a/common/autoware_lanelet2_utils/test/nn_search.cpp
+++ b/common/autoware_lanelet2_utils/test/nn_search.cpp
@@ -27,6 +27,7 @@
 
 #include <filesystem>
 #include <string>
+#include <vector>
 namespace fs = std::filesystem;
 
 namespace autoware::experimental

--- a/common/autoware_lanelet2_utils/test/nn_search.cpp
+++ b/common/autoware_lanelet2_utils/test/nn_search.cpp
@@ -21,6 +21,9 @@
 
 #include <gtest/gtest.h>
 #include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/Lanelet.h>
+#include <lanelet2_core/primitives/LineString.h>
+#include <lanelet2_core/primitives/Point.h>
 
 #include <filesystem>
 #include <string>
@@ -585,6 +588,126 @@ TEST_F(TestNNSearch003, get_road_lanelets_at)
     ASSERT_TRUE(road_lanelets.empty());
     ASSERT_TRUE(shoulder_lanelets.empty());
   }
+}
+
+// Programmatically build a map with two lanelets at different heights so that find_nearest's
+// z-range filtering branch (and the find_z_range / delta_z_from_range helpers) can be exercised
+// directly. The existing yaml-based maps are not z-differentiated, so this path was untested.
+class TestNNSearchZRange : public ::testing::Test
+{
+protected:
+  // Build a lanelet with explicit valid ids so that lanelet::utils::createMap keeps both lanelets
+  // (createMap deduplicates by id, and create_safe_lanelet would assign InvalId to all of them).
+  static lanelet::Lanelet make_lanelet(
+    const std::vector<lanelet::BasicPoint3d> & left_pts,
+    const std::vector<lanelet::BasicPoint3d> & right_pts)
+  {
+    auto to_points = [](const std::vector<lanelet::BasicPoint3d> & pts) {
+      std::vector<lanelet::Point3d> out;
+      out.reserve(pts.size());
+      for (const auto & p : pts) {
+        out.emplace_back(lanelet::utils::getId(), p);
+      }
+      return out;
+    };
+    const lanelet::LineString3d left(lanelet::utils::getId(), to_points(left_pts));
+    const lanelet::LineString3d right(lanelet::utils::getId(), to_points(right_pts));
+    return lanelet::Lanelet(lanelet::utils::getId(), left, right);
+  }
+
+  void SetUp() override
+  {
+    // Lanelet A: footprint y in [-1, 1] at z = 0; covers the origin (2D distance 0 from query).
+    auto ll_low =
+      make_lanelet({{-1.0, 1.0, 0.0}, {1.0, 1.0, 0.0}}, {{-1.0, -1.0, 0.0}, {1.0, -1.0, 0.0}});
+    // Lanelet B: footprint y in [3, 5] at z = 10; in range in 2D but 10 m above query.
+    auto ll_high =
+      make_lanelet({{-1.0, 5.0, 10.0}, {1.0, 5.0, 10.0}}, {{-1.0, 3.0, 10.0}, {1.0, 3.0, 10.0}});
+
+    low_id_ = ll_low.id();
+    high_id_ = ll_high.id();
+
+    lanelet::Lanelets lanelets{ll_low, ll_high};
+    map_ = lanelet::utils::createMap(lanelets);
+  }
+
+  lanelet::LaneletMapPtr map_;
+  lanelet::Id low_id_{lanelet::InvalId};
+  lanelet::Id high_id_{lanelet::InvalId};
+
+  static geometry_msgs::msg::Pose make_pose(double x, double y, double z)
+  {
+    geometry_msgs::msg::Pose pose;
+    pose.position.x = x;
+    pose.position.y = y;
+    pose.position.z = z;
+    pose.orientation.w = 1.0;
+    return pose;
+  }
+};
+
+TEST_F(TestNNSearchZRange, large_z_range_keeps_both_lanelets)
+{
+  // z_range large enough to cover the 10 m height gap: both lanelets pass the filter.
+  const auto query = make_pose(0.0, 0.0, 0.0);
+  const auto nearests =
+    lanelet2_utils::find_nearest(map_->laneletLayer, query, 5, /*r_range=*/20.0, /*z_range=*/20.0);
+  ASSERT_EQ(nearests.size(), 2u);
+  // The low lanelet contains the query, so its 2D distance is 0 and it sorts first.
+  EXPECT_EQ(nearests.front().second.id(), low_id_);
+  EXPECT_DOUBLE_EQ(nearests.front().first, 0.0);
+}
+
+TEST_F(TestNNSearchZRange, small_z_range_filters_out_high_lanelet)
+{
+  // z_range smaller than the 10 m gap: the high lanelet is filtered out (above-range branch of
+  // delta_z_from_range), only the low lanelet remains.
+  const auto query = make_pose(0.0, 0.0, 0.0);
+  const auto nearests =
+    lanelet2_utils::find_nearest(map_->laneletLayer, query, 5, /*r_range=*/20.0, /*z_range=*/0.5);
+  ASSERT_EQ(nearests.size(), 1u);
+  EXPECT_EQ(nearests.front().second.id(), low_id_);
+}
+
+TEST_F(TestNNSearchZRange, small_z_range_filters_out_low_lanelet_from_above)
+{
+  // Query at z = 10 with a small z_range: now the low lanelet is below range and is filtered out,
+  // exercising the below-range branch of delta_z_from_range.
+  const auto query = make_pose(0.0, 0.0, 10.0);
+  const auto nearests =
+    lanelet2_utils::find_nearest(map_->laneletLayer, query, 5, /*r_range=*/20.0, /*z_range=*/0.5);
+  ASSERT_EQ(nearests.size(), 1u);
+  EXPECT_EQ(nearests.front().second.id(), high_id_);
+}
+
+TEST_F(TestNNSearchZRange, zero_z_range_disables_height_filtering)
+{
+  // z_range == 0 takes the "no height filtering" branch, so both lanelets are returned even though
+  // they are 10 m apart in z.
+  const auto query = make_pose(0.0, 0.0, 0.0);
+  const auto nearests =
+    lanelet2_utils::find_nearest(map_->laneletLayer, query, 5, /*r_range=*/20.0, /*z_range=*/0.0);
+  ASSERT_EQ(nearests.size(), 2u);
+}
+
+TEST_F(TestNNSearchZRange, invalid_arguments_return_empty)
+{
+  const auto query = make_pose(0.0, 0.0, 0.0);
+  // count == 0
+  EXPECT_TRUE(lanelet2_utils::find_nearest(map_->laneletLayer, query, 0, 20.0, 2.0).empty());
+  // r_range < 0
+  EXPECT_TRUE(lanelet2_utils::find_nearest(map_->laneletLayer, query, 5, -1.0, 2.0).empty());
+  // z_range < 0
+  EXPECT_TRUE(lanelet2_utils::find_nearest(map_->laneletLayer, query, 5, 20.0, -1.0).empty());
+}
+
+TEST_F(TestNNSearchZRange, no_candidate_in_radius_returns_empty)
+{
+  // Query far away with a tiny r_range: the 2D bounding-box search finds nothing.
+  const auto query = make_pose(1000.0, 1000.0, 0.0);
+  const auto nearests =
+    lanelet2_utils::find_nearest(map_->laneletLayer, query, 5, /*r_range=*/1.0, /*z_range=*/2.0);
+  EXPECT_TRUE(nearests.empty());
 }
 
 }  // namespace autoware::experimental


### PR DESCRIPTION
## Description

Part of the autoware_core quality campaign (testability + coverage + de-duplication), one ROS package per PR.

Internal-only cleanup of `src/geometry.cpp` plus a coverage test for the previously untested z-range branch in `nn_search`.

- **`get_pose_from_2d_arc_length`**: replace the hand-rolled half-yaw quaternion (`half_yaw = atan2(...) * 0.5`, `orientation.z = sin`, `orientation.w = cos`) and the field-by-field point assignment with `autoware_utils_geometry::create_quaternion_from_yaw(yaw)` / `create_point(x, y, z)`. The same file already used `create_quaternion_from_yaw` in `get_closest_center_pose`, so this removes an inconsistent re-implementation and guarantees a normalized quaternion.
- **`get_closest_center_pose`**: use `create_quaternion(0, 0, 0, 1)` for the identity-orientation fallback instead of a hand-written literal.
- **`compute_num_segments`**: compute the segment count directly in `size_t` (`std::max<size_t>(static_cast<size_t>(std::ceil(longer_distance / resolution)), 1)`), removing the prior `static_cast<int>(ceil(...))` narrowing on very long bounds and the bare `ceil`.
- **Dedup the four offset-bound builders** (`get_fine_centerline`, `get_centerline_with_offset`, `get_right_bound_with_offset`, `get_left_bound_with_offset`) into a single anonymous-namespace template helper `build_offset_linestring(lanelet, resolution, use_unique_id, error_context, point_fn)`. The helper centralizes the resample + per-index loop + `create_safe_linestring` + diagnostic scaffolding; each builder now only supplies its per-point formula and id policy. The left-bound builder keeps its `lanelet::utils::getId()` unique-id behavior; the other three keep `lanelet::InvalId`.

## Related links

**Parent Issue:** autowarefoundation/autoware_core#1096

## How was this PR tested?

Adds `TestNNSearchZRange` to `test/nn_search.cpp`, building a programmatic 2-lanelet map at z=0 and z=10 (with explicit valid ids, since `lanelet::utils::createMap` deduplicates by id) to exercise `find_nearest`'s z-range filtering that the yaml-based maps never reached:

- large z_range keeps both lanelets (in-range branch)
- small z_range filters the high lanelet (above-range branch of `delta_z_from_range`)
- query above with small z_range filters the low lanelet (below-range branch)
- z_range == 0 disables height filtering
- early-return guards: `count == 0`, `r_range < 0`, `z_range < 0`
- empty result when nothing is within `r_range`

`colcon build` + `colcon test --packages-select autoware_lanelet2_utils` in the `autoware:core-devel-jazzy` container — all tests pass.

## Notes for reviewers

No public signature changes. The only observable difference is the text of one `RCLCPP_ERROR` diagnostic in `get_centerline_with_offset` (it now uses the shared helper's message); the returned value (empty linestring) is unchanged.

## Interface changes

None.

## Effects on system behavior

None. The geometry-helper swaps are numerically equivalent (and now guarantee a normalized quaternion), and the offset-bound dedup preserves each builder's id policy and output. The only observable change is the wording of one error-log diagnostic.

## youtalk fork CI — build-and-test all green

The full `build-test-tidy-pr` workflow runs on the youtalk fork (`ubicloud-standard-16`). All build-and-test gate jobs pass for head commit `405909c5` ([workflow run](https://github.com/youtalk/autoware_core/actions/runs/26668770429)):

- ✅ `build-and-test-diff-humble / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26668770429/job/78607683447
- ✅ `build-and-test-diff-jazzy / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26668770429/job/78607683462
- ✅ `build-and-test-diff-jazzy-agnocast / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26668770429/job/78607683433
- ✅ `build-and-test-diff-humble / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26668770429/job/78608150717
- ✅ `build-and-test-diff-jazzy / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26668770429/job/78608226226

(The `*-above` universe jobs are bonus coverage and excluded from the gate. Their red here is the pre-existing `autoware_static_centerline_generator` headless-Qt GUI launch-test failure in the universe set — unrelated to this `common/` change.)
