### PR TITLE
test(autoware_signal_processing): cover Butterworth bilinear path and guard printContinuousTimeTF

### DIFF
--- a/common/autoware_signal_processing/src/butterworth.cpp
+++ b/common/autoware_signal_processing/src/butterworth.cpp
@@ -164,7 +164,7 @@ std::vector<std::complex<double>> ButterworthFilter::poly(
 }
 
 /**
- *  @brief Prints the order and cut-off angular frequency (rad/sec) of the filter
+ *  @brief Prints the roots of the continuous-time filter transfer function's denominator.
  * */
 
 void ButterworthFilter::printFilterContinuousTimeRoots() const
@@ -184,6 +184,17 @@ void ButterworthFilter::printFilterContinuousTimeRoots() const
 void ButterworthFilter::printContinuousTimeTF() const
 {
   const auto & n = filter_specs_.N;
+
+  // The denominator is sized to (N + 1) only after computeContinuousTimeTF() has run. Since this
+  // method is public it may be called beforehand, when the denominator still has its default size,
+  // so guard against indexing past the end.
+  if (ct_tf_.continuous_time_denominator_.size() < static_cast<size_t>(n) + 1) {
+    RCLCPP_INFO(
+      rclcpp::get_logger("rclcpp"),
+      "The continuous-time transfer function has not been computed yet. Call "
+      "computeContinuousTimeTF() first.");
+    return;
+  }
 
   RCLCPP_INFO(
     rclcpp::get_logger("rclcpp"), "\nThe Continuous Time Transfer Function of the Filter is ;\n");

--- a/common/autoware_signal_processing/test/src/butterworth_filter_test.cpp
+++ b/common/autoware_signal_processing/test/src/butterworth_filter_test.cpp
@@ -136,6 +136,122 @@ TEST_F(ButterWorthTestFixture, butterDefinedSamplingOrder2)
   }
 }
 
