### PR TITLE
refactor(autoware_lanelet2_map_visualizer): extract pure marker-array builder and reuse autoware_utils_visualization

### DIFF
--- a/map/autoware_lanelet2_map_visualizer/CMakeLists.txt
+++ b/map/autoware_lanelet2_map_visualizer/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 ament_auto_add_library(lanelet2_map_visualization_node SHARED
+  src/lanelet2_map_visualization.cpp
   src/lanelet2_map_visualization_node.cpp
 )
 
@@ -30,6 +31,13 @@ if(BUILD_TESTING)
     test/test_lanelet2_map_visualization_node.cpp
   )
   target_link_libraries(test_lanelet2_map_visualization_node
+    lanelet2_map_visualization_node
+  )
+
+  ament_add_gtest(test_lanelet2_map_visualization
+    test/test_lanelet2_map_visualization.cpp
+  )
+  target_link_libraries(test_lanelet2_map_visualization
     lanelet2_map_visualization_node
   )
 

--- a/map/autoware_lanelet2_map_visualizer/package.xml
+++ b/map/autoware_lanelet2_map_visualizer/package.xml
@@ -20,6 +20,7 @@
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>
+  <depend>autoware_utils_visualization</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>visualization_msgs</depend>

--- a/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization.cpp
+++ b/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization.cpp
@@ -1,0 +1,327 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+ * Copyright 2019 Autoware Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authors: Simon Thompson, Ryohsuke Mitsudome
+ *
+ */
+
+#include "lanelet2_map_visualization.hpp"
+
+#include <autoware_lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp>
+#include <autoware_lanelet2_extension/utility/query.hpp>
+#include <autoware_lanelet2_extension/visualization/visualization.hpp>
+#include <autoware_utils_visualization/marker_helper.hpp>
+
+#include <std_msgs/msg/color_rgba.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+
+#include <vector>
+
+namespace autoware::lanelet2_map_visualizer
+{
+visualization_msgs::msg::MarkerArray create_lanelet_map_marker_array(
+  const lanelet::LaneletMapConstPtr & viz_lanelet_map, const bool viz_centerline)
+{
+  // get lanelets etc to visualize
+  lanelet::ConstLanelets all_lanelets = lanelet::utils::query::laneletLayer(viz_lanelet_map);
+  lanelet::ConstLanelets road_lanelets = lanelet::utils::query::roadLanelets(all_lanelets);
+  lanelet::ConstLanelets shoulder_lanelets = lanelet::utils::query::shoulderLanelets(all_lanelets);
+  lanelet::ConstLanelets crosswalk_lanelets =
+    lanelet::utils::query::crosswalkLanelets(all_lanelets);
+  lanelet::ConstLanelets bicycle_lane_lanelets =
+    lanelet::utils::query::bicycleLaneLanelets(all_lanelets);
+  lanelet::ConstLineStrings3d partitions = lanelet::utils::query::getAllPartitions(viz_lanelet_map);
+  lanelet::ConstLineStrings3d road_borders =
+    lanelet::utils::query::getAllLinestringsWithType(viz_lanelet_map, "road_border");
+  lanelet::ConstLineStrings3d pedestrian_polygon_markings =
+    lanelet::utils::query::getAllPedestrianPolygonMarkings(viz_lanelet_map);
+  lanelet::ConstLineStrings3d pedestrian_line_markings =
+    lanelet::utils::query::getAllPedestrianLineMarkings(viz_lanelet_map);
+  lanelet::ConstLanelets walkway_lanelets = lanelet::utils::query::walkwayLanelets(all_lanelets);
+  std::vector<lanelet::ConstLineString3d> stop_lines =
+    lanelet::utils::query::stopLinesLanelets(road_lanelets);
+  std::vector<lanelet::AutowareTrafficLightConstPtr> aw_tl_reg_elems =
+    lanelet::utils::query::autowareTrafficLights(all_lanelets);
+  std::vector<lanelet::DetectionAreaConstPtr> da_reg_elems =
+    lanelet::utils::query::detectionAreas(all_lanelets);
+  std::vector<lanelet::NoStoppingAreaConstPtr> no_reg_elems =
+    lanelet::utils::query::noStoppingAreas(all_lanelets);
+  std::vector<lanelet::SpeedBumpConstPtr> sb_reg_elems =
+    lanelet::utils::query::speedBumps(all_lanelets);
+  std::vector<lanelet::CrosswalkConstPtr> cw_reg_elems =
+    lanelet::utils::query::crosswalks(all_lanelets);
+  lanelet::ConstLineStrings3d parking_spaces =
+    lanelet::utils::query::getAllParkingSpaces(viz_lanelet_map);
+  lanelet::ConstPolygons3d parking_lots = lanelet::utils::query::getAllParkingLots(viz_lanelet_map);
+  lanelet::ConstPolygons3d obstacle_polygons =
+    lanelet::utils::query::getAllObstaclePolygons(viz_lanelet_map);
+  lanelet::ConstPolygons3d no_obstacle_segmentation_area =
+    lanelet::utils::query::getAllPolygonsByType(viz_lanelet_map, "no_obstacle_segmentation_area");
+  lanelet::ConstPolygons3d no_obstacle_segmentation_area_for_run_out =
+    lanelet::utils::query::getAllPolygonsByType(
+      viz_lanelet_map, "no_obstacle_segmentation_area_for_run_out");
+  lanelet::ConstPolygons3d hatched_road_markings_area =
+    lanelet::utils::query::getAllPolygonsByType(viz_lanelet_map, "hatched_road_markings");
+  lanelet::ConstPolygons3d intersection_areas =
+    lanelet::utils::query::getAllPolygonsByType(viz_lanelet_map, "intersection_area");
+  std::vector<lanelet::NoParkingAreaConstPtr> no_parking_reg_elems =
+    lanelet::utils::query::noParkingAreas(all_lanelets);
+  lanelet::ConstLineStrings3d curbstones = lanelet::utils::query::curbstones(viz_lanelet_map);
+  std::vector<lanelet::BusStopAreaConstPtr> bus_stop_reg_elems =
+    lanelet::utils::query::busStopAreas(all_lanelets);
+  lanelet::ConstLineStrings3d waypoints = lanelet::utils::query::getAllWaypoints(viz_lanelet_map);
+  lanelet::ConstPolygons3d obstacle_removal_areas =
+    lanelet::utils::query::getAllPolygonsByType(viz_lanelet_map, "obstacle_removal_area");
+
+  std::vector<lanelet::ConstArea> lanelet_areas;
+  lanelet_areas.reserve(viz_lanelet_map->areaLayer.size());
+  for (const auto & area : viz_lanelet_map->areaLayer) {
+    lanelet_areas.push_back(area);
+  }
+
+  const std_msgs::msg::ColorRGBA cl_road =
+    autoware_utils_visualization::create_marker_color(0.27, 0.27, 0.27, 0.999);
+  const std_msgs::msg::ColorRGBA cl_shoulder =
+    autoware_utils_visualization::create_marker_color(0.15, 0.15, 0.15, 0.999);
+  const std_msgs::msg::ColorRGBA cl_cross =
+    autoware_utils_visualization::create_marker_color(0.27, 0.3, 0.27, 0.5);
+  const std_msgs::msg::ColorRGBA cl_partitions =
+    autoware_utils_visualization::create_marker_color(0.25, 0.25, 0.25, 0.999);
+  const std_msgs::msg::ColorRGBA cl_road_borders =
+    autoware_utils_visualization::create_marker_color(0.3, 0.25, 0.3, 0.999);
+  const std_msgs::msg::ColorRGBA cl_pedestrian_markings =
+    autoware_utils_visualization::create_marker_color(0.5, 0.5, 0.5, 0.999);
+  const std_msgs::msg::ColorRGBA cl_ll_borders =
+    autoware_utils_visualization::create_marker_color(0.5, 0.5, 0.5, 0.999);
+  const std_msgs::msg::ColorRGBA cl_shoulder_borders =
+    autoware_utils_visualization::create_marker_color(0.2, 0.2, 0.2, 0.999);
+  const std_msgs::msg::ColorRGBA cl_stoplines =
+    autoware_utils_visualization::create_marker_color(0.5, 0.5, 0.5, 0.999);
+  const std_msgs::msg::ColorRGBA cl_trafficlights =
+    autoware_utils_visualization::create_marker_color(0.5, 0.5, 0.5, 0.8);
+  const std_msgs::msg::ColorRGBA cl_detection_areas =
+    autoware_utils_visualization::create_marker_color(0.27, 0.27, 0.37, 0.5);
+  const std_msgs::msg::ColorRGBA cl_speed_bumps =
+    autoware_utils_visualization::create_marker_color(0.56, 0.40, 0.27, 0.5);
+  const std_msgs::msg::ColorRGBA cl_crosswalks =
+    autoware_utils_visualization::create_marker_color(0.80, 0.80, 0.0, 0.5);
+  const std_msgs::msg::ColorRGBA cl_parking_lots =
+    autoware_utils_visualization::create_marker_color(1.0, 1.0, 1.0, 0.2);
+  const std_msgs::msg::ColorRGBA cl_parking_spaces =
+    autoware_utils_visualization::create_marker_color(1.0, 1.0, 1.0, 0.3);
+  const std_msgs::msg::ColorRGBA cl_lanelet_id =
+    autoware_utils_visualization::create_marker_color(0.5, 0.5, 0.5, 0.999);
+  const std_msgs::msg::ColorRGBA cl_obstacle_polygons =
+    autoware_utils_visualization::create_marker_color(0.4, 0.27, 0.27, 0.5);
+  const std_msgs::msg::ColorRGBA cl_no_stopping_areas =
+    autoware_utils_visualization::create_marker_color(0.37, 0.37, 0.37, 0.5);
+  const std_msgs::msg::ColorRGBA cl_no_obstacle_segmentation_area =
+    autoware_utils_visualization::create_marker_color(0.37, 0.37, 0.27, 0.5);
+  const std_msgs::msg::ColorRGBA cl_no_obstacle_segmentation_area_for_run_out =
+    autoware_utils_visualization::create_marker_color(0.37, 0.7, 0.27, 0.5);
+  const std_msgs::msg::ColorRGBA cl_hatched_road_markings_area =
+    autoware_utils_visualization::create_marker_color(0.3, 0.3, 0.3, 0.5);
+  const std_msgs::msg::ColorRGBA cl_hatched_road_markings_line =
+    autoware_utils_visualization::create_marker_color(0.5, 0.5, 0.5, 0.999);
+  const std_msgs::msg::ColorRGBA cl_no_parking_areas =
+    autoware_utils_visualization::create_marker_color(0.42, 0.42, 0.42, 0.5);
+  const std_msgs::msg::ColorRGBA cl_curbstones =
+    autoware_utils_visualization::create_marker_color(0.1, 0.1, 0.2, 0.999);
+  const std_msgs::msg::ColorRGBA cl_intersection_area =
+    autoware_utils_visualization::create_marker_color(0.16, 1.0, 0.69, 0.5);
+  const std_msgs::msg::ColorRGBA cl_bus_stop_area =
+    autoware_utils_visualization::create_marker_color(0.863, 0.863, 0.863, 0.5);
+  const std_msgs::msg::ColorRGBA cl_bicycle_lane =
+    autoware_utils_visualization::create_marker_color(0.0, 0.3843, 0.6274, 0.5);
+  const std_msgs::msg::ColorRGBA cl_waypoints =
+    autoware_utils_visualization::create_marker_color(0.6, 0.4, 0.3, 0.999);
+  const std_msgs::msg::ColorRGBA cl_obstacle_removal_area =
+    autoware_utils_visualization::create_marker_color(0.2, 0.2, 0.5, 0.5);
+  const std_msgs::msg::ColorRGBA cl_lanelet_routing_area =
+    autoware_utils_visualization::create_marker_color(0.8, 0.53, 0.25, 0.35);
+  const std_msgs::msg::ColorRGBA cl_lanelet_routing_area_outline =
+    autoware_utils_visualization::create_marker_color(0.45, 0.28, 0.12, 0.95);
+
+  visualization_msgs::msg::MarkerArray map_marker_array;
+
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::lineStringsAsMarkerArray(stop_lines, "stop_lines", cl_stoplines, 0.5),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::lineStringsAsMarkerArray(partitions, "partitions", cl_partitions, 0.1),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::lineStringsAsMarkerArray(
+      road_borders, "road_borders", cl_road_borders, 0.2),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::laneletDirectionAsMarkerArray(shoulder_lanelets, "shoulder_"),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::laneletDirectionAsMarkerArray(road_lanelets), &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::laneletsAsTriangleMarkerArray(
+      "crosswalk_lanelets", crosswalk_lanelets, cl_cross),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::pedestrianPolygonMarkingsAsMarkerArray(
+      pedestrian_polygon_markings, cl_pedestrian_markings),
+    &map_marker_array);
+
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::pedestrianLineMarkingsAsMarkerArray(
+      pedestrian_line_markings, cl_pedestrian_markings),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::laneletsAsTriangleMarkerArray(
+      "walkway_lanelets", walkway_lanelets, cl_cross),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::obstaclePolygonsAsMarkerArray(obstacle_polygons, cl_obstacle_polygons),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::detectionAreasAsMarkerArray(da_reg_elems, cl_detection_areas),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::noStoppingAreasAsMarkerArray(no_reg_elems, cl_no_stopping_areas),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::speedBumpsAsMarkerArray(sb_reg_elems, cl_speed_bumps),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::crosswalkAreasAsMarkerArray(cw_reg_elems, cl_crosswalks),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::parkingLotsAsMarkerArray(parking_lots, cl_parking_lots),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::parkingSpacesAsMarkerArray(parking_spaces, cl_parking_spaces),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::laneletsBoundaryAsMarkerArray(
+      shoulder_lanelets, cl_shoulder_borders, viz_centerline, "shoulder_"),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::laneletsBoundaryAsMarkerArray(
+      road_lanelets, cl_ll_borders, viz_centerline),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::autowareTrafficLightsAsMarkerArray(aw_tl_reg_elems, cl_trafficlights),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::generateTrafficLightRegulatoryElementIdMaker(
+      road_lanelets, cl_trafficlights),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::generateTrafficLightRegulatoryElementIdMaker(
+      crosswalk_lanelets, cl_trafficlights),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::generateTrafficLightIdMaker(aw_tl_reg_elems, cl_trafficlights),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::generateLaneletIdMarker(shoulder_lanelets, cl_lanelet_id),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::generateLaneletIdMarker(road_lanelets, cl_lanelet_id),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::generateLaneletIdMarker(
+      crosswalk_lanelets, cl_lanelet_id, "crosswalk_lanelet_id"),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::laneletsAsTriangleMarkerArray(
+      "shoulder_road_lanelets", shoulder_lanelets, cl_shoulder),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::laneletsAsTriangleMarkerArray("road_lanelets", road_lanelets, cl_road),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::noObstacleSegmentationAreaAsMarkerArray(
+      no_obstacle_segmentation_area, cl_no_obstacle_segmentation_area),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::noObstacleSegmentationAreaForRunOutAsMarkerArray(
+      no_obstacle_segmentation_area_for_run_out, cl_no_obstacle_segmentation_area_for_run_out),
+    &map_marker_array);
+
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::hatchedRoadMarkingsAreaAsMarkerArray(
+      hatched_road_markings_area, cl_hatched_road_markings_area, cl_hatched_road_markings_line),
+    &map_marker_array);
+
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::noParkingAreasAsMarkerArray(no_parking_reg_elems, cl_no_parking_areas),
+    &map_marker_array);
+
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::lineStringsAsMarkerArray(curbstones, "curbstone", cl_curbstones, 0.2),
+    &map_marker_array);
+
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::intersectionAreaAsMarkerArray(intersection_areas, cl_intersection_area),
+    &map_marker_array);
+
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::busStopAreasAsMarkerArray(bus_stop_reg_elems, cl_bus_stop_area),
+    &map_marker_array);
+
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::laneletDirectionAsMarkerArray(bicycle_lane_lanelets, "bicycle_lane_"),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::laneletsBoundaryAsMarkerArray(
+      bicycle_lane_lanelets, cl_ll_borders /* use ll_border color */, viz_centerline,
+      "bicycle_lane_"),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::generateLaneletIdMarker(
+      bicycle_lane_lanelets, cl_lanelet_id /* use lanelet_id color */),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::laneletsAsTriangleMarkerArray(
+      "bicycle_lane_lanelets", bicycle_lane_lanelets, cl_bicycle_lane),
+    &map_marker_array);
+
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::lineStringsAsMarkerArray(waypoints, "waypoints", cl_waypoints, 0.02),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::obstacleRemovalAreaAsMarkerArray(
+      obstacle_removal_areas, cl_obstacle_removal_area),
+    &map_marker_array);
+  autoware_utils_visualization::append_marker_array(
+    lanelet::visualization::laneletAreasAsMarkerArray(
+      lanelet_areas, cl_lanelet_routing_area, cl_lanelet_routing_area_outline),
+    &map_marker_array);
+
+  return map_marker_array;
+}
+}  // namespace autoware::lanelet2_map_visualizer

