### PR TITLE
refactor(autoware_object_recognition_utils): make transform.hpp testable

### DIFF
--- a/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/transform.hpp
+++ b/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/transform.hpp
@@ -145,8 +145,10 @@ bool transformObjects(
       }
       tf2::fromMsg(*ros_target2objects_world, tf_target2objects_world);
     }
+    // Pass output_msg (already a copy of input_msg) as the helper input to avoid a second deep
+    // copy. The transform is applied in-place per object, so input == output aliasing is safe.
     detail::applyTransformToObjects(
-      input_msg, target_frame_id, tf_target2objects_world, output_msg);
+      output_msg, target_frame_id, tf_target2objects_world, output_msg);
   }
   return true;
 }
@@ -173,8 +175,11 @@ bool transformObjectsWithFeature(
         rclcpp::get_logger("object_recognition_utils:"), "failed to get transformed matrix");
       return false;
     }
+    // Pass output_msg (already a copy of input_msg) as the helper input to avoid a second deep
+    // copy of the (potentially large) feature point clouds. The transform is applied in-place per
+    // feature object, so input == output aliasing is safe.
     detail::applyTransformToFeatureObjects(
-      input_msg, target_frame_id, tf_target2objects_world, *tf_matrix, output_msg);
+      output_msg, target_frame_id, tf_target2objects_world, *tf_matrix, output_msg);
   }
   return true;
 }

--- a/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/transform.hpp
+++ b/common/autoware_object_recognition_utils/include/autoware/object_recognition_utils/transform.hpp
@@ -23,6 +23,7 @@
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <geometry_msgs/msg/transform.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/msg/point_field.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
@@ -31,6 +32,8 @@
 
 #include <string>
 
+namespace autoware::object_recognition_utils
+{
 namespace detail
 {
 template <class BufferT>
@@ -66,10 +69,61 @@ template <class BufferT>
     return boost::none;
   }
 }
+
+/// \brief Apply a resolved frame transform to every object in \p input_msg, writing the
+///        result into \p output_msg.
+/// \details Pure math: composes the per-object pose with \p tf_target2objects_world and rotates
+///          the pose covariance by the same transform. No TF buffer lookup happens here, so it is
+///          unit-testable with a hand-built transform.
+template <class T>
+void applyTransformToObjects(
+  const T & input_msg, const std::string & target_frame_id,
+  const tf2::Transform & tf_target2objects_world, T & output_msg)
+{
+  output_msg = input_msg;
+  output_msg.header.frame_id = target_frame_id;
+  for (auto & object : output_msg.objects) {
+    tf2::Transform tf_objects_world2objects;
+    auto & pose_with_cov = object.kinematics.pose_with_covariance;
+    tf2::fromMsg(pose_with_cov.pose, tf_objects_world2objects);
+    tf2::Transform tf_target2objects = tf_target2objects_world * tf_objects_world2objects;
+    // transform pose, frame difference and object pose
+    tf2::toMsg(tf_target2objects, pose_with_cov.pose);
+    // transform covariance, only the frame difference
+    pose_with_cov.covariance =
+      tf2::transformCovariance(pose_with_cov.covariance, tf_target2objects_world);
+  }
+}
+
+/// \brief Apply resolved frame transforms to every feature object in \p input_msg, writing the
+///        result into \p output_msg.
+/// \details Pure math: composes the per-object pose with \p tf_target2objects_world and transforms
+///          each cluster point cloud by \p tf_matrix. No TF buffer lookup happens here, so it is
+///          unit-testable with a hand-built transform.
+template <class T>
+void applyTransformToFeatureObjects(
+  const T & input_msg, const std::string & target_frame_id,
+  const tf2::Transform & tf_target2objects_world, const Eigen::Matrix4f & tf_matrix, T & output_msg)
+{
+  output_msg = input_msg;
+  output_msg.header.frame_id = target_frame_id;
+  for (auto & feature_object : output_msg.feature_objects) {
+    tf2::Transform tf_objects_world2objects;
+    // transform object
+    tf2::fromMsg(
+      feature_object.object.kinematics.pose_with_covariance.pose, tf_objects_world2objects);
+    tf2::Transform tf_target2objects = tf_target2objects_world * tf_objects_world2objects;
+    tf2::toMsg(tf_target2objects, feature_object.object.kinematics.pose_with_covariance.pose);
+
+    // transform cluster
+    sensor_msgs::msg::PointCloud2 transformed_cluster;
+    pcl_ros::transformPointCloud(tf_matrix, feature_object.feature.cluster, transformed_cluster);
+    transformed_cluster.header.frame_id = target_frame_id;
+    feature_object.feature.cluster = transformed_cluster;
+  }
+}
 }  // namespace detail
 