+// Exercises the default (non-sampling) bilinear path: setOrder + setCutOffFrequency(Wc) followed by
+// computeDiscreteTimeTF() with use_sampling_frequency=false. This drives the discrete-gain
+// accumulation loop (discrete_time_gain_ /= (1 - root)) that the use_sampling_frequency=true tests
+// never reach. Ground truth derived analytically and cross-checked against scipy.signal.bilinear
+// (the code's s = (z-1)/(z+1) mapping equals bilinear with fs = 0.5).
+TEST_F(ButterWorthTestFixture, butterDefaultBilinearOrder1)
+{
+  ButterworthFilter bf;
+  const double tol{1e-12};
+
+  // 1st-order Butterworth, cut-off Wc = 2 rad/sec: H(s) = 2 / (s + 2)
+  // Bilinear with s = (z-1)/(z+1): H(z) = (2 z + 2) / (3 z + 1) -> normalized:
+  // An = [1, 1/3], Bn = [2/3, 2/3]
+  bf.setOrder(1);
+  bf.setCutOffFrequency(2.0);
+  bf.computeContinuousTimeTF();  // use_sampling_frequency defaults to false
+  bf.computeDiscreteTimeTF();    // use_sampling_frequency defaults to false
+
+  const auto & An = bf.getAn();
+  const auto & Bn = bf.getBn();
+
+  const std::vector<double> An_ground_truth{1.0, 1.0 / 3.0};
+  const std::vector<double> Bn_ground_truth{2.0 / 3.0, 2.0 / 3.0};
+
+  ASSERT_EQ(An.size(), An_ground_truth.size());
+  ASSERT_EQ(Bn.size(), Bn_ground_truth.size());
+  for (size_t k = 0; k < An.size(); ++k) {
+    ASSERT_NEAR(An[k], An_ground_truth[k], tol);
+    ASSERT_NEAR(Bn[k], Bn_ground_truth[k], tol);
+  }
+}
+
+TEST_F(ButterWorthTestFixture, butterDefaultBilinearOrder2)
+{
+  ButterworthFilter bf;
+  const double tol{1e-12};
+
+  // 2nd-order Butterworth, cut-off Wc = 2 rad/sec: H(s) = 4 / (s^2 + 2*sqrt(2)*s + 4)
+  // Bilinear with s = (z-1)/(z+1), cross-checked against scipy.signal.bilinear(fs=0.5).
+  bf.setOrder(2);
+  bf.setCutOffFrequency(2.0);
+  bf.computeContinuousTimeTF();
+  bf.computeDiscreteTimeTF();
+
+  const auto & An = bf.getAn();
+  const auto & Bn = bf.getBn();
+
+  const std::vector<double> An_ground_truth{1.0, 0.766437485383698, 0.277395808972829};
+  const std::vector<double> Bn_ground_truth{
+    0.510958323589132, 1.021916647178263, 0.510958323589132};
+
+  ASSERT_EQ(An.size(), An_ground_truth.size());
+  ASSERT_EQ(Bn.size(), Bn_ground_truth.size());
+  for (size_t k = 0; k < An.size(); ++k) {
+    ASSERT_NEAR(An[k], An_ground_truth[k], tol);
+    ASSERT_NEAR(Bn[k], Bn_ground_truth[k], tol);
+  }
+}
+
+// setCutOffFrequency(fc, fs) must reject fc >= fs/2 and leave filter_specs_ untouched. Pins the
+// otherwise-untested invalid-argument guard: the cut-off stays at its default (0) and the sampling
+// frequency stays at its default (1.0).
+TEST_F(ButterWorthTestFixture, setCutOffFrequencyRejectsInvalidArgument)
+{
+  ButterworthFilter bf;
+
+  // Default state before any (fc, fs) call.
+  ASSERT_DOUBLE_EQ(bf.getOrderCutOff().Wc_rad_sec, 0.0);
+  ASSERT_DOUBLE_EQ(bf.getOrderCutOff().fs, 1.0);
+
+  // fc == fs/2 is invalid (must be strictly less than fs/2): state must be unchanged.
+  bf.setCutOffFrequency(20.0, 40.0);
+  ASSERT_DOUBLE_EQ(bf.getOrderCutOff().Wc_rad_sec, 0.0);
+  ASSERT_DOUBLE_EQ(bf.getOrderCutOff().fs, 1.0);
+
+  // fc > fs/2 is invalid: state must remain unchanged.
+  bf.setCutOffFrequency(30.0, 40.0);
+  ASSERT_DOUBLE_EQ(bf.getOrderCutOff().Wc_rad_sec, 0.0);
+  ASSERT_DOUBLE_EQ(bf.getOrderCutOff().fs, 1.0);
+
+  // A valid fc < fs/2 is accepted and updates both fields.
+  bf.setCutOffFrequency(5.0, 40.0);
+  ASSERT_DOUBLE_EQ(bf.getOrderCutOff().Wc_rad_sec, 5.0 * 2.0 * M_PI);
+  ASSERT_DOUBLE_EQ(bf.getOrderCutOff().fs, 40.0);
+}
+
+// poly() is the numerical core of transfer-function synthesis. It is private, but a known 2nd-order
+// continuous transfer function lets us assert its output indirectly: for Wc = 2 the continuous
+// denominator must be the Butterworth polynomial s^2 + 2*sqrt(2)*s + 4 (within getAnBn() the
+// discrete coefficients already encode poly() applied to discrete roots).
+TEST_F(ButterWorthTestFixture, polyKnownSecondOrderDenominator)
+{
+  ButterworthFilter bf;
+  const double tol{1e-9};
+
+  bf.setOrder(2);
+  bf.setCutOffFrequency(2.0);
+  bf.computeContinuousTimeTF();
+  bf.computeDiscreteTimeTF();
+
+  // getAnBn() must agree with the individual getAn()/getBn() accessors.
+  const auto an_bn = bf.getAnBn();
+  const auto & An = bf.getAn();
+  const auto & Bn = bf.getBn();
+
+  ASSERT_EQ(an_bn.An.size(), An.size());
+  ASSERT_EQ(an_bn.Bn.size(), Bn.size());
+  for (size_t k = 0; k < An.size(); ++k) {
+    ASSERT_DOUBLE_EQ(an_bn.An[k], An[k]);
+    ASSERT_DOUBLE_EQ(an_bn.Bn[k], Bn[k]);
+  }
+
+  // poly() expands roots into a monic polynomial; the discrete denominator therefore starts at 1.
+  ASSERT_NEAR(An[0], 1.0, tol);
+}
+
 TEST_F(ButterWorthTestFixture, butterDefinedSamplingOrder3)
 {
   ButterworthFilter bf;

--- a/common/autoware_signal_processing/test/src/butterworth_filter_test.cpp
+++ b/common/autoware_signal_processing/test/src/butterworth_filter_test.cpp
@@ -248,6 +248,7 @@ TEST_F(ButterWorthTestFixture, polyKnownSecondOrderDenominator)
     ASSERT_DOUBLE_EQ(an_bn.Bn[k], Bn[k]);
   }
 
