### PR TITLE
fix(autoware_agnocast_wrapper): get_name,namespace,get_fully_qualified_name

### DIFF
--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -78,9 +78,9 @@ public:
   virtual ~Node() = default;
 
   // ===== Basic information =====
-  std::string get_name() const;
-  std::string get_namespace() const;
-  std::string get_fully_qualified_name() const;
+  const char * get_name() const;
+  const char * get_namespace() const;
+  const char * get_fully_qualified_name() const;
   rclcpp::Logger get_logger() const;
 
   // ===== Time =====

--- a/common/autoware_agnocast_wrapper/src/node.cpp
+++ b/common/autoware_agnocast_wrapper/src/node.cpp
@@ -39,19 +39,23 @@ Node::Node(
   }
 }
 
-std::string Node::get_name() const
+const char * Node::get_name() const
 {
-  return visit_node([](const auto & n) { return std::string(n->get_name()); });
+  // Return the persistent const char * owned by the node base interface so the pointer stays valid
+  // for the node's lifetime. This matches rclcpp::Node::get_name()'s signature (drop-in compatible)
+  // and avoids returning a dangling pointer into a temporary std::string.
+  return visit_node([](const auto & n) { return n->get_node_base_interface()->get_name(); });
 }
 
-std::string Node::get_namespace() const
+const char * Node::get_namespace() const
 {
-  return visit_node([](const auto & n) { return std::string(n->get_namespace()); });
+  return visit_node([](const auto & n) { return n->get_node_base_interface()->get_namespace(); });
 }
 
-std::string Node::get_fully_qualified_name() const
+const char * Node::get_fully_qualified_name() const
 {
-  return visit_node([](const auto & n) { return std::string(n->get_fully_qualified_name()); });
+  return visit_node(
+    [](const auto & n) { return n->get_node_base_interface()->get_fully_qualified_name(); });
 }
 
 rclcpp::Logger Node::get_logger() const


### PR DESCRIPTION
## Description
Make `agnocast_wrapper::Node`'s `get_name()` / `get_namespace()` / `get_fully_qualified_name()` return `const char *` (was `std::string`) to match `rclcpp::Node`.

### Why
  The wrapper should be a drop-in for `rclcpp::Node`, but these returned `std::string` while `rclcpp::Node` returns `const char *`. Generic code written for `rclcpp::Node` failed to compile against the wrapper, e.g. `BasicDebugPublisher<agnocast_wrapper::Node>(this, get_name())` → `no known conversion from 'std::string' to 'const char*'` (in `autoware_object_merger`).

### How
Implemented via `n->get_node_base_interface()->get_name()` inside `visit_node`, so both variants (`rclcpp::Node` / `agnocast::Node`) return the persistent `const char *` owned by the node base. A naive `get_name().c_str()` would dangle since `agnocast::Node::get_name()` returns a temporary `std::string`.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
  `colcon build` of `autoware_agnocast_wrapper` and `autoware_object_merger` both pass (latter was previously failing). No autoware source relied on the old `std::string` return.

## Notes for reviewers
  The proper fix belongs on the agnocast side: `agnocast::Node::get_name()` should itself return `const char *`. That file is a versioned external dependency and would be overwritten on the next bump, so this PR works around the mismatch in the wrapper only; the agnocast-side fix should be pursued upstream.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
