### PR TITLE
test(autoware_stop_filter): add deterministic node integration test and dedup filter eval

### DIFF
--- a/localization/autoware_stop_filter/src/stop_filter_node.cpp
+++ b/localization/autoware_stop_filter/src/stop_filter_node.cpp
@@ -35,10 +35,14 @@ FilterResult StopFilterProcessor::apply_filter(const nav_msgs::msg::Odometry::Sh
 autoware_internal_debug_msgs::msg::BoolStamped StopFilterProcessor::create_stop_flag_msg(
   const nav_msgs::msg::Odometry::SharedPtr input) const
 {
+  return create_stop_flag_msg(input, apply_filter(input));
+}
+
+autoware_internal_debug_msgs::msg::BoolStamped StopFilterProcessor::create_stop_flag_msg(
+  const nav_msgs::msg::Odometry::SharedPtr input, const FilterResult & result)
+{
   autoware_internal_debug_msgs::msg::BoolStamped stop_flag_msg;
   stop_flag_msg.stamp = input->header.stamp;
-
-  FilterResult result = apply_filter(input);
   stop_flag_msg.data = result.was_stopped;
 
   return stop_flag_msg;
@@ -47,9 +51,14 @@ autoware_internal_debug_msgs::msg::BoolStamped StopFilterProcessor::create_stop_
 nav_msgs::msg::Odometry StopFilterProcessor::create_filtered_msg(
   const nav_msgs::msg::Odometry::SharedPtr input) const
 {
+  return create_filtered_msg(input, apply_filter(input));
+}
+
+nav_msgs::msg::Odometry StopFilterProcessor::create_filtered_msg(
+  const nav_msgs::msg::Odometry::SharedPtr input, const FilterResult & result)
+{
   nav_msgs::msg::Odometry filtered_msg = *input;
 
-  FilterResult result = apply_filter(input);
   filtered_msg.twist.twist.linear.x = result.linear_velocity.x;
   filtered_msg.twist.twist.linear.y = result.linear_velocity.y;
   filtered_msg.twist.twist.linear.z = result.linear_velocity.z;
@@ -75,8 +84,9 @@ StopFilterNode::StopFilterNode(const rclcpp::NodeOptions & node_options)
 
 void StopFilterNode::callback_odometry(const nav_msgs::msg::Odometry::SharedPtr msg)
 {
-  pub_stop_flag_->publish(message_processor_.create_stop_flag_msg(msg));
-  pub_odom_->publish(message_processor_.create_filtered_msg(msg));
+  const FilterResult result = message_processor_.apply_filter(msg);
+  pub_stop_flag_->publish(message_processor_.create_stop_flag_msg(msg, result));
+  pub_odom_->publish(message_processor_.create_filtered_msg(msg, result));
 }
 }  // namespace autoware::stop_filter
 

--- a/localization/autoware_stop_filter/src/stop_filter_node.hpp
+++ b/localization/autoware_stop_filter/src/stop_filter_node.hpp
@@ -29,13 +29,23 @@ class StopFilterProcessor
 {
 public:
   StopFilterProcessor(double linear_x_threshold, double angular_z_threshold);
+
+  /// @brief Compute the stop filter result for the given odometry message.
+  FilterResult apply_filter(const nav_msgs::msg::Odometry::SharedPtr input) const;
+
   autoware_internal_debug_msgs::msg::BoolStamped create_stop_flag_msg(
     const nav_msgs::msg::Odometry::SharedPtr input) const;
   nav_msgs::msg::Odometry create_filtered_msg(const nav_msgs::msg::Odometry::SharedPtr input) const;
 
+  /// @brief Build the stop flag message from an already computed filter result.
+  static autoware_internal_debug_msgs::msg::BoolStamped create_stop_flag_msg(
+    const nav_msgs::msg::Odometry::SharedPtr input, const FilterResult & result);
+  /// @brief Build the filtered odometry message from an already computed filter result.
+  static nav_msgs::msg::Odometry create_filtered_msg(
+    const nav_msgs::msg::Odometry::SharedPtr input, const FilterResult & result);
+
 private:
   StopFilter stop_filter_;
-  FilterResult apply_filter(const nav_msgs::msg::Odometry::SharedPtr input) const;
 };
 
 class StopFilterNode : public rclcpp::Node

--- a/localization/autoware_stop_filter/test/test_stop_filter_node.cpp
+++ b/localization/autoware_stop_filter/test/test_stop_filter_node.cpp
@@ -16,7 +16,9 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <memory>
+#include <utility>
 
 nav_msgs::msg::Odometry::SharedPtr createOdometryMessage(
   double linear_x, double linear_y, double linear_z, double angular_x, double angular_y,
@@ -70,88 +72,105 @@ TEST(StopFilterProcessorTest, TestCreateFilteredMsgStopped)
   ASSERT_EQ(filtered_msg.header.stamp, input_msg->header.stamp);
 }
 
-// Test for stop detection in StopFilterNode
-// This test is disabled by default due to its reliance on real-time execution
-// To run this test, you need to enable it manually by removing the DISABLED_ prefix
-TEST(StopFilterNodeTest, DISABLED_TestStopDetection)
+// End-to-end node test fixture.
+//
+// This replaces the previously DISABLED_ real-time test (background spin thread +
+// wall-clock sleeps) with a deterministic SingleThreadedExecutor / spin_some loop:
+// one Odometry message is published, the executor is pumped with spin_some() until
+// both outputs arrive (bounded by a generous wall-clock safety net rather than a
+// fixed sleep), and the published values are asserted.
+class StopFilterNodeTest : public ::testing::Test
 {
-  // Initialize ROS 2 context
-  rclcpp::init(0, nullptr);
+protected:
+  void SetUp() override { rclcpp::init(0, nullptr); }
+  void TearDown() override { rclcpp::shutdown(); }
 
-  // Variable to hold received messages
-  std::shared_ptr<nav_msgs::msg::Odometry> received_odom;
-  std::shared_ptr<autoware_internal_debug_msgs::msg::BoolStamped> received_stop_flag;
-  bool odom_received = false;
-  bool stop_flag_received = false;
-  std::mutex msg_mutex;
+  // Publishes a single Odometry message into the StopFilterNode, deterministically
+  // pumps the executor, and returns the (filtered odometry, stop flag) outputs.
+  std::pair<nav_msgs::msg::Odometry, autoware_internal_debug_msgs::msg::BoolStamped> run_once(
+    double vx_threshold, double wz_threshold, const nav_msgs::msg::Odometry::SharedPtr & input)
+  {
+    nav_msgs::msg::Odometry received_odom;
+    autoware_internal_debug_msgs::msg::BoolStamped received_stop_flag;
+    bool odom_received = false;
+    bool stop_flag_received = false;
 
-  // Subscription to receive output messages
-  std::shared_ptr<rclcpp::Node> test_control_node =
-    std::make_shared<rclcpp::Node>("test_control_node");
-  auto odom_subscription = test_control_node->create_subscription<nav_msgs::msg::Odometry>(
-    "output/odom", 10, [&](const nav_msgs::msg::Odometry::SharedPtr msg) {
-      std::lock_guard<std::mutex> lock(msg_mutex);
-      received_odom = msg;
-      odom_received = true;
-    });
-
-  auto stop_flag_subscription =
-    test_control_node->create_subscription<autoware_internal_debug_msgs::msg::BoolStamped>(
-      "debug/stop_flag", 10,
-      [&](const autoware_internal_debug_msgs::msg::BoolStamped::SharedPtr msg) {
-        std::lock_guard<std::mutex> lock(msg_mutex);
-        received_stop_flag = msg;
-        stop_flag_received = true;
+    auto test_node = std::make_shared<rclcpp::Node>("test_stop_filter_helper_node");
+    auto odom_sub = test_node->create_subscription<nav_msgs::msg::Odometry>(
+      "output/odom", 10, [&](const nav_msgs::msg::Odometry::SharedPtr msg) {
+        received_odom = *msg;
+        odom_received = true;
       });
+    auto stop_flag_sub =
+      test_node->create_subscription<autoware_internal_debug_msgs::msg::BoolStamped>(
+        "debug/stop_flag", 10,
+        [&](const autoware_internal_debug_msgs::msg::BoolStamped::SharedPtr msg) {
+          received_stop_flag = *msg;
+          stop_flag_received = true;
+        });
+    auto publisher = test_node->create_publisher<nav_msgs::msg::Odometry>("input/odom", 10);
 
-  // Create stop filter node and register subscriptions
-  rclcpp::NodeOptions options;
-  options.parameter_overrides({{"vx_threshold", 1.0}, {"wz_threshold", 1.0}});
-  std::shared_ptr<autoware::stop_filter::StopFilterNode> stop_filter_node =
-    std::make_shared<autoware::stop_filter::StopFilterNode>(options);
+    rclcpp::NodeOptions options;
+    options.parameter_overrides({{"vx_threshold", vx_threshold}, {"wz_threshold", wz_threshold}});
+    auto stop_filter_node = std::make_shared<autoware::stop_filter::StopFilterNode>(options);
 
-  // Create executor and register nodes
-  rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(stop_filter_node);
-  executor.add_node(test_control_node);
+    rclcpp::executors::SingleThreadedExecutor executor;
+    executor.add_node(stop_filter_node);
+    executor.add_node(test_node);
 
-  // Run executor in separate thread
-  std::thread executor_thread([&]() { executor.spin(); });
+    // Pump until both publishers/subscribers are matched so the published message
+    // is not dropped before delivery.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (publisher->get_subscription_count() == 0 &&
+           std::chrono::steady_clock::now() < deadline) {
+      executor.spin_some();
+    }
+    EXPECT_GT(publisher->get_subscription_count(), 0u)
+      << "StopFilterNode did not subscribe to input/odom";
 
-  // Create publisher for input messages
-  auto publisher = test_control_node->create_publisher<nav_msgs::msg::Odometry>("input/odom", 10);
+    publisher->publish(*input);
 
-  // Wait for connection to be established
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    while ((!odom_received || !stop_flag_received) && std::chrono::steady_clock::now() < deadline) {
+      executor.spin_some();
+    }
 
-  // Create and publish stop state test message
-  auto stop_msg = nav_msgs::msg::Odometry();
-  stop_msg.header.frame_id = "base_link";
-  stop_msg.header.stamp = rclcpp::Clock().now();
-  stop_msg.twist.twist.linear.x = 0.2;   // below threshold
-  stop_msg.twist.twist.angular.z = 0.2;  // below threshold
-  publisher->publish(stop_msg);
+    EXPECT_TRUE(odom_received) << "output/odom message was not received";
+    EXPECT_TRUE(stop_flag_received) << "debug/stop_flag message was not received";
 
-  // Wait for messages to be received
-  auto start_time = std::chrono::steady_clock::now();
-  while ((!odom_received || !stop_flag_received) &&
-         std::chrono::steady_clock::now() - start_time < std::chrono::seconds(4)) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    return {received_odom, received_stop_flag};
   }
+};
 
-  // Stop executor
-  executor.cancel();
-  if (executor_thread.joinable()) {
-    executor_thread.join();
-  }
-  rclcpp::shutdown();
+TEST_F(StopFilterNodeTest, ZeroesTwistAndRaisesFlagWhenStopped)
+{
+  // Velocities below the configured thresholds -> treated as stopped.
+  auto input = createOdometryMessage(0.05, 0.0, 0.0, 0.0, 0.0, 0.05);
+  auto [odom, stop_flag] = run_once(0.1, 0.1, input);
 
-  // Verify results
-  ASSERT_TRUE(odom_received) << "Odometry message was not received within timeout";
-  ASSERT_TRUE(stop_flag_received) << "Stop flag message was not received within timeout";
-  ASSERT_NE(received_odom, nullptr);
-  ASSERT_NE(received_stop_flag, nullptr);
-  ASSERT_EQ(received_odom->twist.twist.linear.x, 0.0);
-  ASSERT_EQ(received_odom->twist.twist.angular.z, 0.0);
-  ASSERT_TRUE(received_stop_flag->data);
+  // Longitudinal/yaw twist is zeroed and the stop flag is raised.
+  EXPECT_EQ(odom.twist.twist.linear.x, 0.0);
+  EXPECT_EQ(odom.twist.twist.linear.y, 0.0);
+  EXPECT_EQ(odom.twist.twist.linear.z, 0.0);
+  EXPECT_EQ(odom.twist.twist.angular.x, 0.0);
+  EXPECT_EQ(odom.twist.twist.angular.y, 0.0);
+  EXPECT_EQ(odom.twist.twist.angular.z, 0.0);
+  EXPECT_TRUE(stop_flag.data);
+
+  // Header is preserved end-to-end.
+  EXPECT_EQ(odom.header.frame_id, input->header.frame_id);
+  EXPECT_EQ(odom.header.stamp, input->header.stamp);
+  EXPECT_EQ(stop_flag.stamp, input->header.stamp);
+}
+
+TEST_F(StopFilterNodeTest, PassesTwistThroughAndClearsFlagWhenMoving)
+{
+  // Velocities above the configured thresholds -> treated as moving.
+  auto input = createOdometryMessage(0.2, 0.0, 0.0, 0.0, 0.0, 0.2);
+  auto [odom, stop_flag] = run_once(0.1, 0.1, input);
+
+  // Twist passes through unchanged and the stop flag stays low.
+  EXPECT_EQ(odom.twist.twist.linear.x, 0.2);
+  EXPECT_EQ(odom.twist.twist.angular.z, 0.2);
+  EXPECT_FALSE(stop_flag.data);
+  EXPECT_EQ(stop_flag.stamp, input->header.stamp);
 }

--- a/localization/autoware_stop_filter/test/test_stop_filter_node.cpp
+++ b/localization/autoware_stop_filter/test/test_stop_filter_node.cpp
@@ -118,19 +118,32 @@ protected:
     executor.add_node(stop_filter_node);
     executor.add_node(test_node);
 
-    // Pump until both publishers/subscribers are matched so the published message
-    // is not dropped before delivery.
-    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
-    while (publisher->get_subscription_count() == 0 &&
-           std::chrono::steady_clock::now() < deadline) {
+    // Pump until the pub/sub graph is fully matched in BOTH directions before
+    // publishing, otherwise the node may emit its outputs in the input callback
+    // before the test's subscriptions are connected and the messages get dropped:
+    //   - the test's input/odom publisher must see the node's subscription, and
+    //   - the test's output/odom and debug/stop_flag subscriptions must each see
+    //     the node's publisher.
+    const auto discovery_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while ((publisher->get_subscription_count() == 0 || odom_sub->get_publisher_count() == 0 ||
+            stop_flag_sub->get_publisher_count() == 0) &&
+           std::chrono::steady_clock::now() < discovery_deadline) {
       executor.spin_some();
     }
     EXPECT_GT(publisher->get_subscription_count(), 0u)
       << "StopFilterNode did not subscribe to input/odom";
+    EXPECT_GT(odom_sub->get_publisher_count(), 0u)
+      << "StopFilterNode did not advertise output/odom";
+    EXPECT_GT(stop_flag_sub->get_publisher_count(), 0u)
+      << "StopFilterNode did not advertise debug/stop_flag";
 
     publisher->publish(*input);
 
-    while ((!odom_received || !stop_flag_received) && std::chrono::steady_clock::now() < deadline) {
+    // Use a fresh deadline for the receive phase so discovery time does not eat
+    // into the receive timeout.
+    const auto receive_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while ((!odom_received || !stop_flag_received) &&
+           std::chrono::steady_clock::now() < receive_deadline) {
       executor.spin_some();
     }
 


### PR DESCRIPTION
## Description

Part of the autoware_core quality campaign (testability + coverage), one ROS package per PR.

1. **Deterministic node integration test.** Replaces the `DISABLED_TestStopDetection` test — which relied on a background `executor.spin()` thread plus `std::this_thread::sleep_for` waits and was therefore never run in CI — with a `StopFilterNodeTest` fixture that drives the node through a `SingleThreadedExecutor` pumped with `spin_some()`. It publishes one `Odometry`, pumps until both outputs arrive (bounded by a wall-clock safety net rather than fixed sleeps), and asserts the published values for both the stopped and moving cases (twist zeroing / pass-through, `debug/stop_flag` value, and header/stamp propagation). This gives real node-level coverage of the topic wiring, parameter declaration (`vx_threshold`/`wz_threshold`) and the publish-on-callback path.

2. **Single filter evaluation per callback.** `callback_odometry` previously computed the filter twice per message (`create_stop_flag_msg` and `create_filtered_msg` each called `apply_filter`). It now computes the `FilterResult` once and passes it to both message builders.

## Related links

**Parent Issue:** autowarefoundation/autoware_core#1096

## How was this PR tested?

`StopFilterNodeTest` (the new fixture) asserts the published stop-flag and filtered-odometry values for the stopped and moving cases. `colcon build` + `colcon test --packages-select autoware_stop_filter` in the `autoware:core-devel-jazzy` container — build green, all 8 gtests pass (the 2 new node tests run in ~5-15 ms with no real-time sleeps), clang-format compliant, copyright/cppcheck/lint_cmake/xmllint linters pass.

## Notes for reviewers

Additive only. `apply_filter` is promoted from private to public on `StopFilterProcessor`, and two new `create_stop_flag_msg` / `create_filtered_msg` overloads that accept a precomputed `const FilterResult &` are added. The existing single-argument overloads keep their signatures and now delegate to the new ones, so all prior callers/tests remain valid.

## Interface changes

Additive only: `apply_filter` made public; two new precomputed-`FilterResult` message-builder overloads. No existing signature changes.

## Effects on system behavior

None. The published stop-flag and filtered-odometry values are identical; only the redundant per-callback recomputation is removed.

## youtalk fork CI — build-and-test all green

The full `build-test-tidy-pr` workflow runs on the youtalk fork (`ubicloud-standard-16`). All build-and-test gate jobs pass for head commit `966552b6` ([workflow run](https://github.com/youtalk/autoware_core/actions/runs/26674821758)):

- ✅ `build-and-test-diff-humble / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26674821758/job/78624638308
- ✅ `build-and-test-diff-jazzy / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26674821758/job/78624638314
- ✅ `build-and-test-diff-jazzy-agnocast / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26674821758/job/78624638371
- ✅ `build-and-test-diff-humble / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26674821758/job/78624745277
- ✅ `build-and-test-diff-jazzy / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26674821758/job/78624760261

(The `*-above` universe jobs are bonus coverage and excluded from the gate. The `humble-above` red is the pre-existing `autoware_static_centerline_generator` headless-Qt GUI launch-test failure in the universe set — unrelated to this change.)
