### PR TITLE
refactor(autoware_vehicle_velocity_converter): extract pure convert() and use XYZRPY_COV_IDX

### DIFF
--- a/sensing/autoware_vehicle_velocity_converter/package.xml
+++ b/sensing/autoware_vehicle_velocity_converter/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_agnocast_wrapper</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>

--- a/sensing/autoware_vehicle_velocity_converter/src/vehicle_velocity_converter.cpp
+++ b/sensing/autoware_vehicle_velocity_converter/src/vehicle_velocity_converter.cpp
@@ -14,10 +14,33 @@
 
 #include "vehicle_velocity_converter.hpp"
 
+#include <autoware_utils_geometry/msg/covariance.hpp>
+
 #include <string>
 
 namespace autoware::vehicle_velocity_converter
 {
+geometry_msgs::msg::TwistWithCovarianceStamped convert(
+  const autoware_vehicle_msgs::msg::VelocityReport & msg, const double speed_scale_factor,
+  const double stddev_vx, const double stddev_wz)
+{
+  using COV_IDX = autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+
+  geometry_msgs::msg::TwistWithCovarianceStamped twist_with_covariance_msg;
+  twist_with_covariance_msg.header = msg.header;
+  twist_with_covariance_msg.twist.twist.linear.x = msg.longitudinal_velocity * speed_scale_factor;
+  twist_with_covariance_msg.twist.twist.linear.y = msg.lateral_velocity;
+  twist_with_covariance_msg.twist.twist.angular.z = msg.heading_rate;
+  twist_with_covariance_msg.twist.covariance[COV_IDX::X_X] = stddev_vx * stddev_vx;
+  twist_with_covariance_msg.twist.covariance[COV_IDX::Y_Y] = 10000.0;
+  twist_with_covariance_msg.twist.covariance[COV_IDX::Z_Z] = 10000.0;
+  twist_with_covariance_msg.twist.covariance[COV_IDX::ROLL_ROLL] = 10000.0;
+  twist_with_covariance_msg.twist.covariance[COV_IDX::PITCH_PITCH] = 10000.0;
+  twist_with_covariance_msg.twist.covariance[COV_IDX::YAW_YAW] = stddev_wz * stddev_wz;
+
+  return twist_with_covariance_msg;
+}
+
 VehicleVelocityConverter::VehicleVelocityConverter(const rclcpp::NodeOptions & options)
 : rclcpp::Node("vehicle_velocity_converter", options),
   frame_id_(declare_parameter<std::string>("frame_id")),
@@ -41,19 +64,7 @@ void VehicleVelocityConverter::callback_velocity_report(
   }
 
   // set twist with covariance msg from vehicle report msg
-  geometry_msgs::msg::TwistWithCovarianceStamped twist_with_covariance_msg;
-  twist_with_covariance_msg.header = msg->header;
-  twist_with_covariance_msg.twist.twist.linear.x = msg->longitudinal_velocity * speed_scale_factor_;
-  twist_with_covariance_msg.twist.twist.linear.y = msg->lateral_velocity;
-  twist_with_covariance_msg.twist.twist.angular.z = msg->heading_rate;
-  twist_with_covariance_msg.twist.covariance[0 + 0 * 6] = stddev_vx_ * stddev_vx_;
-  twist_with_covariance_msg.twist.covariance[1 + 1 * 6] = 10000.0;
-  twist_with_covariance_msg.twist.covariance[2 + 2 * 6] = 10000.0;
-  twist_with_covariance_msg.twist.covariance[3 + 3 * 6] = 10000.0;
-  twist_with_covariance_msg.twist.covariance[4 + 4 * 6] = 10000.0;
-  twist_with_covariance_msg.twist.covariance[5 + 5 * 6] = stddev_wz_ * stddev_wz_;
-
-  twist_with_covariance_pub_->publish(twist_with_covariance_msg);
+  twist_with_covariance_pub_->publish(convert(*msg, speed_scale_factor_, stddev_vx_, stddev_wz_));
 }
 }  // namespace autoware::vehicle_velocity_converter
 

