### PR TITLE
fix(ndt_scan_matcher): explicitly include omp.h

### DIFF
--- a/localization/autoware_ndt_scan_matcher/src/ndt_omp/multigrid_ndt_omp_impl.hpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_omp/multigrid_ndt_omp_impl.hpp
@@ -58,7 +58,6 @@
 // cspell:ignore multigrid, nnvn, colj
 
 #include <autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h>
-
 #include <omp.h>
 
 #include <algorithm>

--- a/localization/autoware_ndt_scan_matcher/src/ndt_omp/multigrid_ndt_omp_impl.hpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_omp/multigrid_ndt_omp_impl.hpp
@@ -59,6 +59,8 @@
 
 #include <autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h>
 
+#include <omp.h>
+
 #include <algorithm>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
## Description

- Add explicit `#include <omp.h>` in `multigrid_ndt_omp_impl.hpp` to avoid build failure with `-DEIGEN_DONT_PARALLELIZE`.

- `multigrid_ndt_omp_impl.hpp` uses OpenMP APIs (`omp_get_max_threads()`, `omp_get_thread_num()`, `#pragma omp parallel for`) but did not explicitly include `<omp.h>`. The header was transitively included through Eigen's Core header, which includes `<omp.h>` only when both `_OPENMP` is defined and `EIGEN_DONT_PARALLELIZE` is not defined:

```
  // Eigen/Core
  #if (defined _OPENMP) && (!defined EIGEN_DONT_PARALLELIZE)
    #define EIGEN_HAS_OPENMP
  #endif
  #ifdef EIGEN_HAS_OPENMP
  #include <omp.h>
  #endif
```

- Building with `-DEIGEN_DONT_PARALLELIZE` may be appropriate for NDT because NDT manages its own thread-level parallelism over source point cloud iterations and should not rely on Eigen's internal OpenMP parallelization. However, this flag also prevents Eigen from including `<omp.h>`, causing a build failure.
  - Note: whether `-DEIGEN_DONT_PARALLELIZE` should be applied to NDT requires further discussion. Regardless, the missing `#include <omp.h>` in `multigrid_ndt_omp_impl.hpp` is a latent bug — the file uses OpenMP APIs and must explicitly include their header rather than relying on a transitive include from Eigen.
- This fix makes the dependency on `<omp.h>` explicit.

### Build Error Message

```
colcon build --symlink-install --cmake-args \
  -DCMAKE_BUILD_TYPE=Release \
  -DBUILD_TESTING=Off \
  -DCMAKE_CXX_FLAGS="-w -DEIGEN_DONT_PARALLELIZE"


--- stderr: autoware_ndt_scan_matcher
In file included from /home/takeshiiwanari/iwa/project/autoware/src/core/autoware_core/localization/autoware_ndt_scan_matcher/src/ndt_omp/multigrid_ndt_omp.cpp:15:
/home/takeshiiwanari/iwa/project/autoware/src/core/autoware_core/localization/autoware_ndt_scan_matcher/src/ndt_omp/multigrid_ndt_omp_impl.hpp: In constructor ‘pclomp::MultiGridNormalDistributionsTransform<PointSource, PointTarget>::MultiGridNormalDistributionsTransform()’:
/home/takeshiiwanari/iwa/project/autoware/src/core/autoware_core/localization/autoware_ndt_scan_matcher/src/ndt_omp/multigrid_ndt_omp_impl.hpp:225:25: error: there are no arguments to ‘omp_get_max_threads’ that depend on a template parameter, so a declaration of ‘omp_get_max_threads’ must be available [-fpermissive]
  225 |   params_.num_threads = omp_get_max_threads();
      |                         ^~~~~~~~~~~~~~~~~~~
```

## Related links

**Parent Issue:**

None

**Private Links:**

- [TIER IV internal link](https://star4.slack.com/archives/CRUE57C30/p1780882292292139?thread_ts=1779929948.087319&cid=CRUE57C30)
- [TIER IV internal link](https://star4.slack.com/archives/CRUE57C30/p1780892744546649?thread_ts=1780482942.701449&cid=CRUE57C30)


## How was this PR tested?

Built with `-DEIGEN_DONT_PARALLELIZE` and confirmed no compilation errors.

```
colcon build --symlink-install --cmake-args \
  -DCMAKE_BUILD_TYPE=Release \
  -DBUILD_TESTING=Off \
  -DCMAKE_CXX_FLAGS="-w -DEIGEN_DONT_PARALLELIZE"
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
