### PR TITLE
fix: [codecov] excluding examples from codecov (this time for real)

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -26,4 +26,5 @@ ignore:
   - "**/test/**/*"
   - "**/debug.*"
   - tools/**
-  - "**/examples/**"
+  - "**/examples/*"
+  - "**/examples/**/*"


### PR DESCRIPTION
## Description

This is another attempt to fix what was supposed to be done at #1168 . 

Basically, I'm trying to exclude all `examples` directories - which contain only C++ visualization proof-of-concept scripts, having nothing to do with codecov CI/CD pipeline - from the pipeline itself.

However after that PR was merged, nothing happened on [CodeCov site](https://app.codecov.io/gh/autowarefoundation/autoware_core/tree/main/common%2Fautoware_trajectory), so I had a discussion with Software WG last night and we kinda agreed on imitating the syntax used for ignoring `test` directories :

```yaml
ignore:
  - "**/test/*"
  - "**/test/**/*"
```

Why? Because it works.

## Related links

[CodeCov - ignoring paths](https://docs.codecov.com/docs/ignoring-paths)