### PR TITLE
fix: separate application logic from ROS-dependent part

### DIFF
--- a/sensing/autoware_downsample_filters/CMakeLists.txt
+++ b/sensing/autoware_downsample_filters/CMakeLists.txt
@@ -26,6 +26,12 @@ rclcpp_components_register_node(${PROJECT_NAME}
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
+
+  ament_auto_add_gtest(test_faster_voxel_grid_downsample_filter
+    test/test_faster_voxel_grid_downsample_filter.cpp
+  )
+  target_include_directories(test_faster_voxel_grid_downsample_filter PRIVATE src)
+
   ament_auto_add_gtest(test_voxel_grid_downsample_filter_integration
     test/test_voxel_grid_downsample_filter_integration.cpp
   )

--- a/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/faster_voxel_grid_downsample_filter.cpp
+++ b/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/faster_voxel_grid_downsample_filter.cpp
@@ -37,8 +37,8 @@ void FasterVoxelGridDownsampleFilter::set_voxel_size(
     Eigen::Array3f::Ones() / Eigen::Array3f(voxel_size_x, voxel_size_y, voxel_size_z);
 }
 
-void FasterVoxelGridDownsampleFilter::set_field_offsets(
-  const PointCloud2ConstPtr & input, const rclcpp::Logger & logger)
+FasterVoxelGridDownsampleFilter::Status FasterVoxelGridDownsampleFilter::set_field_offsets(
+  const PointCloud2ConstPtr & input)
 {
   x_offset_ = static_cast<int>(input->fields[pcl::getFieldIndex(*input, "x")].offset);
   y_offset_ = static_cast<int>(input->fields[pcl::getFieldIndex(*input, "y")].offset);
@@ -48,10 +48,7 @@ void FasterVoxelGridDownsampleFilter::set_field_offsets(
   if (
     intensity_index_ < 0 || input->fields[pcl::getFieldIndex(*input, "intensity")].datatype !=
                               sensor_msgs::msg::PointField::UINT8) {
-    RCLCPP_ERROR(
-      logger,
-      "There is no intensity field in the input point cloud or the intensity field is not of type "
-      "UINT8.");
+    return Status::kIntensityFieldNotFoundOrInvalidType;
   }
 
   if (intensity_index_ != -1) {
@@ -60,26 +57,25 @@ void FasterVoxelGridDownsampleFilter::set_field_offsets(
     intensity_offset_ = -1;
   }
   offset_initialized_ = true;
+  return Status::kSuccess;
 }
 
-void FasterVoxelGridDownsampleFilter::filter(
-  const PointCloud2ConstPtr & input, PointCloud2 & output, const TransformInfo & transform_info,
-  const rclcpp::Logger & logger)
+FasterVoxelGridDownsampleFilter::Status FasterVoxelGridDownsampleFilter::filter(
+  const PointCloud2ConstPtr & input, PointCloud2 & output, const TransformInfo & transform_info)
 {
   // Check if the field offset has been set
   if (!offset_initialized_) {
-    set_field_offsets(input, logger);
+    const auto offset_status = set_field_offsets(input);
+    if (offset_status != Status::kSuccess) {
+      return offset_status;
+    }
   }
 
   // Compute the minimum and maximum voxel coordinates
   Eigen::Vector3i min_voxel, max_voxel;
   if (!get_min_max_voxel(input, min_voxel, max_voxel)) {
-    RCLCPP_ERROR(
-      logger,
-      "Voxel size is too small for the input dataset. "
-      "Integer indices would overflow.");
     output = *input;
-    return;
+    return Status::kVoxelIndexWouldOverflow;
   }
 
   // Storage for mapping voxel coordinates to centroids
@@ -98,6 +94,8 @@ void FasterVoxelGridDownsampleFilter::filter(
 
   // Copy the centroids to the output
   copy_centroids_to_output(voxel_centroid_map, output, transform_info);
+
+  return Status::kSuccess;
 }
 
 Eigen::Vector4f FasterVoxelGridDownsampleFilter::get_point_from_global_offset(

--- a/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/faster_voxel_grid_downsample_filter.hpp
+++ b/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/faster_voxel_grid_downsample_filter.hpp
@@ -33,8 +33,7 @@ class FasterVoxelGridDownsampleFilter
   using PointCloud2ConstPtr = sensor_msgs::msg::PointCloud2::ConstSharedPtr;
 
 public:
-  enum class Status
-  {
+  enum class Status {
     kSuccess,
     kIntensityFieldNotFoundOrInvalidType,
     kVoxelIndexWouldOverflow,

--- a/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/faster_voxel_grid_downsample_filter.hpp
+++ b/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/faster_voxel_grid_downsample_filter.hpp
@@ -33,7 +33,8 @@ class FasterVoxelGridDownsampleFilter
   using PointCloud2ConstPtr = sensor_msgs::msg::PointCloud2::ConstSharedPtr;
 
 public:
-  enum class Status {
+  enum class Status
+  {
     kSuccess,
     kIntensityFieldNotFoundOrInvalidType,
     kVoxelIndexWouldOverflow,

--- a/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/faster_voxel_grid_downsample_filter.hpp
+++ b/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/faster_voxel_grid_downsample_filter.hpp
@@ -33,12 +33,18 @@ class FasterVoxelGridDownsampleFilter
   using PointCloud2ConstPtr = sensor_msgs::msg::PointCloud2::ConstSharedPtr;
 
 public:
+  enum class Status
+  {
+    kSuccess,
+    kIntensityFieldNotFoundOrInvalidType,
+    kVoxelIndexWouldOverflow,
+  };
+
   FasterVoxelGridDownsampleFilter();
   void set_voxel_size(float voxel_size_x, float voxel_size_y, float voxel_size_z);
-  void set_field_offsets(const PointCloud2ConstPtr & input, const rclcpp::Logger & logger);
-  void filter(
-    const PointCloud2ConstPtr & input, PointCloud2 & output, const TransformInfo & transform_info,
-    const rclcpp::Logger & logger);
+  Status set_field_offsets(const PointCloud2ConstPtr & input);
+  Status filter(
+    const PointCloud2ConstPtr & input, PointCloud2 & output, const TransformInfo & transform_info);
 
 private:
   struct Centroid

--- a/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.cpp
@@ -219,9 +219,7 @@ void VoxelGridDownsampleFilter::filter(
   faster_voxel_filter.set_voxel_size(voxel_size_x_, voxel_size_y_, voxel_size_z_);
 
   const auto offset_status = faster_voxel_filter.set_field_offsets(input);
-  if (
-    offset_status ==
-    FasterVoxelGridDownsampleFilter::Status::kIntensityFieldNotFoundOrInvalidType) {
+  if (offset_status == FasterVoxelGridDownsampleFilter::Status::kIntensityFieldNotFoundOrInvalidType) {
     RCLCPP_ERROR(
       this->get_logger(),
       "There is no intensity field in the input point cloud or the intensity field is not of type "

--- a/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.cpp
@@ -219,7 +219,9 @@ void VoxelGridDownsampleFilter::filter(
   faster_voxel_filter.set_voxel_size(voxel_size_x_, voxel_size_y_, voxel_size_z_);
 
   const auto offset_status = faster_voxel_filter.set_field_offsets(input);
-  if (offset_status == FasterVoxelGridDownsampleFilter::Status::kIntensityFieldNotFoundOrInvalidType) {
+  if (
+    offset_status ==
+    FasterVoxelGridDownsampleFilter::Status::kIntensityFieldNotFoundOrInvalidType) {
     RCLCPP_ERROR(
       this->get_logger(),
       "There is no intensity field in the input point cloud or the intensity field is not of type "

--- a/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.cpp
@@ -217,8 +217,22 @@ void VoxelGridDownsampleFilter::filter(
   std::scoped_lock lock(mutex_);
   FasterVoxelGridDownsampleFilter faster_voxel_filter;
   faster_voxel_filter.set_voxel_size(voxel_size_x_, voxel_size_y_, voxel_size_z_);
-  faster_voxel_filter.set_field_offsets(input, this->get_logger());
-  faster_voxel_filter.filter(input, output, transform_info, this->get_logger());
+
+  const auto offset_status = faster_voxel_filter.set_field_offsets(input);
+  if (offset_status == FasterVoxelGridDownsampleFilter::Status::kIntensityFieldNotFoundOrInvalidType) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "There is no intensity field in the input point cloud or the intensity field is not of type "
+      "UINT8.");
+    return;
+  }
+
+  const auto filter_status = faster_voxel_filter.filter(input, output, transform_info);
+  if (filter_status == FasterVoxelGridDownsampleFilter::Status::kVoxelIndexWouldOverflow) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Voxel size is too small for the input dataset. Integer indices would overflow.");
+  }
 }
 }  // namespace autoware::downsample_filters
 

--- a/sensing/autoware_downsample_filters/test/pointcloud_test_utils.hpp
+++ b/sensing/autoware_downsample_filters/test/pointcloud_test_utils.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE_DOWNSAMPLE_FILTERS__TEST__POINTCLOUD_TEST_UTILS_HPP_
-#define AUTOWARE_DOWNSAMPLE_FILTERS__TEST__POINTCLOUD_TEST_UTILS_HPP_
+#ifndef POINTCLOUD_TEST_UTILS_HPP_
+#define POINTCLOUD_TEST_UTILS_HPP_
 
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
@@ -35,10 +35,10 @@ inline sensor_msgs::msg::PointCloud2 create_pointcloud2(const std::vector<PointX
   sensor_msgs::msg::PointCloud2 cloud;
   sensor_msgs::PointCloud2Modifier modifier(cloud);
   modifier.setPointCloud2Fields(
-    6, "x", 1, sensor_msgs::msg::PointField::FLOAT32, "y", 1,
-    sensor_msgs::msg::PointField::FLOAT32, "z", 1, sensor_msgs::msg::PointField::FLOAT32,
-    "intensity", 1, sensor_msgs::msg::PointField::UINT8, "return_type", 1,
-    sensor_msgs::msg::PointField::UINT8, "channel", 1, sensor_msgs::msg::PointField::UINT16);
+    6, "x", 1, sensor_msgs::msg::PointField::FLOAT32, "y", 1, sensor_msgs::msg::PointField::FLOAT32,
+    "z", 1, sensor_msgs::msg::PointField::FLOAT32, "intensity", 1,
+    sensor_msgs::msg::PointField::UINT8, "return_type", 1, sensor_msgs::msg::PointField::UINT8,
+    "channel", 1, sensor_msgs::msg::PointField::UINT16);
   modifier.resize(points.size());
 
   sensor_msgs::PointCloud2Iterator<float> iter_x(cloud, "x");
@@ -101,4 +101,4 @@ inline void expect_points_near(
 
 }  // namespace autoware::downsample_filters::test_utils
 
-#endif  // AUTOWARE_DOWNSAMPLE_FILTERS__TEST__POINTCLOUD_TEST_UTILS_HPP_
+#endif  // POINTCLOUD_TEST_UTILS_HPP_

--- a/sensing/autoware_downsample_filters/test/pointcloud_test_utils.hpp
+++ b/sensing/autoware_downsample_filters/test/pointcloud_test_utils.hpp
@@ -1,0 +1,104 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE_DOWNSAMPLE_FILTERS__TEST__POINTCLOUD_TEST_UTILS_HPP_
+#define AUTOWARE_DOWNSAMPLE_FILTERS__TEST__POINTCLOUD_TEST_UTILS_HPP_
+
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace autoware::downsample_filters::test_utils
+{
+using PointXYZ = std::array<float, 3>;
+
+inline sensor_msgs::msg::PointCloud2 create_pointcloud2(const std::vector<PointXYZ> & points)
+{
+  sensor_msgs::msg::PointCloud2 cloud;
+  sensor_msgs::PointCloud2Modifier modifier(cloud);
+  modifier.setPointCloud2Fields(
+    6, "x", 1, sensor_msgs::msg::PointField::FLOAT32, "y", 1,
+    sensor_msgs::msg::PointField::FLOAT32, "z", 1, sensor_msgs::msg::PointField::FLOAT32,
+    "intensity", 1, sensor_msgs::msg::PointField::UINT8, "return_type", 1,
+    sensor_msgs::msg::PointField::UINT8, "channel", 1, sensor_msgs::msg::PointField::UINT16);
+  modifier.resize(points.size());
+
+  sensor_msgs::PointCloud2Iterator<float> iter_x(cloud, "x");
+  sensor_msgs::PointCloud2Iterator<float> iter_y(cloud, "y");
+  sensor_msgs::PointCloud2Iterator<float> iter_z(cloud, "z");
+  sensor_msgs::PointCloud2Iterator<uint8_t> iter_intensity(cloud, "intensity");
+  sensor_msgs::PointCloud2Iterator<uint8_t> iter_return_type(cloud, "return_type");
+  sensor_msgs::PointCloud2Iterator<uint16_t> iter_channel(cloud, "channel");
+
+  for (const auto & point : points) {
+    *iter_x = point[0];
+    *iter_y = point[1];
+    *iter_z = point[2];
+    *iter_intensity = 100U;
+    *iter_return_type = 0U;
+    *iter_channel = 0U;
+    ++iter_x;
+    ++iter_y;
+    ++iter_z;
+    ++iter_intensity;
+    ++iter_return_type;
+    ++iter_channel;
+  }
+
+  return cloud;
+}
+
+inline std::vector<PointXYZ> extract_points_from_cloud(const sensor_msgs::msg::PointCloud2 & cloud)
+{
+  std::vector<PointXYZ> points;
+  sensor_msgs::PointCloud2ConstIterator<float> iter_x(cloud, "x");
+  sensor_msgs::PointCloud2ConstIterator<float> iter_y(cloud, "y");
+  sensor_msgs::PointCloud2ConstIterator<float> iter_z(cloud, "z");
+
+  for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z) {
+    points.push_back({*iter_x, *iter_y, *iter_z});
+  }
+
+  return points;
+}
+
+inline void expect_points_near(
+  std::vector<PointXYZ> actual, std::vector<PointXYZ> expected, const float tolerance)
+{
+  ASSERT_EQ(actual.size(), expected.size());
+
+  const auto less = [](const PointXYZ & a, const PointXYZ & b) {
+    return std::tie(a[0], a[1], a[2]) < std::tie(b[0], b[1], b[2]);
+  };
+  std::sort(actual.begin(), actual.end(), less);
+  std::sort(expected.begin(), expected.end(), less);
+
+  for (size_t i = 0; i < expected.size(); ++i) {
+    SCOPED_TRACE("point index " + std::to_string(i));
+    EXPECT_NEAR(actual[i][0], expected[i][0], tolerance);
+    EXPECT_NEAR(actual[i][1], expected[i][1], tolerance);
+    EXPECT_NEAR(actual[i][2], expected[i][2], tolerance);
+  }
+}
+
+}  // namespace autoware::downsample_filters::test_utils
+
+#endif  // AUTOWARE_DOWNSAMPLE_FILTERS__TEST__POINTCLOUD_TEST_UTILS_HPP_

--- a/sensing/autoware_downsample_filters/test/test_faster_voxel_grid_downsample_filter.cpp
+++ b/sensing/autoware_downsample_filters/test/test_faster_voxel_grid_downsample_filter.cpp
@@ -15,76 +15,27 @@
 #include "voxel_grid_downsample_filter/faster_voxel_grid_downsample_filter.hpp"
 #include "voxel_grid_downsample_filter/transform_info.hpp"
 
-#include <sensor_msgs/msg/point_cloud2.hpp>
-#include <sensor_msgs/point_cloud2_iterator.hpp>
+#include "pointcloud_test_utils.hpp"
 
+#include <sensor_msgs/msg/point_cloud2.hpp>
 #include <gtest/gtest.h>
 
-#include <array>
 #include <vector>
 
 namespace
 {
-using PointXYZ = std::array<float, 3>;
 using autoware::downsample_filters::FasterVoxelGridDownsampleFilter;
 using autoware::downsample_filters::TransformInfo;
-
-sensor_msgs::msg::PointCloud2 make_cloud(const std::vector<PointXYZ> & points)
-{
-  sensor_msgs::msg::PointCloud2 cloud;
-  sensor_msgs::PointCloud2Modifier modifier(cloud);
-  modifier.setPointCloud2Fields(
-    6, "x", 1, sensor_msgs::msg::PointField::FLOAT32, "y", 1,
-    sensor_msgs::msg::PointField::FLOAT32, "z", 1, sensor_msgs::msg::PointField::FLOAT32,
-    "intensity", 1, sensor_msgs::msg::PointField::UINT8, "return_type", 1,
-    sensor_msgs::msg::PointField::UINT8, "channel", 1, sensor_msgs::msg::PointField::UINT16);
-  modifier.resize(points.size());
-
-  sensor_msgs::PointCloud2Iterator<float> iter_x(cloud, "x");
-  sensor_msgs::PointCloud2Iterator<float> iter_y(cloud, "y");
-  sensor_msgs::PointCloud2Iterator<float> iter_z(cloud, "z");
-  sensor_msgs::PointCloud2Iterator<uint8_t> iter_intensity(cloud, "intensity");
-  sensor_msgs::PointCloud2Iterator<uint8_t> iter_return_type(cloud, "return_type");
-  sensor_msgs::PointCloud2Iterator<uint16_t> iter_channel(cloud, "channel");
-
-  for (const auto & point : points) {
-    *iter_x = point[0];
-    *iter_y = point[1];
-    *iter_z = point[2];
-    *iter_intensity = 100U;
-    *iter_return_type = 0U;
-    *iter_channel = 0U;
-    ++iter_x;
-    ++iter_y;
-    ++iter_z;
-    ++iter_intensity;
-    ++iter_return_type;
-    ++iter_channel;
-  }
-
-  cloud.header.frame_id = "sensor_frame";
-  return cloud;
-}
-
-std::vector<PointXYZ> read_xyz(const sensor_msgs::msg::PointCloud2 & cloud)
-{
-  std::vector<PointXYZ> points;
-  sensor_msgs::PointCloud2ConstIterator<float> iter_x(cloud, "x");
-  sensor_msgs::PointCloud2ConstIterator<float> iter_y(cloud, "y");
-  sensor_msgs::PointCloud2ConstIterator<float> iter_z(cloud, "z");
-
-  for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z) {
-    points.push_back({*iter_x, *iter_y, *iter_z});
-  }
-
-  return points;
-}
+using autoware::downsample_filters::test_utils::PointXYZ;
+using autoware::downsample_filters::test_utils::create_pointcloud2;
+using autoware::downsample_filters::test_utils::expect_points_near;
+using autoware::downsample_filters::test_utils::extract_points_from_cloud;
 }  // namespace
 
 TEST(FasterVoxelGridDownsampleFilterTest, ReturnsCentroidForSingleVoxel)
 {
   const auto cloud = std::make_shared<sensor_msgs::msg::PointCloud2>(
-    make_cloud({{0.1f, 0.1f, 0.1f}, {0.2f, 0.2f, 0.2f}, {0.9f, 0.9f, 0.9f}}));
+    create_pointcloud2({{0.1f, 0.1f, 0.1f}, {0.2f, 0.2f, 0.2f}, {0.9f, 0.9f, 0.9f}}));
 
   FasterVoxelGridDownsampleFilter filter;
   filter.set_voxel_size(1.0f, 1.0f, 1.0f);
@@ -94,18 +45,17 @@ TEST(FasterVoxelGridDownsampleFilterTest, ReturnsCentroidForSingleVoxel)
   const auto status = filter.filter(cloud, output, transform_info);
 
   ASSERT_EQ(status, FasterVoxelGridDownsampleFilter::Status::kSuccess);
-  ASSERT_EQ(output.width, 1U);
-
-  const auto points = read_xyz(output);
-  ASSERT_EQ(points.size(), 1U);
-  EXPECT_NEAR(points.front()[0], 0.4f, 1.0e-4f);
-  EXPECT_NEAR(points.front()[1], 0.4f, 1.0e-4f);
-  EXPECT_NEAR(points.front()[2], 0.4f, 1.0e-4f);
+  const auto output_points = extract_points_from_cloud(output);
+  const std::vector<PointXYZ> expected_points = {
+    {0.4f, 0.4f, 0.4f},
+  };
+  expect_points_near(output_points, expected_points, 1.0e-4f);
 }
 
 TEST(FasterVoxelGridDownsampleFilterTest, FailsForInvalidIntensityFieldType)
 {
-  auto cloud = std::make_shared<sensor_msgs::msg::PointCloud2>(make_cloud({{0.1f, 0.1f, 0.1f}}));
+  auto cloud =
+    std::make_shared<sensor_msgs::msg::PointCloud2>(create_pointcloud2({{0.1f, 0.1f, 0.1f}}));
 
   for (auto & field : cloud->fields) {
     if (field.name == "intensity") {

--- a/sensing/autoware_downsample_filters/test/test_faster_voxel_grid_downsample_filter.cpp
+++ b/sensing/autoware_downsample_filters/test/test_faster_voxel_grid_downsample_filter.cpp
@@ -34,10 +34,10 @@ sensor_msgs::msg::PointCloud2 make_cloud(const std::vector<PointXYZ> & points)
   sensor_msgs::msg::PointCloud2 cloud;
   sensor_msgs::PointCloud2Modifier modifier(cloud);
   modifier.setPointCloud2Fields(
-    6, "x", 1, sensor_msgs::msg::PointField::FLOAT32, "y", 1,
-    sensor_msgs::msg::PointField::FLOAT32, "z", 1, sensor_msgs::msg::PointField::FLOAT32,
-    "intensity", 1, sensor_msgs::msg::PointField::UINT8, "return_type", 1,
-    sensor_msgs::msg::PointField::UINT8, "channel", 1, sensor_msgs::msg::PointField::UINT16);
+    6, "x", 1, sensor_msgs::msg::PointField::FLOAT32, "y", 1, sensor_msgs::msg::PointField::FLOAT32,
+    "z", 1, sensor_msgs::msg::PointField::FLOAT32, "intensity", 1,
+    sensor_msgs::msg::PointField::UINT8, "return_type", 1, sensor_msgs::msg::PointField::UINT8,
+    "channel", 1, sensor_msgs::msg::PointField::UINT16);
   modifier.resize(points.size());
 
   sensor_msgs::PointCloud2Iterator<float> iter_x(cloud, "x");

--- a/sensing/autoware_downsample_filters/test/test_faster_voxel_grid_downsample_filter.cpp
+++ b/sensing/autoware_downsample_filters/test/test_faster_voxel_grid_downsample_filter.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "pointcloud_test_utils.hpp"
 #include "voxel_grid_downsample_filter/faster_voxel_grid_downsample_filter.hpp"
 #include "voxel_grid_downsample_filter/transform_info.hpp"
 
-#include "pointcloud_test_utils.hpp"
-
 #include <sensor_msgs/msg/point_cloud2.hpp>
+
 #include <gtest/gtest.h>
 
 #include <vector>
@@ -26,10 +26,10 @@ namespace
 {
 using autoware::downsample_filters::FasterVoxelGridDownsampleFilter;
 using autoware::downsample_filters::TransformInfo;
-using autoware::downsample_filters::test_utils::PointXYZ;
 using autoware::downsample_filters::test_utils::create_pointcloud2;
 using autoware::downsample_filters::test_utils::expect_points_near;
 using autoware::downsample_filters::test_utils::extract_points_from_cloud;
+using autoware::downsample_filters::test_utils::PointXYZ;
 }  // namespace
 
 TEST(FasterVoxelGridDownsampleFilterTest, ReturnsCentroidForSingleVoxel)

--- a/sensing/autoware_downsample_filters/test/test_faster_voxel_grid_downsample_filter.cpp
+++ b/sensing/autoware_downsample_filters/test/test_faster_voxel_grid_downsample_filter.cpp
@@ -1,0 +1,125 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "voxel_grid_downsample_filter/faster_voxel_grid_downsample_filter.hpp"
+#include "voxel_grid_downsample_filter/transform_info.hpp"
+
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <vector>
+
+namespace
+{
+using PointXYZ = std::array<float, 3>;
+using autoware::downsample_filters::FasterVoxelGridDownsampleFilter;
+using autoware::downsample_filters::TransformInfo;
+
+sensor_msgs::msg::PointCloud2 make_cloud(const std::vector<PointXYZ> & points)
+{
+  sensor_msgs::msg::PointCloud2 cloud;
+  sensor_msgs::PointCloud2Modifier modifier(cloud);
+  modifier.setPointCloud2Fields(
+    6, "x", 1, sensor_msgs::msg::PointField::FLOAT32, "y", 1,
+    sensor_msgs::msg::PointField::FLOAT32, "z", 1, sensor_msgs::msg::PointField::FLOAT32,
+    "intensity", 1, sensor_msgs::msg::PointField::UINT8, "return_type", 1,
+    sensor_msgs::msg::PointField::UINT8, "channel", 1, sensor_msgs::msg::PointField::UINT16);
+  modifier.resize(points.size());
+
+  sensor_msgs::PointCloud2Iterator<float> iter_x(cloud, "x");
+  sensor_msgs::PointCloud2Iterator<float> iter_y(cloud, "y");
+  sensor_msgs::PointCloud2Iterator<float> iter_z(cloud, "z");
+  sensor_msgs::PointCloud2Iterator<uint8_t> iter_intensity(cloud, "intensity");
+  sensor_msgs::PointCloud2Iterator<uint8_t> iter_return_type(cloud, "return_type");
+  sensor_msgs::PointCloud2Iterator<uint16_t> iter_channel(cloud, "channel");
+
+  for (const auto & point : points) {
+    *iter_x = point[0];
+    *iter_y = point[1];
+    *iter_z = point[2];
+    *iter_intensity = 100U;
+    *iter_return_type = 0U;
+    *iter_channel = 0U;
+    ++iter_x;
+    ++iter_y;
+    ++iter_z;
+    ++iter_intensity;
+    ++iter_return_type;
+    ++iter_channel;
+  }
+
+  cloud.header.frame_id = "sensor_frame";
+  return cloud;
+}
+
+std::vector<PointXYZ> read_xyz(const sensor_msgs::msg::PointCloud2 & cloud)
+{
+  std::vector<PointXYZ> points;
+  sensor_msgs::PointCloud2ConstIterator<float> iter_x(cloud, "x");
+  sensor_msgs::PointCloud2ConstIterator<float> iter_y(cloud, "y");
+  sensor_msgs::PointCloud2ConstIterator<float> iter_z(cloud, "z");
+
+  for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z) {
+    points.push_back({*iter_x, *iter_y, *iter_z});
+  }
+
+  return points;
+}
+}  // namespace
+
+TEST(FasterVoxelGridDownsampleFilterTest, ReturnsCentroidForSingleVoxel)
+{
+  const auto cloud = std::make_shared<sensor_msgs::msg::PointCloud2>(
+    make_cloud({{0.1f, 0.1f, 0.1f}, {0.2f, 0.2f, 0.2f}, {0.9f, 0.9f, 0.9f}}));
+
+  FasterVoxelGridDownsampleFilter filter;
+  filter.set_voxel_size(1.0f, 1.0f, 1.0f);
+
+  sensor_msgs::msg::PointCloud2 output;
+  TransformInfo transform_info;
+  const auto status = filter.filter(cloud, output, transform_info);
+
+  ASSERT_EQ(status, FasterVoxelGridDownsampleFilter::Status::kSuccess);
+  ASSERT_EQ(output.width, 1U);
+
+  const auto points = read_xyz(output);
+  ASSERT_EQ(points.size(), 1U);
+  EXPECT_NEAR(points.front()[0], 0.4f, 1.0e-4f);
+  EXPECT_NEAR(points.front()[1], 0.4f, 1.0e-4f);
+  EXPECT_NEAR(points.front()[2], 0.4f, 1.0e-4f);
+}
+
+TEST(FasterVoxelGridDownsampleFilterTest, FailsForInvalidIntensityFieldType)
+{
+  auto cloud = std::make_shared<sensor_msgs::msg::PointCloud2>(make_cloud({{0.1f, 0.1f, 0.1f}}));
+
+  for (auto & field : cloud->fields) {
+    if (field.name == "intensity") {
+      field.datatype = sensor_msgs::msg::PointField::FLOAT32;
+      break;
+    }
+  }
+
+  FasterVoxelGridDownsampleFilter filter;
+  filter.set_voxel_size(1.0f, 1.0f, 1.0f);
+
+  sensor_msgs::msg::PointCloud2 output;
+  TransformInfo transform_info;
+  const auto status = filter.filter(cloud, output, transform_info);
+
+  EXPECT_EQ(status, FasterVoxelGridDownsampleFilter::Status::kIntensityFieldNotFoundOrInvalidType);
+}

--- a/sensing/autoware_downsample_filters/test/test_voxel_grid_downsample_filter_integration.cpp
+++ b/sensing/autoware_downsample_filters/test/test_voxel_grid_downsample_filter_integration.cpp
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.hpp"
-
 #include "pointcloud_test_utils.hpp"
+#include "voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.hpp"
 
 #include <rclcpp/executors.hpp>
 
@@ -34,10 +33,10 @@
 #include <thread>
 #include <vector>
 
-using autoware::downsample_filters::test_utils::PointXYZ;
 using autoware::downsample_filters::test_utils::create_pointcloud2;
 using autoware::downsample_filters::test_utils::expect_points_near;
 using autoware::downsample_filters::test_utils::extract_points_from_cloud;
+using autoware::downsample_filters::test_utils::PointXYZ;
 
 class VoxelGridIntegrationHarness
 {

--- a/sensing/autoware_downsample_filters/test/test_voxel_grid_downsample_filter_integration.cpp
+++ b/sensing/autoware_downsample_filters/test/test_voxel_grid_downsample_filter_integration.cpp
@@ -14,6 +14,8 @@
 
 #include "voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.hpp"
 
+#include "pointcloud_test_utils.hpp"
+
 #include <rclcpp/executors.hpp>
 
 #include <geometry_msgs/msg/transform_stamped.hpp>
@@ -23,7 +25,6 @@
 #include <gtest/gtest.h>
 #include <tf2_ros/static_transform_broadcaster.h>
 
-#include <algorithm>
 #include <array>
 #include <atomic>
 #include <chrono>
@@ -31,79 +32,12 @@
 #include <memory>
 #include <string>
 #include <thread>
-#include <tuple>
 #include <vector>
 
-using PointXYZ = std::array<float, 3>;
-
-sensor_msgs::msg::PointCloud2 create_pointcloud2(const std::vector<PointXYZ> & points)
-{
-  sensor_msgs::msg::PointCloud2 cloud;
-  sensor_msgs::PointCloud2Modifier modifier(cloud);
-  modifier.setPointCloud2Fields(
-    6, "x", 1, sensor_msgs::msg::PointField::FLOAT32, "y", 1, sensor_msgs::msg::PointField::FLOAT32,
-    "z", 1, sensor_msgs::msg::PointField::FLOAT32, "intensity", 1,
-    sensor_msgs::msg::PointField::UINT8, "return_type", 1, sensor_msgs::msg::PointField::UINT8,
-    "channel", 1, sensor_msgs::msg::PointField::UINT16);
-  modifier.resize(points.size());
-
-  sensor_msgs::PointCloud2Iterator<float> iter_x(cloud, "x");
-  sensor_msgs::PointCloud2Iterator<float> iter_y(cloud, "y");
-  sensor_msgs::PointCloud2Iterator<float> iter_z(cloud, "z");
-  sensor_msgs::PointCloud2Iterator<uint8_t> iter_intensity(cloud, "intensity");
-  sensor_msgs::PointCloud2Iterator<uint8_t> iter_return_type(cloud, "return_type");
-  sensor_msgs::PointCloud2Iterator<uint16_t> iter_channel(cloud, "channel");
-
-  for (const auto & point : points) {
-    *iter_x = point[0];
-    *iter_y = point[1];
-    *iter_z = point[2];
-    *iter_intensity = 100U;
-    *iter_return_type = 0U;
-    *iter_channel = 0U;
-    ++iter_x;
-    ++iter_y;
-    ++iter_z;
-    ++iter_intensity;
-    ++iter_return_type;
-    ++iter_channel;
-  }
-
-  return cloud;
-}
-
-std::vector<PointXYZ> extract_points_from_cloud(const sensor_msgs::msg::PointCloud2 & cloud)
-{
-  std::vector<PointXYZ> points;
-  sensor_msgs::PointCloud2ConstIterator<float> iter_x(cloud, "x");
-  sensor_msgs::PointCloud2ConstIterator<float> iter_y(cloud, "y");
-  sensor_msgs::PointCloud2ConstIterator<float> iter_z(cloud, "z");
-
-  for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z) {
-    points.push_back({*iter_x, *iter_y, *iter_z});
-  }
-
-  return points;
-}
-
-void expect_points_near(
-  std::vector<PointXYZ> actual, std::vector<PointXYZ> expected, const float tolerance)
-{
-  ASSERT_EQ(actual.size(), expected.size());
-
-  const auto less = [](const PointXYZ & a, const PointXYZ & b) {
-    return std::tie(a[0], a[1], a[2]) < std::tie(b[0], b[1], b[2]);
-  };
-  std::sort(actual.begin(), actual.end(), less);
-  std::sort(expected.begin(), expected.end(), less);
-
-  for (size_t i = 0; i < expected.size(); ++i) {
-    SCOPED_TRACE("point index " + std::to_string(i));
-    EXPECT_NEAR(actual[i][0], expected[i][0], tolerance);
-    EXPECT_NEAR(actual[i][1], expected[i][1], tolerance);
-    EXPECT_NEAR(actual[i][2], expected[i][2], tolerance);
-  }
-}
+using autoware::downsample_filters::test_utils::PointXYZ;
+using autoware::downsample_filters::test_utils::create_pointcloud2;
+using autoware::downsample_filters::test_utils::expect_points_near;
+using autoware::downsample_filters::test_utils::extract_points_from_cloud;
 
 class VoxelGridIntegrationHarness
 {


### PR DESCRIPTION
## Description

:warning: THIS PR DESCRIPTION IS A DRAFT MADE BY CODEX (but of coursely I have reviewed and edited it) AND SUBJECT TO CHANGE DEPENDING ON REFACTORING :warning:

This PR starts the refactoring to separate ROS-dependent logic from application logic in `autoware_downsample_filters` (`voxel_grid_downsample_filter`).

Main changes:
- Removed direct ROS logging (`RCLCPP_*`) dependency from `FasterVoxelGridDownsampleFilter`.
- Introduced status-based error reporting in the application-logic layer:
	- `kSuccess`
	- `kIntensityFieldNotFoundOrInvalidType`
	- `kVoxelIndexWouldOverflow`
- Moved ROS logging responsibility to `VoxelGridDownsampleFilter` node layer only.
- Added a new unit test target for application logic (`test_faster_voxel_grid_downsample_filter`) so core logic can be tested without spinning up ROS nodes.
- Kept and validated the existing integration test (`test_voxel_grid_downsample_filter_integration`).

## Related links

- Parent task/context: separate ROS-dependent layer from application logic in voxel grid downsample filter

## How was this PR tested?

Built and tested with:

```bash
colcon build --packages-select autoware_downsample_filters --event-handlers console_direct+
colcon test --packages-select autoware_downsample_filters --event-handlers console_direct+ --ctest-args -R "test_faster_voxel_grid_downsample_filter|test_voxel_grid_downsample_filter_integration"
```

Results:
- `test_faster_voxel_grid_downsample_filter`: PASSED
- `test_voxel_grid_downsample_filter_integration`: PASSED

<img width="1274" height="345" alt="Screenshot from 2026-06-03 22-21-13" src="https://github.com/user-attachments/assets/edb3bce0-ae67-4876-89b0-0ee73f21c1dc" />

## Notes for reviewers

- This PR focuses on the first step only: moving logging and ROS dependency boundaries.
- The filtering algorithm behavior is intentionally kept unchanged.
- Follow-up PRs can continue extracting ROS message/TF handling from core application logic and expand non-node unit tests.

## Interface changes

- Internal C++ interface change in `FasterVoxelGridDownsampleFilter`:
	- `set_field_offsets(...)` now returns `Status` instead of `void`.
	- `filter(...)` now returns `Status` instead of `void`.
- No external topic/service API changes.

### Topic changes

- None.

## Effects on system behavior

- No intended functional change in normal filtering behavior.
- Error paths now report status in application logic and emit ROS logs in node layer.
- Improves testability by enabling function/class-level unit tests without ROS node startup.