--- a/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization.hpp
+++ b/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization.hpp
@@ -1,0 +1,40 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LANELET2_MAP_VISUALIZATION_HPP_
+#define LANELET2_MAP_VISUALIZATION_HPP_
+
+#include <visualization_msgs/msg/marker_array.hpp>
+
+#include <lanelet2_core/Forward.h>
+
+namespace autoware::lanelet2_map_visualizer
+{
+/// \brief Build the RViz MarkerArray that visualizes every supported element category of a
+/// Lanelet2 map.
+///
+/// This is the pure, ROS-publish-free core of the visualization node: given a deserialized
+/// Lanelet2 map it queries each element category (lanelets, crosswalks, traffic lights, stop
+/// lines, parking, curbstones, bicycle lanes, etc.) and assembles the corresponding markers into
+/// a single MarkerArray. It performs no subscription/publication and depends only on the map and
+/// the centerline flag, which makes it directly unit testable.
+///
+/// \param viz_lanelet_map deserialized Lanelet2 map to visualize.
+/// \param viz_centerline  when true, lanelet boundary markers also include the centerline.
+/// \return the assembled MarkerArray (empty when the map contains no elements to visualize).
+visualization_msgs::msg::MarkerArray create_lanelet_map_marker_array(
+  const lanelet::LaneletMapConstPtr & viz_lanelet_map, bool viz_centerline);
+}  // namespace autoware::lanelet2_map_visualizer
+
+#endif  // LANELET2_MAP_VISUALIZATION_HPP_

