### PR TITLE
fix(autoware_pyplot): implement declared-but-undefined Axes/Text forwarders and fix move ctors

### DIFF
--- a/testing/autoware_pyplot/include/autoware/pyplot/axes.hpp
+++ b/testing/autoware_pyplot/include/autoware/pyplot/axes.hpp
@@ -55,6 +55,10 @@ public:
     const pybind11::tuple & args = pybind11::tuple(),
     const pybind11::dict & kwargs = pybind11::dict()) const;
 
+  PyObjectWrapper contourf(
+    const pybind11::tuple & args = pybind11::tuple(),
+    const pybind11::dict & kwargs = pybind11::dict()) const;
+
   PyObjectWrapper errorbar(
     const pybind11::tuple & args = pybind11::tuple(),
     const pybind11::dict & kwargs = pybind11::dict()) const;
@@ -141,9 +145,11 @@ private:
   pybind11::object add_patch_attr;
   pybind11::object axhline_attr;
   pybind11::object axvline_attr;
+  pybind11::object bar_label_attr;
   pybind11::object cla_attr;
   pybind11::object contour_attr;
   pybind11::object contourf_attr;
+  pybind11::object errorbar_attr;
   pybind11::object fill_attr;
   pybind11::object fill_between_attr;
   pybind11::object get_xlim_attr;

--- a/testing/autoware_pyplot/src/axes.cpp
+++ b/testing/autoware_pyplot/src/axes.cpp
@@ -16,6 +16,7 @@
 #include <autoware/pyplot/loader.hpp>
 
 #include <tuple>
