### PR TITLE
test(autoware_agnocast_wrapper): add first gtest suite and extract pure validation helpers

### DIFF
--- a/common/autoware_agnocast_wrapper/CMakeLists.txt
+++ b/common/autoware_agnocast_wrapper/CMakeLists.txt
@@ -97,4 +97,13 @@ install(
   DESTINATION share/${PROJECT_NAME}
 )
 
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  ament_auto_add_gtest(test_${PROJECT_NAME}
+    test/test_agnocast_wrapper.cpp
+  )
+endif()
+
 autoware_ament_auto_package()

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -14,8 +14,53 @@
 
 #pragma once
 
+#include <chrono>
+#include <cstdlib>
+#include <stdexcept>
 #include <string>
 #include <utility>
+
+namespace autoware::agnocast_wrapper::detail
+{
+
+/// @brief Parse the ENABLE_AGNOCAST environment-variable value.
+///
+/// Pure helper shared by both build variants so the parse rule is unit-testable
+/// without an Agnocast toolchain. Mirrors the historical getenv()+atoi()
+/// behavior: a missing (null) value parses to 0, otherwise the value is parsed
+/// with std::atoi() (leading whitespace skipped, trailing garbage ignored,
+/// non-numeric leading text yielding 0).
+///
+/// @param value The raw environment-variable string, or nullptr if unset.
+/// @return The parsed integer; 0 when @p value is nullptr.
+inline int parse_enable_agnocast(const char * value)
+{
+  if (value != nullptr) {
+    return std::atoi(value);
+  }
+  return 0;
+}
+
+/// @brief Validate a timer period against the rclcpp create_wall_timer precondition.
+///
+/// Pure helper shared by both build variants so the throw/no-throw boundary is
+/// unit-testable without constructing a node, clock, or timer handle. Mirrors
+/// rclcpp::create_wall_timer's precondition 0 <= period < nanoseconds::max().
+///
+/// @param period The requested timer period.
+/// @throws std::invalid_argument if @p period is negative or equal to
+///   std::chrono::nanoseconds::max().
+inline void validate_timer_period(std::chrono::nanoseconds period)
+{
+  if (period < std::chrono::nanoseconds::zero()) {
+    throw std::invalid_argument{"timer period cannot be negative"};
+  }
+  if (period == std::chrono::nanoseconds::max()) {
+    throw std::invalid_argument{"timer period must be less than std::chrono::nanoseconds::max()"};
+  }
+}
+
+}  // namespace autoware::agnocast_wrapper::detail
 
 #ifdef USE_AGNOCAST_ENABLED
 
@@ -26,10 +71,7 @@
 
 #include <rcl/timer.h>
 
-#include <chrono>
-#include <cstdlib>
 #include <memory>
-#include <stdexcept>
 #include <type_traits>
 
 #define AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) \
@@ -337,11 +379,7 @@ public:
 // Defaults to zero if the environment variable is missing or invalid.
 inline int get_ENABLE_AGNOCAST()
 {
-  const char * env = std::getenv("ENABLE_AGNOCAST");
-  if (env) {
-    return std::atoi(env);
-  }
-  return 0;
+  return detail::parse_enable_agnocast(std::getenv("ENABLE_AGNOCAST"));
 }
 
 inline bool use_agnocast()
@@ -831,12 +869,7 @@ private:
 ///   between backends).
 inline void set_period(const Timer::SharedPtr & timer, std::chrono::nanoseconds period)
 {
-  if (period < std::chrono::nanoseconds::zero()) {
-    throw std::invalid_argument{"timer period cannot be negative"};
-  }
-  if (period == std::chrono::nanoseconds::max()) {
-    throw std::invalid_argument{"timer period must be less than std::chrono::nanoseconds::max()"};
-  }
+  detail::validate_timer_period(period);
   timer->set_period(period);
 }
 
