### PR TITLE
feat(`downsample_filters`): remove TF operations from voxel grid filter node

### DIFF
--- a/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.cpp
@@ -121,8 +121,7 @@ bool VoxelGridDownsampleFilter::is_valid(const PointCloud2ConstPtr & cloud)
   return true;
 }
 
-void VoxelGridDownsampleFilter::filter(
-  const PointCloud2ConstPtr & input, PointCloud2 & output)
+void VoxelGridDownsampleFilter::filter(const PointCloud2ConstPtr & input, PointCloud2 & output)
 {
   std::scoped_lock lock(mutex_);
   FasterVoxelGridDownsampleFilter faster_voxel_filter;

--- a/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.cpp
@@ -17,10 +17,6 @@
 #include "faster_voxel_grid_downsample_filter.hpp"
 #include "memory.hpp"
 #include "transform_info.hpp"
-
-#include <pcl_ros/transforms.hpp>
-#include <tf2_eigen/tf2_eigen.hpp>
-
 #include <pcl/common/io.h>
 #include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/search/kdtree.h>
@@ -38,8 +34,6 @@ VoxelGridDownsampleFilter::VoxelGridDownsampleFilter(const rclcpp::NodeOptions &
   voxel_size_x_(static_cast<float>(declare_parameter<double>("voxel_size_x"))),
   voxel_size_y_(static_cast<float>(declare_parameter<double>("voxel_size_y"))),
   voxel_size_z_(static_cast<float>(declare_parameter<double>("voxel_size_z"))),
-  tf_input_frame_(declare_parameter<std::string>("input_frame")),
-  tf_output_frame_(declare_parameter<std::string>("output_frame")),
   max_queue_size_(static_cast<std::size_t>(declare_parameter<int64_t>("max_queue_size")))
 {
   // Set publishers
@@ -58,7 +52,6 @@ VoxelGridDownsampleFilter::VoxelGridDownsampleFilter(const rclcpp::NodeOptions &
     sub_input_ = create_subscription<PointCloud2>(
       "input", rclcpp::SensorDataQoS().keep_last(max_queue_size_),
       std::bind(&VoxelGridDownsampleFilter::input_callback, this, std::placeholders::_1));
-    transform_listener_ = std::make_unique<autoware_utils_tf::TransformListener>(this);
   }
 
   RCLCPP_DEBUG(this->get_logger(), "[Filter Constructor] successfully created.");
@@ -77,18 +70,9 @@ void VoxelGridDownsampleFilter::input_callback(const PointCloud2ConstPtr cloud)
     "received.",
     cloud->width * cloud->height, cloud->header.frame_id.c_str());
 
-  tf_input_orig_frame_ = cloud->header.frame_id;
-
-  // For performance reason, defer the transform computation.
-  // Do not use pcl_ros::transformPointCloud(). It's too slow due to the unnecessary copy.
-  TransformInfo transform_info;
-  if (!calculate_transform_matrix(tf_input_frame_, *cloud, transform_info)) return;
-
   auto output = std::make_unique<PointCloud2>();
 
-  filter(cloud, *output, transform_info);
-
-  if (!convert_output_costly(output)) return;
+  filter(cloud, *output);
 
   output->header.stamp = cloud->header.stamp;
   pub_output_->publish(std::move(output));
@@ -136,89 +120,14 @@ bool VoxelGridDownsampleFilter::is_valid(const PointCloud2ConstPtr & cloud)
   return true;
 }
 
-bool VoxelGridDownsampleFilter::calculate_transform_matrix(
-  const std::string & target_frame, const sensor_msgs::msg::PointCloud2 & from,
-  TransformInfo & transform_info)
-{
-  transform_info.need_transform = false;
-
-  if (target_frame.empty() || from.header.frame_id == target_frame) return true;
-
-  RCLCPP_DEBUG(
-    this->get_logger(), "[get_transform_matrix] Transforming input dataset from %s to %s.",
-    from.header.frame_id.c_str(), target_frame.c_str());
-
-  auto tf_ptr = transform_listener_->get_transform(
-    target_frame, from.header.frame_id, from.header.stamp, rclcpp::Duration::from_seconds(1.0));
-
-  if (!tf_ptr) {
-    return false;
-  }
-
-  auto eigen_tf = tf2::transformToEigen(*tf_ptr);
-  transform_info.eigen_transform = eigen_tf.matrix().cast<float>();
-  transform_info.need_transform = true;
-  return true;
-}
-
-bool VoxelGridDownsampleFilter::convert_output_costly(std::unique_ptr<PointCloud2> & output)
-{
-  if (!tf_output_frame_.empty() && output->header.frame_id != tf_output_frame_) {
-    RCLCPP_DEBUG(
-      this->get_logger(), "[convert_output_costly] Transforming output dataset from %s to %s.",
-      output->header.frame_id.c_str(), tf_output_frame_.c_str());
-
-    // Convert the cloud into the different frame
-    auto cloud_transformed = std::make_unique<PointCloud2>();
-
-    auto tf_ptr = transform_listener_->get_transform(
-      tf_output_frame_, output->header.frame_id, output->header.stamp,
-      rclcpp::Duration::from_seconds(1.0));
-    if (!tf_ptr) {
-      RCLCPP_ERROR(
-        this->get_logger(),
-        "[convert_output_costly] Error converting output dataset from %s to %s.",
-        output->header.frame_id.c_str(), tf_output_frame_.c_str());
-      return false;
-    }
-
-    auto eigen_tf = tf2::transformToEigen(*tf_ptr);
-    pcl_ros::transformPointCloud(eigen_tf.matrix().cast<float>(), *output, *cloud_transformed);
-    output = std::move(cloud_transformed);
-  }
-
-  if (tf_output_frame_.empty() && output->header.frame_id != tf_input_orig_frame_) {
-    // No tf_output_frame given, transform the dataset to its original frame
-    RCLCPP_DEBUG(
-      this->get_logger(), "[convert_output_costly] Transforming output dataset from %s back to %s.",
-      output->header.frame_id.c_str(), tf_input_orig_frame_.c_str());
-
-    auto cloud_transformed = std::make_unique<sensor_msgs::msg::PointCloud2>();
-
-    auto tf_ptr = transform_listener_->get_transform(
-      tf_input_orig_frame_, output->header.frame_id, output->header.stamp,
-      rclcpp::Duration::from_seconds(1.0));
-
-    if (!tf_ptr) {
-      return false;
-    }
-
-    auto eigen_tf = tf2::transformToEigen(*tf_ptr);
-    pcl_ros::transformPointCloud(eigen_tf.matrix().cast<float>(), *output, *cloud_transformed);
-    output = std::move(cloud_transformed);
-  }
-
-  return true;
-}
-
 void VoxelGridDownsampleFilter::filter(
-  const PointCloud2ConstPtr & input, PointCloud2 & output, const TransformInfo & transform_info)
+  const PointCloud2ConstPtr & input, PointCloud2 & output)
 {
   std::scoped_lock lock(mutex_);
   FasterVoxelGridDownsampleFilter faster_voxel_filter;
   faster_voxel_filter.set_voxel_size(voxel_size_x_, voxel_size_y_, voxel_size_z_);
-  faster_voxel_filter.set_field_offsets(input, this->get_logger());
-  faster_voxel_filter.filter(input, output, transform_info, this->get_logger());
+  faster_voxel_filter.set_field_offsets(input);
+  faster_voxel_filter.filter(input, output, TransformInfo{});
 }
 }  // namespace autoware::downsample_filters
 