--- a/sensing/autoware_vehicle_velocity_converter/src/vehicle_velocity_converter.hpp
+++ b/sensing/autoware_vehicle_velocity_converter/src/vehicle_velocity_converter.hpp
@@ -27,6 +27,22 @@
 
 namespace autoware::vehicle_velocity_converter
 {
+/// \brief Convert a VelocityReport into a TwistWithCovarianceStamped.
+///
+/// Pure conversion logic shared by the node callback: applies the longitudinal
+/// speed scale factor, maps the report axes onto the twist, and fills the fixed
+/// diagonal covariance (large values on the unobserved axes). The header is
+/// copied verbatim from the input message.
+///
+/// \param msg input velocity report
+/// \param speed_scale_factor multiplier applied to the longitudinal velocity
+/// \param stddev_vx longitudinal velocity standard deviation (variance = stddev_vx^2)
+/// \param stddev_wz yaw rate standard deviation (variance = stddev_wz^2)
+/// \return converted twist with covariance
+geometry_msgs::msg::TwistWithCovarianceStamped convert(
+  const autoware_vehicle_msgs::msg::VelocityReport & msg, double speed_scale_factor,
+  double stddev_vx, double stddev_wz);
+
 class VehicleVelocityConverter : public rclcpp::Node
 {
 public:

--- a/sensing/autoware_vehicle_velocity_converter/test/test_vehicle_velocity_converter.cpp
+++ b/sensing/autoware_vehicle_velocity_converter/test/test_vehicle_velocity_converter.cpp
@@ -14,9 +14,8 @@
 
 #include "../src/vehicle_velocity_converter.hpp"
 
-#include <rclcpp/publisher.hpp>
+#include <autoware_utils_geometry/msg/covariance.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <rclcpp/subscription.hpp>
 
 #include <autoware_vehicle_msgs/msg/velocity_report.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
@@ -24,70 +23,121 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <set>
 #include <string>
-#include <vector>
 
+using autoware::vehicle_velocity_converter::convert;
 using autoware::vehicle_velocity_converter::VehicleVelocityConverter;
 using autoware_vehicle_msgs::msg::VelocityReport;
 using geometry_msgs::msg::TwistWithCovarianceStamped;
-using std::chrono::milliseconds;
-using std::chrono::system_clock;
+using COV_IDX = autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
 
-class TestVehicleVelocityConverter : public ::testing::Test
+namespace
 {
-protected:
-  void SetUp() override
-  {
-    // Initialize ROS context for test
-    if (!rclcpp::ok()) {
-      rclcpp::init(0, nullptr);
-    }
-
-    // Create a test node
-    node_ptr_ = std::make_shared<rclcpp::Node>("test_vehicle_velocity_converter");
-
-    // Create a publisher for velocity report
-    velocity_pub_ = node_ptr_->create_publisher<VelocityReport>("velocity_status", 10);
-
-    // Create a subscription to receive the converted twist
-    twist_sub_ = node_ptr_->create_subscription<TwistWithCovarianceStamped>(
-      "twist_with_covariance", 10,
-      [this](const TwistWithCovarianceStamped::SharedPtr msg) { received_twist_ = msg; });
-  }
-
-  void TearDown() override
-  {
-    node_ptr_.reset();
-    // Do not shutdown ROS context here as it's shared between tests
-  }
-
-  rclcpp::Node::SharedPtr node_ptr_{nullptr};
-  rclcpp::Publisher<VelocityReport>::SharedPtr velocity_pub_{nullptr};
-  rclcpp::Subscription<TwistWithCovarianceStamped>::SharedPtr twist_sub_{nullptr};
-  TwistWithCovarianceStamped::SharedPtr received_twist_{nullptr};
-
-  void spinSome() { rclcpp::spin_some(node_ptr_); }
-
-  bool waitForTwistMessage(
-    const std::chrono::milliseconds & timeout = std::chrono::milliseconds(1000))
-  {
-    const auto start_time = system_clock::now();
-    received_twist_ = nullptr;
-
-    while (rclcpp::ok() && !received_twist_) {
-      spinSome();
-      if (system_clock::now() - start_time > timeout) {
-        return false;
-      }
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
-    return received_twist_ != nullptr;
-  }
-};
-
-TEST_F(TestVehicleVelocityConverter, NodeInstantiation)
+VelocityReport make_report(
+  const double longitudinal_velocity, const double lateral_velocity, const double heading_rate,
+  const std::string & frame_id = "base_link")
 {
-  // Test node creation with default parameters
+  VelocityReport msg;
+  msg.header.frame_id = frame_id;
+  msg.header.stamp.sec = 123;
+  msg.header.stamp.nanosec = 456;
+  msg.longitudinal_velocity = static_cast<float>(longitudinal_velocity);
+  msg.lateral_velocity = static_cast<float>(lateral_velocity);
+  msg.heading_rate = static_cast<float>(heading_rate);
+  return msg;
+}
+
+// Assert that every covariance entry except the six diagonal indices is exactly zero.
+void expect_off_diagonal_zero(const TwistWithCovarianceStamped & twist)
+{
+  const std::set<size_t> diagonal = {COV_IDX::X_X,       COV_IDX::Y_Y,         COV_IDX::Z_Z,
+                                     COV_IDX::ROLL_ROLL, COV_IDX::PITCH_PITCH, COV_IDX::YAW_YAW};
+  for (size_t i = 0; i < twist.twist.covariance.size(); ++i) {
+    if (diagonal.count(i) == 0U) {
+      EXPECT_EQ(twist.twist.covariance[i], 0.0) << "covariance[" << i << "] expected to be zero";
+    }
+  }
+}
+}  // namespace
+
+// Pure-conversion tests: no ROS context, deterministic struct in / struct out.
+
+TEST(VehicleVelocityConverterConvert, AxisMappingAndScale)
+{
+  const auto msg = make_report(2.0, 0.1, 0.3);
+  const auto twist = convert(msg, 1.5, 0.2, 0.1);
+
+  // Longitudinal velocity is multiplied by the scale factor, lateral and yaw mapped directly.
+  EXPECT_DOUBLE_EQ(twist.twist.twist.linear.x, 2.0F * 1.5);
+  EXPECT_DOUBLE_EQ(twist.twist.twist.linear.y, static_cast<double>(0.1F));
+  EXPECT_DOUBLE_EQ(twist.twist.twist.angular.z, static_cast<double>(0.3F));
+
+  // Unused twist components must stay zero.
+  EXPECT_EQ(twist.twist.twist.linear.z, 0.0);
+  EXPECT_EQ(twist.twist.twist.angular.x, 0.0);
+  EXPECT_EQ(twist.twist.twist.angular.y, 0.0);
+}
+
+TEST(VehicleVelocityConverterConvert, FullCovarianceLayout)
+{
+  const auto msg = make_report(2.0, 0.1, 0.3);
+  const auto twist = convert(msg, 1.5, 0.2, 0.1);
+
+  // Diagonal entries: vx/wz variances from stddev^2, the rest large fixed values.
+  EXPECT_DOUBLE_EQ(twist.twist.covariance[COV_IDX::X_X], 0.2 * 0.2);
+  EXPECT_DOUBLE_EQ(twist.twist.covariance[COV_IDX::Y_Y], 10000.0);
+  EXPECT_DOUBLE_EQ(twist.twist.covariance[COV_IDX::Z_Z], 10000.0);
+  EXPECT_DOUBLE_EQ(twist.twist.covariance[COV_IDX::ROLL_ROLL], 10000.0);
+  EXPECT_DOUBLE_EQ(twist.twist.covariance[COV_IDX::PITCH_PITCH], 10000.0);
+  EXPECT_DOUBLE_EQ(twist.twist.covariance[COV_IDX::YAW_YAW], 0.1 * 0.1);
+
+  // All 30 off-diagonal entries must be zero.
+  expect_off_diagonal_zero(twist);
+}
+
+TEST(VehicleVelocityConverterConvert, HeaderCopiedVerbatim)
+{
+  const auto msg = make_report(2.0, 0.1, 0.3, "custom_frame");
+  const auto twist = convert(msg, 1.0, 0.2, 0.1);
+
+  EXPECT_EQ(twist.header.frame_id, "custom_frame");
+  EXPECT_EQ(twist.header.stamp.sec, msg.header.stamp.sec);
+  EXPECT_EQ(twist.header.stamp.nanosec, msg.header.stamp.nanosec);
+}
+
+TEST(VehicleVelocityConverterConvert, ZeroScaleFactor)
+{
+  const auto msg = make_report(2.0, 0.1, 0.3);
+  const auto twist = convert(msg, 0.0, 0.2, 0.1);
+
+  EXPECT_EQ(twist.twist.twist.linear.x, 0.0);
+  // Lateral and yaw are unaffected by the scale factor.
+  EXPECT_DOUBLE_EQ(twist.twist.twist.linear.y, static_cast<double>(0.1F));
+  EXPECT_DOUBLE_EQ(twist.twist.twist.angular.z, static_cast<double>(0.3F));
+}
+
+TEST(VehicleVelocityConverterConvert, NegativeVelocityAndScale)
+{
+  const auto msg = make_report(-2.0, -0.1, -0.3);
+  const auto twist = convert(msg, -1.5, 0.2, 0.1);
+
+  EXPECT_DOUBLE_EQ(twist.twist.twist.linear.x, -2.0F * -1.5);
+  EXPECT_DOUBLE_EQ(twist.twist.twist.linear.y, static_cast<double>(-0.1F));
+  EXPECT_DOUBLE_EQ(twist.twist.twist.angular.z, static_cast<double>(-0.3F));
+
+  // Variances stay non-negative (stddev squared) regardless of velocity sign.
+  EXPECT_DOUBLE_EQ(twist.twist.covariance[COV_IDX::X_X], 0.2 * 0.2);
+  EXPECT_DOUBLE_EQ(twist.twist.covariance[COV_IDX::YAW_YAW], 0.1 * 0.1);
+}
+
+// Thin smoke test for the ROS wiring (construction with parameter overrides).
+TEST(VehicleVelocityConverterNode, NodeInstantiation)
+{
+  if (!rclcpp::ok()) {
+    rclcpp::init(0, nullptr);
+  }
+
   rclcpp::NodeOptions options;
   options.parameter_overrides().push_back(rclcpp::Parameter("frame_id", "base_link"));
   options.parameter_overrides().push_back(rclcpp::Parameter("velocity_stddev_xx", 0.2));
@@ -98,115 +148,11 @@ TEST_F(TestVehicleVelocityConverter, NodeInstantiation)
   EXPECT_NE(vehicle_velocity_converter, nullptr);
 }
 
-TEST_F(TestVehicleVelocityConverter, MessageConversion)
-{
-  // Start the node with parameters
-  rclcpp::NodeOptions options;
-  options.parameter_overrides().push_back(rclcpp::Parameter("frame_id", "base_link"));
-  options.parameter_overrides().push_back(rclcpp::Parameter("velocity_stddev_xx", 0.2));
-  options.parameter_overrides().push_back(rclcpp::Parameter("angular_velocity_stddev_zz", 0.1));
-  options.parameter_overrides().push_back(rclcpp::Parameter("speed_scale_factor", 1.5));
-
-  auto vehicle_velocity_converter = std::make_shared<VehicleVelocityConverter>(options);
-
-  // Create and publish a velocity report message
-  auto velocity_msg = std::make_shared<VelocityReport>();
-  velocity_msg->header.frame_id = "base_link";
-  velocity_msg->header.stamp = node_ptr_->now();
-  velocity_msg->longitudinal_velocity = 2.0;
-  velocity_msg->lateral_velocity = 0.1;
-  velocity_msg->heading_rate = 0.3;
-
-  // Use a separate thread for executor to process messages
-  std::thread executor_thread([&]() {
-    rclcpp::executors::SingleThreadedExecutor executor;
-    executor.add_node(vehicle_velocity_converter);
-    auto start_time = system_clock::now();
-    while (system_clock::now() - start_time < std::chrono::seconds(2)) {
-      executor.spin_some(std::chrono::milliseconds(100));
-    }
-  });
-
-  // Wait a moment for the executor to set up
-  std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
-  // Publish the message
-  velocity_pub_->publish(*velocity_msg);
-
-  // Wait for the converted message
-  EXPECT_TRUE(waitForTwistMessage());
-
-  // Check that the conversion was correct
-  EXPECT_EQ(received_twist_->header.frame_id, velocity_msg->header.frame_id);
-  EXPECT_EQ(received_twist_->twist.twist.linear.x, velocity_msg->longitudinal_velocity * 1.5);
-  EXPECT_EQ(received_twist_->twist.twist.linear.y, velocity_msg->lateral_velocity);
-  EXPECT_EQ(received_twist_->twist.twist.angular.z, velocity_msg->heading_rate);
-
-  // Check covariance values
-  EXPECT_EQ(received_twist_->twist.covariance[0], 0.2 * 0.2);
-  EXPECT_EQ(received_twist_->twist.covariance[7], 10000.0);
-  EXPECT_EQ(received_twist_->twist.covariance[14], 10000.0);
-  EXPECT_EQ(received_twist_->twist.covariance[21], 10000.0);
-  EXPECT_EQ(received_twist_->twist.covariance[28], 10000.0);
-  EXPECT_EQ(received_twist_->twist.covariance[35], 0.1 * 0.1);
-
-  // Join the executor thread
-  executor_thread.join();
-}
-
-TEST_F(TestVehicleVelocityConverter, DifferentFrameId)
-{
-  // Start the node with parameters
-  rclcpp::NodeOptions options;
-  options.parameter_overrides().push_back(rclcpp::Parameter("frame_id", "base_link"));
-  options.parameter_overrides().push_back(rclcpp::Parameter("velocity_stddev_xx", 0.2));
-  options.parameter_overrides().push_back(rclcpp::Parameter("angular_velocity_stddev_zz", 0.1));
-  options.parameter_overrides().push_back(rclcpp::Parameter("speed_scale_factor", 1.0));
-
-  auto vehicle_velocity_converter = std::make_shared<VehicleVelocityConverter>(options);
-
-  // Create and publish a velocity report message with a different frame_id
-  auto velocity_msg = std::make_shared<VelocityReport>();
-  velocity_msg->header.frame_id = "different_frame";  // Not base_link
-  velocity_msg->header.stamp = node_ptr_->now();
-  velocity_msg->longitudinal_velocity = 2.0;
-  velocity_msg->lateral_velocity = 0.1;
-  velocity_msg->heading_rate = 0.3;
-
-  // Use a separate thread for executor to process messages
-  std::thread executor_thread([&]() {
-    rclcpp::executors::SingleThreadedExecutor executor;
-    executor.add_node(vehicle_velocity_converter);
-    auto start_time = system_clock::now();
-    while (system_clock::now() - start_time < std::chrono::seconds(2)) {
-      executor.spin_some(std::chrono::milliseconds(100));
-    }
-  });
-
-  // Wait a moment for the executor to set up
-  std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
-  // Publish the message
-  velocity_pub_->publish(*velocity_msg);
-
-  // Wait for the converted message
-  EXPECT_TRUE(waitForTwistMessage());
-
-  // Even with different frame_id, the conversion should still work
-  EXPECT_EQ(received_twist_->header.frame_id, velocity_msg->header.frame_id);
-  EXPECT_EQ(received_twist_->twist.twist.linear.x, velocity_msg->longitudinal_velocity);
-  EXPECT_EQ(received_twist_->twist.twist.linear.y, velocity_msg->lateral_velocity);
-  EXPECT_EQ(received_twist_->twist.twist.angular.z, velocity_msg->heading_rate);
-
-  // Join the executor thread
-  executor_thread.join();
-}
-
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);
   rclcpp::init(argc, argv);
-  int result = RUN_ALL_TESTS();
+  const int result = RUN_ALL_TESTS();
   rclcpp::shutdown();
   return result;
 }


