### PR TITLE
perf(autoware_crop_box_filter): identity transform fast-path and testable param merge

### DIFF
--- a/sensing/autoware_crop_box_filter/package.xml
+++ b/sensing/autoware_crop_box_filter/package.xml
@@ -22,6 +22,7 @@
 
   <depend>autoware_point_types</depend>
   <depend>autoware_utils_debug</depend>
+  <depend>autoware_utils_rclcpp</depend>
   <depend>autoware_utils_system</depend>
   <depend>autoware_utils_tf</depend>
   <depend>geometry_msgs</depend>

--- a/sensing/autoware_crop_box_filter/src/crop_box_filter.cpp
+++ b/sensing/autoware_crop_box_filter/src/crop_box_filter.cpp
@@ -14,6 +14,7 @@
 
 #include "crop_box_filter.hpp"
 
+#include <autoware_utils_rclcpp/parameter.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <sensor_msgs/msg/point_field.hpp>
@@ -21,6 +22,7 @@
 
 #include <sstream>
 #include <string>
+#include <vector>
 
 namespace autoware::crop_box_filter
 {
@@ -132,17 +134,38 @@ geometry_msgs::msg::PolygonStamped generate_crop_box_polygon(
   return polygon_msg;
 }
 
+CropBoxFilterConfig merge_crop_box_params(
+  const CropBoxFilterConfig & current, const std::vector<rclcpp::Parameter> & params)
+{
+  using autoware_utils_rclcpp::update_param;
+
+  CropBoxFilterConfig merged = current;
+  CropBoxParam & p = merged.param;
+
+  update_param(params, "min_x", p.min_x);
+  update_param(params, "min_y", p.min_y);
+  update_param(params, "min_z", p.min_z);
+  update_param(params, "max_x", p.max_x);
+  update_param(params, "max_y", p.max_y);
+  update_param(params, "max_z", p.max_z);
+  update_param(params, "negative", merged.keep_outside_box);
+
+  return merged;
+}
+
 CropBoxFilter::CropBoxFilter(const CropBoxFilterConfig & config) : config_(config)
 {
   if (config_.preprocess_transform) {
     const auto eigen_transform = tf2::transformToEigen(config_.preprocess_transform.value());
     eigen_transform_preprocess_ = eigen_transform.matrix().cast<float>();
     output_frame_id_ = config_.preprocess_transform->header.frame_id;
+    has_preprocess_ = true;
   }
   if (config_.postprocess_transform) {
     const auto eigen_transform = tf2::transformToEigen(config_.postprocess_transform.value());
     eigen_transform_postprocess_ = eigen_transform.matrix().cast<float>();
     output_frame_id_ = config_.postprocess_transform->header.frame_id;
+    has_postprocess_ = true;
   }
 }
 
@@ -170,23 +193,31 @@ CropBoxFilterResult CropBoxFilter::filter(const PointCloud2 & cloud) const
 
   for (size_t point_index = 0; input_x != input_x.end();
        ++input_x, ++input_y, ++input_z, ++point_index) {
-    Eigen::Vector4f point;
-    point[0] = *input_x;
-    point[1] = *input_y;
-    point[2] = *input_z;
-    point[3] = 1;
+    const float raw_x = *input_x;
+    const float raw_y = *input_y;
+    const float raw_z = *input_z;
 
-    if (!std::isfinite(point[0]) || !std::isfinite(point[1]) || !std::isfinite(point[2])) {
+    if (!std::isfinite(raw_x) || !std::isfinite(raw_y) || !std::isfinite(raw_z)) {
       result.skipped_nan_count++;
       continue;
     }
 
-    const Eigen::Vector4f point_preprocessed = eigen_transform_preprocess_ * point;
+    // Apply the preprocess transform only when one is configured; otherwise the matrix is the
+    // identity and the raw coordinates can be used directly, avoiding a 4x4 matrix multiply.
+    float pre_x = raw_x;
+    float pre_y = raw_y;
+    float pre_z = raw_z;
+    if (has_preprocess_) {
+      const Eigen::Vector4f point(raw_x, raw_y, raw_z, 1.0f);
+      const Eigen::Vector4f point_preprocessed = eigen_transform_preprocess_ * point;
+      pre_x = point_preprocessed[0];
+      pre_y = point_preprocessed[1];
+      pre_z = point_preprocessed[2];
+    }
 
-    bool point_is_inside =
-      point_preprocessed[2] > config_.param.min_z && point_preprocessed[2] < config_.param.max_z &&
-      point_preprocessed[1] > config_.param.min_y && point_preprocessed[1] < config_.param.max_y &&
-      point_preprocessed[0] > config_.param.min_x && point_preprocessed[0] < config_.param.max_x;
+    const bool point_is_inside = pre_z > config_.param.min_z && pre_z < config_.param.max_z &&
+                                 pre_y > config_.param.min_y && pre_y < config_.param.max_y &&
+                                 pre_x > config_.param.min_x && pre_x < config_.param.max_x;
 
     if (
       (!config_.keep_outside_box && point_is_inside) ||
@@ -195,10 +226,19 @@ CropBoxFilterResult CropBoxFilter::filter(const PointCloud2 & cloud) const
 
       memcpy(&output.data[output_size], &cloud.data[global_offset], cloud.point_step);
 
-      const Eigen::Vector4f point_output = eigen_transform_postprocess_ * point_preprocessed;
-      *output_x = point_output[0];
-      *output_y = point_output[1];
-      *output_z = point_output[2];
+      // Apply the postprocess transform only when one is configured; otherwise the preprocessed
+      // coordinates are already in the output frame.
+      if (has_postprocess_) {
+        const Eigen::Vector4f point_preprocessed(pre_x, pre_y, pre_z, 1.0f);
+        const Eigen::Vector4f point_output = eigen_transform_postprocess_ * point_preprocessed;
+        *output_x = point_output[0];
+        *output_y = point_output[1];
+        *output_z = point_output[2];
+      } else {
+        *output_x = pre_x;
+        *output_y = pre_y;
+        *output_z = pre_z;
+      }
 
       ++output_x;
       ++output_y;

--- a/sensing/autoware_crop_box_filter/src/crop_box_filter.cpp
+++ b/sensing/autoware_crop_box_filter/src/crop_box_filter.cpp
@@ -20,6 +20,7 @@
 #include <sensor_msgs/msg/point_field.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 
+#include <cmath>
 #include <sstream>
 #include <string>
 #include <vector>

--- a/sensing/autoware_crop_box_filter/src/crop_box_filter.hpp
+++ b/sensing/autoware_crop_box_filter/src/crop_box_filter.hpp
@@ -86,9 +86,10 @@ geometry_msgs::msg::PolygonStamped generate_crop_box_polygon(
 
 /// \brief Merge a SetParameters request into an existing crop-box configuration.
 ///
-/// Each crop-box bound and the keep_outside_box flag is taken from \p params when present,
-/// otherwise it falls back to the corresponding value in \p current. The pre/post-process
-/// transforms in \p current are preserved unchanged.
+/// Each crop-box bound is taken from \p params when present (parameter names \c min_x ...
+/// \c max_z), and the \c keep_outside_box flag is taken from the \c negative parameter when
+/// present; otherwise each value falls back to the corresponding value in \p current. The
+/// pre/post-process transforms in \p current are preserved unchanged.
 CropBoxFilterConfig merge_crop_box_params(
   const CropBoxFilterConfig & current, const std::vector<rclcpp::Parameter> & params);
 

--- a/sensing/autoware_crop_box_filter/src/crop_box_filter.hpp
+++ b/sensing/autoware_crop_box_filter/src/crop_box_filter.hpp
@@ -16,6 +16,7 @@
 #define CROP_BOX_FILTER_HPP_
 
 #include <Eigen/Eigen>
+#include <rclcpp/parameter.hpp>
 
 #include <geometry_msgs/msg/polygon_stamped.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
@@ -23,6 +24,7 @@
 
 #include <optional>
 #include <string>
+#include <vector>
 
 using PointCloud2 = sensor_msgs::msg::PointCloud2;
 using PointCloud2ConstPtr = sensor_msgs::msg::PointCloud2::ConstSharedPtr;
@@ -73,12 +75,22 @@ private:
   CropBoxFilterConfig config_;
   Eigen::Matrix4f eigen_transform_preprocess_{Eigen::Matrix4f::Identity()};
   Eigen::Matrix4f eigen_transform_postprocess_{Eigen::Matrix4f::Identity()};
+  bool has_preprocess_{false};
+  bool has_postprocess_{false};
   std::optional<std::string> output_frame_id_;
 };
 
 geometry_msgs::msg::PolygonStamped generate_crop_box_polygon(
   const CropBoxParam & param, const std::string & frame_id,
   const builtin_interfaces::msg::Time & stamp);
+
+/// \brief Merge a SetParameters request into an existing crop-box configuration.
+///
+/// Each crop-box bound and the keep_outside_box flag is taken from \p params when present,
+/// otherwise it falls back to the corresponding value in \p current. The pre/post-process
+/// transforms in \p current are preserved unchanged.
+CropBoxFilterConfig merge_crop_box_params(
+  const CropBoxFilterConfig & current, const std::vector<rclcpp::Parameter> & params);
 
 }  // namespace autoware::crop_box_filter
 

--- a/sensing/autoware_crop_box_filter/src/crop_box_filter_node.cpp
+++ b/sensing/autoware_crop_box_filter/src/crop_box_filter_node.cpp
@@ -192,20 +192,7 @@ rcl_interfaces::msg::SetParametersResult CropBoxFilterNode::param_callback(
 {
   std::scoped_lock lock(mutex_);
 
-  CropBoxParam new_param{};
-
-  new_param.min_x = get_param(p, "min_x", new_param.min_x) ? new_param.min_x : config_.param.min_x;
-  new_param.min_y = get_param(p, "min_y", new_param.min_y) ? new_param.min_y : config_.param.min_y;
-  new_param.min_z = get_param(p, "min_z", new_param.min_z) ? new_param.min_z : config_.param.min_z;
-  new_param.max_x = get_param(p, "max_x", new_param.max_x) ? new_param.max_x : config_.param.max_x;
-  new_param.max_y = get_param(p, "max_y", new_param.max_y) ? new_param.max_y : config_.param.max_y;
-  new_param.max_z = get_param(p, "max_z", new_param.max_z) ? new_param.max_z : config_.param.max_z;
-  bool new_keep_outside_box = false;
-  config_.keep_outside_box = get_param(p, "negative", new_keep_outside_box)
-                               ? new_keep_outside_box
-                               : config_.keep_outside_box;
-
-  config_.param = new_param;
+  config_ = merge_crop_box_params(config_, p);
 
   // recreate CropBoxFilter with updated config
   crop_box_filter_.emplace(config_);

--- a/sensing/autoware_crop_box_filter/src/crop_box_filter_node.hpp
+++ b/sensing/autoware_crop_box_filter/src/crop_box_filter_node.hpp
@@ -73,20 +73,6 @@ private:
   /** \brief Parameter service callback */
   rcl_interfaces::msg::SetParametersResult param_callback(const std::vector<rclcpp::Parameter> & p);
 
-  /** \brief For parameter service callback */
-  template <typename T>
-  bool get_param(const std::vector<rclcpp::Parameter> & p, const std::string & name, T & value)
-  {
-    auto it = std::find_if(p.cbegin(), p.cend(), [&name](const rclcpp::Parameter & parameter) {
-      return parameter.get_name() == name;
-    });
-    if (it != p.cend()) {
-      value = it->template get_value<T>();
-      return true;
-    }
-    return false;
-  }
-
 public:
   explicit CropBoxFilterNode(const rclcpp::NodeOptions & node_options);
 };

--- a/sensing/autoware_crop_box_filter/test/test_crop_box_filter.cpp
+++ b/sensing/autoware_crop_box_filter/test/test_crop_box_filter.cpp
@@ -14,12 +14,16 @@
 
 #include "crop_box_filter.hpp"
 
+#include <rclcpp/parameter.hpp>
+
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 
 #include <gtest/gtest.h>
 
 #include <algorithm>
 #include <array>
+#include <cmath>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -375,6 +379,187 @@ TEST(GenerateCropBoxPolygonTest, SetsFrameIdStampAndPointCount)
   EXPECT_EQ(polygon.header.stamp.sec, 123);
   EXPECT_EQ(polygon.header.stamp.nanosec, 456u);
   EXPECT_EQ(polygon.polygon.points.size(), 16u);
+}
+
+TEST(ValidatePointCloud2Test, RejectsTruncatedData)
+{
+  // width * height * point_step = 1 * 1 * 12 = 12, but data is only 8 bytes long.
+  auto cloud = make_cloud(
+    {make_field("x", 0, sensor_msgs::msg::PointField::FLOAT32),
+     make_field("y", 4, sensor_msgs::msg::PointField::FLOAT32),
+     make_field("z", 8, sensor_msgs::msg::PointField::FLOAT32)},
+    12);
+  cloud.data.resize(8);
+
+  const auto result = autoware::crop_box_filter::validate_pointcloud2(cloud);
+
+  EXPECT_FALSE(result.is_valid);
+}
+
+TEST(CropBoxFilterTest, SkipsNonFinitePointsAndCountsThem)
+{
+  // Arrange
+  autoware::crop_box_filter::CropBoxFilterConfig config;
+  config.param = {-5.0f, 5.0f, -5.0f, 5.0f, -5.0f, 5.0f};
+  config.keep_outside_box = false;
+
+  // The two finite points are inside the box and kept; the three non-finite points are skipped.
+  PointXYZList input_points = {
+    {0.5f, 0.5f, 0.5f},
+    {std::numeric_limits<float>::quiet_NaN(), 0.0f, 0.0f},
+    {0.0f, std::numeric_limits<float>::infinity(), 0.0f},
+    {0.0f, 0.0f, -std::numeric_limits<float>::infinity()},
+    {1.0f, 1.0f, 1.0f},
+  };
+
+  const auto input_cloud = create_pointcloud2(input_points);
+  const autoware::crop_box_filter::CropBoxFilter filter(config);
+
+  // Act
+  const auto result = filter.filter(input_cloud);
+  const auto kept_points = extract_points_from_cloud(result.pointcloud);
+
+  // Assert
+  EXPECT_EQ(result.skipped_nan_count, 3);
+  PointXYZList expected_points = {{0.5f, 0.5f, 0.5f}, {1.0f, 1.0f, 1.0f}};
+  EXPECT_TRUE(is_same_points(expected_points, kept_points));
+}
+
+TEST(CropBoxFilterTest, PointExactlyOnBoundaryIsTreatedAsOutside)
+{
+  // The inside test uses strict < and > on all six bounds, so a point sitting exactly on a
+  // bound is excluded. keep_outside_box = false → only strictly-inside points are kept.
+  autoware::crop_box_filter::CropBoxFilterConfig config;
+  config.param = {-1.0f, 1.0f, -1.0f, 1.0f, -1.0f, 1.0f};
+  config.keep_outside_box = false;
+
+  PointXYZList input_points = {
+    {1.0f, 0.0f, 0.0f},   // exactly on max_x → outside → filtered
+    {-1.0f, 0.0f, 0.0f},  // exactly on min_x → outside → filtered
+    {0.0f, 1.0f, 0.0f},   // exactly on max_y → outside → filtered
+    {0.0f, 0.0f, 1.0f},   // exactly on max_z → outside → filtered
+    {0.5f, 0.5f, 0.5f},   // strictly inside → kept
+  };
+
+  const auto output = apply_crop_box_filter(input_points, config);
+
+  PointXYZList expected_points = {{0.5f, 0.5f, 0.5f}};
+  EXPECT_TRUE(is_same_points(expected_points, output.points));
+}
+
+TEST(CropBoxFilterTest, IdentityFastPathKeepsCoordinatesUnchanged)
+{
+  // With no transform configured, the kept point's coordinates must equal the input exactly
+  // and the output frame must fall back to the input cloud frame.
+  autoware::crop_box_filter::CropBoxFilterConfig config;
+  config.param = {-5.0f, 5.0f, -5.0f, 5.0f, -5.0f, 5.0f};
+  config.keep_outside_box = false;
+
+  PointXYZList input_points = {{1.25f, -2.5f, 3.75f}};
+
+  const auto output = apply_crop_box_filter(input_points, config);
+
+  ASSERT_EQ(output.points.size(), 1u);
+  EXPECT_FLOAT_EQ(output.points[0][0], 1.25f);
+  EXPECT_FLOAT_EQ(output.points[0][1], -2.5f);
+  EXPECT_FLOAT_EQ(output.points[0][2], 3.75f);
+  EXPECT_EQ(output.frame_id, "base_link");
+}
+
+autoware::crop_box_filter::CropBoxFilterConfig make_default_merge_config()
+{
+  autoware::crop_box_filter::CropBoxFilterConfig config;
+  config.param = {-1.0f, 1.0f, -2.0f, 2.0f, -3.0f, 3.0f};
+  config.keep_outside_box = false;
+  return config;
+}
+
+TEST(MergeCropBoxParamsTest, EmptyUpdateIsNoOp)
+{
+  const auto current = make_default_merge_config();
+
+  const auto merged = autoware::crop_box_filter::merge_crop_box_params(current, {});
+
+  EXPECT_FLOAT_EQ(merged.param.min_x, current.param.min_x);
+  EXPECT_FLOAT_EQ(merged.param.max_x, current.param.max_x);
+  EXPECT_FLOAT_EQ(merged.param.min_y, current.param.min_y);
+  EXPECT_FLOAT_EQ(merged.param.max_y, current.param.max_y);
+  EXPECT_FLOAT_EQ(merged.param.min_z, current.param.min_z);
+  EXPECT_FLOAT_EQ(merged.param.max_z, current.param.max_z);
+  EXPECT_EQ(merged.keep_outside_box, current.keep_outside_box);
+}
+
+TEST(MergeCropBoxParamsTest, PartialUpdateKeepsUntouchedFields)
+{
+  const auto current = make_default_merge_config();
+
+  const std::vector<rclcpp::Parameter> params = {
+    rclcpp::Parameter("min_x", -10.0), rclcpp::Parameter("max_z", 30.0)};
+
+  const auto merged = autoware::crop_box_filter::merge_crop_box_params(current, params);
+
+  // Updated fields
+  EXPECT_FLOAT_EQ(merged.param.min_x, -10.0f);
+  EXPECT_FLOAT_EQ(merged.param.max_z, 30.0f);
+  // Untouched fields keep current values
+  EXPECT_FLOAT_EQ(merged.param.max_x, current.param.max_x);
+  EXPECT_FLOAT_EQ(merged.param.min_y, current.param.min_y);
+  EXPECT_FLOAT_EQ(merged.param.max_y, current.param.max_y);
+  EXPECT_FLOAT_EQ(merged.param.min_z, current.param.min_z);
+  EXPECT_EQ(merged.keep_outside_box, current.keep_outside_box);
+}
+
+TEST(MergeCropBoxParamsTest, FullUpdateReplacesAllFields)
+{
+  const auto current = make_default_merge_config();
+
+  const std::vector<rclcpp::Parameter> params = {
+    rclcpp::Parameter("min_x", -11.0),   rclcpp::Parameter("max_x", 11.0),
+    rclcpp::Parameter("min_y", -12.0),   rclcpp::Parameter("max_y", 12.0),
+    rclcpp::Parameter("min_z", -13.0),   rclcpp::Parameter("max_z", 13.0),
+    rclcpp::Parameter("negative", true),
+  };
+
+  const auto merged = autoware::crop_box_filter::merge_crop_box_params(current, params);
+
+  EXPECT_FLOAT_EQ(merged.param.min_x, -11.0f);
+  EXPECT_FLOAT_EQ(merged.param.max_x, 11.0f);
+  EXPECT_FLOAT_EQ(merged.param.min_y, -12.0f);
+  EXPECT_FLOAT_EQ(merged.param.max_y, 12.0f);
+  EXPECT_FLOAT_EQ(merged.param.min_z, -13.0f);
+  EXPECT_FLOAT_EQ(merged.param.max_z, 13.0f);
+  EXPECT_TRUE(merged.keep_outside_box);
+}
+
+TEST(MergeCropBoxParamsTest, NegativeToggleUpdatesKeepOutsideBox)
+{
+  auto current = make_default_merge_config();
+  current.keep_outside_box = true;
+
+  const std::vector<rclcpp::Parameter> params = {rclcpp::Parameter("negative", false)};
+
+  const auto merged = autoware::crop_box_filter::merge_crop_box_params(current, params);
+
+  EXPECT_FALSE(merged.keep_outside_box);
+  // Box bounds untouched
+  EXPECT_FLOAT_EQ(merged.param.min_x, current.param.min_x);
+}
+
+TEST(MergeCropBoxParamsTest, PreservesConfiguredTransforms)
+{
+  auto current = make_default_merge_config();
+  current.preprocess_transform = make_translation_transform("intermediate", 5.0, 0.0, 0.0);
+  current.postprocess_transform = make_translation_transform("output_frame", 0.0, 10.0, 0.0);
+
+  const std::vector<rclcpp::Parameter> params = {rclcpp::Parameter("min_x", -7.0)};
+
+  const auto merged = autoware::crop_box_filter::merge_crop_box_params(current, params);
+
+  ASSERT_TRUE(merged.preprocess_transform.has_value());
+  ASSERT_TRUE(merged.postprocess_transform.has_value());
+  EXPECT_EQ(merged.preprocess_transform->header.frame_id, "intermediate");
+  EXPECT_EQ(merged.postprocess_transform->header.frame_id, "output_frame");
+  EXPECT_FLOAT_EQ(merged.param.min_x, -7.0f);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Description

Part of the autoware_core quality campaign (testability + coverage + performance + de-duplication), one ROS package per PR. Three internal-only, behavior-preserving changes to `autoware_crop_box_filter`:

1. **Identity transform fast-path in the hot loop.** `CropBoxFilter::filter` previously performed two unconditional 4x4-by-4x1 Eigen matrix multiplies per point (preprocess + postprocess), even when no transform was configured (both matrices the identity). The presence of each optional transform is now cached once in the constructor (`has_preprocess_`, `has_postprocess_`). When a transform is absent, the raw coordinates are read directly into the bounds comparison and copied straight to the output, skipping the homogeneous `Vector4f` construction and the matmul. For the common case (`input_pointcloud_frame == input_frame == output_frame`) every point avoids ~28 redundant float multiply-adds, which is measurable for multi-hundred-thousand-point lidar clouds at 10–20 Hz.

2. **Extract a pure, testable parameter-merge function.** The merge logic that lived inside the ROS `param_callback` is extracted into a free function `merge_crop_box_params(const CropBoxFilterConfig & current, const std::vector<rclcpp::Parameter> & params) -> CropBoxFilterConfig` in `crop_box_filter.cpp`. `param_callback` now just assigns the merged config under the lock. This adds a unit-test seam without changing any public node API.

3. **Drop the duplicated `get_param` helper.** The private template `CropBoxFilterNode::get_param` was a verbatim copy of `autoware_utils_rclcpp::update_param`; the merge function now calls `update_param` directly and the local helper is deleted. Adds the `autoware_utils_rclcpp` dependency (the package already depends on sibling `autoware_utils_*` packages).

## Related links

**Parent Issue:** autowarefoundation/autoware_core#1096

## How was this PR tested?

Added unit tests for previously untested branches and the new seam (all assert concrete values/branches, not bare no-throw):

- `ValidatePointCloud2Test.RejectsTruncatedData` — pins `validate_data_size`'s invalid branch.
- `CropBoxFilterTest.SkipsNonFinitePointsAndCountsThem` — NaN/Inf points dropped, `skipped_nan_count == 3`.
- `CropBoxFilterTest.PointExactlyOnBoundaryIsTreatedAsOutside` — strict `<`/`>` boundary semantics.
- `CropBoxFilterTest.IdentityFastPathKeepsCoordinatesUnchanged` — no-transform output equals input, frame falls back to input frame.
- `MergeCropBoxParamsTest.*` (5 cases) — empty/partial/full update, negative toggle, transforms preserved.

`colcon build` + `colcon test --packages-select autoware_crop_box_filter` in the `autoware:core-devel-jazzy` container — all 9 new gtest cases pass; clang-format verified with the pinned `clang-format` v21.1.8 pre-commit hook.

## Notes for reviewers

- Fast-path: when an optional transform is absent the stored matrix is the identity, so reading raw coordinates is numerically identical to multiplying by `Identity`. Existing transform unit tests still pass.
- Merge: `merge_crop_box_params` starts from `current` and overwrites only the fields present in the request, exactly matching the previous per-field fallback to the current value. The `negative` flag and the pre/post transforms are handled the same way.

## Interface changes

None. The new `merge_crop_box_params` free function is internal (`src/`); the node's public API is unchanged.

## Effects on system behavior

None. The identity fast-path is numerically identical to the prior identity matmul, and the parameter-merge extraction reproduces the previous per-field fallback exactly (both pinned by the new tests).

## youtalk fork CI — build-and-test all green

The full `build-test-tidy-pr` workflow runs on the youtalk fork (`ubicloud-standard-16`). All build-and-test gate jobs pass for head commit `bb7f15b9` ([workflow run](https://github.com/youtalk/autoware_core/actions/runs/26673242653)):

- ✅ `build-and-test-diff-humble / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26673242653/job/78620378755
- ✅ `build-and-test-diff-jazzy / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26673242653/job/78620378749
- ✅ `build-and-test-diff-jazzy-agnocast / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26673242653/job/78620378748
- ✅ `build-and-test-diff-humble / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26673242653/job/78620522952
- ✅ `build-and-test-diff-jazzy / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26673242653/job/78620525309

(The `*-above` universe jobs are bonus coverage and excluded from the gate; both are also green on this PR.)