--- a/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.cpp
@@ -121,91 +121,14 @@ bool VoxelGridDownsampleFilter::is_valid(const PointCloud2ConstPtr & cloud)
   return true;
 }
 
-bool VoxelGridDownsampleFilter::calculate_transform_matrix(
-  const std::string & target_frame, const sensor_msgs::msg::PointCloud2 & from,
-  TransformInfo & transform_info)
-{
-  transform_info.need_transform = false;
-
-  if (target_frame.empty() || from.header.frame_id == target_frame) return true;
-
-  RCLCPP_DEBUG(
-    this->get_logger(), "[get_transform_matrix] Transforming input dataset from %s to %s.",
-    from.header.frame_id.c_str(), target_frame.c_str());
-
-  auto tf_ptr = transform_listener_->get_transform(
-    target_frame, from.header.frame_id, from.header.stamp, rclcpp::Duration::from_seconds(1.0));
-
-  if (!tf_ptr) {
-    return false;
-  }
-
-  auto eigen_tf = tf2::transformToEigen(*tf_ptr);
-  transform_info.eigen_transform = eigen_tf.matrix().cast<float>();
-  transform_info.need_transform = true;
-  return true;
-}
-
-bool VoxelGridDownsampleFilter::convert_output_costly(std::unique_ptr<PointCloud2> & output)
-{
-  if (!tf_output_frame_.empty() && output->header.frame_id != tf_output_frame_) {
-    RCLCPP_DEBUG(
-      this->get_logger(), "[convert_output_costly] Transforming output dataset from %s to %s.",
-      output->header.frame_id.c_str(), tf_output_frame_.c_str());
-
-    // Convert the cloud into the different frame
-    auto cloud_transformed = std::make_unique<PointCloud2>();
-
-    auto tf_ptr = transform_listener_->get_transform(
-      tf_output_frame_, output->header.frame_id, output->header.stamp,
-      rclcpp::Duration::from_seconds(1.0));
-    if (!tf_ptr) {
-      RCLCPP_ERROR(
-        this->get_logger(),
-        "[convert_output_costly] Error converting output dataset from %s to %s.",
-        output->header.frame_id.c_str(), tf_output_frame_.c_str());
-      return false;
-    }
-
-    auto eigen_tf = tf2::transformToEigen(*tf_ptr);
-    pcl_ros::transformPointCloud(eigen_tf.matrix().cast<float>(), *output, *cloud_transformed);
-    output = std::move(cloud_transformed);
-    output->header.frame_id = tf_output_frame_;
-  }
-
-  if (tf_output_frame_.empty() && output->header.frame_id != tf_input_orig_frame_) {
-    // No tf_output_frame given, transform the dataset to its original frame
-    RCLCPP_DEBUG(
-      this->get_logger(), "[convert_output_costly] Transforming output dataset from %s back to %s.",
-      output->header.frame_id.c_str(), tf_input_orig_frame_.c_str());
-
-    auto cloud_transformed = std::make_unique<sensor_msgs::msg::PointCloud2>();
-
-    auto tf_ptr = transform_listener_->get_transform(
-      tf_input_orig_frame_, output->header.frame_id, output->header.stamp,
-      rclcpp::Duration::from_seconds(1.0));
-
-    if (!tf_ptr) {
-      return false;
-    }
-
-    auto eigen_tf = tf2::transformToEigen(*tf_ptr);
-    pcl_ros::transformPointCloud(eigen_tf.matrix().cast<float>(), *output, *cloud_transformed);
-    output = std::move(cloud_transformed);
-    output->header.frame_id = tf_input_orig_frame_;
-  }
-
-  return true;
-}
-
 void VoxelGridDownsampleFilter::filter(
-  const PointCloud2ConstPtr & input, PointCloud2 & output, const TransformInfo & transform_info)
+  const PointCloud2ConstPtr & input, PointCloud2 & output)
 {
   std::scoped_lock lock(mutex_);
   FasterVoxelGridDownsampleFilter faster_voxel_filter;
   faster_voxel_filter.set_voxel_size(voxel_size_x_, voxel_size_y_, voxel_size_z_);
-  faster_voxel_filter.set_field_offsets(input);
-  faster_voxel_filter.filter(input, output, TransformInfo{});
+  faster_voxel_filter.set_field_offsets(input, this->get_logger());
+  faster_voxel_filter.filter(input, output, TransformInfo{}, this->get_logger());
 }
 }  // namespace autoware::downsample_filters
 