+#include <utility>
 
 namespace autoware::pyplot
 {
@@ -25,7 +26,7 @@ Axes::Axes(const pybind11::object & object) : PyObjectWrapper(object)
 {
   load_attrs();
 }
-Axes::Axes(pybind11::object && object) : PyObjectWrapper(object)
+Axes::Axes(pybind11::object && object) : PyObjectWrapper(std::move(object))
 {
   load_attrs();
 }
@@ -45,6 +46,11 @@ PyObjectWrapper Axes::axvline(const pybind11::tuple & args, const pybind11::dict
   return PyObjectWrapper{axvline_attr(*args, **kwargs)};
 }
 
+PyObjectWrapper Axes::bar_label(const pybind11::tuple & args, const pybind11::dict & kwargs) const
+{
+  return PyObjectWrapper{bar_label_attr(*args, **kwargs)};
+}
+
 PyObjectWrapper Axes::cla(const pybind11::tuple & args, const pybind11::dict & kwargs) const
 {
   return PyObjectWrapper{cla_attr(*args, **kwargs)};
@@ -53,6 +59,16 @@ PyObjectWrapper Axes::cla(const pybind11::tuple & args, const pybind11::dict & k
 PyObjectWrapper Axes::contour(const pybind11::tuple & args, const pybind11::dict & kwargs) const
 {
   return PyObjectWrapper{contour_attr(*args, **kwargs)};
+}
+
+PyObjectWrapper Axes::contourf(const pybind11::tuple & args, const pybind11::dict & kwargs) const
+{
+  return PyObjectWrapper{contourf_attr(*args, **kwargs)};
+}
+
+PyObjectWrapper Axes::errorbar(const pybind11::tuple & args, const pybind11::dict & kwargs) const
+{
+  return PyObjectWrapper{errorbar_attr(*args, **kwargs)};
 }
 
 PyObjectWrapper Axes::fill(const pybind11::tuple & args, const pybind11::dict & kwargs) const
@@ -167,9 +183,11 @@ void Axes::load_attrs()
   LOAD_FUNC_ATTR(add_patch, self_);
   LOAD_FUNC_ATTR(axhline, self_);
   LOAD_FUNC_ATTR(axvline, self_);
+  LOAD_FUNC_ATTR(bar_label, self_);
   LOAD_FUNC_ATTR(cla, self_);
   LOAD_FUNC_ATTR(contour, self_);
   LOAD_FUNC_ATTR(contourf, self_);
+  LOAD_FUNC_ATTR(errorbar, self_);
   LOAD_FUNC_ATTR(fill, self_);
   LOAD_FUNC_ATTR(fill_between, self_);
   LOAD_FUNC_ATTR(get_xlim, self_);

--- a/testing/autoware_pyplot/src/figure.cpp
+++ b/testing/autoware_pyplot/src/figure.cpp
@@ -15,6 +15,8 @@
 #include <autoware/pyplot/figure.hpp>
 #include <autoware/pyplot/loader.hpp>
 
+#include <utility>
+
 namespace autoware::pyplot
 {
 inline namespace figure
@@ -23,7 +25,7 @@ Figure::Figure(const pybind11::object & object) : PyObjectWrapper(object)
 {
   load_attrs();
 }
-Figure::Figure(pybind11::object && object) : PyObjectWrapper(object)
+Figure::Figure(pybind11::object && object) : PyObjectWrapper(std::move(object))
 {
   load_attrs();
 }

--- a/testing/autoware_pyplot/src/legend.cpp
+++ b/testing/autoware_pyplot/src/legend.cpp
@@ -14,6 +14,8 @@
 
 #include <autoware/pyplot/legend.hpp>
 
+#include <utility>
+
 namespace autoware::pyplot
 {
 inline namespace legend
@@ -21,7 +23,7 @@ inline namespace legend
 Legend::Legend(const pybind11::object & object) : PyObjectWrapper(object)
 {
 }
-Legend::Legend(pybind11::object && object) : PyObjectWrapper(object)
+Legend::Legend(pybind11::object && object) : PyObjectWrapper(std::move(object))
 {
 }
 }  // namespace legend

--- a/testing/autoware_pyplot/src/quiver.cpp
+++ b/testing/autoware_pyplot/src/quiver.cpp
@@ -14,6 +14,8 @@
 
 #include <autoware/pyplot/quiver.hpp>
 
+#include <utility>
+
 namespace autoware::pyplot
 {
 inline namespace quiver
@@ -21,7 +23,7 @@ inline namespace quiver
 Quiver::Quiver(const pybind11::object & object) : PyObjectWrapper(object)
 {
 }
-Quiver::Quiver(pybind11::object && object) : PyObjectWrapper(object)
+Quiver::Quiver(pybind11::object && object) : PyObjectWrapper(std::move(object))
 {
 }
 }  // namespace quiver

--- a/testing/autoware_pyplot/src/text.cpp
+++ b/testing/autoware_pyplot/src/text.cpp
@@ -15,16 +15,26 @@
 #include <autoware/pyplot/loader.hpp>
 #include <autoware/pyplot/text.hpp>
 
+#include <utility>
+
 namespace autoware::pyplot
 {
 inline namespace text
 {
 Text::Text(const pybind11::object & object) : PyObjectWrapper(object)
 {
+  load_attrs();
 }
 
-Text::Text(pybind11::object && object) : PyObjectWrapper(object)
+Text::Text(pybind11::object && object) : PyObjectWrapper(std::move(object))
 {
+  load_attrs();
+}
+
+PyObjectWrapper Text::set_rotation(
+  const pybind11::tuple & args, const pybind11::dict & kwargs) const
+{
+  return PyObjectWrapper{set_rotation_attr(*args, **kwargs)};
 }
 
 void Text::load_attrs()

--- a/testing/autoware_pyplot/test/test_pyplot.cpp
+++ b/testing/autoware_pyplot/test/test_pyplot.cpp
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// cspell:ignore yerr
+
 #include <autoware/pyplot/patches.hpp>
 #include <autoware/pyplot/pyplot.hpp>
+#include <autoware/pyplot/text.hpp>
 
 #include <gtest/gtest.h>
 #include <pybind11/embed.h>
@@ -23,6 +26,7 @@
  */
 #include <pybind11/stl.h>
 
+#include <cstddef>
 #include <vector>
 
 TEST(PyPlot, single_plot)
@@ -42,6 +46,7 @@ TEST(PyPlot, single_plot)
   }
   {
     auto [fig, axes] = plt.subplots(1, 2);
+    EXPECT_EQ(axes.size(), 2);
     auto & ax1 = axes[0];
     auto & ax2 = axes[1];
 
@@ -60,5 +65,61 @@ TEST(PyPlot, single_plot)
     ax1.set_aspect(Args("equal"));
     ax2.set_aspect(Args("equal"));
     plt.savefig(Args("test_double_plot.svg"));
+  }
+  {
+    // subplots(r, c) NxM (r > 1 && c > 1) row-major flattening branch
+    const int rows = 2;
+    const int cols = 3;
+    auto [fig, axes] = plt.subplots(rows, cols);
+    EXPECT_EQ(axes.size(), static_cast<std::size_t>(rows * cols));
+    // every flattened cell must be a usable Axes wrapper
+    for (auto & ax : axes) {
+      ax.set_xlim(Args(0, 1));
+      const auto [xmin, xmax] = ax.get_xlim();
+      EXPECT_DOUBLE_EQ(xmin, 0.0);
+      EXPECT_DOUBLE_EQ(xmax, 1.0);
+    }
+  }
+  {
+    // subplots(1, 3) Nx1 / 1xN flattening branch
+    auto [fig, axes] = plt.subplots(1, 3);
+    EXPECT_EQ(axes.size(), 3);
+  }
+  {
+    // subplots(1, 1) single-Axes branch
+    auto [fig, axes] = plt.subplots(1, 1);
+    EXPECT_EQ(axes.size(), 1);
+  }
+  {
+    // newly wired Axes forwarders: errorbar / bar_label / contourf
+    auto [fig, axes] = plt.subplots(1, 1);
+    auto & ax = axes[0];
+
+    // errorbar returns an ErrorbarContainer
+    ax.errorbar(
+      Args(std::vector<double>({0.0, 1.0, 2.0}), std::vector<double>({0.0, 1.0, 4.0})),
+      Kwargs("yerr"_a = 0.5));
+
+    // bar() + bar_label() must round-trip without a link error
+    auto bars =
+      ax.unwrap().attr("bar")(std::vector<double>({0.0, 1.0}), std::vector<double>({1.0, 2.0}));
+    ax.bar_label(Args(bars));
+
+    // contourf uses the eagerly loaded contourf_attr
+    ax.contourf(Args(
+      std::vector<std::vector<double>>({{0.0, 1.0}, {1.0, 2.0}}),
+      std::vector<std::vector<double>>({{0.0, 1.0}, {1.0, 2.0}}),
+      std::vector<std::vector<double>>({{1.0, 2.0}, {3.0, 4.0}})));
+    plt.savefig(Args("test_axes_forwarders.png"));
+  }
+  {
+    // Text::set_rotation: load_attrs() is now wired into the constructor, so the
+    // forwarder resolves and applies the rotation to the underlying Text artist.
+    auto [fig, axes] = plt.subplots(1, 1);
+    auto & ax = axes[0];
+    auto text_obj = ax.text(Args(0.5, 0.5, "label"));
+    autoware::pyplot::Text txt(text_obj.unwrap());
+    txt.set_rotation(Args(45.0));
+    EXPECT_DOUBLE_EQ(txt.unwrap().attr("get_rotation")().cast<double>(), 45.0);
   }
 }


### PR DESCRIPTION
## Description

Part of the autoware_core quality campaign (testability + coverage), one ROS package per PR.

`autoware_pyplot` is a thin C++17/pybind11 forwarding wrapper over `matplotlib.pyplot`. Several public members were declared in headers but had no definition, and some eagerly loaded Python attributes were dead state. Because the library is `STATIC`, unreferenced member functions are not emitted, so this compiled — but any caller of those symbols would hit an undefined-reference link error. This PR closes those latent public-API gaps and fixes the move constructors, then adds gtest coverage for the new paths.

Changes (all additive / behavior-preserving):

- **`Axes::bar_label` / `Axes::errorbar`** were declared but never defined and never loaded in `load_attrs()`. Add their backing `_attr` members, load them, and define the forwarders.
- **`Axes::contourf`** added. `contourf_attr` was eagerly loaded for every `Axes` but had no public forwarder (dead state + wasted attribute lookup); add the forwarder so it is used, mirroring `Axes::contour`.
- **`Text`** was effectively unusable: `Text::load_attrs()` was never called from either constructor (so `set_rotation_attr` stayed null) and `Text::set_rotation()` had no body. Wire `load_attrs()` into both constructors and define `set_rotation()`.
- **Move constructors** of `Axes`, `Figure`, `Legend`, `Quiver`, `Text` forwarded their `pybind11::object &&` to the base as an lvalue (`PyObjectWrapper(object)`), so the base move overload was never selected. Pass `std::move(object)` to select it (semantically identical for `pybind11::object`, avoids a refcount bump).

No existing signature was changed; all additions are new symbols or internal wiring.

## Related links

**Parent Issue:** autowarefoundation/autoware_core#1096

## How was this PR tested?

Extended the existing single `PyPlot.single_plot` gtest (the package's interpreter constraint means one `scoped_interpreter` per process) to exercise:

- `subplots(r, c)` 1x1 / 1xN / NxM row-major flattening branches with `axes.size()` assertions, plus per-cell `set_xlim`/`get_xlim` round-trip on the NxM grid;
- `Axes::errorbar`, `Axes::bar_label`, `Axes::contourf` forwarders (link + execute);
- `Text::set_rotation` with a value assertion (`get_rotation() == 45.0`) that fails if `load_attrs()` is not wired in.

`colcon build` + `colcon test --packages-select autoware_pyplot` in the `autoware:core-devel-jazzy` container — green (gtest + copyright + cppcheck + lint_cmake + xmllint all pass); `pre-commit` (clang-format, cpplint) clean.

## Notes for reviewers

The previously declared-but-undefined `Axes::bar_label`/`errorbar` and `Text::set_rotation` would have produced undefined-reference link errors for any caller (the `STATIC` library simply never emitted the unreferenced symbols). This fills in the missing definitions and adds tests that link+execute them, so the gap can't silently reopen.

## Interface changes

None. `Axes::contourf` is a new forwarder; the previously-declared `bar_label`/`errorbar`/`Text::set_rotation` now have definitions. No existing signature changes.

## Effects on system behavior

None for existing callers (the affected symbols were previously undefined or non-functional). The move-constructor fix is semantically identical (selects the base move overload, avoiding a refcount bump).

## youtalk fork CI — build-and-test all green

The full `build-test-tidy-pr` workflow runs on the youtalk fork (`ubicloud-standard-16`). All build-and-test gate jobs pass for head commit `48750e75` ([workflow run](https://github.com/youtalk/autoware_core/actions/runs/26785854682)):

- ✅ `build-and-test-diff-humble / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26785854682/job/78961302849
- ✅ `build-and-test-diff-jazzy / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26785854682/job/78961302942
- ✅ `build-and-test-diff-jazzy-agnocast / build-and-test-diff` — https://github.com/youtalk/autoware_core/actions/runs/26785854682/job/78961302886
- ✅ `build-and-test-diff-humble / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26785854682/job/78962403115
- ✅ `build-and-test-diff-jazzy / clang-tidy-diff` — https://github.com/youtalk/autoware_core/actions/runs/26785854682/job/78962460267

(The `*-above` universe jobs are bonus coverage and excluded from the gate.)
