### PR TITLE
fix(`voxel_grid_downsample_filter`): separate application logic

### DIFF
--- a/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/faster_voxel_grid_downsample_filter.cpp
+++ b/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/faster_voxel_grid_downsample_filter.cpp
@@ -45,17 +45,15 @@ FasterVoxelGridDownsampleFilter::Status FasterVoxelGridDownsampleFilter::set_fie
   z_offset_ = static_cast<int>(input->fields[pcl::getFieldIndex(*input, "z")].offset);
   intensity_index_ = pcl::getFieldIndex(*input, "intensity");
 
-  if (
-    intensity_index_ < 0 || input->fields[pcl::getFieldIndex(*input, "intensity")].datatype !=
-                              sensor_msgs::msg::PointField::UINT8) {
+  if (intensity_index_ < 0) {
     return Status::kIntensityFieldNotFoundOrInvalidType;
   }
 
-  if (intensity_index_ != -1) {
-    intensity_offset_ = static_cast<int>(input->fields[intensity_index_].offset);
-  } else {
-    intensity_offset_ = -1;
+  if (input->fields[intensity_index_].datatype != sensor_msgs::msg::PointField::UINT8) {
+    return Status::kIntensityFieldNotFoundOrInvalidType;
   }
+
+  intensity_offset_ = static_cast<int>(input->fields[intensity_index_].offset);
   offset_initialized_ = true;
   return Status::kSuccess;
 }

--- a/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/faster_voxel_grid_downsample_filter.cpp
+++ b/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/faster_voxel_grid_downsample_filter.cpp
@@ -37,8 +37,8 @@ void FasterVoxelGridDownsampleFilter::set_voxel_size(
     Eigen::Array3f::Ones() / Eigen::Array3f(voxel_size_x, voxel_size_y, voxel_size_z);
 }
 
-void FasterVoxelGridDownsampleFilter::set_field_offsets(
-  const PointCloud2ConstPtr & input, const rclcpp::Logger & logger)
+FasterVoxelGridDownsampleFilter::Status FasterVoxelGridDownsampleFilter::set_field_offsets(
+  const PointCloud2ConstPtr & input)
 {
   x_offset_ = static_cast<int>(input->fields[pcl::getFieldIndex(*input, "x")].offset);
   y_offset_ = static_cast<int>(input->fields[pcl::getFieldIndex(*input, "y")].offset);
@@ -48,10 +48,7 @@ void FasterVoxelGridDownsampleFilter::set_field_offsets(
   if (
     intensity_index_ < 0 || input->fields[pcl::getFieldIndex(*input, "intensity")].datatype !=
                               sensor_msgs::msg::PointField::UINT8) {
-    RCLCPP_ERROR(
-      logger,
-      "There is no intensity field in the input point cloud or the intensity field is not of type "
-      "UINT8.");
+    return Status::kIntensityFieldNotFoundOrInvalidType;
   }
 
   if (intensity_index_ != -1) {
@@ -60,26 +57,25 @@ void FasterVoxelGridDownsampleFilter::set_field_offsets(
     intensity_offset_ = -1;
   }
   offset_initialized_ = true;
+  return Status::kSuccess;
 }
 
-void FasterVoxelGridDownsampleFilter::filter(
-  const PointCloud2ConstPtr & input, PointCloud2 & output, const TransformInfo & transform_info,
-  const rclcpp::Logger & logger)
+FasterVoxelGridDownsampleFilter::Status FasterVoxelGridDownsampleFilter::filter(
+  const PointCloud2ConstPtr & input, PointCloud2 & output, const TransformInfo & transform_info)
 {
   // Check if the field offset has been set
   if (!offset_initialized_) {
-    set_field_offsets(input, logger);
+    const auto offset_status = set_field_offsets(input);
+    if (offset_status != Status::kSuccess) {
+      return offset_status;
+    }
   }
 
   // Compute the minimum and maximum voxel coordinates
   Eigen::Vector3i min_voxel, max_voxel;
   if (!get_min_max_voxel(input, min_voxel, max_voxel)) {
-    RCLCPP_ERROR(
-      logger,
-      "Voxel size is too small for the input dataset. "
-      "Integer indices would overflow.");
     output = *input;
-    return;
+    return Status::kVoxelIndexWouldOverflow;
   }
 
   // Storage for mapping voxel coordinates to centroids
@@ -98,6 +94,8 @@ void FasterVoxelGridDownsampleFilter::filter(
 
   // Copy the centroids to the output
   copy_centroids_to_output(voxel_centroid_map, output, transform_info);
+
+  return Status::kSuccess;
 }
 
 Eigen::Vector4f FasterVoxelGridDownsampleFilter::get_point_from_global_offset(

--- a/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/faster_voxel_grid_downsample_filter.hpp
+++ b/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/faster_voxel_grid_downsample_filter.hpp
@@ -33,12 +33,17 @@ class FasterVoxelGridDownsampleFilter
   using PointCloud2ConstPtr = sensor_msgs::msg::PointCloud2::ConstSharedPtr;
 
 public:
+  enum class Status {
+    kSuccess,
+    kIntensityFieldNotFoundOrInvalidType,
+    kVoxelIndexWouldOverflow,
+  };
+
   FasterVoxelGridDownsampleFilter();
   void set_voxel_size(float voxel_size_x, float voxel_size_y, float voxel_size_z);
-  void set_field_offsets(const PointCloud2ConstPtr & input, const rclcpp::Logger & logger);
-  void filter(
-    const PointCloud2ConstPtr & input, PointCloud2 & output, const TransformInfo & transform_info,
-    const rclcpp::Logger & logger);
+  Status set_field_offsets(const PointCloud2ConstPtr & input);
+  Status filter(
+    const PointCloud2ConstPtr & input, PointCloud2 & output, const TransformInfo & transform_info);
 
 private:
   struct Centroid

--- a/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.cpp
@@ -217,8 +217,24 @@ void VoxelGridDownsampleFilter::filter(
   std::scoped_lock lock(mutex_);
   FasterVoxelGridDownsampleFilter faster_voxel_filter;
   faster_voxel_filter.set_voxel_size(voxel_size_x_, voxel_size_y_, voxel_size_z_);
-  faster_voxel_filter.set_field_offsets(input, this->get_logger());
-  faster_voxel_filter.filter(input, output, transform_info, this->get_logger());
+
+  const auto offset_status = faster_voxel_filter.set_field_offsets(input);
+  if (
+    offset_status ==
+    FasterVoxelGridDownsampleFilter::Status::kIntensityFieldNotFoundOrInvalidType) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "There is no intensity field in the input point cloud or the intensity field is not of type "
+      "UINT8.");
+    return;
+  }
+
+  const auto filter_status = faster_voxel_filter.filter(input, output, transform_info);
+  if (filter_status == FasterVoxelGridDownsampleFilter::Status::kVoxelIndexWouldOverflow) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Voxel size is too small for the input dataset. Integer indices would overflow.");
+  }
 }
 }  // namespace autoware::downsample_filters
 


### PR DESCRIPTION
## Description

(Note: Some of this PR description and files changed are written by using Codex, while I reviewed the generated answer.)

This PR starts the refactoring to separate ROS-dependent logic from application logic in `autoware_downsample_filters` (`voxel_grid_downsample_filter`).

Main changes:
- Removed direct ROS logging (`RCLCPP_*`) dependency from `FasterVoxelGridDownsampleFilter`.
- Introduced status-based error reporting in the application-logic layer:
	- `kSuccess`
	- `kIntensityFieldNotFoundOrInvalidType`
	- `kVoxelIndexWouldOverflow`
- Moved ROS logging responsibility to `VoxelGridDownsampleFilter` node layer only.
- Kept and validated the existing integration test (`test_voxel_grid_downsample_filter_integration`).

## Related links

- Parent task/context: separate ROS-dependent layer from application logic in voxel grid downsample filter

## How was this PR tested?

Built and tested with:

```bash
colcon build --packages-select autoware_downsample_filters --event-handlers console_direct+
colcon test --packages-select autoware_downsample_filters --event-handlers console_direct+ --ctest-args -R "test_voxel_grid_downsample_filter_integration"
```

Results:
- `test_voxel_grid_downsample_filter_integration`: PASSED

## Notes for reviewers

- This PR focuses on the first step only: moving logging and ROS dependency boundaries.
- The filtering algorithm behavior is intentionally kept unchanged.
- Unit-test implementation details will be submitted in a separate PR.

## Interface changes

- Internal C++ interface change in `FasterVoxelGridDownsampleFilter`:
	- `set_field_offsets(...)` now returns `Status` instead of `void`.
	- `filter(...)` now returns `Status` instead of `void`.
- No external topic/service API changes.

### Topic changes

- None.

## Effects on system behavior

- No intended functional change in normal filtering behavior.
- Error paths now report status in application logic and emit ROS logs in node layer.