@@ -851,9 +884,7 @@ inline void set_period(const Timer::SharedPtr & timer, std::chrono::nanoseconds 
 
 #include <rcl/timer.h>
 
-#include <chrono>
 #include <memory>
-#include <stdexcept>
 #include <type_traits>
 
 namespace autoware::agnocast_wrapper
@@ -871,12 +902,7 @@ namespace autoware::agnocast_wrapper
 /// @throws rclcpp::exceptions::RCLError on rcl-level failure.
 inline void set_period(const rclcpp::TimerBase::SharedPtr & timer, std::chrono::nanoseconds period)
 {
-  if (period < std::chrono::nanoseconds::zero()) {
-    throw std::invalid_argument{"timer period cannot be negative"};
-  }
-  if (period == std::chrono::nanoseconds::max()) {
-    throw std::invalid_argument{"timer period must be less than std::chrono::nanoseconds::max()"};
-  }
+  detail::validate_timer_period(period);
   int64_t old_period = 0;
   const rcl_ret_t ret =
     rcl_timer_exchange_period(timer->get_timer_handle().get(), period.count(), &old_period);

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -31,6 +31,11 @@ namespace autoware::agnocast_wrapper::detail
 /// with std::atoi() (leading whitespace skipped, trailing garbage ignored,
 /// non-numeric leading text yielding 0).
 ///
+/// @note The value is parsed with std::atoi(), whose behavior is undefined when
+///   the parsed integer falls outside the range of int (e.g. "9999999999").
+///   Callers must supply a value within int range; in practice ENABLE_AGNOCAST
+///   is always "0" or "1".
+///
 /// @param value The raw environment-variable string, or nullptr if unset.
 /// @return The parsed integer; 0 when @p value is nullptr.
 inline int parse_enable_agnocast(const char * value)

--- a/common/autoware_agnocast_wrapper/package.xml
+++ b/common/autoware_agnocast_wrapper/package.xml
@@ -28,6 +28,7 @@
 
   <exec_depend condition="$ENABLE_AGNOCAST == 1">agnocast_components</exec_depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/common/autoware_agnocast_wrapper/test/test_agnocast_wrapper.cpp
+++ b/common/autoware_agnocast_wrapper/test/test_agnocast_wrapper.cpp
@@ -50,6 +50,13 @@ TEST(ParseEnableAgnocast, OneStringParsesToOne)
   EXPECT_EQ(detail::parse_enable_agnocast("1"), 1);
 }
 
+TEST(ParseEnableAgnocast, LeadingWhitespaceIsSkipped)
+{
+  // std::atoi skips leading whitespace before parsing the integer.
+  EXPECT_EQ(detail::parse_enable_agnocast("  1"), 1);
+  EXPECT_EQ(detail::parse_enable_agnocast("\t0"), 0);
+}
+
 TEST(ParseEnableAgnocast, GarbageLeadingTextParsesToZero)
 {
   // std::atoi returns 0 when no leading digits are present.
@@ -107,27 +114,6 @@ TEST(ValidateTimerPeriod, MaxPeriodThrowsInvalidArgument)
 {
   EXPECT_THROW(
     detail::validate_timer_period(std::chrono::nanoseconds::max()), std::invalid_argument);
-}
-
-TEST(ValidateTimerPeriod, NegativePeriodCarriesExpectedMessage)
-{
-  try {
-    detail::validate_timer_period(std::chrono::nanoseconds{-5});
-    FAIL() << "expected std::invalid_argument";
-  } catch (const std::invalid_argument & e) {
-    EXPECT_EQ(std::string{e.what()}, "timer period cannot be negative");
-  }
-}
-
-TEST(ValidateTimerPeriod, MaxPeriodCarriesExpectedMessage)
-{
-  try {
-    detail::validate_timer_period(std::chrono::nanoseconds::max());
-    FAIL() << "expected std::invalid_argument";
-  } catch (const std::invalid_argument & e) {
-    EXPECT_EQ(
-      std::string{e.what()}, "timer period must be less than std::chrono::nanoseconds::max()");
-  }
 }
 
 }  // namespace

--- a/common/autoware_agnocast_wrapper/test/test_agnocast_wrapper.cpp
+++ b/common/autoware_agnocast_wrapper/test/test_agnocast_wrapper.cpp
@@ -1,0 +1,134 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace autoware::agnocast_wrapper
+{
+namespace
+{
+
+// ---------------------------------------------------------------------------
+// detail::parse_enable_agnocast: ENABLE_AGNOCAST environment-value parsing.
+// ---------------------------------------------------------------------------
+
+TEST(ParseEnableAgnocast, NullptrParsesToZero)
+{
+  EXPECT_EQ(detail::parse_enable_agnocast(nullptr), 0);
+}
+
+TEST(ParseEnableAgnocast, EmptyStringParsesToZero)
+{
+  EXPECT_EQ(detail::parse_enable_agnocast(""), 0);
+}
+
+TEST(ParseEnableAgnocast, ZeroStringParsesToZero)
+{
+  EXPECT_EQ(detail::parse_enable_agnocast("0"), 0);
+}
+
+TEST(ParseEnableAgnocast, OneStringParsesToOne)
+{
+  EXPECT_EQ(detail::parse_enable_agnocast("1"), 1);
+}
+
+TEST(ParseEnableAgnocast, GarbageLeadingTextParsesToZero)
+{
+  // std::atoi returns 0 when no leading digits are present.
+  EXPECT_EQ(detail::parse_enable_agnocast("yes"), 0);
+  EXPECT_EQ(detail::parse_enable_agnocast("true"), 0);
+  EXPECT_EQ(detail::parse_enable_agnocast("on"), 0);
+}
+
+TEST(ParseEnableAgnocast, TrailingGarbageIsIgnored)
+{
+  // std::atoi parses the leading integer and ignores the remainder.
+  EXPECT_EQ(detail::parse_enable_agnocast("1abc"), 1);
+  EXPECT_EQ(detail::parse_enable_agnocast("0xyz"), 0);
+}
+
+TEST(ParseEnableAgnocast, NegativeValueParsesToNegative)
+{
+  // Only the literal value 1 enables Agnocast; a negative value is not 1.
+  EXPECT_EQ(detail::parse_enable_agnocast("-1"), -1);
+}
+
+TEST(ParseEnableAgnocast, OtherPositiveValuesAreNotOne)
+{
+  // use_agnocast() compares the parsed value against exactly 1, so 2 stays 2.
+  EXPECT_EQ(detail::parse_enable_agnocast("2"), 2);
+}
+
+// ---------------------------------------------------------------------------
+// detail::validate_timer_period: timer-period precondition boundary.
+// ---------------------------------------------------------------------------
+
+TEST(ValidateTimerPeriod, ZeroIsAccepted)
+{
+  EXPECT_NO_THROW(detail::validate_timer_period(std::chrono::nanoseconds::zero()));
+}
+
+TEST(ValidateTimerPeriod, PositivePeriodIsAccepted)
+{
+  EXPECT_NO_THROW(detail::validate_timer_period(std::chrono::milliseconds(10)));
+}
+
+TEST(ValidateTimerPeriod, LargeButNotMaxIsAccepted)
+{
+  const auto just_below_max =
+    std::chrono::nanoseconds{std::numeric_limits<std::chrono::nanoseconds::rep>::max() - 1};
+  EXPECT_NO_THROW(detail::validate_timer_period(just_below_max));
+}
+
+TEST(ValidateTimerPeriod, NegativePeriodThrowsInvalidArgument)
+{
+  EXPECT_THROW(detail::validate_timer_period(std::chrono::nanoseconds{-1}), std::invalid_argument);
+}
+
+TEST(ValidateTimerPeriod, MaxPeriodThrowsInvalidArgument)
+{
+  EXPECT_THROW(
+    detail::validate_timer_period(std::chrono::nanoseconds::max()), std::invalid_argument);
+}
+
+TEST(ValidateTimerPeriod, NegativePeriodCarriesExpectedMessage)
+{
+  try {
+    detail::validate_timer_period(std::chrono::nanoseconds{-5});
+    FAIL() << "expected std::invalid_argument";
+  } catch (const std::invalid_argument & e) {
+    EXPECT_EQ(std::string{e.what()}, "timer period cannot be negative");
+  }
+}
+
+TEST(ValidateTimerPeriod, MaxPeriodCarriesExpectedMessage)
+{
+  try {
+    detail::validate_timer_period(std::chrono::nanoseconds::max());
+    FAIL() << "expected std::invalid_argument";
+  } catch (const std::invalid_argument & e) {
+    EXPECT_EQ(
+      std::string{e.what()}, "timer period must be less than std::chrono::nanoseconds::max()");
+  }
+}
+
+}  // namespace
+}  // namespace autoware::agnocast_wrapper


### PR DESCRIPTION
## Description

Part of the autoware_core quality campaign (testability + coverage + de-duplication), one ROS package per PR.

`autoware_agnocast_wrapper` shipped **zero tests** and was not wired for gtest / `ament_lint_auto` in CMake, even though `package.xml` already declares `ament_lint_auto` and `autoware_lint_common` as `test_depend`. This PR adds the first test infrastructure for the package and a unit-test suite.

To make the package's pure logic unit-testable in the **default non-Agnocast build** (the one CI and most users build, `ENABLE_AGNOCAST=0`) without requiring an Agnocast toolchain, two pure helpers were extracted into a new internal `autoware::agnocast_wrapper::detail` namespace at the top of the header (shared by both build variants):

- `detail::parse_enable_agnocast(const char *)` — the `ENABLE_AGNOCAST` env parse rule (`getenv` + `atoi`: null/missing → 0, otherwise `std::atoi`). `get_ENABLE_AGNOCAST()` now delegates to it. This isolates the parse step from `use_agnocast()`'s function-local-static memoization so the parse rule is testable across values.
- `detail::validate_timer_period(std::chrono::nanoseconds)` — the timer-period precondition (`period < 0` or `== nanoseconds::max()` throws `std::invalid_argument`, mirroring `rclcpp::create_wall_timer`). Both `set_period()` overloads (Agnocast `Timer::SharedPtr` build and non-Agnocast `rclcpp::TimerBase::SharedPtr` build) now call it, collapsing the previously duplicated check into a single home.

Other changes:

- `CMakeLists.txt`: add an `if(BUILD_TESTING)` block running `ament_lint_auto_find_test_dependencies()` and an `ament_auto_add_gtest` target.
- `include/.../autoware_agnocast_wrapper.hpp`: add the `detail` namespace with the two pure helpers (and the `<chrono>`/`<cstdlib>`/`<stdexcept>` includes they need at the shared top, removed from the now-redundant per-branch include blocks); route `get_ENABLE_AGNOCAST()` and both `set_period()` overloads through them.

## Related links

**Parent Issue:** autowarefoundation/autoware_core#1096

## How was this PR tested?

New `test/test_agnocast_wrapper.cpp` gtest suite (15 cases) asserting:

- the env-parse mapping (null/empty/0/1/garbage/trailing-garbage/negative/other-positive)
- the timer-period throw/no-throw boundary (zero, positive, just-below-max accepted; negative and max throw; exact exception messages pinned)

`colcon build` + `colcon test --packages-select autoware_agnocast_wrapper` in the `autoware:core-devel-jazzy` container (default `ENABLE_AGNOCAST=0`) — green.

## Notes for reviewers

The public `set_period()`, `get_ENABLE_AGNOCAST()`, and `use_agnocast()` signatures and runtime behavior are unchanged — the extraction is a pure internal refactor plus additive test code. The new `detail` helpers are additive API. Tests exercise the non-Agnocast build path; the Agnocast `set_period()` overload shares the same `detail::validate_timer_period` precondition.

## Interface changes

None. The public wrapper signatures are unchanged; the two `detail::` helpers are additive internal API.

## Effects on system behavior

None. `get_ENABLE_AGNOCAST()` and both `set_period()` overloads now delegate to the extracted helpers but compute exactly the same result / throw the same exceptions as before.

## youtalk fork CI — build-and-test all green

The full `build-test-tidy-pr` workflow runs on the youtalk fork (`ubicloud-standard-16`). All build-and-test gate jobs pass for head commit `1f4a0cb9` ([workflow run](https://github.com/youtalk/autoware_core/actions/runs/26670311158)):

- ✅ `build-and-test-diff-humble / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26670311158/job/78612183282
- ✅ `build-and-test-diff-jazzy / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26670311158/job/78612183312
- ✅ `build-and-test-diff-jazzy-agnocast / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26670311158/job/78612183253
- ✅ `build-and-test-diff-humble / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26670311158/job/78612395061
- ✅ `build-and-test-diff-jazzy / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26670311158/job/78612384715

The `jazzy-agnocast` build (which compiles the package with `ENABLE_AGNOCAST=1`) is green, so the shared `detail` helpers and the Agnocast `set_period()` overload also build cleanly. (The `*-above` universe jobs are bonus coverage and excluded from the gate; the `jazzy-above` red here is the pre-existing `autoware_static_centerline_generator` headless-Qt GUI launch-test failure in the universe set — unrelated to this change, which built cleanly across all universe packages.)