--- a/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.cpp
@@ -17,6 +17,7 @@
 #include "faster_voxel_grid_downsample_filter.hpp"
 #include "memory.hpp"
 #include "transform_info.hpp"
+
 #include <pcl/common/io.h>
 #include <pcl/kdtree/kdtree_flann.h>
 #include <pcl/search/kdtree.h>
@@ -120,8 +121,7 @@ bool VoxelGridDownsampleFilter::is_valid(const PointCloud2ConstPtr & cloud)
   return true;
 }
 
-void VoxelGridDownsampleFilter::filter(
-  const PointCloud2ConstPtr & input, PointCloud2 & output)
+void VoxelGridDownsampleFilter::filter(const PointCloud2ConstPtr & input, PointCloud2 & output)
 {
   std::scoped_lock lock(mutex_);
   FasterVoxelGridDownsampleFilter faster_voxel_filter;

--- a/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.hpp
+++ b/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.hpp
@@ -75,7 +75,6 @@ private:
   /** \param cloud point cloud */
   /** \return true if point cloud is valid, false otherwise */
   bool is_valid(const PointCloud2ConstPtr & cloud);
-
 };
 }  // namespace autoware::downsample_filters
 

--- a/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.hpp
+++ b/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.hpp
@@ -15,10 +15,6 @@
 #ifndef VOXEL_GRID_DOWNSAMPLE_FILTER__VOXEL_GRID_DOWNSAMPLE_FILTER_NODE_HPP_  // NOLINT
 #define VOXEL_GRID_DOWNSAMPLE_FILTER__VOXEL_GRID_DOWNSAMPLE_FILTER_NODE_HPP_  // NOLINT
 