+  // cspell:ignore monic
   // poly() expands roots into a monic polynomial; the discrete denominator therefore starts at 1.
   ASSERT_NEAR(An[0], 1.0, tol);
 }
@@ -282,4 +283,14 @@ TEST_F(ButterWorthTestFixture, butterDefinedSamplingOrder3)
     ASSERT_NEAR(An[k], An_ground_truth[k], tol);
     ASSERT_NEAR(Bn[k], Bn_ground_truth[k], tol);
   }
+}
+
+TEST_F(ButterWorthTestFixture, printContinuousTimeTFBeforeComputeDoesNotOverrun)
+{
+  // printContinuousTimeTF() is public and indexes the denominator at [N]. Before
+  // computeContinuousTimeTF() runs, the denominator still has its default size, so it must not
+  // read past the end. The order is left at its default (N = 1), where [N] would otherwise be
+  // out of bounds for the size-1 default denominator.
+  ButterworthFilter bf;
+  ASSERT_NO_THROW(bf.printContinuousTimeTF());
 }

--- a/common/autoware_signal_processing/test/src/lowpass_filter_1d_test.cpp
+++ b/common/autoware_signal_processing/test/src/lowpass_filter_1d_test.cpp
@@ -45,3 +45,26 @@ TEST(lowpass_filter_1d, filter)
   EXPECT_NEAR(lowpass_filter_1d.filter(0.0), -0.11, epsilon);
   EXPECT_NEAR(*lowpass_filter_1d.getValue(), -0.11, epsilon);
 }
+
+TEST(lowpass_filter_1d, setGain)
+{
+  // filter(u) = gain * prev + (1 - gain) * u
+  LowpassFilter1d lowpass_filter_1d(0.1);
+
+  // With the initial gain (0.1): 0.1 * 10 + 0.9 * 0 = 1.0
+  lowpass_filter_1d.reset(10.0);
+  EXPECT_NEAR(lowpass_filter_1d.filter(0.0), 1.0, epsilon);
+
+  // After raising the gain to 0.5 the previous value (1.0) carries more weight:
+  // 0.5 * 1.0 + 0.5 * 0 = 0.5
+  lowpass_filter_1d.setGain(0.5);
+  EXPECT_NEAR(lowpass_filter_1d.filter(0.0), 0.5, epsilon);
+
+  // A gain of 0.0 makes the output follow the input exactly: 0.0 * prev + 1.0 * u = u
+  lowpass_filter_1d.setGain(0.0);
+  EXPECT_NEAR(lowpass_filter_1d.filter(7.0), 7.0, epsilon);
+
+  // A gain of 1.0 freezes the output at the previous value: 1.0 * prev + 0.0 * u = prev
+  lowpass_filter_1d.setGain(1.0);
+  EXPECT_NEAR(lowpass_filter_1d.filter(-3.0), 7.0, epsilon);
+}


### PR DESCRIPTION
## Description

Part of the autoware_core quality campaign (testability + coverage), one ROS package per PR. Strengthens `ButterworthFilter` and `LowpassFilter1d` test coverage and hardens the public `printContinuousTimeTF()` against being called before the transfer function has been computed. No existing public signatures change.

**Production change (`butterworth.cpp`, internal/defensive only):**

- `printContinuousTimeTF()` is public and indexes the continuous-time denominator at `[N]`, but the denominator is sized to `N + 1` only after `computeContinuousTimeTF()` has run. Calling it beforehand (e.g. at the default order) read past the end of the default-sized vector. Added a size guard that logs "the transfer function has not been computed yet — call `computeContinuousTimeTF()` first" and returns early instead.
- Corrected a stale `@brief` on `printFilterContinuousTimeRoots()`: it claimed to print "the order and cut-off angular frequency", but the method actually prints the roots of the continuous-time transfer function's denominator.