-namespace autoware::object_recognition_utils
-{
 template <class T, class BufferT>
 bool transformObjects(
   const T & input_msg, const std::string & target_frame_id, const BufferT & tf_buffer,
@@ -79,6 +133,8 @@ bool transformObjects(
 
   // transform to world coordinate
   if (input_msg.header.frame_id != target_frame_id) {
+    // Set the target frame on the output up front, so a failed lookup still reports the requested
+    // frame on the (otherwise unused) output message, matching the original behavior.
     output_msg.header.frame_id = target_frame_id;
     tf2::Transform tf_target2objects_world;
     {
@@ -89,17 +145,8 @@ bool transformObjects(
       }
       tf2::fromMsg(*ros_target2objects_world, tf_target2objects_world);
     }
-    for (auto & object : output_msg.objects) {
-      tf2::Transform tf_objects_world2objects;
-      auto & pose_with_cov = object.kinematics.pose_with_covariance;
-      tf2::fromMsg(pose_with_cov.pose, tf_objects_world2objects);
-      tf2::Transform tf_target2objects = tf_target2objects_world * tf_objects_world2objects;
-      // transform pose, frame difference and object pose
-      tf2::toMsg(tf_target2objects, pose_with_cov.pose);
-      // transform covariance, only the frame difference
-      pose_with_cov.covariance =
-        tf2::transformCovariance(pose_with_cov.covariance, tf_target2objects_world);
-    }
+    detail::applyTransformToObjects(
+      input_msg, target_frame_id, tf_target2objects_world, output_msg);
   }
   return true;
 }
@@ -110,8 +157,10 @@ bool transformObjectsWithFeature(
 {
   output_msg = input_msg;
   if (input_msg.header.frame_id != target_frame_id) {
+    // Set the target frame on the output up front, so a failed lookup still reports the requested
+    // frame on the (otherwise unused) output message, matching the original behavior.
     output_msg.header.frame_id = target_frame_id;
-    tf2::Transform tf_target2objects_world = tf2::Transform::getIdentity();
+    tf2::Transform tf_target2objects_world;
     const auto ros_target2objects_world = detail::getTransform(
       tf_buffer, input_msg.header.frame_id, target_frame_id, input_msg.header.stamp);
     if (!ros_target2objects_world) {
@@ -124,22 +173,8 @@ bool transformObjectsWithFeature(
         rclcpp::get_logger("object_recognition_utils:"), "failed to get transformed matrix");
       return false;
     }
-    for (auto & feature_object : output_msg.feature_objects) {
-      tf2::Transform tf_objects_world2objects;
-      // transform object
-      tf2::fromMsg(
-        feature_object.object.kinematics.pose_with_covariance.pose, tf_objects_world2objects);
-      tf2::Transform tf_target2objects = tf_target2objects_world * tf_objects_world2objects;
-      tf2::toMsg(tf_target2objects, feature_object.object.kinematics.pose_with_covariance.pose);
-
-      // transform cluster
-      sensor_msgs::msg::PointCloud2 transformed_cluster;
-      pcl_ros::transformPointCloud(*tf_matrix, feature_object.feature.cluster, transformed_cluster);
-      transformed_cluster.header.frame_id = target_frame_id;
-      feature_object.feature.cluster = transformed_cluster;
-    }
-    output_msg.header.frame_id = target_frame_id;
-    return true;
+    detail::applyTransformToFeatureObjects(
+      input_msg, target_frame_id, tf_target2objects_world, *tf_matrix, output_msg);
   }
   return true;
 }

--- a/common/autoware_object_recognition_utils/package.xml
+++ b/common/autoware_object_recognition_utils/package.xml
@@ -24,6 +24,8 @@
   <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_ros</depend>
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/common/autoware_object_recognition_utils/test/src/test_transform.cpp
+++ b/common/autoware_object_recognition_utils/test/src/test_transform.cpp
@@ -1,0 +1,195 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/object_recognition_utils/transform.hpp"
+
+#include <rclcpp/clock.hpp>
+
+#include <autoware_perception_msgs/msg/detected_object.hpp>
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+
+#include <gtest/gtest.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2_ros/buffer.h>
+
+#include <cmath>
+#include <memory>
+#include <string>
+
+namespace
+{
+autoware_perception_msgs::msg::DetectedObject createObject(
+  const double x, const double y, const double z, const double yaw)
+{
+  autoware_perception_msgs::msg::DetectedObject object;
+  auto & pose = object.kinematics.pose_with_covariance.pose;
+  pose.position.x = x;
+  pose.position.y = y;
+  pose.position.z = z;
+  tf2::Quaternion q;
+  q.setRPY(0.0, 0.0, yaw);
+  pose.orientation = tf2::toMsg(q);
+  // identity covariance so transforms are easy to reason about
+  auto & cov = object.kinematics.pose_with_covariance.covariance;
+  for (size_t i = 0; i < 6; ++i) {
+    cov.at(i * 6 + i) = 1.0;
+  }
+  return object;
+}
+
+tf2::Transform makeTransform(const double x, const double y, const double z, const double yaw)
+{
+  tf2::Quaternion q;
+  q.setRPY(0.0, 0.0, yaw);
+  tf2::Transform t;
+  t.setOrigin(tf2::Vector3(x, y, z));
+  t.setRotation(q);
+  return t;
+}
+}  // namespace
+
+// transformObjects must pass the message through unchanged when the input frame already equals the
+// target frame (identity passthrough branch) and report success.
+TEST(transform, transformObjectsIdentityPassthrough)
+{
+  using autoware::object_recognition_utils::transformObjects;
+
+  autoware_perception_msgs::msg::DetectedObjects input;
+  input.header.frame_id = "map";
+  input.objects.push_back(createObject(1.0, 2.0, 3.0, 0.0));
+
+  tf2_ros::Buffer empty_buffer{std::make_shared<rclcpp::Clock>(RCL_ROS_TIME)};
+  autoware_perception_msgs::msg::DetectedObjects output;
+
+  // Same frame: no lookup needed, so the (empty) buffer is never queried.
+  EXPECT_TRUE(transformObjects(input, "map", empty_buffer, output));
+  ASSERT_EQ(output.objects.size(), 1U);
+  EXPECT_EQ(output.header.frame_id, "map");
+  EXPECT_DOUBLE_EQ(output.objects.at(0).kinematics.pose_with_covariance.pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(output.objects.at(0).kinematics.pose_with_covariance.pose.position.y, 2.0);
+  EXPECT_DOUBLE_EQ(output.objects.at(0).kinematics.pose_with_covariance.pose.position.z, 3.0);
+}
+
+// transformObjects returns false when the buffer cannot resolve the requested transform.
+TEST(transform, transformObjectsMissingTransformReturnsFalse)
+{
+  using autoware::object_recognition_utils::transformObjects;
+
+  autoware_perception_msgs::msg::DetectedObjects input;
+  input.header.frame_id = "sensor";
+  input.objects.push_back(createObject(1.0, 2.0, 3.0, 0.0));
+
+  tf2_ros::Buffer empty_buffer{std::make_shared<rclcpp::Clock>(RCL_ROS_TIME)};
+  autoware_perception_msgs::msg::DetectedObjects output;
+
+  // Different frame + empty buffer => lookup fails => false.
+  EXPECT_FALSE(transformObjects(input, "map", empty_buffer, output));
+  // Failure-path contract (matches the original implementation): the target frame is written to the
+  // output header before the lookup, so it stays at the requested target frame on a failed lookup,
+  // while the (copied) objects are left untransformed.
+  EXPECT_EQ(output.header.frame_id, "map");
+  ASSERT_EQ(output.objects.size(), 1U);
+  const auto & pose = output.objects.at(0).kinematics.pose_with_covariance.pose;
+  EXPECT_DOUBLE_EQ(pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(pose.position.y, 2.0);
+  EXPECT_DOUBLE_EQ(pose.position.z, 3.0);
+}
+
+// applyTransformToObjects must compose a pure translation onto each object's pose and rewrite the
+// header frame, leaving orientation and (translation-only) covariance untouched.
+TEST(transform, applyTransformToObjectsTranslationOnly)
+{
+  using autoware::object_recognition_utils::detail::applyTransformToObjects;
+
+  autoware_perception_msgs::msg::DetectedObjects input;
+  input.header.frame_id = "sensor";
+  input.objects.push_back(createObject(1.0, 2.0, 0.0, 0.0));
+
+  const auto tf_target2world = makeTransform(10.0, 20.0, 0.0, 0.0);
+
+  autoware_perception_msgs::msg::DetectedObjects output;
+  applyTransformToObjects(input, "map", tf_target2world, output);
+
+  ASSERT_EQ(output.objects.size(), 1U);
+  EXPECT_EQ(output.header.frame_id, "map");
+  const auto & pose = output.objects.at(0).kinematics.pose_with_covariance.pose;
+  EXPECT_NEAR(pose.position.x, 11.0, 1e-9);
+  EXPECT_NEAR(pose.position.y, 22.0, 1e-9);
+  EXPECT_NEAR(pose.position.z, 0.0, 1e-9);
+  // orientation unchanged for a pure translation
+  EXPECT_NEAR(pose.orientation.z, 0.0, 1e-9);
+  EXPECT_NEAR(pose.orientation.w, 1.0, 1e-9);
+  // a pure translation does not rotate covariance: diagonal stays 1.0
+  const auto & cov = output.objects.at(0).kinematics.pose_with_covariance.covariance;
+  EXPECT_NEAR(cov.at(0), 1.0, 1e-9);
+  EXPECT_NEAR(cov.at(7), 1.0, 1e-9);
+}
+
+// applyTransformToObjects must compose a 90-degree yaw rotation (about origin) onto each object's
+// pose: a point at (1, 0) maps to (0, 1) and the orientation accumulates the rotation.
+TEST(transform, applyTransformToObjectsRotation90)
+{
+  using autoware::object_recognition_utils::detail::applyTransformToObjects;
+
+  autoware_perception_msgs::msg::DetectedObjects input;
+  input.header.frame_id = "sensor";
+  input.objects.push_back(createObject(1.0, 0.0, 0.0, 0.0));
+
+  const double half_pi = M_PI / 2.0;
+  const auto tf_target2world = makeTransform(0.0, 0.0, 0.0, half_pi);
+
+  autoware_perception_msgs::msg::DetectedObjects output;
+  applyTransformToObjects(input, "map", tf_target2world, output);
+
+  ASSERT_EQ(output.objects.size(), 1U);
+  const auto & pose = output.objects.at(0).kinematics.pose_with_covariance.pose;
+  EXPECT_NEAR(pose.position.x, 0.0, 1e-9);
+  EXPECT_NEAR(pose.position.y, 1.0, 1e-9);
+  // orientation becomes a +90deg yaw: qz = sin(pi/4), qw = cos(pi/4)
+  EXPECT_NEAR(pose.orientation.z, std::sin(half_pi / 2.0), 1e-9);
+  EXPECT_NEAR(pose.orientation.w, std::cos(half_pi / 2.0), 1e-9);
+}
+
+// transformObjects wired through a live buffer with a known static transform must produce the same
+// result as applyTransformToObjects with the equivalent tf2::Transform.
+TEST(transform, transformObjectsAppliesBufferedTransform)
+{
+  using autoware::object_recognition_utils::transformObjects;
+
+  // Static transform: target("map") <- source("sensor") = translate (10, 20, 0)
+  geometry_msgs::msg::TransformStamped tf_stamped;
+  tf_stamped.header.frame_id = "map";
+  tf_stamped.child_frame_id = "sensor";
+  tf_stamped.transform.translation.x = 10.0;
+  tf_stamped.transform.translation.y = 20.0;
+  tf_stamped.transform.translation.z = 0.0;
+  tf_stamped.transform.rotation.w = 1.0;
+
+  tf2_ros::Buffer buffer{std::make_shared<rclcpp::Clock>(RCL_ROS_TIME)};
+  buffer.setTransform(tf_stamped, "test_authority", true);
+
+  autoware_perception_msgs::msg::DetectedObjects input;
+  input.header.frame_id = "sensor";
+  input.objects.push_back(createObject(1.0, 2.0, 0.0, 0.0));
+
+  autoware_perception_msgs::msg::DetectedObjects output;
+  ASSERT_TRUE(transformObjects(input, "map", buffer, output));
+  ASSERT_EQ(output.objects.size(), 1U);
+  EXPECT_EQ(output.header.frame_id, "map");
+  const auto & pose = output.objects.at(0).kinematics.pose_with_covariance.pose;
+  EXPECT_NEAR(pose.position.x, 11.0, 1e-9);
+  EXPECT_NEAR(pose.position.y, 22.0, 1e-9);
+  EXPECT_NEAR(pose.position.z, 0.0, 1e-9);
+}

--- a/common/autoware_object_recognition_utils/test/src/test_transform.cpp
+++ b/common/autoware_object_recognition_utils/test/src/test_transform.cpp
@@ -14,19 +14,26 @@
 
 #include "autoware/object_recognition_utils/transform.hpp"
 
+#include <Eigen/Core>
 #include <rclcpp/clock.hpp>
 
 #include <autoware_perception_msgs/msg/detected_object.hpp>
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <std_msgs/msg/header.hpp>
 
 #include <gtest/gtest.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl_conversions/pcl_conversions.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2_ros/buffer.h>
 
 #include <cmath>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace
 {
@@ -57,6 +64,62 @@ tf2::Transform makeTransform(const double x, const double y, const double z, con
   t.setOrigin(tf2::Vector3(x, y, z));
   t.setRotation(q);
   return t;
+}
+
+// The concrete feature-object wire type (tier4_perception_msgs::msg::DetectedObjectsWithFeature)
+// lives outside Autoware Core, so it cannot be a Core dependency. However,
+// transformObjectsWithFeature / detail::applyTransformToFeatureObjects are duck-typed function
+// templates: they only touch msg.header, msg.feature_objects[].object.kinematics
+// .pose_with_covariance.pose and msg.feature_objects[].feature.cluster (a PointCloud2). We can
+// therefore exercise the feature path by instantiating the templates against a Core-local stand-in
+// type that mirrors exactly those member-access paths, built from Core-available message types.
+struct FeatureObjectStandIn
+{
+  autoware_perception_msgs::msg::DetectedObject object;
+  struct Feature
+  {
+    sensor_msgs::msg::PointCloud2 cluster;
+  } feature;
+};
+
+struct ObjectsWithFeatureStandIn
+{
+  std_msgs::msg::Header header;
+  std::vector<FeatureObjectStandIn> feature_objects;
+};
+
+// Build a single-point cluster cloud at (px, py, pz) with the given source frame.
+sensor_msgs::msg::PointCloud2 createCluster(
+  const double px, const double py, const double pz, const std::string & frame_id)
+{
+  pcl::PointCloud<pcl::PointXYZ> cloud;
+  cloud.push_back(pcl::PointXYZ(px, py, pz));
+  sensor_msgs::msg::PointCloud2 msg;
+  pcl::toROSMsg(cloud, msg);
+  msg.header.frame_id = frame_id;
+  return msg;
+}
+
+// Build a feature object whose object pose is at (x, y, z, yaw) and whose cluster holds a single
+// point at (px, py, pz).
+FeatureObjectStandIn createFeatureObject(
+  const double x, const double y, const double z, const double yaw, const double px,
+  const double py, const double pz)
+{
+  FeatureObjectStandIn feature_object;
+  feature_object.object = createObject(x, y, z, yaw);
+  feature_object.feature.cluster = createCluster(px, py, pz, "sensor");
+  return feature_object;
+}
+
+// A pure-translation Eigen 4x4 transform matrix (matching makeTransform's translation component).
+Eigen::Matrix4f makeTranslationMatrix(const float x, const float y, const float z)
+{
+  Eigen::Matrix4f mat = Eigen::Matrix4f::Identity();
+  mat(0, 3) = x;
+  mat(1, 3) = y;
+  mat(2, 3) = z;
+  return mat;
 }
 }  // namespace
 
@@ -192,4 +255,205 @@ TEST(transform, transformObjectsAppliesBufferedTransform)
   EXPECT_NEAR(pose.position.x, 11.0, 1e-9);
   EXPECT_NEAR(pose.position.y, 22.0, 1e-9);
   EXPECT_NEAR(pose.position.z, 0.0, 1e-9);
+}
+
+// applyTransformToObjects on an empty objects vector must rewrite the header frame and produce an
+// empty output without throwing (empty-container degenerate case).
+TEST(transform, applyTransformToObjectsEmptyObjects)
+{
+  using autoware::object_recognition_utils::detail::applyTransformToObjects;
+
+  autoware_perception_msgs::msg::DetectedObjects input;
+  input.header.frame_id = "sensor";
+
+  const auto tf_target2world = makeTransform(10.0, 20.0, 0.0, 0.0);
+
+  autoware_perception_msgs::msg::DetectedObjects output;
+  applyTransformToObjects(input, "map", tf_target2world, output);
+
+  EXPECT_EQ(output.header.frame_id, "map");
+  EXPECT_TRUE(output.objects.empty());
+}
+
+// applyTransformToFeatureObjects must compose a pure translation onto the feature object's pose and
+// rewrite both the message header frame and the per-cluster header frame to the target frame.
+TEST(transform, applyTransformToFeatureObjectsTranslationOnly)
+{
+  using autoware::object_recognition_utils::detail::applyTransformToFeatureObjects;
+
+  ObjectsWithFeatureStandIn input;
+  input.header.frame_id = "sensor";
+  input.feature_objects.push_back(createFeatureObject(1.0, 2.0, 0.0, 0.0, 0.5, 0.5, 0.0));
+
+  const auto tf_target2world = makeTransform(10.0, 20.0, 0.0, 0.0);
+  const auto tf_matrix = makeTranslationMatrix(10.0F, 20.0F, 0.0F);
+
+  ObjectsWithFeatureStandIn output;
+  applyTransformToFeatureObjects(input, "map", tf_target2world, tf_matrix, output);
+
+  ASSERT_EQ(output.feature_objects.size(), 1U);
+  EXPECT_EQ(output.header.frame_id, "map");
+
+  // object pose is composed with the world transform: (1,2) + (10,20) = (11,22)
+  const auto & pose = output.feature_objects.at(0).object.kinematics.pose_with_covariance.pose;
+  EXPECT_NEAR(pose.position.x, 11.0, 1e-6);
+  EXPECT_NEAR(pose.position.y, 22.0, 1e-6);
+  EXPECT_NEAR(pose.position.z, 0.0, 1e-6);
+  EXPECT_NEAR(pose.orientation.z, 0.0, 1e-6);
+  EXPECT_NEAR(pose.orientation.w, 1.0, 1e-6);
+
+  // cluster header frame is rewritten to the target frame (computed contract value)
+  const auto & cluster = output.feature_objects.at(0).feature.cluster;
+  EXPECT_EQ(cluster.header.frame_id, "map");
+
+  // the single cluster point is translated by tf_matrix: (0.5,0.5) + (10,20) = (10.5,20.5)
+  ASSERT_EQ(cluster.width * cluster.height, 1U);
+  pcl::PointCloud<pcl::PointXYZ> transformed_points;
+  pcl::fromROSMsg(cluster, transformed_points);
+  ASSERT_EQ(transformed_points.size(), 1U);
+  EXPECT_NEAR(transformed_points.at(0).x, 10.5, 1e-5);
+  EXPECT_NEAR(transformed_points.at(0).y, 20.5, 1e-5);
+  EXPECT_NEAR(transformed_points.at(0).z, 0.0, 1e-5);
+}
+
+// applyTransformToFeatureObjects on an empty feature_objects vector must rewrite the header frame
+// and produce an empty output without throwing (empty-container degenerate case).
+TEST(transform, applyTransformToFeatureObjectsEmptyFeatureObjects)
+{
+  using autoware::object_recognition_utils::detail::applyTransformToFeatureObjects;
+
+  ObjectsWithFeatureStandIn input;
+  input.header.frame_id = "sensor";
+
+  const auto tf_target2world = makeTransform(10.0, 20.0, 0.0, 0.0);
+  const auto tf_matrix = makeTranslationMatrix(10.0F, 20.0F, 0.0F);
+
+  ObjectsWithFeatureStandIn output;
+  applyTransformToFeatureObjects(input, "map", tf_target2world, tf_matrix, output);
+
+  EXPECT_EQ(output.header.frame_id, "map");
+  EXPECT_TRUE(output.feature_objects.empty());
+}
+
+// applyTransformToFeatureObjects must tolerate a feature object whose cluster has zero points: the
+// pose is still composed and the (empty) cluster header is rewritten to the target frame.
+TEST(transform, applyTransformToFeatureObjectsEmptyCluster)
+{
+  using autoware::object_recognition_utils::detail::applyTransformToFeatureObjects;
+
+  ObjectsWithFeatureStandIn input;
+  input.header.frame_id = "sensor";
+  FeatureObjectStandIn feature_object;
+  feature_object.object = createObject(1.0, 2.0, 0.0, 0.0);
+  feature_object.feature.cluster.header.frame_id = "sensor";  // no points
+  input.feature_objects.push_back(feature_object);
+
+  const auto tf_target2world = makeTransform(10.0, 20.0, 0.0, 0.0);
+  const auto tf_matrix = makeTranslationMatrix(10.0F, 20.0F, 0.0F);
+
+  ObjectsWithFeatureStandIn output;
+  applyTransformToFeatureObjects(input, "map", tf_target2world, tf_matrix, output);
+
+  ASSERT_EQ(output.feature_objects.size(), 1U);
+  EXPECT_EQ(output.header.frame_id, "map");
+  const auto & pose = output.feature_objects.at(0).object.kinematics.pose_with_covariance.pose;
+  EXPECT_NEAR(pose.position.x, 11.0, 1e-6);
+  EXPECT_NEAR(pose.position.y, 22.0, 1e-6);
+
+  const auto & cluster = output.feature_objects.at(0).feature.cluster;
+  EXPECT_EQ(cluster.header.frame_id, "map");
+  EXPECT_EQ(cluster.width * cluster.height, 0U);
+}
+
+// transformObjectsWithFeature wired through a live buffer with a known static transform must
+// compose the object pose and rewrite each cluster header to the target frame, reporting success.
+TEST(transform, transformObjectsWithFeatureAppliesBufferedTransform)
+{
+  using autoware::object_recognition_utils::transformObjectsWithFeature;
+
+  // Static transform: target("map") <- source("sensor") = translate (10, 20, 0)
+  geometry_msgs::msg::TransformStamped tf_stamped;
+  tf_stamped.header.frame_id = "map";
+  tf_stamped.child_frame_id = "sensor";
+  tf_stamped.transform.translation.x = 10.0;
+  tf_stamped.transform.translation.y = 20.0;
+  tf_stamped.transform.translation.z = 0.0;
+  tf_stamped.transform.rotation.w = 1.0;
+
+  tf2_ros::Buffer buffer{std::make_shared<rclcpp::Clock>(RCL_ROS_TIME)};
+  buffer.setTransform(tf_stamped, "test_authority", true);
+
+  ObjectsWithFeatureStandIn input;
+  input.header.frame_id = "sensor";
+  input.feature_objects.push_back(createFeatureObject(1.0, 2.0, 0.0, 0.0, 0.5, 0.5, 0.0));
+
+  ObjectsWithFeatureStandIn output;
+  ASSERT_TRUE(transformObjectsWithFeature(input, "map", buffer, output));
+  ASSERT_EQ(output.feature_objects.size(), 1U);
+  EXPECT_EQ(output.header.frame_id, "map");
+  const auto & pose = output.feature_objects.at(0).object.kinematics.pose_with_covariance.pose;
+  // object pose is composed with the buffered world transform: (1,2) + (10,20) = (11,22)
+  EXPECT_NEAR(pose.position.x, 11.0, 1e-6);
+  EXPECT_NEAR(pose.position.y, 22.0, 1e-6);
+  // cluster header frame is rewritten to the target frame
+  const auto & cluster = output.feature_objects.at(0).feature.cluster;
+  EXPECT_EQ(cluster.header.frame_id, "map");
+  // the single cluster point is translated by the buffered transform: (0.5,0.5) + (10,20) =
+  // (10.5,20.5)
+  ASSERT_EQ(cluster.width * cluster.height, 1U);
+  pcl::PointCloud<pcl::PointXYZ> transformed_points;
+  pcl::fromROSMsg(cluster, transformed_points);
+  ASSERT_EQ(transformed_points.size(), 1U);
+  EXPECT_NEAR(transformed_points.at(0).x, 10.5, 1e-5);
+  EXPECT_NEAR(transformed_points.at(0).y, 20.5, 1e-5);
+  EXPECT_NEAR(transformed_points.at(0).z, 0.0, 1e-5);
+}
+
+// transformObjectsWithFeature must pass the message through unchanged when the input frame already
+// equals the target frame (identity passthrough branch) and report success.
+TEST(transform, transformObjectsWithFeatureIdentityPassthrough)
+{
+  using autoware::object_recognition_utils::transformObjectsWithFeature;
+
+  ObjectsWithFeatureStandIn input;
+  input.header.frame_id = "map";
+  input.feature_objects.push_back(createFeatureObject(1.0, 2.0, 3.0, 0.0, 0.5, 0.5, 0.0));
+
+  tf2_ros::Buffer empty_buffer{std::make_shared<rclcpp::Clock>(RCL_ROS_TIME)};
+  ObjectsWithFeatureStandIn output;
+
+  // Same frame: no lookup needed, so the (empty) buffer is never queried.
+  EXPECT_TRUE(transformObjectsWithFeature(input, "map", empty_buffer, output));
+  ASSERT_EQ(output.feature_objects.size(), 1U);
+  EXPECT_EQ(output.header.frame_id, "map");
+  const auto & pose = output.feature_objects.at(0).object.kinematics.pose_with_covariance.pose;
+  EXPECT_DOUBLE_EQ(pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(pose.position.y, 2.0);
+  EXPECT_DOUBLE_EQ(pose.position.z, 3.0);
+}
+
+// transformObjectsWithFeature returns false when the buffer cannot resolve the requested transform.
+// Mirrors transformObjectsMissingTransformReturnsFalse for the feature path.
+TEST(transform, transformObjectsWithFeatureMissingTransformReturnsFalse)
+{
+  using autoware::object_recognition_utils::transformObjectsWithFeature;
+
+  ObjectsWithFeatureStandIn input;
+  input.header.frame_id = "sensor";
+  input.feature_objects.push_back(createFeatureObject(1.0, 2.0, 3.0, 0.0, 0.5, 0.5, 0.0));
+
+  tf2_ros::Buffer empty_buffer{std::make_shared<rclcpp::Clock>(RCL_ROS_TIME)};
+  ObjectsWithFeatureStandIn output;
+
+  // Different frame + empty buffer => lookup fails => false.
+  EXPECT_FALSE(transformObjectsWithFeature(input, "map", empty_buffer, output));
+  // Failure-path contract: the target frame is written to the output header before the lookup, so
+  // it stays at the requested target frame on a failed lookup, while the (copied) feature objects
+  // are left untransformed.
+  EXPECT_EQ(output.header.frame_id, "map");
+  ASSERT_EQ(output.feature_objects.size(), 1U);
+  const auto & pose = output.feature_objects.at(0).object.kinematics.pose_with_covariance.pose;
+  EXPECT_DOUBLE_EQ(pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(pose.position.y, 2.0);
+  EXPECT_DOUBLE_EQ(pose.position.z, 3.0);
 }


### PR DESCRIPTION
## Description

Part of the autoware_core quality campaign (testability + coverage + de-duplication), one ROS package per PR.

Refactor `transform.hpp` to add a testing seam and remove a global-namespace hazard, then add the previously-missing `test/src/test_transform.cpp`.

- Move the TF helpers `getTransform` / `getTransformMatrix` out of the **global** `namespace detail` and into `autoware::object_recognition_utils::detail`. They were previously leaking into `::detail` for every translation unit that includes the installed `object_recognition_utils.hpp`, an ODR / symbol-collision hazard with any other library that uses a global `detail` namespace. (The `[[maybe_unused]]` attributes are dropped because the helpers are now referenced by the wrappers in the same namespace.)
- Extract the per-object transform math into two pure helper templates, `detail::applyTransformToObjects` and `detail::applyTransformToFeatureObjects`, that take an already-resolved `tf2::Transform` (and `Eigen::Matrix4f`). `transformObjects` and `transformObjectsWithFeature` become thin lookup+apply wrappers. This makes the pose/covariance/cluster math unit-testable without a live `tf2_ros::Buffer`.
- Declare `tf2_geometry_msgs` and `tf2_ros` in `package.xml`: both are directly `#include`d by this public header (and the new test includes `<tf2_ros/buffer.h>`), but were previously resolved only transitively. This is dependency hygiene; no build behavior changes.

## Related links

**Parent Issue:** autowarefoundation/autoware_core#1096

## How was this PR tested?

Add `test/src/test_transform.cpp` (transform.hpp previously had zero coverage):

- `transformObjectsIdentityPassthrough` — input frame == target frame returns true and passes the message through unchanged (the buffer is never queried).
- `transformObjectsMissingTransformReturnsFalse` — different frame + empty buffer returns false; also pins the failure-path output contract (header keeps the requested target frame, objects left untransformed).
- `applyTransformToObjectsTranslationOnly` — pure translation composes onto each pose; orientation and (translation-only) covariance are untouched.
- `applyTransformToObjectsRotation90` — a 90-degree yaw maps (1,0) to (0,1) and accumulates the orientation.
- `transformObjectsAppliesBufferedTransform` — end-to-end lookup+apply through a live `tf2_ros::Buffer` seeded with a static transform.

`colcon build` + `colcon test --packages-select autoware_object_recognition_utils` in the `autoware:core-devel-jazzy` container — all tests pass.

## Notes for reviewers

Public template API (`transformObjects`, `transformObjectsWithFeature`) signatures are unchanged. No external consumer referenced the old global `::detail` helpers.

## Interface changes

None. The public template signatures are unchanged; the moved helpers were internal (`detail`) only, and the `package.xml` additions (`tf2_geometry_msgs`, `tf2_ros`) make already-used includes explicit.

## Effects on system behavior

None. Behavior-preserving on **both** the success and failure paths: the `output_msg.header.frame_id = target_frame_id` assignment is kept before the TF lookup, so on a failed lookup the wrappers still return `false` with the output header set to the target frame, exactly as before. On the success path the transform math is unchanged (now relocated into the pure helper templates).

## youtalk fork CI — build-and-test all green

The full `build-test-tidy-pr` workflow runs on the youtalk fork (`ubicloud-standard-16`). All build-and-test gate jobs pass for head commit `77e9beca` ([workflow run](https://github.com/youtalk/autoware_core/actions/runs/26670102713)):

- ✅ `build-and-test-diff-humble / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26670102713/job/78611497846
- ✅ `build-and-test-diff-jazzy / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26670102713/job/78611497835
- ✅ `build-and-test-diff-jazzy-agnocast / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26670102713/job/78611497827
- ✅ `build-and-test-diff-humble / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26670102713/job/78611947977
- ✅ `build-and-test-diff-jazzy / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26670102713/job/78611831029

(The `*-above` universe jobs are bonus coverage and excluded from the gate.)