-#include "transform_info.hpp"
-
-#include <boost/thread/mutex.hpp>
-
 #include <memory>
 #include <string>
 
@@ -32,7 +28,6 @@
 #include <autoware_utils_debug/debug_publisher.hpp>
 #include <autoware_utils_debug/published_time_publisher.hpp>
 #include <autoware_utils_system/stop_watch.hpp>
-#include <autoware_utils_tf/transform_listener.hpp>
 
 namespace autoware::downsample_filters
 {
@@ -52,9 +47,6 @@ private:
   /** \brief The output PointCloud2 publisher. */
   rclcpp::Publisher<PointCloud2>::SharedPtr pub_output_;
 
-  /** \brief transform listener */
-  std::unique_ptr<autoware_utils_tf::TransformListener> transform_listener_{nullptr};
-
   /** \brief processing time publisher. **/
   std::unique_ptr<autoware_utils_system::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
   std::unique_ptr<autoware_utils_debug::DebugPublisher> debug_publisher_;
@@ -63,15 +55,10 @@ private:
   /** \brief PointCloud2 data callback. */
   void input_callback(const PointCloud2ConstPtr cloud);
 
-  /** \brief Convert output to PointCloud2. */
-  bool convert_output_costly(std::unique_ptr<PointCloud2> & output);
-
-  /** \brief apply voxel grid downsample filter and transform point cloud */
+  /** \brief apply voxel grid downsample filter */
   /** \param input input point cloud */
   /** \param output output point cloud */
-  /** \param transform_info transform info */
-  void filter(
-    const PointCloud2ConstPtr & input, PointCloud2 & output, const TransformInfo & transform_info);
+  void filter(const PointCloud2ConstPtr & input, PointCloud2 & output);
 
   /** \brief voxel size x */
   float voxel_size_x_;
@@ -79,14 +66,6 @@ private:
   float voxel_size_y_;
   /** \brief voxel size z */
   float voxel_size_z_;
-  /** \brief The input TF frame the data should be transformed into,
-   * if input.header.frame_id is different. */
-  std::string tf_input_frame_;
-  /** \brief The original data input TF frame. */
-  std::string tf_input_orig_frame_;
-  /** \brief The output TF frame the data should be transformed into,
-   * if input.header.frame_id is different. */
-  std::string tf_output_frame_;
   /** \brief Internal mutex. */
   std::mutex mutex_;
   /** \brief The maximum queue size (default: 3). */
@@ -97,14 +76,6 @@ private:
   /** \return true if point cloud is valid, false otherwise */
   bool is_valid(const PointCloud2ConstPtr & cloud);
 
-  /** \brief calculate transform matrix */
-  /** \param target_frame target frame */
-  /** \param from point cloud with original frame id and timestamp */
-  /** \param transform_info transform info */
-  /** \return true if transform matrix is calculated, false otherwise */
-  bool calculate_transform_matrix(
-    const std::string & target_frame, const sensor_msgs::msg::PointCloud2 & from,
-    TransformInfo & transform_info /*output*/);
 };
 }  // namespace autoware::downsample_filters
 