### PR DESCRIPTION
## Description

Part of the autoware_core quality campaign (testability + coverage + de-duplication), one ROS package per PR.

- **Extract a pure conversion seam.** The `VelocityReport` → `TwistWithCovarianceStamped` math (scale-factor application, axis mapping, covariance fill, header copy) was inlined in the void-returning, private ROS subscription callback `callback_velocity_report`, with no way to unit-test it without spinning a full executor. It is now a pure, namespace-level free function `convert(const VelocityReport & msg, double speed_scale_factor, double stddev_vx, double stddev_wz) -> TwistWithCovarianceStamped`. The callback just calls it and publishes. This is purely additive — the public `VehicleVelocityConverter` class API is unchanged.
- **Replace magic covariance indices with the named enum.** The hand-written row-major arithmetic `[0 + 0 * 6]` … `[5 + 5 * 6]` is replaced with `autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX` (`X_X`, `Y_Y`, `Z_Z`, `ROLL_ROLL`, `PITCH_PITCH`, `YAW_YAW`), matching the direct downstream consumer `autoware_gyro_odometer` which already uses this enum for the identical twist-covariance layout. `autoware_utils_geometry` is added to `package.xml` (sorted).

## Related links

**Parent Issue:** autowarefoundation/autoware_core#1096