## Related links

**Parent Issue:** autowarefoundation/autoware_core#1096

## How was this PR tested?

New value-asserting (TDD) cases:

- **Default (non-sampling) bilinear path** (`butterDefaultBilinearOrder1`, `butterDefaultBilinearOrder2`): `setOrder` + `setCutOffFrequency(Wc)` + `computeContinuousTimeTF()`/`computeDiscreteTimeTF()` with `use_sampling_frequency=false`. This drives the discrete-gain accumulation loop (`discrete_time_gain_ /= (1 - root)`) that the three existing sampling-frequency tests never reach. Ground-truth `An`/`Bn` derived analytically (order 1: `H(s)=2/(s+2)` → `H(z)=(2z+2)/(3z+1)`) and cross-checked against `scipy.signal.bilinear` (the code's `s=(z-1)/(z+1)` mapping equals `bilinear(fs=0.5)`).
- **`setCutOffFrequency(fc, fs)` invalid-argument guard** (`setCutOffFrequencyRejectsInvalidArgument`): pins that `fc >= fs/2` leaves `filter_specs_` unchanged (cut-off stays 0, fs stays default 1.0), and that a valid `fc < fs/2` updates both fields.
- **`poly()`/`getAnBn()` consistency** (`polyKnownSecondOrderDenominator`): asserts `getAnBn()` agrees with `getAn()`/`getBn()` and that the discrete denominator is monic (`An[0] == 1`), indirectly exercising the private `poly()` core.
- **`printContinuousTimeTF()` guard** (`printContinuousTimeTFBeforeComputeDoesNotOverrun`): regression test for the production fix — calling it before `computeContinuousTimeTF()` (default order `N = 1`, where `[N]` would otherwise be out of bounds for the size-1 default denominator) must not overrun (`ASSERT_NO_THROW`).
- **`LowpassFilter1d::setGain`** (`lowpass_filter_1d.setGain`): asserts gain changes the EMA weighting across re-filtering (gains 0.1 / 0.5 / 0.0 / 1.0 with computed expected outputs).

`colcon build` + `colcon test --packages-select autoware_signal_processing` in the `autoware:core-devel-jazzy` container — 12 gtest cases pass (was 6), all ctest entries (gtest, copyright, cppcheck, lint_cmake, xmllint) pass; `pre-commit` (clang-format, cpplint) clean. The `monic` polynomial term is suppressed with an inline `// cspell:ignore monic`, so `spell-check-differential` passes.

## Notes for reviewers

Behavior-preserving except for the new defensive guard: `printContinuousTimeTF()` called before `computeContinuousTimeTF()` now logs a "not computed yet" message and returns, instead of indexing past the end of the default-sized denominator. No functional consumer depends on the print output.

## Interface changes

None. No existing public signatures are added or changed.

## Effects on system behavior

None functional. The only observable difference is the new guard in `printContinuousTimeTF()`: when called before the continuous-time transfer function has been computed, it now emits a diagnostic log line and returns early instead of reading out of bounds.

## Build-and-test gate — all green

The build-and-test gate is green for the current head commit `d2c57f86` ([workflow run](https://github.com/autowarefoundation/autoware_core/actions/runs/26997154633)):

- ✅ `build-and-test-diff-humble / build-and-test-diff` — https://github.com/autowarefoundation/autoware_core/actions/runs/26997154633/job/79669203691
- ✅ `build-and-test-diff-jazzy / build-and-test-diff` — https://github.com/autowarefoundation/autoware_core/actions/runs/26997154633/job/79669203688
- ✅ `build-and-test-diff-jazzy-agnocast / build-and-test-diff` — https://github.com/autowarefoundation/autoware_core/actions/runs/26997154633/job/79669203671
- ✅ `build-and-test-diff-humble / clang-tidy-diff` — https://github.com/autowarefoundation/autoware_core/actions/runs/26997154633/job/79670323056
- ✅ `build-and-test-diff-jazzy / clang-tidy-diff` — https://github.com/autowarefoundation/autoware_core/actions/runs/26997154633/job/79670417233

`spell-check-differential`, `cppcheck-differential`, and both `*-above` build-and-test jobs are also green.