--- a/sensing/autoware_downsample_filters/test/test_voxel_grid_downsample_filter_integration.cpp
+++ b/sensing/autoware_downsample_filters/test/test_voxel_grid_downsample_filter_integration.cpp
@@ -16,12 +16,10 @@
 
 #include <rclcpp/executors.hpp>
 
-#include <geometry_msgs/msg/transform_stamped.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 
 #include <gtest/gtest.h>
-#include <tf2_ros/static_transform_broadcaster.h>
 
 #include <algorithm>
 #include <array>
@@ -114,9 +112,6 @@ public:
   {
     executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
 
-    tf_node_ = rclcpp::Node::make_shared("voxel_grid_tf_publisher");
-    static_tf_broadcaster_ = std::make_shared<tf2_ros::StaticTransformBroadcaster>(tf_node_);
-
     filter_node_ =
       std::make_shared<autoware::downsample_filters::VoxelGridDownsampleFilter>(filter_options);
 
@@ -132,7 +127,6 @@ public:
         is_received_.store(true);
       });
 
-    executor_->add_node(tf_node_);
     executor_->add_node(filter_node_);
     executor_->add_node(input_pub_node_);
     executor_->add_node(output_sub_node_);
@@ -150,29 +144,9 @@ public:
 
     output_sub_.reset();
     input_pub_.reset();
-    static_tf_broadcaster_.reset();
     output_sub_node_.reset();
     input_pub_node_.reset();
     filter_node_.reset();
-    tf_node_.reset();
-  }
-
-  void publish_static_transform(
-    const std::string & parent_frame, const std::string & child_frame, const double tx,
-    const double ty, const double tz)
-  {
-    geometry_msgs::msg::TransformStamped transform;
-    transform.header.stamp = tf_node_->get_clock()->now();
-    transform.header.frame_id = parent_frame;
-    transform.child_frame_id = child_frame;
-    transform.transform.translation.x = tx;
-    transform.transform.translation.y = ty;
-    transform.transform.translation.z = tz;
-    transform.transform.rotation.x = 0.0;
-    transform.transform.rotation.y = 0.0;
-    transform.transform.rotation.z = 0.0;
-    transform.transform.rotation.w = 1.0;
-    static_tf_broadcaster_->sendTransform(transform);
   }
 
   void publish_points(const std::vector<PointXYZ> & points, const std::string & frame_id)
@@ -216,9 +190,6 @@ private:
 private:
   std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor_;
   std::thread executor_thread_;
-
-  rclcpp::Node::SharedPtr tf_node_;
-  std::shared_ptr<tf2_ros::StaticTransformBroadcaster> static_tf_broadcaster_;
 
   std::shared_ptr<autoware::downsample_filters::VoxelGridDownsampleFilter> filter_node_;
 
@@ -397,7 +368,6 @@ TEST(
   });
 
   VoxelGridIntegrationHarness harness(options);
