### PR TITLE
test(autoware_map_projection_loader): add gtest for load_info_from_yaml and load_map_projector_info

### DIFF
--- a/map/autoware_map_projection_loader/CMakeLists.txt
+++ b/map/autoware_map_projection_loader/CMakeLists.txt
@@ -54,6 +54,7 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
   add_testcase(test/test_load_info_from_lanelet2_map.cpp)
+  add_testcase(test/test_load_info_from_yaml.cpp)
 endif()
 
 autoware_ament_auto_package(

--- a/map/autoware_map_projection_loader/test/test_load_info_from_yaml.cpp
+++ b/map/autoware_map_projection_loader/test/test_load_info_from_yaml.cpp
@@ -1,0 +1,230 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/map_projection_loader/map_projection_loader.hpp"
+
+#include <autoware_map_msgs/msg/map_projector_info.hpp>
+
+#include <gmock/gmock.h>
+
+#include <fstream>
+#include <stdexcept>
+#include <string>
+
+namespace
+{
+void write_yaml(const std::string & content, const std::string & output_path)
+{
+  std::ofstream file(output_path);
+  file << content;
+  file.close();
+}
+}  // namespace
+
+TEST(TestLoadInfoFromYaml, LoadMgrs)
+{
+  const std::string output_path = "/tmp/test_load_info_from_yaml_mgrs.yaml";
+  write_yaml(
+    "projector_type: MGRS\n"
+    "vertical_datum: WGS84\n"
+    "mgrs_grid: 54SUE\n",
+    output_path);
+
+  const auto msg = autoware::map_projection_loader::load_info_from_yaml(output_path);
+
+  EXPECT_EQ(msg.projector_type, autoware_map_msgs::msg::MapProjectorInfo::MGRS);
+  EXPECT_EQ(msg.vertical_datum, "WGS84");
+  EXPECT_EQ(msg.mgrs_grid, "54SUE");
+  // MGRS is overwritten with the UTM scale factor.
+  EXPECT_FLOAT_EQ(msg.scale_factor, 0.9996F);
+}
+
+TEST(TestLoadInfoFromYaml, LoadLocalCartesianUtm)
+{
+  const std::string output_path = "/tmp/test_load_info_from_yaml_local_cartesian_utm.yaml";
+  write_yaml(
+    "projector_type: LocalCartesianUTM\n"
+    "vertical_datum: WGS84\n"
+    "map_origin:\n"
+    "  latitude: 35.6762\n"
+    "  longitude: 139.6503\n"
+    "  altitude: 123.45\n",
+    output_path);
+
+  const auto msg = autoware::map_projection_loader::load_info_from_yaml(output_path);
+
+  EXPECT_EQ(msg.projector_type, autoware_map_msgs::msg::MapProjectorInfo::LOCAL_CARTESIAN_UTM);
+  EXPECT_EQ(msg.vertical_datum, "WGS84");
+  EXPECT_DOUBLE_EQ(msg.map_origin.latitude, 35.6762);
+  EXPECT_DOUBLE_EQ(msg.map_origin.longitude, 139.6503);
+  // Altitude is always forced to 0.0 regardless of the YAML value.
+  EXPECT_DOUBLE_EQ(msg.map_origin.altitude, 0.0);
+  EXPECT_FLOAT_EQ(msg.scale_factor, 0.9996F);
+}
+
+TEST(TestLoadInfoFromYaml, LoadLocalCartesian)
+{
+  const std::string output_path = "/tmp/test_load_info_from_yaml_local_cartesian.yaml";
+  write_yaml(
+    "projector_type: LocalCartesian\n"
+    "vertical_datum: WGS84\n"
+    "map_origin:\n"
+    "  latitude: 35.6762\n"
+    "  longitude: 139.6503\n"
+    "  altitude: 0.0\n",
+    output_path);
+
+  const auto msg = autoware::map_projection_loader::load_info_from_yaml(output_path);
+
+  EXPECT_EQ(msg.projector_type, autoware_map_msgs::msg::MapProjectorInfo::LOCAL_CARTESIAN);
+  EXPECT_EQ(msg.vertical_datum, "WGS84");
+  EXPECT_DOUBLE_EQ(msg.map_origin.latitude, 35.6762);
+  EXPECT_DOUBLE_EQ(msg.map_origin.longitude, 139.6503);
+  EXPECT_DOUBLE_EQ(msg.map_origin.altitude, 0.0);
+  // LocalCartesian is overwritten with the local scale factor.
+  EXPECT_FLOAT_EQ(msg.scale_factor, 1.0F);
+}
+
+TEST(TestLoadInfoFromYaml, LoadLocal)
+{
+  const std::string output_path = "/tmp/test_load_info_from_yaml_local.yaml";
+  write_yaml("projector_type: Local\n", output_path);
+
+  const auto msg = autoware::map_projection_loader::load_info_from_yaml(output_path);
+
+  EXPECT_EQ(msg.projector_type, autoware_map_msgs::msg::MapProjectorInfo::LOCAL);
+  // Local only sets the projector type and the scale factor.
+  EXPECT_EQ(msg.vertical_datum, "");
+  EXPECT_FLOAT_EQ(msg.scale_factor, 1.0F);
+}
+
+TEST(TestLoadInfoFromYaml, LoadTransverseMercatorDefaultScaleFactor)
+{
+  const std::string output_path = "/tmp/test_load_info_from_yaml_tm_default.yaml";
+  write_yaml(
+    "projector_type: TransverseMercator\n"
+    "vertical_datum: WGS84\n"
+    "map_origin:\n"
+    "  latitude: 35.6762\n"
+    "  longitude: 139.6503\n"
+    "  altitude: 0.0\n",
+    output_path);
+
+  const auto msg = autoware::map_projection_loader::load_info_from_yaml(output_path);
+
+  EXPECT_EQ(msg.projector_type, autoware_map_msgs::msg::MapProjectorInfo::TRANSVERSE_MERCATOR);
+  EXPECT_EQ(msg.vertical_datum, "WGS84");
+  EXPECT_DOUBLE_EQ(msg.map_origin.latitude, 35.6762);
+  EXPECT_DOUBLE_EQ(msg.map_origin.longitude, 139.6503);
+  EXPECT_DOUBLE_EQ(msg.map_origin.altitude, 0.0);
+  // No scale_factor key -> defaults to the UTM scale factor.
+  EXPECT_FLOAT_EQ(msg.scale_factor, 0.9996F);
+}
+
+TEST(TestLoadInfoFromYaml, LoadTransverseMercatorExplicitScaleFactor)
+{
+  const std::string output_path = "/tmp/test_load_info_from_yaml_tm_explicit.yaml";
+  write_yaml(
+    "projector_type: TransverseMercator\n"
+    "vertical_datum: WGS84\n"
+    "scale_factor: 0.5\n"
+    "map_origin:\n"
+    "  latitude: 35.6762\n"
+    "  longitude: 139.6503\n"
+    "  altitude: 0.0\n",
+    output_path);
+
+  const auto msg = autoware::map_projection_loader::load_info_from_yaml(output_path);
+
+  EXPECT_EQ(msg.projector_type, autoware_map_msgs::msg::MapProjectorInfo::TRANSVERSE_MERCATOR);
+  // An explicit scale_factor key overrides the default.
+  EXPECT_FLOAT_EQ(msg.scale_factor, 0.5F);
+}
+
+TEST(TestLoadInfoFromYaml, LoadDeprecatedLowercaseLocal)
+{
+  const std::string output_path = "/tmp/test_load_info_from_yaml_deprecated_local.yaml";
+  write_yaml("projector_type: local\n", output_path);
+
+  const auto msg = autoware::map_projection_loader::load_info_from_yaml(output_path);
+
+  // Deprecated lowercase "local" is remapped to the canonical "Local".
+  EXPECT_EQ(msg.projector_type, autoware_map_msgs::msg::MapProjectorInfo::LOCAL);
+  EXPECT_FLOAT_EQ(msg.scale_factor, 1.0F);
+}
+
+TEST(TestLoadInfoFromYaml, InvalidProjectorTypeThrows)
+{
+  const std::string output_path = "/tmp/test_load_info_from_yaml_invalid_type.yaml";
+  write_yaml("projector_type: NotARealProjector\n", output_path);
+
+  EXPECT_THROW(
+    autoware::map_projection_loader::load_info_from_yaml(output_path), std::runtime_error);
+}
+
+TEST(TestLoadInfoFromYaml, NonPositiveScaleFactorThrows)
+{
+  const std::string output_path = "/tmp/test_load_info_from_yaml_bad_scale.yaml";
+  write_yaml(
+    "projector_type: TransverseMercator\n"
+    "vertical_datum: WGS84\n"
+    "scale_factor: 0.0\n"
+    "map_origin:\n"
+    "  latitude: 35.6762\n"
+    "  longitude: 139.6503\n"
+    "  altitude: 0.0\n",
+    output_path);
+
+  EXPECT_THROW(
+    autoware::map_projection_loader::load_info_from_yaml(output_path), std::runtime_error);
+}
+
+TEST(TestLoadMapProjectorInfo, YamlTakesPrecedenceOverLanelet2)
+{
+  const std::string yaml_path = "/tmp/test_load_map_projector_info_precedence.yaml";
+  write_yaml(
+    "projector_type: MGRS\n"
+    "vertical_datum: WGS84\n"
+    "mgrs_grid: 54SUE\n",
+    yaml_path);
+
+  // The lanelet2 path also exists but the yaml must win.
+  const std::string lanelet2_path = "/tmp/test_load_map_projector_info_precedence.osm";
+  write_yaml(
+    "<?xml version=\"1.0\"?>\n"
+    "<osm version=\"0.6\" generator=\"lanelet2\">\n"
+    "  <node id=\"1\" lat=\"\" lon=\"\"/>\n"
+    "</osm>",
+    lanelet2_path);
+
+  const auto msg =
+    autoware::map_projection_loader::load_map_projector_info(yaml_path, lanelet2_path);
+
+  EXPECT_EQ(msg.projector_type, autoware_map_msgs::msg::MapProjectorInfo::MGRS);
+  EXPECT_EQ(msg.mgrs_grid, "54SUE");
+}
+
+TEST(TestLoadMapProjectorInfo, NoFilesFoundThrows)
+{
+  EXPECT_THROW(
+    autoware::map_projection_loader::load_map_projector_info(
+      "/tmp/does_not_exist_projector.yaml", "/tmp/does_not_exist_lanelet2.osm"),
+    std::runtime_error);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleMock(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Description

Part of the autoware_core quality campaign (testability + coverage), one ROS package per PR.

Adds a direct C++ gtest suite for `load_info_from_yaml` and `load_map_projector_info`, mirroring the existing `test_load_info_from_lanelet2_map.cpp` pattern with temporary YAML files. This closes the high-severity coverage gap: before this PR these pure parser functions were exercised only indirectly by the four `launch_test` python files, which assert solely that `received_message.projector_type` matches the YAML's `projector_type` and never verify `scale_factor`, `mgrs_grid`, `map_origin`, the altitude-forced-to-0.0 behavior, `vertical_datum`, or any error branch.

## Related links

**Parent Issue:** autowarefoundation/autoware_core#1096

## How was this PR tested?

New `test/test_load_info_from_yaml.cpp` (wired into `CMakeLists.txt` via the existing `add_testcase` helper).

`load_info_from_yaml`:

- Full message contents per projector_type: MGRS, LocalCartesianUTM, LocalCartesian, Local, TransverseMercator (asserting `vertical_datum`, `mgrs_grid`, `map_origin.latitude/longitude`, and that `map_origin.altitude` is always forced to `0.0`).
- The scale_factor defaulting matrix: TransverseMercator defaults to `0.9996` when no `scale_factor` key is present and uses the explicit value when present; MGRS / LocalCartesianUTM are overwritten with `0.9996`; Local / LocalCartesian are overwritten with `1.0`.
- The deprecated lowercase `"local"` → `Local` remapping.
- Error branches: invalid `projector_type` and `scale_factor <= 0.0` both throw `std::runtime_error`.

`load_map_projector_info`:

- YAML takes precedence over lanelet2 when both files exist.
- No-files-found throws `std::runtime_error`.

`colcon build` + `colcon test --packages-select autoware_map_projection_loader` in the `autoware:core-devel-jazzy` container — green.

## Notes for reviewers

Tests only. No public API/ABI changes; no production code changed. The only non-test edit is wiring the new test into `CMakeLists.txt`. These are characterization tests pinning current behavior.

## Interface changes

None.

## Effects on system behavior

None. Test-only addition.

## youtalk fork CI — build-and-test all green

The full `build-test-tidy-pr` workflow runs on the youtalk fork (`ubicloud-standard-16`). All build-and-test gate jobs pass for head commit `a8b8c168` ([workflow run](https://github.com/youtalk/autoware_core/actions/runs/26673246005)):

- ✅ `build-and-test-diff-humble / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26673246005/job/78620392372
- ✅ `build-and-test-diff-jazzy / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26673246005/job/78620392365
- ✅ `build-and-test-diff-jazzy-agnocast / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26673246005/job/78620392369
- ✅ `build-and-test-diff-humble / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26673246005/job/78620516504
- ✅ `build-and-test-diff-jazzy / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26673246005/job/78620504876

(The `*-above` universe jobs are bonus coverage and excluded from the gate. This PR is test-only and changes no production code; the `humble-above` red is the pre-existing `autoware_static_centerline_generator` headless-Qt GUI launch-test failure in the universe set — unrelated to this change.)