## How was this PR tested?

The old `MessageConversion` / `DifferentFrameId` tests (which built a second node, launched a `SingleThreadedExecutor` on a detached thread, slept 200ms, and polled — slow and timing-flaky) are replaced by direct `convert()` calls (no ROS context) that assert the full 36-element covariance (all six diagonal values and that every off-diagonal entry is zero), the zeroed unused twist fields (`linear.z`, `angular.x`, `angular.y`), verbatim header copy (stamp + frame_id), and `speed_scale_factor`/sign edge cases. One thin `NodeInstantiation` smoke test is kept for the ROS wiring.

`colcon build` + `colcon test --packages-select autoware_vehicle_velocity_converter` in the `autoware:core-devel-jazzy` container — 6 gtest cases pass (5 pure `convert` cases + 1 node smoke test); all ament linters pass; clang-format clean.

## Notes for reviewers

Behavior-preserving. The `XYZRPY_COV_IDX` enum members map to exactly the same flat array positions (0, 7, 14, 21, 28, 35) as the previous `[i + j * 6]` expressions, and the conversion arithmetic is unchanged.

## Interface changes

Additive only: a new namespace-level pure `convert(...)` free function. The `VehicleVelocityConverter` class API is unchanged.

## Effects on system behavior

None. The published message is byte-for-byte identical (same covariance positions via `XYZRPY_COV_IDX`, same arithmetic).

## youtalk fork CI — build-and-test all green

The full `build-test-tidy-pr` workflow runs on the youtalk fork (`ubicloud-standard-16`). All build-and-test gate jobs pass for head commit `b7c777f9` ([workflow run](https://github.com/youtalk/autoware_core/actions/runs/26675220706)):

- ✅ `build-and-test-diff-humble / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26675220706/job/78625609769
- ✅ `build-and-test-diff-jazzy / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26675220706/job/78625609760
- ✅ `build-and-test-diff-jazzy-agnocast / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26675220706/job/78625609764
- ✅ `build-and-test-diff-humble / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26675220706/job/78625718449
- ✅ `build-and-test-diff-jazzy / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26675220706/job/78625733503

(The `*-above` universe jobs are bonus coverage and excluded from the gate; both are also green on this PR.)
