### PR TITLE
fix: [codecov] exclude C++ scripts from examples directory

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -26,3 +26,4 @@ ignore:
   - "**/test/**/*"
   - "**/debug.*"
   - tools/**
+  - "**/examples/**"


### PR DESCRIPTION
## Description

I'm working on ensuring `autoware_core`'s software quality gating via logical unit tests. Upon inspecting the `common/autoware_trajectory`, I spotted that the current coverage, as you can see, while `include/autoware/trajectory` and `src` have ~80% coverage which is good, `examples` has zero coverage. Upon closer inspection, it seems `examples` only contains scripts purely for human readability, documentation, and demonstration.

<img width="1300" height="344" alt="image" src="https://github.com/user-attachments/assets/b91a150b-8236-47d5-9b0c-19d95b329e34" />

(another case of using this `examples` directory for this purpose, is at `common/autoware_lanelet2_utils`)

It really makes no sense to include this directory into code coverage, thus allow me to exclude it from Codecov pipeline.