--- a/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization_node.cpp
+++ b/map/autoware_lanelet2_map_visualizer/src/lanelet2_map_visualization_node.cpp
@@ -33,38 +33,21 @@
 
 #include "lanelet2_map_visualization_node.hpp"
 
+#include "lanelet2_map_visualization.hpp"
+
 #include <autoware/lanelet2_utils/conversion.hpp>
-#include <autoware_lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp>
-#include <autoware_lanelet2_extension/utility/query.hpp>
-#include <autoware_lanelet2_extension/visualization/visualization.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
-#include <sensor_msgs/msg/point_cloud2.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_projection/UTM.h>
 
-#include <memory>
-#include <vector>
+#include <functional>
 
 namespace autoware::lanelet2_map_visualizer
 {
-void insert_marker_array(
-  visualization_msgs::msg::MarkerArray * a1, const visualization_msgs::msg::MarkerArray & a2)
-{
-  a1->markers.insert(a1->markers.end(), a2.markers.begin(), a2.markers.end());
-}
-
-void set_color(std_msgs::msg::ColorRGBA * cl, double r, double g, double b, double a)
-{
-  cl->r = static_cast<float>(r);
-  cl->g = static_cast<float>(g);
-  cl->b = static_cast<float>(b);
-  cl->a = static_cast<float>(a);
-}
-
 Lanelet2MapVisualizationNode::Lanelet2MapVisualizationNode(const rclcpp::NodeOptions & options)
 : Node("lanelet2_map_visualization", options)
 {
@@ -83,269 +66,12 @@ Lanelet2MapVisualizationNode::Lanelet2MapVisualizationNode(const rclcpp::NodeOpt
 void Lanelet2MapVisualizationNode::on_map_bin(
   const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg)
 {
-  lanelet::LaneletMapPtr viz_lanelet_map = autoware::experimental::lanelet2_utils::remove_const(
-    autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*msg));
+  lanelet::LaneletMapConstPtr viz_lanelet_map =
+    autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*msg);
   RCLCPP_INFO(this->get_logger(), "Map is loaded\n");
 
-  // get lanelets etc to visualize
-  lanelet::ConstLanelets all_lanelets = lanelet::utils::query::laneletLayer(viz_lanelet_map);
-  lanelet::ConstLanelets road_lanelets = lanelet::utils::query::roadLanelets(all_lanelets);
-  lanelet::ConstLanelets shoulder_lanelets = lanelet::utils::query::shoulderLanelets(all_lanelets);
-  lanelet::ConstLanelets crosswalk_lanelets =
-    lanelet::utils::query::crosswalkLanelets(all_lanelets);
-  lanelet::ConstLanelets bicycle_lane_lanelets =
-    lanelet::utils::query::bicycleLaneLanelets(all_lanelets);
-  lanelet::ConstLineStrings3d partitions = lanelet::utils::query::getAllPartitions(viz_lanelet_map);
-  lanelet::ConstLineStrings3d road_borders =
-    lanelet::utils::query::getAllLinestringsWithType(viz_lanelet_map, "road_border");
-  lanelet::ConstLineStrings3d pedestrian_polygon_markings =
-    lanelet::utils::query::getAllPedestrianPolygonMarkings(viz_lanelet_map);
-  lanelet::ConstLineStrings3d pedestrian_line_markings =
-    lanelet::utils::query::getAllPedestrianLineMarkings(viz_lanelet_map);
-  lanelet::ConstLanelets walkway_lanelets = lanelet::utils::query::walkwayLanelets(all_lanelets);
-  std::vector<lanelet::ConstLineString3d> stop_lines =
-    lanelet::utils::query::stopLinesLanelets(road_lanelets);
-  std::vector<lanelet::AutowareTrafficLightConstPtr> aw_tl_reg_elems =
-    lanelet::utils::query::autowareTrafficLights(all_lanelets);
-  std::vector<lanelet::DetectionAreaConstPtr> da_reg_elems =
-    lanelet::utils::query::detectionAreas(all_lanelets);
-  std::vector<lanelet::NoStoppingAreaConstPtr> no_reg_elems =
-    lanelet::utils::query::noStoppingAreas(all_lanelets);
-  std::vector<lanelet::SpeedBumpConstPtr> sb_reg_elems =
-    lanelet::utils::query::speedBumps(all_lanelets);
-  std::vector<lanelet::CrosswalkConstPtr> cw_reg_elems =
-    lanelet::utils::query::crosswalks(all_lanelets);
-  lanelet::ConstLineStrings3d parking_spaces =
-    lanelet::utils::query::getAllParkingSpaces(viz_lanelet_map);
-  lanelet::ConstPolygons3d parking_lots = lanelet::utils::query::getAllParkingLots(viz_lanelet_map);
-  lanelet::ConstPolygons3d obstacle_polygons =
-    lanelet::utils::query::getAllObstaclePolygons(viz_lanelet_map);
-  lanelet::ConstPolygons3d no_obstacle_segmentation_area =
-    lanelet::utils::query::getAllPolygonsByType(viz_lanelet_map, "no_obstacle_segmentation_area");
-  lanelet::ConstPolygons3d no_obstacle_segmentation_area_for_run_out =
-    lanelet::utils::query::getAllPolygonsByType(
-      viz_lanelet_map, "no_obstacle_segmentation_area_for_run_out");
-  lanelet::ConstPolygons3d hatched_road_markings_area =
-    lanelet::utils::query::getAllPolygonsByType(viz_lanelet_map, "hatched_road_markings");
-  lanelet::ConstPolygons3d intersection_areas =
-    lanelet::utils::query::getAllPolygonsByType(viz_lanelet_map, "intersection_area");
-  std::vector<lanelet::NoParkingAreaConstPtr> no_parking_reg_elems =
-    lanelet::utils::query::noParkingAreas(all_lanelets);
-  lanelet::ConstLineStrings3d curbstones = lanelet::utils::query::curbstones(viz_lanelet_map);
-  std::vector<lanelet::BusStopAreaConstPtr> bus_stop_reg_elems =
-    lanelet::utils::query::busStopAreas(all_lanelets);
-  lanelet::ConstLineStrings3d waypoints = lanelet::utils::query::getAllWaypoints(viz_lanelet_map);
-  lanelet::ConstPolygons3d obstacle_removal_areas =
-    lanelet::utils::query::getAllPolygonsByType(viz_lanelet_map, "obstacle_removal_area");
-
-  std::vector<lanelet::ConstArea> lanelet_areas;
-  lanelet_areas.reserve(viz_lanelet_map->areaLayer.size());
-  for (const auto & area : viz_lanelet_map->areaLayer) {
-    lanelet_areas.push_back(area);
-  }
-
-  std_msgs::msg::ColorRGBA cl_road;
-  std_msgs::msg::ColorRGBA cl_shoulder;
-  std_msgs::msg::ColorRGBA cl_cross;
-  std_msgs::msg::ColorRGBA cl_partitions;
-  std_msgs::msg::ColorRGBA cl_road_borders;
-  std_msgs::msg::ColorRGBA cl_pedestrian_markings;
-  std_msgs::msg::ColorRGBA cl_ll_borders;
-  std_msgs::msg::ColorRGBA cl_shoulder_borders;
-  std_msgs::msg::ColorRGBA cl_stoplines;
-  std_msgs::msg::ColorRGBA cl_trafficlights;
-  std_msgs::msg::ColorRGBA cl_detection_areas;
-  std_msgs::msg::ColorRGBA cl_speed_bumps;
-  std_msgs::msg::ColorRGBA cl_crosswalks;
-  std_msgs::msg::ColorRGBA cl_parking_lots;
-  std_msgs::msg::ColorRGBA cl_parking_spaces;
-  std_msgs::msg::ColorRGBA cl_lanelet_id;
-  std_msgs::msg::ColorRGBA cl_obstacle_polygons;
-  std_msgs::msg::ColorRGBA cl_no_stopping_areas;
-  std_msgs::msg::ColorRGBA cl_no_obstacle_segmentation_area;
-  std_msgs::msg::ColorRGBA cl_no_obstacle_segmentation_area_for_run_out;
-  std_msgs::msg::ColorRGBA cl_hatched_road_markings_area;
-  std_msgs::msg::ColorRGBA cl_hatched_road_markings_line;
-  std_msgs::msg::ColorRGBA cl_no_parking_areas;
-  std_msgs::msg::ColorRGBA cl_curbstones;
-  std_msgs::msg::ColorRGBA cl_intersection_area;
-  std_msgs::msg::ColorRGBA cl_bus_stop_area;
-  std_msgs::msg::ColorRGBA cl_bicycle_lane;
-  std_msgs::msg::ColorRGBA cl_waypoints;
-  std_msgs::msg::ColorRGBA cl_obstacle_removal_area;
-  std_msgs::msg::ColorRGBA cl_lanelet_routing_area;
-  std_msgs::msg::ColorRGBA cl_lanelet_routing_area_outline;
-
-  set_color(&cl_road, 0.27, 0.27, 0.27, 0.999);
-  set_color(&cl_shoulder, 0.15, 0.15, 0.15, 0.999);
-  set_color(&cl_cross, 0.27, 0.3, 0.27, 0.5);
-  set_color(&cl_partitions, 0.25, 0.25, 0.25, 0.999);
-  set_color(&cl_road_borders, 0.3, 0.25, 0.3, 0.999);
-  set_color(&cl_pedestrian_markings, 0.5, 0.5, 0.5, 0.999);
-  set_color(&cl_ll_borders, 0.5, 0.5, 0.5, 0.999);
-  set_color(&cl_shoulder_borders, 0.2, 0.2, 0.2, 0.999);
-  set_color(&cl_stoplines, 0.5, 0.5, 0.5, 0.999);
-  set_color(&cl_trafficlights, 0.5, 0.5, 0.5, 0.8);
-  set_color(&cl_detection_areas, 0.27, 0.27, 0.37, 0.5);
-  set_color(&cl_no_stopping_areas, 0.37, 0.37, 0.37, 0.5);
-  set_color(&cl_speed_bumps, 0.56, 0.40, 0.27, 0.5);
-  set_color(&cl_crosswalks, 0.80, 0.80, 0.0, 0.5);
-  set_color(&cl_obstacle_polygons, 0.4, 0.27, 0.27, 0.5);
-  set_color(&cl_parking_lots, 1.0, 1.0, 1.0, 0.2);
-  set_color(&cl_parking_spaces, 1.0, 1.0, 1.0, 0.3);
-  set_color(&cl_lanelet_id, 0.5, 0.5, 0.5, 0.999);
-  set_color(&cl_no_obstacle_segmentation_area, 0.37, 0.37, 0.27, 0.5);
-  set_color(&cl_no_obstacle_segmentation_area_for_run_out, 0.37, 0.7, 0.27, 0.5);
-  set_color(&cl_hatched_road_markings_area, 0.3, 0.3, 0.3, 0.5);
-  set_color(&cl_hatched_road_markings_line, 0.5, 0.5, 0.5, 0.999);
-  set_color(&cl_no_parking_areas, 0.42, 0.42, 0.42, 0.5);
-  set_color(&cl_curbstones, 0.1, 0.1, 0.2, 0.999);
-  set_color(&cl_intersection_area, 0.16, 1.0, 0.69, 0.5);
-  set_color(&cl_bus_stop_area, 0.863, 0.863, 0.863, 0.5);
-  set_color(&cl_bicycle_lane, 0.0, 0.3843, 0.6274, 0.5);
-  set_color(&cl_waypoints, 0.6, 0.4, 0.3, 0.999);
-  set_color(&cl_obstacle_removal_area, 0.2, 0.2, 0.5, 0.5);
-  // Static map fill for areaLayer namespace lanelet_routing_area; darker edge in
-  // lanelet_routing_area_outline
-  set_color(&cl_lanelet_routing_area, 0.8, 0.53, 0.25, 0.35);
-  set_color(&cl_lanelet_routing_area_outline, 0.45, 0.28, 0.12, 0.95);
-
-  visualization_msgs::msg::MarkerArray map_marker_array;
-
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::lineStringsAsMarkerArray(stop_lines, "stop_lines", cl_stoplines, 0.5));
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::lineStringsAsMarkerArray(partitions, "partitions", cl_partitions, 0.1));
-  insert_marker_array(
-    &map_marker_array, lanelet::visualization::lineStringsAsMarkerArray(
-                         road_borders, "road_borders", cl_road_borders, 0.2));
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::laneletDirectionAsMarkerArray(shoulder_lanelets, "shoulder_"));
-  insert_marker_array(
-    &map_marker_array, lanelet::visualization::laneletDirectionAsMarkerArray(road_lanelets));
-  insert_marker_array(
-    &map_marker_array, lanelet::visualization::laneletsAsTriangleMarkerArray(
-                         "crosswalk_lanelets", crosswalk_lanelets, cl_cross));
-  insert_marker_array(
-    &map_marker_array, lanelet::visualization::pedestrianPolygonMarkingsAsMarkerArray(
-                         pedestrian_polygon_markings, cl_pedestrian_markings));
-
-  insert_marker_array(
-    &map_marker_array, lanelet::visualization::pedestrianLineMarkingsAsMarkerArray(
-                         pedestrian_line_markings, cl_pedestrian_markings));
-  insert_marker_array(
-    &map_marker_array, lanelet::visualization::laneletsAsTriangleMarkerArray(
-                         "walkway_lanelets", walkway_lanelets, cl_cross));
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::obstaclePolygonsAsMarkerArray(obstacle_polygons, cl_obstacle_polygons));
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::detectionAreasAsMarkerArray(da_reg_elems, cl_detection_areas));
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::noStoppingAreasAsMarkerArray(no_reg_elems, cl_no_stopping_areas));
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::speedBumpsAsMarkerArray(sb_reg_elems, cl_speed_bumps));
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::crosswalkAreasAsMarkerArray(cw_reg_elems, cl_crosswalks));
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::parkingLotsAsMarkerArray(parking_lots, cl_parking_lots));
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::parkingSpacesAsMarkerArray(parking_spaces, cl_parking_spaces));
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::laneletsBoundaryAsMarkerArray(
-      shoulder_lanelets, cl_shoulder_borders, viz_lanelets_centerline_, "shoulder_"));
-  insert_marker_array(
-    &map_marker_array, lanelet::visualization::laneletsBoundaryAsMarkerArray(
-                         road_lanelets, cl_ll_borders, viz_lanelets_centerline_));
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::autowareTrafficLightsAsMarkerArray(aw_tl_reg_elems, cl_trafficlights));
-  insert_marker_array(
-    &map_marker_array, lanelet::visualization::generateTrafficLightRegulatoryElementIdMaker(
-                         road_lanelets, cl_trafficlights));
-  insert_marker_array(
-    &map_marker_array, lanelet::visualization::generateTrafficLightRegulatoryElementIdMaker(
-                         crosswalk_lanelets, cl_trafficlights));
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::generateTrafficLightIdMaker(aw_tl_reg_elems, cl_trafficlights));
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::generateLaneletIdMarker(shoulder_lanelets, cl_lanelet_id));
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::generateLaneletIdMarker(road_lanelets, cl_lanelet_id));
-  insert_marker_array(
-    &map_marker_array, lanelet::visualization::generateLaneletIdMarker(
-                         crosswalk_lanelets, cl_lanelet_id, "crosswalk_lanelet_id"));
-  insert_marker_array(
-    &map_marker_array, lanelet::visualization::laneletsAsTriangleMarkerArray(
-                         "shoulder_road_lanelets", shoulder_lanelets, cl_shoulder));
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::laneletsAsTriangleMarkerArray("road_lanelets", road_lanelets, cl_road));
-  insert_marker_array(
-    &map_marker_array, lanelet::visualization::noObstacleSegmentationAreaAsMarkerArray(
-                         no_obstacle_segmentation_area, cl_no_obstacle_segmentation_area));
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::noObstacleSegmentationAreaForRunOutAsMarkerArray(
-      no_obstacle_segmentation_area_for_run_out, cl_no_obstacle_segmentation_area_for_run_out));
-
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::hatchedRoadMarkingsAreaAsMarkerArray(
-      hatched_road_markings_area, cl_hatched_road_markings_area, cl_hatched_road_markings_line));
-
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::noParkingAreasAsMarkerArray(no_parking_reg_elems, cl_no_parking_areas));
-
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::lineStringsAsMarkerArray(curbstones, "curbstone", cl_curbstones, 0.2));
-
-  insert_marker_array(
-    &map_marker_array, lanelet::visualization::intersectionAreaAsMarkerArray(
-                         intersection_areas, cl_intersection_area));
-
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::busStopAreasAsMarkerArray(bus_stop_reg_elems, cl_bus_stop_area));
-
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::laneletDirectionAsMarkerArray(bicycle_lane_lanelets, "bicycle_lane_"));
-  insert_marker_array(
-    &map_marker_array, lanelet::visualization::laneletsBoundaryAsMarkerArray(
-                         bicycle_lane_lanelets, cl_ll_borders /* use ll_border color */,
-                         viz_lanelets_centerline_, "bicycle_lane_"));
-  insert_marker_array(
-    &map_marker_array, lanelet::visualization::generateLaneletIdMarker(
-                         bicycle_lane_lanelets, cl_lanelet_id /* use lanelet_id color */));
-  insert_marker_array(
-    &map_marker_array, lanelet::visualization::laneletsAsTriangleMarkerArray(
-                         "bicycle_lane_lanelets", bicycle_lane_lanelets, cl_bicycle_lane));
-
-  insert_marker_array(
-    &map_marker_array,
-    lanelet::visualization::lineStringsAsMarkerArray(waypoints, "waypoints", cl_waypoints, 0.02));
-  insert_marker_array(
-    &map_marker_array, lanelet::visualization::obstacleRemovalAreaAsMarkerArray(
-                         obstacle_removal_areas, cl_obstacle_removal_area));
-  insert_marker_array(
-    &map_marker_array, lanelet::visualization::laneletAreasAsMarkerArray(
-                         lanelet_areas, cl_lanelet_routing_area, cl_lanelet_routing_area_outline));
+  const visualization_msgs::msg::MarkerArray map_marker_array =
+    create_lanelet_map_marker_array(viz_lanelet_map, viz_lanelets_centerline_);
 
   pub_marker_->publish(map_marker_array);
 }

