### PR TITLE
fix(`autoware_downsample_filters`): a bug which causes wrong `frame_id` propagation in transformation

### DIFF
--- a/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.cpp
+++ b/sensing/autoware_downsample_filters/src/voxel_grid_downsample_filter/voxel_grid_downsample_filter_node.cpp
@@ -185,6 +185,7 @@ bool VoxelGridDownsampleFilter::convert_output_costly(std::unique_ptr<PointCloud
     auto eigen_tf = tf2::transformToEigen(*tf_ptr);
     pcl_ros::transformPointCloud(eigen_tf.matrix().cast<float>(), *output, *cloud_transformed);
     output = std::move(cloud_transformed);
+    output->header.frame_id = tf_output_frame_;
   }
 
   if (tf_output_frame_.empty() && output->header.frame_id != tf_input_orig_frame_) {
@@ -206,6 +207,7 @@ bool VoxelGridDownsampleFilter::convert_output_costly(std::unique_ptr<PointCloud
     auto eigen_tf = tf2::transformToEigen(*tf_ptr);
     pcl_ros::transformPointCloud(eigen_tf.matrix().cast<float>(), *output, *cloud_transformed);
     output = std::move(cloud_transformed);
+    output->header.frame_id = tf_input_orig_frame_;
   }
 
   return true;

--- a/sensing/autoware_downsample_filters/test/test_voxel_grid_downsample_filter_integration.cpp
+++ b/sensing/autoware_downsample_filters/test/test_voxel_grid_downsample_filter_integration.cpp
@@ -374,8 +374,7 @@ TEST(
 }
 
 TEST(
-  VoxelGridDownsampleFilterIntegrationTest,
-  OutputFrameParameterShouldSetOutputFrameIdToOutputFrame)
+  VoxelGridDownsampleFilterIntegrationTest, OutputFrameParameterShouldSetOutputFrameIdToOutputFrame)
 {
   rclcpp::NodeOptions options;
   options.parameter_overrides({

--- a/sensing/autoware_downsample_filters/test/test_voxel_grid_downsample_filter_integration.cpp
+++ b/sensing/autoware_downsample_filters/test/test_voxel_grid_downsample_filter_integration.cpp
@@ -373,10 +373,9 @@ TEST(
   expect_points_near(output_points, expected_points, 0.01f);
 }
 
-// TODO(sasakisasaki): Re-enable after fixing the bug
 TEST(
   VoxelGridDownsampleFilterIntegrationTest,
-  DISABLED_OutputFrameParameterShouldSetOutputFrameIdToOutputFrame)
+  OutputFrameParameterShouldSetOutputFrameIdToOutputFrame)
 {
   rclcpp::NodeOptions options;
   options.parameter_overrides({
@@ -403,7 +402,6 @@ TEST(
   ASSERT_NE(harness.received_cloud(), nullptr);
 
   const auto output_points = extract_points_from_cloud(*harness.received_cloud());
-  // FIXME: Expected behavior after bug fix: output cloud should use output_frame in header.
   EXPECT_EQ(harness.received_cloud()->header.frame_id, "map");
   expect_points_near(output_points, expected_points, 1.0e-4f);
 }


### PR DESCRIPTION
## Description

**NOTE: Most of applied changes in this PR are generated with Codex. All the generated contents are reviewed by myself :+1:** 

Fix frame ID handling in `autoware_downsample_filters` voxel-grid output when `output_frame` is specified.

Previously, point coordinates were transformed into `output_frame`, but the published `PointCloud2` header `frame_id` could remain the old frame, causing inconsistency between data and metadata.

This PR:
- updates `VoxelGridDownsampleFilter::convert_output_costly` to set `output->header.frame_id` after each transform path,
- re-enables the integration test that validates `output_frame` behavior.

## Related links
N/A

## How was this PR tested?
Built and tested the target package:

```bash
colcon build --packages-select autoware_downsample_filters
colcon test --packages-select autoware_downsample_filters --event-handlers console_direct+
colcon test-result --verbose --test-result-base build/autoware_downsample_filters
```

Test results:
- `test_voxel_grid_downsample_filter_integration`: PASSED
- Re-enabled test `OutputFrameParameterShouldSetOutputFrameIdToOutputFrame`: PASSED
- Package test summary: `0 errors, 0 failures`

## Notes for reviewers
- Root cause: after `pcl_ros::transformPointCloud`, the cloud frame was transformed geometrically but `header.frame_id` was not explicitly synchronized.
- Fix sets:
	- `output->header.frame_id = tf_output_frame_` after transform to output frame.
	- `output->header.frame_id = tf_input_orig_frame_` after transform back to original frame.

## Interface changes
None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior
Improves correctness and consistency of published point cloud metadata:
- when `output_frame` is set, output points and `header.frame_id` now consistently refer to the same frame,
- enabled integration test now protects this behavior from regressions.