-  harness.publish_static_transform("map", "sensor_frame", 1.5, 0.0, 0.0);
 
   const std::vector<PointXYZ> input_points = {
     {1.0f, 2.0f, 3.0f},

--- a/sensing/autoware_downsample_filters/test/test_voxel_grid_downsample_filter_integration.cpp
+++ b/sensing/autoware_downsample_filters/test/test_voxel_grid_downsample_filter_integration.cpp
@@ -263,7 +263,9 @@ TEST(VoxelGridDownsampleFilterIntegrationTest, CollapsesPointsInSameVoxelToSingl
   expect_points_near(output_points, expected_points, 1.0e-4f);
 }
 
-TEST(VoxelGridDownsampleFilterIntegrationTest, DoesNotPublishWhenInputTransformIsMissing)
+TEST(
+  VoxelGridDownsampleFilterIntegrationTest,
+  PublishesOutputEvenWhenInputFrameParameterCannotBeTransformed)
 {
   rclcpp::NodeOptions options;
   options.parameter_overrides({
@@ -281,10 +283,17 @@ TEST(VoxelGridDownsampleFilterIntegrationTest, DoesNotPublishWhenInputTransformI
     {0.1f, 0.1f, 0.1f},
     {0.2f, 0.2f, 0.2f},
   };
+  const std::vector<PointXYZ> expected_points = {
+    {0.15f, 0.15f, 0.15f},
+  };
   harness.publish_points(input_points, "missing_source_frame");
 
-  EXPECT_FALSE(harness.wait_for_output(std::chrono::milliseconds(1000)));
-  EXPECT_EQ(harness.received_cloud(), nullptr);
+  ASSERT_TRUE(harness.wait_for_output(std::chrono::milliseconds(5000)));
+  ASSERT_NE(harness.received_cloud(), nullptr);
+
+  const auto output_points = extract_points_from_cloud(*harness.received_cloud());
+  EXPECT_EQ(harness.received_cloud()->header.frame_id, "missing_source_frame");
+  expect_points_near(output_points, expected_points, 1.0e-4f);
 }
 
 TEST(VoxelGridDownsampleFilterIntegrationTest, EmptyInputResultsInEmptyOutput)
@@ -374,7 +383,8 @@ TEST(
 }
 
 TEST(
-  VoxelGridDownsampleFilterIntegrationTest, OutputFrameParameterShouldSetOutputFrameIdToOutputFrame)
+  VoxelGridDownsampleFilterIntegrationTest,
+  OutputFrameParameterDoesNotRewriteFrameIdOrTransformPoints)
 {
   rclcpp::NodeOptions options;
   options.parameter_overrides({
@@ -393,7 +403,7 @@ TEST(
     {1.0f, 2.0f, 3.0f},
   };
   const std::vector<PointXYZ> expected_points = {
-    {2.5f, 2.0f, 3.0f},
+    {1.0f, 2.0f, 3.0f},
   };
   harness.publish_points(input_points, "sensor_frame");
 
@@ -401,7 +411,7 @@ TEST(
   ASSERT_NE(harness.received_cloud(), nullptr);
 
   const auto output_points = extract_points_from_cloud(*harness.received_cloud());
-  EXPECT_EQ(harness.received_cloud()->header.frame_id, "map");
+  EXPECT_EQ(harness.received_cloud()->header.frame_id, "sensor_frame");
   expect_points_near(output_points, expected_points, 1.0e-4f);
 }
 


### PR DESCRIPTION
## Description

~~:warning: As this PR's contents are mostly generated by Codex, I'll review the changes carefully to ensure this PR aligns with the intended refactoring goals and do not introduce unintended side effects. I'll mark this PR as "Ready for Review" after my review. :warning:~~

**→ Now ready for review :+1:** 

This PR refactors `voxel_grid_downsample_filter_node` so the package focuses only on downsampling and no longer performs TF-related processing.

Main changes:
- Removed input-side transform handling by deleting `calculate_transform_matrix` and all related logic in the callback path.
- Removed output-side frame conversion by deleting `convert_output_costly` and related transform calls.
- Simplified filter invocation to downsampling-only operation.
- Removed TF listener dependency and TF frame parameters from the node implementation and interface.
- Removed unnecessary TF/PCL transform includes from the node source/header.

## Related links

- N/A

## How was this PR tested?

- Ran:
  - colcon test --packages-select autoware_downsample_filters --ctest-args -R voxel_grid_downsample_filter_integration
- Result:
  - Passed (exit code 0)

## Notes for reviewers

- This change intentionally narrows responsibility of this package to downsampling only.
- Frame transformation responsibility is expected to be handled outside this node.
- Behavior is now simpler and avoids costly transform operations in the node callback path.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name | Type | Default Value | Description |
|:--|:--|:--|:--|:--|
| Removed | input_frame | string | N/A | Input transform target frame is no longer used by this node |
| Removed | output_frame | string | N/A | Output transform target frame is no longer used by this node |

## Effects on system behavior

- The node no longer transforms input point clouds before downsampling.
- The node no longer transforms output point clouds to a requested output frame.
- Output is published in the original frame context carried by the incoming point cloud data path.
- Systems that previously relied on this node for frame conversion must perform transforms in another component.