--- a/map/autoware_lanelet2_map_visualizer/test/test_lanelet2_map_visualization.cpp
+++ b/map/autoware_lanelet2_map_visualizer/test/test_lanelet2_map_visualization.cpp
@@ -1,0 +1,169 @@
+// Copyright 2025 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/lanelet2_map_visualization.hpp"
+
+#include <visualization_msgs/msg/marker_array.hpp>
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/Lanelet.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+
+namespace
+{
+using autoware::lanelet2_map_visualizer::create_lanelet_map_marker_array;
+
+// Build a single straight road lanelet (left/right bounds) and add it to a fresh map.
+lanelet::LaneletMapPtr make_road_lanelet_map()
+{
+  lanelet::Point3d p1{1, 0, 0, 0};
+  lanelet::Point3d p2{2, 10, 0, 0};
+  lanelet::Point3d p3{3, 0, 5, 0};
+  lanelet::Point3d p4{4, 10, 5, 0};
+
+  lanelet::LineString3d left_ls(5, {p1, p2});
+  lanelet::LineString3d right_ls(6, {p3, p4});
+
+  lanelet::Lanelet ll(7, left_ls, right_ls);
+  ll.attributes()["subtype"] = "road";
+
+  lanelet::LaneletMapPtr map = std::make_shared<lanelet::LaneletMap>();
+  map->add(ll);
+  return map;
+}
+
+// Collect the set of namespaces present in a MarkerArray.
+bool has_namespace(const visualization_msgs::msg::MarkerArray & arr, const std::string & ns)
+{
+  return std::any_of(
+    arr.markers.begin(), arr.markers.end(), [&](const auto & m) { return m.ns == ns; });
+}
+
+const visualization_msgs::msg::Marker * find_namespace(
+  const visualization_msgs::msg::MarkerArray & arr, const std::string & ns)
+{
+  for (const auto & m : arr.markers) {
+    if (m.ns == ns) {
+      return &m;
+    }
+  }
+  return nullptr;
+}
+}  // namespace
+
+TEST(CreateLaneletMapMarkerArray, EmptyMapProducesEmptyArray)
+{
+  const auto map = std::make_shared<lanelet::LaneletMap>();
+
+  const auto markers = create_lanelet_map_marker_array(map, /*viz_centerline=*/true);
+
+  EXPECT_TRUE(markers.markers.empty());
+}
+
+TEST(CreateLaneletMapMarkerArray, RoadLaneletProducesRoadTriangleAndBoundaryMarkers)
+{
+  const auto map = make_road_lanelet_map();
+
+  const auto markers = create_lanelet_map_marker_array(map, /*viz_centerline=*/true);
+
+  ASSERT_FALSE(markers.markers.empty());
+
+  // The road triangle marker must be present under the "road_lanelets" namespace.
+  const auto * road_triangle = find_namespace(markers, "road_lanelets");
+  ASSERT_NE(road_triangle, nullptr);
+  EXPECT_EQ(road_triangle->type, visualization_msgs::msg::Marker::TRIANGLE_LIST);
+  EXPECT_EQ(road_triangle->header.frame_id, "map");
+
+  // Every produced marker is anchored to the "map" frame.
+  for (const auto & marker : markers.markers) {
+    EXPECT_EQ(marker.header.frame_id, "map");
+  }
+
+  // The road boundary markers must be present.
+  EXPECT_TRUE(has_namespace(markers, "left_lane_bound"));
+  EXPECT_TRUE(has_namespace(markers, "right_lane_bound"));
+}
+
+TEST(CreateLaneletMapMarkerArray, RoadTriangleUsesRoadColor)
+{
+  const auto map = make_road_lanelet_map();
+
+  const auto markers = create_lanelet_map_marker_array(map, /*viz_centerline=*/true);
+
+  const auto * road_triangle = find_namespace(markers, "road_lanelets");
+  ASSERT_NE(road_triangle, nullptr);
+  ASSERT_FALSE(road_triangle->colors.empty());
+
+  // The per-vertex colors carry the hard-coded road color (0.27, 0.27, 0.27, 0.999).
+  const auto & color = road_triangle->colors.front();
+  EXPECT_FLOAT_EQ(color.r, 0.27f);
+  EXPECT_FLOAT_EQ(color.g, 0.27f);
+  EXPECT_FLOAT_EQ(color.b, 0.27f);
+  EXPECT_FLOAT_EQ(color.a, 0.999f);
+}
+
+TEST(CreateLaneletMapMarkerArray, CurbstoneLineStringProducesCurbstoneMarkerWithCurbstoneColor)
+{
+  lanelet::Point3d c1{10, 0, 0, 0};
+  lanelet::Point3d c2{11, 5, 0, 0};
+  lanelet::LineString3d curb(12, {c1, c2});
+  curb.attributes()["type"] = "curbstone";
+
+  const auto map = std::make_shared<lanelet::LaneletMap>();
+  map->add(curb);
+
+  const auto markers = create_lanelet_map_marker_array(map, /*viz_centerline=*/true);
+
+  const auto * curbstone_marker = find_namespace(markers, "curbstone");
+  ASSERT_NE(curbstone_marker, nullptr);
+
+  // The curbstone marker carries the hard-coded curbstone color (0.1, 0.1, 0.2, 0.999).
+  EXPECT_FLOAT_EQ(curbstone_marker->color.r, 0.1f);
+  EXPECT_FLOAT_EQ(curbstone_marker->color.g, 0.1f);
+  EXPECT_FLOAT_EQ(curbstone_marker->color.b, 0.2f);
+  EXPECT_FLOAT_EQ(curbstone_marker->color.a, 0.999f);
+}
+
+TEST(CreateLaneletMapMarkerArray, CenterlineFlagTogglesCenterlineMarkers)
+{
+  const auto map = make_road_lanelet_map();
+
+  const auto with_centerline = create_lanelet_map_marker_array(map, /*viz_centerline=*/true);
+  const auto without_centerline = create_lanelet_map_marker_array(map, /*viz_centerline=*/false);
+
+  // With the centerline enabled, the center-line markers are emitted; the boundary markers are
+  // present in both cases, so this isolates the centerline branch.
+  EXPECT_TRUE(has_namespace(with_centerline, "center_lane_line"));
+  EXPECT_TRUE(has_namespace(with_centerline, "center_line_arrows"));
+
+  EXPECT_FALSE(has_namespace(without_centerline, "center_lane_line"));
+  EXPECT_FALSE(has_namespace(without_centerline, "center_line_arrows"));
+
+  // The left boundary is unaffected by the centerline flag.
+  EXPECT_TRUE(has_namespace(with_centerline, "left_lane_bound"));
+  EXPECT_TRUE(has_namespace(without_centerline, "left_lane_bound"));
+
+  // Disabling the centerline strictly reduces the marker count.
+  EXPECT_LT(without_centerline.markers.size(), with_centerline.markers.size());
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/map/autoware_lanelet2_map_visualizer/test/test_lanelet2_map_visualization.cpp
+++ b/map/autoware_lanelet2_map_visualizer/test/test_lanelet2_map_visualization.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 The Autoware Contributors
+// Copyright 2026 The Autoware Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

Part of the autoware_core quality campaign (testability + coverage + de-duplication), one ROS package per PR.

- Extract the entire LaneletMap-to-MarkerArray assembly out of the `on_map_bin` ROS subscription callback into a pure, internally-headered free function `create_lanelet_map_marker_array(const lanelet::LaneletMapConstPtr & viz_lanelet_map, bool viz_centerline) -> visualization_msgs::msg::MarkerArray` (new `src/lanelet2_map_visualization.{hpp,cpp}`). The node callback now deserializes, calls this function, and publishes. This adds a directly unit-testable seam with no ROS publish/subscribe round-trip required.
- Replace the two `.cpp`-local helpers (`set_color`, `insert_marker_array`) with `autoware_utils_visualization::create_marker_color` / `append_marker_array`. These are semantically identical: `append_marker_array` with the default (omitted) `current_time` performs the same per-marker push-back, and `create_marker_color(float,...)` produces the same `ColorRGBA` that `set_color` did via its internal `static_cast<float>`. Both helpers were internal to the `.cpp`, so the public API is unaffected.
- Add `autoware_utils_visualization` to `package.xml` (kept sorted).

## Related links

**Parent Issue:** autowarefoundation/autoware_core#1096

## How was this PR tested?

New `test/test_lanelet2_map_visualization.cpp` exercises the extracted pure function with no `rclcpp` init/shutdown:

- `EmptyMapProducesEmptyArray` — empty/degenerate map yields an empty MarkerArray (no crash).
- `RoadLaneletProducesRoadTriangleAndBoundaryMarkers` — asserts the `road_lanelets` TRIANGLE_LIST marker plus `left_lane_bound`/`right_lane_bound` namespaces, all anchored to the `map` frame.
- `RoadTriangleUsesRoadColor` — asserts the road triangle's per-vertex color equals the hard-coded road color (0.27, 0.27, 0.27, 0.999).
- `CurbstoneLineStringProducesCurbstoneMarkerWithCurbstoneColor` — asserts the `curbstone` namespace marker with the curbstone color (0.1, 0.1, 0.2, 0.999).
- `CenterlineFlagTogglesCenterlineMarkers` — asserts `viz_centerline=true` emits `center_lane_line`/`center_line_arrows` markers and `false` omits them, with the left boundary unaffected, and that disabling strictly reduces the marker count.

`colcon build` + `colcon test --packages-select autoware_lanelet2_map_visualizer` in the `autoware:core-devel-jazzy` container — green.

## Notes for reviewers

Behavior-preserving; the published MarkerArray is unchanged. As an incidental cleanup, the deserialized map is now passed directly as a `LaneletMapConstPtr` to the read-only `lanelet::utils::query::*` calls (which all already take `const LaneletMapConstPtr &`) instead of first being routed through `autoware::experimental::lanelet2_utils::remove_const`. `remove_const` is a `std::const_pointer_cast` (shares the same underlying `LaneletMap` — no copy), so this only removes a redundant no-op const-cast round-trip; the produced markers are byte-for-byte identical.

## Interface changes

None. The new `create_lanelet_map_marker_array` lives in a package-internal `src/` header.

## Effects on system behavior

None. The published MarkerArray is unchanged (the `autoware_utils_visualization` helpers are semantically identical to the removed local helpers, pinned by the new tests).

## youtalk fork CI — build-and-test all green

The full `build-test-tidy-pr` workflow runs on the youtalk fork (`ubicloud-standard-16`). All build-and-test gate jobs pass for head commit `0ffc0f07` ([workflow run](https://github.com/youtalk/autoware_core/actions/runs/26783430928)):

- ✅ `build-and-test-diff-humble / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26783430928/job/78953415033
- ✅ `build-and-test-diff-jazzy / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26783430928/job/78953414963
- ✅ `build-and-test-diff-jazzy-agnocast / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26783430928/job/78953415037
- ✅ `build-and-test-diff-humble / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26783430928/job/78953901640
- ✅ `build-and-test-diff-jazzy / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26783430928/job/78953897184

(The `*-above` universe jobs are bonus coverage and excluded from the gate. The `jazzy-above` red is the pre-existing `autoware_static_centerline_generator` headless-Qt GUI launch-test failure in the universe set — unrelated to this change.)
