### PR TITLE
feat: [codecov/refactoring] [simple_pure_pursuit] implement characterization test

### DIFF
--- a/control/autoware_simple_pure_pursuit/CMakeLists.txt
+++ b/control/autoware_simple_pure_pursuit/CMakeLists.txt
@@ -33,5 +33,4 @@ autoware_ament_auto_package(
   INSTALL_TO_SHARE
     launch
     config
-    test
 )

--- a/control/autoware_simple_pure_pursuit/CMakeLists.txt
+++ b/control/autoware_simple_pure_pursuit/CMakeLists.txt
@@ -15,8 +15,7 @@ rclcpp_components_register_node(${PROJECT_NAME}_lib
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
-  ament_auto_add_gtest(
-    test_simple_pure_pursuit_integration
+  ament_add_ros_isolated_gtest(test_simple_pure_pursuit_integration
     test/test_simple_pure_pursuit_integration.cpp
   )
   target_include_directories(test_simple_pure_pursuit_integration PRIVATE src)

--- a/control/autoware_simple_pure_pursuit/CMakeLists.txt
+++ b/control/autoware_simple_pure_pursuit/CMakeLists.txt
@@ -14,6 +14,13 @@ rclcpp_components_register_node(${PROJECT_NAME}_lib
 )
 
 if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_auto_add_gtest(
+    test_simple_pure_pursuit_integration
+    test/test_simple_pure_pursuit_integration.cpp
+  )
+  target_include_directories(test_simple_pure_pursuit_integration PRIVATE src)
+  target_link_libraries(test_simple_pure_pursuit_integration ${PROJECT_NAME}_lib)
   ament_add_ros_isolated_gtest(${PROJECT_NAME}_test
     test/test_simple_pure_pursuit.cpp
   )
@@ -26,4 +33,5 @@ autoware_ament_auto_package(
   INSTALL_TO_SHARE
     launch
     config
+    test
 )

--- a/control/autoware_simple_pure_pursuit/package.xml
+++ b/control/autoware_simple_pure_pursuit/package.xml
@@ -22,6 +22,8 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/control/autoware_simple_pure_pursuit/package.xml
+++ b/control/autoware_simple_pure_pursuit/package.xml
@@ -23,8 +23,8 @@
   <depend>rclcpp_components</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -394,6 +394,49 @@ namespace autoware::control::simple_pure_pursuit
 
             };
 
+            // Synchronization safety check
+            // Same standard happy case as above, but delayed between odom and traj publishes
+            TEST(
+                SimplePurePursuitIntegrationTest, 
+                DoesNotPublishUntilBothInputsAreAvailable
+            ) {
+                
+                SimplePurePursuitIntegrationHarness harness(make_node_options());
+
+                const auto stamp = harness.now();
+                const auto odom = make_odometry(
+                    0.0, 0.0, 0.0, 0.0, 
+                    stamp
+                );
+                const auto traj = make_straight_trajectory(
+                    {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0}, 
+                    1.0, 
+                    stamp
+                );
+
+                // Publish odom first
+                // Expect no received command cuz traj is not published yet
+                harness.publish_odometry(odom);
+                EXPECT_FALSE(
+                    harness.wait_for_output(
+                        std::chrono::duration_cast<std::chrono::milliseconds>(no_output_timeout)
+                    )
+                );
+
+                // Then publish traj
+                // Expect to receive command within timeout
+                harness.publish_inputs(
+                    odom, 
+                    traj
+                );
+                ASSERT_TRUE(
+                    harness.wait_for_output(
+                        std::chrono::duration_cast<std::chrono::milliseconds>(output_timeout)
+                    )
+                );
+
+            };
+
     }; // namespace
 
 }; // namespace autoware::control::simple_pure_pursuit

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -27,7 +27,8 @@
 
 #include <cmath>
 #include <memory>
-
+#include <string>
+#include <vector>
 namespace autoware::control::simple_pure_pursuit
 {
 

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -16,599 +16,437 @@
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
 #include <autoware_test_utils/autoware_test_utils.hpp>
+#include <rclcpp/executors.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 #include <autoware_control_msgs/msg/control.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 
 #include <gtest/gtest.h>
-#include <rclcpp/executors.hpp>
-#include <rclcpp/rclcpp.hpp>
 
 #include <cmath>
 #include <memory>
 
-
 namespace autoware::control::simple_pure_pursuit
 {
 
-    using autoware_control_msgs::msg::Control;
-    using autoware_planning_msgs::msg::Trajectory;
-    using autoware_planning_msgs::msg::TrajectoryPoint;
-    using nav_msgs::msg::Odometry;
+using autoware_control_msgs::msg::Control;
+using autoware_planning_msgs::msg::Trajectory;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+using nav_msgs::msg::Odometry;
 
-    namespace
-    {
+namespace
+{
 
-        constexpr auto connection_timeout = std::chrono::seconds(3);
-        constexpr auto output_timeout = std::chrono::seconds(5);
-        constexpr auto no_output_timeout = std::chrono::milliseconds(250);
-        constexpr auto spin_sleep = std::chrono::milliseconds(10);
+constexpr auto connection_timeout = std::chrono::seconds(3);
+constexpr auto output_timeout = std::chrono::seconds(5);
+constexpr auto no_output_timeout = std::chrono::milliseconds(250);
+constexpr auto spin_sleep = std::chrono::milliseconds(10);
 
+/**
+ * @brief Create a dummy Odometry message with some given params.
+ * This dummy one is a pose on the x-y plane with a yaw angle, and a longitudinal velocity.
+ *
+ * @param x dummy odometry's x position.
+ * @param y dummy odometry's y position.
+ * @param yaw dummy odometry's yaw angle.
+ * @param longitudinal_velocity dummy odometry's longitudinal velocity.
+ * @param stamp dummy odometry's timestamp.
+ *
+ * @return Odometry dummy message.
+ */
+Odometry make_odometry(
+  const double x, const double y, const double yaw, const double longitudinal_velocity,
+  const builtin_interfaces::msg::Time & stamp)
+{
+  Odometry odom;
+  odom.header.frame_id = "map";
+  odom.header.stamp = stamp;
+  odom.pose.pose.position.x = x;
+  odom.pose.pose.position.y = y;
+  odom.pose.pose.orientation.z = std::sin(yaw / 2.0);
+  odom.pose.pose.orientation.w = std::cos(yaw / 2.0);
+  odom.twist.twist.linear.x = longitudinal_velocity;
 
-        /**
-        * @brief Create a dummy Odometry message with some given params.
-        * This dummy one is a pose on the x-y plane with a yaw angle, and a longitudinal velocity.
-        *
-        * @param x dummy odometry's x position.
-        * @param y dummy odometry's y position.
-        * @param yaw dummy odometry's yaw angle.
-        * @param longitudinal_velocity dummy odometry's longitudinal velocity.
-        * @param stamp dummy odometry's timestamp.
-        *
-        * @return Odometry dummy message.
-        */
-        Odometry make_odometry(
-            const double x, 
-            const double y, 
-            const double yaw, 
-            const double longitudinal_velocity,
-            const builtin_interfaces::msg::Time & stamp
-        ) {
-            
-            Odometry odom;
-            odom.header.frame_id = "map";
-            odom.header.stamp = stamp;
-            odom.pose.pose.position.x = x;
-            odom.pose.pose.position.y = y;
-            odom.pose.pose.orientation.z = std::sin(yaw / 2.0);
-            odom.pose.pose.orientation.w = std::cos(yaw / 2.0);
-            odom.twist.twist.linear.x = longitudinal_velocity;
+  return odom;
+};
 
-            return odom;
+/**
+ * @brief Create a dummy Trajectory message with some given params.
+ * This dummy one is a straight line along x-axis,
+ * so all y's are 0.0 and all yaw angles are 0.0.
+ *
+ * @param x_positions dummy trajectory's x positions.
+ * @param longitudinal_velocity dummy trajectory's longitudinal velocity.
+ * @param stamp dummy trajectory's timestamp.
+ *
+ * @return Trajectory dummy message.
+ */
+Trajectory make_straight_trajectory(
+  const std::vector<double> & x_positions, const double longitudinal_velocity,
+  const builtin_interfaces::msg::Time & stamp)
+{
+  Trajectory traj;
+  traj.header.frame_id = "map";
+  traj.header.stamp = stamp;
 
-        };
+  for (const auto x : x_positions) {
+    TrajectoryPoint point;
+    point.pose.position.x = x;
+    point.pose.position.y = 0.0;
+    point.longitudinal_velocity_mps = static_cast<float>(longitudinal_velocity);
+    traj.points.push_back(point);
+  }
 
-        /**
-        * @brief Create a dummy Trajectory message with some given params.
-        * This dummy one is a straight line along x-axis,
-        * so all y's are 0.0 and all yaw angles are 0.0.
-        *
-        * @param x_positions dummy trajectory's x positions.
-        * @param longitudinal_velocity dummy trajectory's longitudinal velocity.
-        * @param stamp dummy trajectory's timestamp.
-        *
-        * @return Trajectory dummy message.
-        */
-        Trajectory make_straight_trajectory(
-            const std::vector<double> & x_positions,
-            const double longitudinal_velocity,
-            const builtin_interfaces::msg::Time & stamp
-        ) {
+  return traj;
+};
 
-            Trajectory traj;
-            traj.header.frame_id = "map";
-            traj.header.stamp = stamp;
+/**
+ * @brief Create a NodeOptions with some given overrides and some default config files.
+ *
+ * @param overrides a vector of pairs of <param name, param value> to override default ones.
+ *
+ * @return NodeOptions with given overrides and default config files.
+ */
+rclcpp::NodeOptions make_node_options(
+  const std::vector<std::pair<std::string, rclcpp::ParameterValue>> & overrides = {})
+{
+  const auto autoware_test_utils_dir =
+    ament_index_cpp::get_package_share_directory("autoware_test_utils");
+  const auto autoware_simple_pure_pursuit_dir =
+    ament_index_cpp::get_package_share_directory("autoware_simple_pure_pursuit");
 
-            for (const auto x : x_positions) {
-                TrajectoryPoint point;
-                point.pose.position.x = x;
-                point.pose.position.y = 0.0;
-                point.longitudinal_velocity_mps = static_cast<float>(longitudinal_velocity);
-                traj.points.push_back(point);
-            }
+  auto node_options = rclcpp::NodeOptions{};
+  autoware::test_utils::updateNodeOptions(
+    node_options, {autoware_test_utils_dir + "/config/test_vehicle_info.param.yaml",
+                   autoware_simple_pure_pursuit_dir + "/config/simple_pure_pursuit.param.yaml"});
 
-            return traj;
+  for (const auto & [name, value] : overrides) {
+    node_options.append_parameter_override(name, value);
+  }
 
-        };
+  return node_options;
+};
 
-        /**
-        * @brief Create a NodeOptions with some given overrides and some default config files.
-        *
-        * @param overrides a vector of pairs of <param name, param value> to override default ones.
-        *
-        * @return NodeOptions with given overrides and default config files.
-        */
-        rclcpp::NodeOptions make_node_options(
-            const std::vector<std::pair<std::string, rclcpp::ParameterValue>> & overrides = {}
-        ) {
-            
-            const auto autoware_test_utils_dir =
-                ament_index_cpp::get_package_share_directory("autoware_test_utils");
-            const auto autoware_simple_pure_pursuit_dir =
-                ament_index_cpp::get_package_share_directory("autoware_simple_pure_pursuit");
+class SimplePurePursuitIntegrationHarness
+{
+public:
+  /**
+  * @brief Construct a new SimplePurePursuitIntegrationHarness object,
+          which sets up test env for integration testing of SimplePurePursuitNode.
+  *
+  * @param node_options NodeOptions to construct target SimplePurePursuitNode,
+                      can be used to override some default params if needed.
+  */
+  explicit SimplePurePursuitIntegrationHarness(const rclcpp::NodeOptions & node_options)
+  {
+    executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
 
-            auto node_options = rclcpp::NodeOptions{};
-            autoware::test_utils::updateNodeOptions(
-                node_options,
-                {
-                    autoware_test_utils_dir + "/config/test_vehicle_info.param.yaml",
-                    autoware_simple_pure_pursuit_dir + "/config/simple_pure_pursuit.param.yaml"
-                }
-            );
+    target_node_ = std::make_shared<SimplePurePursuitNode>(node_options);
+    input_pub_node_ = rclcpp::Node::make_shared("simple_pure_pursuit_test_input_publisher");
+    output_sub_node_ = rclcpp::Node::make_shared("simple_pure_pursuit_test_output_subscriber");
 
-            for (const auto & [name, value] : overrides) {
-                node_options.append_parameter_override(name, value);
-            }
-
-            return node_options;
-
-        };
-
-
-        class SimplePurePursuitIntegrationHarness
+    odom_pub_ = input_pub_node_->create_publisher<Odometry>(
+      "/simple_pure_pursuit/input/odometry", rclcpp::QoS{1});
+    traj_pub_ = input_pub_node_->create_publisher<Trajectory>(
+      "/simple_pure_pursuit/input/trajectory", rclcpp::QoS{1});
+    control_sub_ = output_sub_node_->create_subscription<Control>(
+      "/simple_pure_pursuit/output/control_command", rclcpp::QoS{1}.transient_local(),
+      [this](const Control::SharedPtr msg) {
         {
-            
-            public:
-
-                /**
-                * @brief Construct a new SimplePurePursuitIntegrationHarness object, 
-                        which sets up test env for integration testing of SimplePurePursuitNode.
-                *
-                * @param node_options NodeOptions to construct target SimplePurePursuitNode, 
-                                    can be used to override some default params if needed.
-                */
-                explicit SimplePurePursuitIntegrationHarness(
-                    const rclcpp::NodeOptions & node_options
-                ) {
-                    
-                    executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-
-                    target_node_ = std::make_shared<SimplePurePursuitNode>(node_options);
-                    input_pub_node_ = rclcpp::Node::make_shared("simple_pure_pursuit_test_input_publisher");
-                    output_sub_node_ = rclcpp::Node::make_shared("simple_pure_pursuit_test_output_subscriber");
-
-                    odom_pub_ = input_pub_node_ -> create_publisher<Odometry>(
-                        "/simple_pure_pursuit/input/odometry", 
-                        rclcpp::QoS{1}
-                    );
-                    traj_pub_ = input_pub_node_ -> create_publisher<Trajectory>(
-                        "/simple_pure_pursuit/input/trajectory", 
-                        rclcpp::QoS{1}
-                    );
-                    control_sub_ = output_sub_node_ -> create_subscription<Control>(
-                        "/simple_pure_pursuit/output/control_command", 
-                        rclcpp::QoS{1}.transient_local(),
-                        [this](const Control::SharedPtr msg) {
-                            {
-                            std::scoped_lock lock(received_control_mutex_);
-                            received_control_ = msg;
-                            }
-                            is_received_.store(true);
-                        }
-                    );
-
-                    executor_ -> add_node(target_node_);
-                    executor_ -> add_node(input_pub_node_);
-                    executor_ -> add_node(output_sub_node_);
-
-                    // Spin it up!
-                    executor_thread_ = std::thread([this]() { executor_ -> spin(); });
-                    (void)wait_for_connections(connection_timeout);
-
-                };
-
-                // Delete copy and move constructors/assignment operators
-                SimplePurePursuitIntegrationHarness(const SimplePurePursuitIntegrationHarness &) = delete;
-                SimplePurePursuitIntegrationHarness & operator=(const SimplePurePursuitIntegrationHarness &) = delete;
-                SimplePurePursuitIntegrationHarness(SimplePurePursuitIntegrationHarness &&) = delete;
-                SimplePurePursuitIntegrationHarness & operator=(SimplePurePursuitIntegrationHarness &&) = delete;
-
-                // Just simple destructor to clean up env resources
-                ~SimplePurePursuitIntegrationHarness()
-                {
-                    
-                    executor_ -> cancel();
-                    if (executor_thread_.joinable()) {
-                        executor_thread_.join();
-                    }
-
-                    control_sub_.reset();
-                    traj_pub_.reset();
-                    odom_pub_.reset();
-                    output_sub_node_.reset();
-                    input_pub_node_.reset();
-                    target_node_.reset();
-                    executor_.reset();
-
-                };
-
-                // Get time now from input_pub_node's clock
-                [[nodiscard]] builtin_interfaces::msg::Time now() const
-                {
-                    return input_pub_node_ -> get_clock() -> now();
-                };
-
-                // Funcs to publish odometry, trajectory or both as inputs to target node
-                void publish_odometry(
-                    const Odometry & odom
-                ) {
-                    clear_received_control();
-                    odom_pub_ -> publish(odom);
-                };
-
-                void publish_trajectory(
-                    const Trajectory & traj
-                ) {
-                    clear_received_control();
-                    traj_pub_ -> publish(traj);
-                };
-
-                void publish_inputs(
-                    const Odometry & odom, 
-                    const Trajectory & traj
-                ) {
-                    clear_received_control();
-                    odom_pub_ -> publish(odom);
-                    traj_pub_ -> publish(traj);
-                };
-
-                // Return true if received control command within timeout, false otherwise
-                [[nodiscard]] bool wait_for_output(
-                    const std::chrono::milliseconds timeout
-                ) const {
-                    
-                    const auto start = std::chrono::steady_clock::now();
-
-                    while (!is_received_.load()) {
-                        if (std::chrono::steady_clock::now() - start > timeout) {
-                            return false;
-                        }
-                        std::this_thread::sleep_for(spin_sleep);
-                    }
-
-                    return true;
-                    
-                };
-
-                // Return true if control command received
-                [[nodiscard]] Control::SharedPtr received_control() const
-                {
-                    std::scoped_lock lock(received_control_mutex_);
-                    return received_control_;
-                };
-
-            private:
-                
-                // Simple nuke received control command to prepare for next test case
-                void clear_received_control()
-                {
-                    is_received_.store(false);
-                    std::scoped_lock lock(received_control_mutex_);
-                    received_control_.reset();
-                };
-
-                // Wait until all publishers and subscribers are connected or timeout happens, 
-                // return true if all connected, false otherwise
-                bool wait_for_connections(
-                    const std::chrono::milliseconds timeout
-                ) {
-                    
-                    const auto start = std::chrono::steady_clock::now();
-                    // Wait until all connections are established or timeout happens
-                    while (
-                        (
-                            (odom_pub_ -> get_subscription_count() == 0U) || 
-                            (traj_pub_ -> get_subscription_count() == 0U) ||
-                            (control_sub_ -> get_publisher_count() == 0U)
-                        ) && (
-                            (std::chrono::steady_clock::now() - start <= timeout)
-                        )
-                    ) {
-                        std::this_thread::sleep_for(spin_sleep);
-                    }
-
-                    return (
-                        (odom_pub_ -> get_subscription_count() > 0U) && 
-                        (traj_pub_ -> get_subscription_count() > 0U) &&
-                        (control_sub_->get_publisher_count() > 0U)
-                    );
-
-                };
-
-                // Consts for connection and receiving timeouts and spin sleep duration
-                std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor_{nullptr};
-                std::thread executor_thread_;
-
-                std::shared_ptr<SimplePurePursuitNode> target_node_{nullptr};
-                rclcpp::Node::SharedPtr input_pub_node_{nullptr};
-                rclcpp::Node::SharedPtr output_sub_node_{nullptr};
-                rclcpp::Publisher<Odometry>::SharedPtr odom_pub_{nullptr};
-                rclcpp::Publisher<Trajectory>::SharedPtr traj_pub_{nullptr};
-                rclcpp::Subscription<Control>::SharedPtr control_sub_{nullptr};
-
-                mutable std::mutex received_control_mutex_;
-                std::atomic_bool is_received_{false};
-                Control::SharedPtr received_control_;
-
-            };
-
-            // ================== TESTING AREA HERE ==================
-
-            // TEST 1. Standard happy case test:
-            // - Straight trajectory
-            // - Vehicle starts at beginning, 0 yaw, 1 m/s velocity
-            // => Expect to receive 1 m/s velocity, and 0 steering angle within timeout
-            TEST(
-                SimplePurePursuitIntegrationTest, 
-                PublishesControlCommandForStraightTrajectory
-            ) {
-
-                SimplePurePursuitIntegrationHarness harness(make_node_options());
-
-                const auto stamp = harness.now();
-                const auto odom = make_odometry(
-                    0.0, 0.0, 0.0, 0.0, 
-                    stamp
-                );
-                const auto traj = make_straight_trajectory(
-                    {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0}, 
-                    1.0, 
-                    stamp
-                );
-
-                harness.publish_inputs(
-                    odom, 
-                    traj
-                );
-
-                // Receive control command within timeout
-                ASSERT_TRUE(
-                    harness.wait_for_output(
-                        std::chrono::duration_cast<std::chrono::milliseconds>(output_timeout)
-                    )
-                );
-                
-                // Check non-nullptr and expected values 
-                const auto control = harness.received_control();
-                ASSERT_NE(
-                    control, 
-                    nullptr
-                );
-
-                // Check expected values
-                EXPECT_EQ(
-                    control->stamp, 
-                    stamp
-                );
-                EXPECT_FLOAT_EQ(
-                    control->longitudinal.velocity, 
-                    1.0F
-                );
-                EXPECT_FLOAT_EQ(
-                    control->longitudinal.acceleration, 
-                    1.0F
-                );
-                EXPECT_FLOAT_EQ(
-                    control->lateral.steering_tire_angle, 
-                    0.0F
-                );
-
-            };
-
-            // TEST 2. Synchronization safety check
-            // Same standard happy case as above, but delayed between odom and traj publishes
-            TEST(
-                SimplePurePursuitIntegrationTest, 
-                DoesNotPublishUntilBothInputsAreAvailable
-            ) {
-                
-                SimplePurePursuitIntegrationHarness harness(make_node_options());
-
-                const auto stamp = harness.now();
-                const auto odom = make_odometry(
-                    0.0, 0.0, 0.0, 0.0, 
-                    stamp
-                );
-                const auto traj = make_straight_trajectory(
-                    {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0}, 
-                    1.0, 
-                    stamp
-                );
-
-                // Publish odom first
-                // Expect no received command cuz traj is not published yet
-                harness.publish_odometry(odom);
-                EXPECT_FALSE(
-                    harness.wait_for_output(
-                        std::chrono::duration_cast<std::chrono::milliseconds>(no_output_timeout)
-                    )
-                );
-
-                // Then publish traj
-                // Expect to receive command within timeout
-                harness.publish_inputs(
-                    odom, 
-                    traj
-                );
-                ASSERT_TRUE(
-                    harness.wait_for_output(
-                        std::chrono::duration_cast<std::chrono::milliseconds>(output_timeout)
-                    )
-                );
-
-            };
-
-            // TEST 3. Goal stop command test
-            // Same straight traj, vehicle starts at traj end
-            // Expected 0 velocity
-            TEST(
-                SimplePurePursuitIntegrationTest, 
-                PublishesGoalStopCommandAtTrajectoryEnd
-            ) {
-            
-                SimplePurePursuitIntegrationHarness harness(make_node_options());
-
-                const auto stamp = harness.now();
-                const auto odom = make_odometry(
-                    6.0, 0.0, 0.0, 0.0, 
-                    stamp
-                );
-                const auto traj = make_straight_trajectory(
-                    {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0}, 
-                    1.0, 
-                    stamp
-                );
-
-                harness.publish_inputs(odom, traj);
-
-                // Receive control command within timeout
-                ASSERT_TRUE(
-                    harness.wait_for_output(
-                        std::chrono::duration_cast<std::chrono::milliseconds>(output_timeout)
-                    )
-                );
-
-                // Check non-nullptr and expected values
-                const auto control = harness.received_control();
-                ASSERT_NE(control, nullptr);
-
-                // Expected 0 velocity
-                EXPECT_FLOAT_EQ(
-                    control->longitudinal.velocity, 
-                    0.0F
-                );
-
-                // Expected strong deceleration
-                // Here I already checked during development that terminal decel value is -10
-                // Seems like this module hard-coded this value. Imma freezin it here as characterization test
-                EXPECT_FLOAT_EQ(
-                    control->longitudinal.acceleration, 
-                    -10.0F
-                );
-                EXPECT_TRUE(control->longitudinal.is_defined_acceleration);
-
-            };
-
-            // TEST 4. Empty trajectory safety check
-            // Same vehicle state as TEST 1 & 2 but empty trajectory
-            // Expect to receive 0 velocity command within timeout (at least it ain't no command or crash)
-            TEST(
-                SimplePurePursuitIntegrationTest, 
-                PublishesZeroCommandForEmptyTrajectory
-            ) {
-                
-                SimplePurePursuitIntegrationHarness harness(make_node_options());
-
-                const auto stamp = harness.now();
-                const auto odom = make_odometry(
-                    0.0, 0.0, 0.0, 0.0, 
-                    stamp
-                );
-                // Empty traj
-                Trajectory traj;
-                traj.header.frame_id = "map";
-                traj.header.stamp = stamp;
-                
-                harness.publish_inputs(odom, traj);
-
-                // Check receiving control command within timeout
-                ASSERT_TRUE(
-                    harness.wait_for_output(
-                        std::chrono::duration_cast<std::chrono::milliseconds>(output_timeout)
-                    )
-                );
-
-                // Check non-nullptr and expected values
-                const auto control = harness.received_control();
-                ASSERT_NE(control, nullptr);
-
-                // Expected 0 velocity and 0 accel
-                EXPECT_FLOAT_EQ(
-                    control->longitudinal.velocity, 
-                    0.0F
-                );
-                EXPECT_FLOAT_EQ(
-                    control->longitudinal.acceleration, 
-                    0.0F
-                );
-
-            };
-
-            // TEST 5. External target velocity test
-            // Same straight traj and vehicle state as TEST 1, but with external target velocity enabled at 2.5 m/s
-            // Expect to receive 2.5 m/s velocity command within timeout (that ext. vel is used properly)
-            TEST(
-                SimplePurePursuitIntegrationTest, 
-                UsesExternalTargetVelocityWhenEnabled
-            ) {
-                
-                SimplePurePursuitIntegrationHarness harness(
-                    make_node_options({
-                        {"use_external_target_vel", rclcpp::ParameterValue{true}},
-                        {"external_target_vel", rclcpp::ParameterValue{2.5}},
-                    })
-                );
-
-                const auto stamp = harness.now();
-                const auto odom = make_odometry(
-                    0.0, 0.0, 0.0, 0.5, 
-                    stamp
-                );
-                const auto traj = make_straight_trajectory(
-                    {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0}, 
-                    1.0, 
-                    stamp
-                );
-
-                harness.publish_inputs(odom, traj);
-
-                // Check receiving control command within timeout
-                ASSERT_TRUE(
-                    harness.wait_for_output(
-                        std::chrono::duration_cast<std::chrono::milliseconds>(output_timeout)
-                    )
-                );
-
-                const auto control = harness.received_control();
-
-                // Check non-nullptr and expected values
-                ASSERT_NE(control, nullptr);
-
-                // Expected ext. vel 2.5 m/s, not traj's 1.0 m/s or car's current 0.5 m/s
-                // Basically ext. vel is used properly
-                EXPECT_FLOAT_EQ(
-                    control->longitudinal.velocity, 
-                    2.5F
-                );
-
-                // Car goin 0.5 m/s, target 2.5 m/s, so expect accel 2.0 m/s^2
-                // Already confirmed via test run during dev
-                EXPECT_FLOAT_EQ(
-                    control->longitudinal.acceleration, 
-                    2.0F
-                );
-
-                // Expected 0 steering angle for straight traj
-                EXPECT_FLOAT_EQ(
-                    control->lateral.steering_tire_angle, 
-                    0.0F
-                );
-
-            };
-
-    }; // namespace
-
-}; // namespace autoware::control::simple_pure_pursuit
-
-int main(int argc, char ** argv) {
-
-    rclcpp::init(argc, argv);
-    testing::InitGoogleTest(&argc, argv);
-
-    const auto result = RUN_ALL_TESTS();
-
-    rclcpp::shutdown();
-    return result;
-
+          std::scoped_lock lock(received_control_mutex_);
+          received_control_ = msg;
+        }
+        is_received_.store(true);
+      });
+
+    executor_->add_node(target_node_);
+    executor_->add_node(input_pub_node_);
+    executor_->add_node(output_sub_node_);
+
+    // Spin it up!
+    executor_thread_ = std::thread([this]() { executor_->spin(); });
+    (void)wait_for_connections(connection_timeout);
+  };
+
+  // Delete copy and move constructors/assignment operators
+  SimplePurePursuitIntegrationHarness(const SimplePurePursuitIntegrationHarness &) = delete;
+  SimplePurePursuitIntegrationHarness & operator=(const SimplePurePursuitIntegrationHarness &) =
+    delete;
+  SimplePurePursuitIntegrationHarness(SimplePurePursuitIntegrationHarness &&) = delete;
+  SimplePurePursuitIntegrationHarness & operator=(SimplePurePursuitIntegrationHarness &&) = delete;
+
+  // Just simple destructor to clean up env resources
+  ~SimplePurePursuitIntegrationHarness()
+  {
+    executor_->cancel();
+    if (executor_thread_.joinable()) {
+      executor_thread_.join();
+    }
+
+    control_sub_.reset();
+    traj_pub_.reset();
+    odom_pub_.reset();
+    output_sub_node_.reset();
+    input_pub_node_.reset();
+    target_node_.reset();
+    executor_.reset();
+  };
+
+  // Get time now from input_pub_node's clock
+  [[nodiscard]] builtin_interfaces::msg::Time now() const
+  {
+    return input_pub_node_->get_clock()->now();
+  };
+
+  // Funcs to publish odometry, trajectory or both as inputs to target node
+  void publish_odometry(const Odometry & odom)
+  {
+    clear_received_control();
+    odom_pub_->publish(odom);
+  };
+
+  void publish_trajectory(const Trajectory & traj)
+  {
+    clear_received_control();
+    traj_pub_->publish(traj);
+  };
+
+  void publish_inputs(const Odometry & odom, const Trajectory & traj)
+  {
+    clear_received_control();
+    odom_pub_->publish(odom);
+    traj_pub_->publish(traj);
+  };
+
+  // Return true if received control command within timeout, false otherwise
+  [[nodiscard]] bool wait_for_output(const std::chrono::milliseconds timeout) const
+  {
+    const auto start = std::chrono::steady_clock::now();
+
+    while (!is_received_.load()) {
+      if (std::chrono::steady_clock::now() - start > timeout) {
+        return false;
+      }
+      std::this_thread::sleep_for(spin_sleep);
+    }
+
+    return true;
+  };
+
+  // Return true if control command received
+  [[nodiscard]] Control::SharedPtr received_control() const
+  {
+    std::scoped_lock lock(received_control_mutex_);
+    return received_control_;
+  };
+
+private:
+  // Simple nuke received control command to prepare for next test case
+  void clear_received_control()
+  {
+    is_received_.store(false);
+    std::scoped_lock lock(received_control_mutex_);
+    received_control_.reset();
+  };
+
+  // Wait until all publishers and subscribers are connected or timeout happens,
+  // return true if all connected, false otherwise
+  bool wait_for_connections(const std::chrono::milliseconds timeout)
+  {
+    const auto start = std::chrono::steady_clock::now();
+    // Wait until all connections are established or timeout happens
+    while (((odom_pub_->get_subscription_count() == 0U) ||
+            (traj_pub_->get_subscription_count() == 0U) ||
+            (control_sub_->get_publisher_count() == 0U)) &&
+           ((std::chrono::steady_clock::now() - start <= timeout))) {
+      std::this_thread::sleep_for(spin_sleep);
+    }
+
+    return (
+      (odom_pub_->get_subscription_count() > 0U) && (traj_pub_->get_subscription_count() > 0U) &&
+      (control_sub_->get_publisher_count() > 0U));
+  };
+
+  // Consts for connection and receiving timeouts and spin sleep duration
+  std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor_{nullptr};
+  std::thread executor_thread_;
+
+  std::shared_ptr<SimplePurePursuitNode> target_node_{nullptr};
+  rclcpp::Node::SharedPtr input_pub_node_{nullptr};
+  rclcpp::Node::SharedPtr output_sub_node_{nullptr};
+  rclcpp::Publisher<Odometry>::SharedPtr odom_pub_{nullptr};
+  rclcpp::Publisher<Trajectory>::SharedPtr traj_pub_{nullptr};
+  rclcpp::Subscription<Control>::SharedPtr control_sub_{nullptr};
+
+  mutable std::mutex received_control_mutex_;
+  std::atomic_bool is_received_{false};
+  Control::SharedPtr received_control_;
+};
+
+// ================== TESTING AREA HERE ==================
+
+// TEST 1. Standard happy case test:
+// - Straight trajectory
+// - Vehicle starts at beginning, 0 yaw, 1 m/s velocity
+// => Expect to receive 1 m/s velocity, and 0 steering angle within timeout
+TEST(SimplePurePursuitIntegrationTest, PublishesControlCommandForStraightTrajectory)
+{
+  SimplePurePursuitIntegrationHarness harness(make_node_options());
+
+  const auto stamp = harness.now();
+  const auto odom = make_odometry(0.0, 0.0, 0.0, 0.0, stamp);
+  const auto traj = make_straight_trajectory({0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0}, 1.0, stamp);
+
+  harness.publish_inputs(odom, traj);
+
+  // Receive control command within timeout
+  ASSERT_TRUE(
+    harness.wait_for_output(std::chrono::duration_cast<std::chrono::milliseconds>(output_timeout)));
+
+  // Check non-nullptr and expected values
+  const auto control = harness.received_control();
+  ASSERT_NE(control, nullptr);
+
+  // Check expected values
+  EXPECT_EQ(control->stamp, stamp);
+  EXPECT_FLOAT_EQ(control->longitudinal.velocity, 1.0F);
+  EXPECT_FLOAT_EQ(control->longitudinal.acceleration, 1.0F);
+  EXPECT_FLOAT_EQ(control->lateral.steering_tire_angle, 0.0F);
+};
+
+// TEST 2. Synchronization safety check
+// Same standard happy case as above, but delayed between odom and traj publishes
+TEST(SimplePurePursuitIntegrationTest, DoesNotPublishUntilBothInputsAreAvailable)
+{
+  SimplePurePursuitIntegrationHarness harness(make_node_options());
+
+  const auto stamp = harness.now();
+  const auto odom = make_odometry(0.0, 0.0, 0.0, 0.0, stamp);
+  const auto traj = make_straight_trajectory({0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0}, 1.0, stamp);
+
+  // Publish odom first
+  // Expect no received command cuz traj is not published yet
+  harness.publish_odometry(odom);
+  EXPECT_FALSE(harness.wait_for_output(
+    std::chrono::duration_cast<std::chrono::milliseconds>(no_output_timeout)));
+
+  // Then publish traj
+  // Expect to receive command within timeout
+  harness.publish_inputs(odom, traj);
+  ASSERT_TRUE(
+    harness.wait_for_output(std::chrono::duration_cast<std::chrono::milliseconds>(output_timeout)));
+};
+
+// TEST 3. Goal stop command test
+// Same straight traj, vehicle starts at traj end
+// Expected 0 velocity
+TEST(SimplePurePursuitIntegrationTest, PublishesGoalStopCommandAtTrajectoryEnd)
+{
+  SimplePurePursuitIntegrationHarness harness(make_node_options());
+
+  const auto stamp = harness.now();
+  const auto odom = make_odometry(6.0, 0.0, 0.0, 0.0, stamp);
+  const auto traj = make_straight_trajectory({0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0}, 1.0, stamp);
+
+  harness.publish_inputs(odom, traj);
+
+  // Receive control command within timeout
+  ASSERT_TRUE(
+    harness.wait_for_output(std::chrono::duration_cast<std::chrono::milliseconds>(output_timeout)));
+
+  // Check non-nullptr and expected values
+  const auto control = harness.received_control();
+  ASSERT_NE(control, nullptr);
+
+  // Expected 0 velocity
+  EXPECT_FLOAT_EQ(control->longitudinal.velocity, 0.0F);
+
+  // Expected strong deceleration
+  // Here I already checked during development that terminal decel value is -10
+  // Seems like this module hard-coded this value. Imma freezin it here as characterization test
+  EXPECT_FLOAT_EQ(control->longitudinal.acceleration, -10.0F);
+  EXPECT_TRUE(control->longitudinal.is_defined_acceleration);
+};
+
+// TEST 4. Empty trajectory safety check
+// Same vehicle state as TEST 1 & 2 but empty trajectory
+// Expect to receive 0 velocity command within timeout (at least it ain't no command or crash)
+TEST(SimplePurePursuitIntegrationTest, PublishesZeroCommandForEmptyTrajectory)
+{
+  SimplePurePursuitIntegrationHarness harness(make_node_options());
+
+  const auto stamp = harness.now();
+  const auto odom = make_odometry(0.0, 0.0, 0.0, 0.0, stamp);
+  // Empty traj
+  Trajectory traj;
+  traj.header.frame_id = "map";
+  traj.header.stamp = stamp;
+
+  harness.publish_inputs(odom, traj);
+
+  // Check receiving control command within timeout
+  ASSERT_TRUE(
+    harness.wait_for_output(std::chrono::duration_cast<std::chrono::milliseconds>(output_timeout)));
+
+  // Check non-nullptr and expected values
+  const auto control = harness.received_control();
+  ASSERT_NE(control, nullptr);
+
+  // Expected 0 velocity and 0 accel
+  EXPECT_FLOAT_EQ(control->longitudinal.velocity, 0.0F);
+  EXPECT_FLOAT_EQ(control->longitudinal.acceleration, 0.0F);
+};
+
+// TEST 5. External target velocity test
+// Same straight traj and vehicle state as TEST 1, but with external target velocity enabled at 2.5
+// m/s Expect to receive 2.5 m/s velocity command within timeout (that ext. vel is used properly)
+TEST(SimplePurePursuitIntegrationTest, UsesExternalTargetVelocityWhenEnabled)
+{
+  SimplePurePursuitIntegrationHarness harness(make_node_options({
+    {"use_external_target_vel", rclcpp::ParameterValue{true}},
+    {"external_target_vel", rclcpp::ParameterValue{2.5}},
+  }));
+
+  const auto stamp = harness.now();
+  const auto odom = make_odometry(0.0, 0.0, 0.0, 0.5, stamp);
+  const auto traj = make_straight_trajectory({0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0}, 1.0, stamp);
+
+  harness.publish_inputs(odom, traj);
+
+  // Check receiving control command within timeout
+  ASSERT_TRUE(
+    harness.wait_for_output(std::chrono::duration_cast<std::chrono::milliseconds>(output_timeout)));
+
+  const auto control = harness.received_control();
+
+  // Check non-nullptr and expected values
+  ASSERT_NE(control, nullptr);
+
+  // Expected ext. vel 2.5 m/s, not traj's 1.0 m/s or car's current 0.5 m/s
+  // Basically ext. vel is used properly
+  EXPECT_FLOAT_EQ(control->longitudinal.velocity, 2.5F);
+
+  // Car goin 0.5 m/s, target 2.5 m/s, so expect accel 2.0 m/s^2
+  // Already confirmed via test run during dev
+  EXPECT_FLOAT_EQ(control->longitudinal.acceleration, 2.0F);
+
+  // Expected 0 steering angle for straight traj
+  EXPECT_FLOAT_EQ(control->lateral.steering_tire_angle, 0.0F);
+};
+
+};  // namespace
+
+};  // namespace autoware::control::simple_pure_pursuit
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  testing::InitGoogleTest(&argc, argv);
+
+  const auto result = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+  return result;
 }

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -11,3 +11,20 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+#include "simple_pure_pursuit.hpp"
+
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <autoware_test_utils/autoware_test_utils.hpp>
+
+#include <autoware_control_msgs/msg/control.hpp>
+#include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+#include <gtest/gtest.h>
+#include <rclcpp/executors.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <cmath>
+#include <memory>
+

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -367,7 +367,7 @@ TEST(SimplePurePursuitIntegrationTest, PublishesGoalStopCommandAtTrajectoryEnd)
   // Expected 0 velocity
   EXPECT_NEAR(control->longitudinal.velocity, 0.0F, near_tol);
 
-  // Expected strong decelerationeration
+  // Expected strong deceleration
   // Here I already checked during development that terminal deceleration value is -10
   // Seems like this module hard-coded this value. I will freeze it here as characterization test
   EXPECT_NEAR(control->longitudinal.acceleration, -10.0F, near_tol);

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -335,7 +335,7 @@ namespace autoware::control::simple_pure_pursuit
 
             // ================== TESTING AREA HERE ==================
 
-            // Standard happy case test:
+            // TEST 1. Standard happy case test:
             // - Straight trajectory
             // - Vehicle starts at beginning, 0 yaw, 1 m/s velocity
             // => Expect to receive 1 m/s velocity, and 0 steering angle within timeout
@@ -396,7 +396,7 @@ namespace autoware::control::simple_pure_pursuit
 
             };
 
-            // Synchronization safety check
+            // TEST 2. Synchronization safety check
             // Same standard happy case as above, but delayed between odom and traj publishes
             TEST(
                 SimplePurePursuitIntegrationTest, 
@@ -439,7 +439,7 @@ namespace autoware::control::simple_pure_pursuit
 
             };
 
-            // Goal stop command test
+            // TEST 3. Goal stop command test
             // Same straight traj, vehicle starts at traj end
             // Expected 0 velocity
             TEST(
@@ -488,6 +488,51 @@ namespace autoware::control::simple_pure_pursuit
                 );
                 EXPECT_TRUE(control->longitudinal.is_defined_acceleration);
 
+            };
+
+            // TEST 4. Empty trajectory safety check
+            // Same vehicle state as TEST 1 & 2 but empty trajectory
+            // Expect to receive 0 velocity command within timeout (at least it ain't no command or crash)
+            TEST(
+                SimplePurePursuitIntegrationTest, 
+                PublishesZeroCommandForEmptyTrajectory
+            ) {
+                
+                SimplePurePursuitIntegrationHarness harness(make_node_options());
+
+                const auto stamp = harness.now();
+                const auto odom = make_odometry(
+                    0.0, 0.0, 0.0, 0.0, 
+                    stamp
+                );
+                // Empty traj
+                Trajectory traj;
+                traj.header.frame_id = "map";
+                traj.header.stamp = stamp;
+                
+                harness.publish_inputs(odom, traj);
+
+                // Check receiving control command within timeout
+                ASSERT_TRUE(
+                    harness.wait_for_output(
+                        std::chrono::duration_cast<std::chrono::milliseconds>(output_timeout)
+                    )
+                );
+
+                // Check non-nullptr and expected values
+                const auto control = harness.received_control();
+                ASSERT_NE(control, nullptr);
+
+                // Expected 0 velocity and 0 accel
+                EXPECT_FLOAT_EQ(
+                    control->longitudinal.velocity, 
+                    0.0F
+                );
+                EXPECT_FLOAT_EQ(
+                    control->longitudinal.acceleration, 
+                    0.0F
+                );
+                
             }
 
     }; // namespace

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -175,8 +175,8 @@ namespace autoware::control::simple_pure_pursuit
                     rclcpp::QoS{1}.transient_local(),
                     [this](const Control::SharedPtr msg) {
                         {
-                        std::scoped_lock lock(received_control_mutex_);
-                        received_control_ = msg;
+                        std::scoped_lock lock(received_control_mutex);
+                        received_control = msg;
                         }
                         is_received_.store(true);
                     }
@@ -203,21 +203,19 @@ namespace autoware::control::simple_pure_pursuit
             {
                 
                 executor -> cancel();
-                if (executor_thread_.joinable()) {
-                    executor_thread_.join();
+                if (executor_thread.joinable()) {
+                    executor_thread.join();
                 }
 
-                control_sub_.reset();
-                traj_pub_.reset();
-                odom_pub_.reset();
-                output_sub_node_.reset();
-                input_pub_node_.reset();
-                target_node_.reset();
-                executor_.reset();
+                control_sub.reset();
+                traj_pub.reset();
+                odom_pub.reset();
+                output_sub_node.reset();
+                input_pub_node.reset();
+                target_node.reset();
+                executor.reset();
 
             };
-
-            // Some helper functions for testing
 
             // Get time now from input_pub_node's clock
             [[nodiscard]] builtin_interfaces::msg::Time now() const
@@ -247,6 +245,31 @@ namespace autoware::control::simple_pure_pursuit
                 clear_received_control();
                 odom_pub -> publish(odom);
                 traj_pub -> publish(traj);
+            };
+
+            // Return true if received control command within timeout, false otherwise
+            [[nodiscard]] bool wait_for_output(
+                const std::chrono::milliseconds timeout
+            ) const {
+                
+                const auto start = std::chrono::steady_clock::now();
+
+                while (!is_received_.load()) {
+                    if (std::chrono::steady_clock::now() - start > timeout) {
+                        return false;
+                    }
+                    std::this_thread::sleep_for(spin_sleep);
+                }
+
+                return true;
+                
+            };
+
+            // Return true if control command received
+            [[nodiscard]] Control::SharedPtr received_control() const
+            {
+                std::scoped_lock lock(received_control_mutex);
+                return received_control;
             };
 
     }; // namespace

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -440,9 +440,9 @@ TEST(SimplePurePursuitIntegrationTest, UsesExternalTargetVelocityWhenEnabled)
 };
 
 // TEST 6. Lateral offset check
-// Straight traj along Y=0, but vehicle starts at Y=1.0 (1 m offset to the left of traj), facing +X, stopped
-// Expect to receive control command with negative steering angle (right turn) within timeout
-// (that it can calculate correct steering for lateral offset and not just output 0)
+// Straight traj along Y=0, but vehicle starts at Y=1.0 (1 m offset to the left of traj), facing +X,
+// stopped Expect to receive control command with negative steering angle (right turn) within
+// timeout (that it can calculate correct steering for lateral offset and not just output 0)
 TEST(SimplePurePursuitIntegrationTest, PublishesNonZeroSteeringForLateralOffset)
 {
   SimplePurePursuitIntegrationHarness harness(make_node_options());
@@ -464,7 +464,6 @@ TEST(SimplePurePursuitIntegrationTest, PublishesNonZeroSteeringForLateralOffset)
   // Expected negative steering angle to correct 1 m lateral offset to the right, not 0
   // Already confirmed via test run during dev
   EXPECT_NEAR(control->lateral.steering_tire_angle, -0.82152F, near_tol);
-
 };
 
 };  // namespace

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -310,6 +310,24 @@ namespace autoware::control::simple_pure_pursuit
 
                 };
 
+                // Consts for connection and receiving timeouts and spin sleep duration
+                std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor{nullptr};
+                std::thread executor_thread;
+
+                std::shared_ptr<SimplePurePursuitNode> target_node{nullptr};
+                rclcpp::Node::SharedPtr input_pub_node{nullptr};
+                rclcpp::Node::SharedPtr output_sub_node{nullptr};
+                rclcpp::Publisher<Odometry>::SharedPtr odom_pub{nullptr};
+                rclcpp::Publisher<Trajectory>::SharedPtr traj_pub{nullptr};
+                rclcpp::Subscription<Control>::SharedPtr control_sub{nullptr};
+
+                mutable std::mutex received_control_mutex;
+                std::atomic_bool is_received{false};
+                Control::SharedPtr received_control;
+
+
+            
+
     }; // namespace
 
 }; // namespace autoware::control::simple_pure_pursuit

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -1,0 +1,13 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -139,6 +139,59 @@ namespace autoware::control::simple_pure_pursuit
 
         };
 
+
+        class SimplePurePursuitIntegrationHarness
+        {
+            
+            public:
+
+            /**
+            * @brief Construct a new SimplePurePursuitIntegrationHarness object, 
+                     which sets up test env for integration testing of SimplePurePursuitNode.
+            *
+            * @param node_options NodeOptions to construct target SimplePurePursuitNode, 
+                                  can be used to override some default params if needed.
+            */
+            explicit SimplePurePursuitIntegrationHarness(
+                const rclcpp::NodeOptions & node_options
+            ) {
+                
+                executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+
+                target_node = std::make_shared<SimplePurePursuitNode>(node_options);
+                input_pub_node = rclcpp::Node::make_shared("simple_pure_pursuit_test_input_publisher");
+                output_sub_node = rclcpp::Node::make_shared("simple_pure_pursuit_test_output_subscriber");
+
+                odom_pub = input_pub_node -> create_publisher<Odometry>(
+                    "/simple_pure_pursuit/input/odometry", 
+                    rclcpp::QoS{1}
+                );
+                traj_pub = input_pub_node -> create_publisher<Trajectory>(
+                    "/simple_pure_pursuit/input/trajectory", 
+                    rclcpp::QoS{1}
+                );
+                control_sub = output_sub_node -> create_subscription<Control>(
+                    "/simple_pure_pursuit/output/control_command", 
+                    rclcpp::QoS{1}.transient_local(),
+                    [this](const Control::SharedPtr msg) {
+                        {
+                        std::scoped_lock lock(received_control_mutex_);
+                        received_control_ = msg;
+                        }
+                        is_received_.store(true);
+                    }
+                );
+
+                executor -> add_node(target_node);
+                executor -> add_node(input_pub_node);
+                executor -> add_node(output_sub_node);
+
+                // Spin it up!
+                executor_thread = std::thread([this]() { executor -> spin(); });
+                (void)wait_for_connections(connection_timeout);
+
+            };
+
     }; // namespace
 
 }; // namespace autoware::control::simple_pure_pursuit

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -40,7 +40,37 @@ namespace autoware::control::simple_pure_pursuit
     namespace
     {
 
-        
+        /**
+        * @brief Create a dummy Odometry message with some given params.
+        *
+        * @param x dummy odometry's x position.
+        * @param y dummy odometry's y position.
+        * @param yaw dummy odometry's yaw angle.
+        * @param longitudinal_velocity dummy odometry's longitudinal velocity.
+        * @param stamp dummy odometry's timestamp.
+        *
+        * @return Odometry dummy message.
+        */
+        Odometry make_odometry(
+            const double x, 
+            const double y, 
+            const double yaw, 
+            const double longitudinal_velocity,
+            const builtin_interfaces::msg::Time & stamp
+        ) {
+            
+            Odometry odom;
+            odom.header.frame_id = "map";
+            odom.header.stamp = stamp;
+            odom.pose.pose.position.x = x;
+            odom.pose.pose.position.y = y;
+            odom.pose.pose.orientation.z = std::sin(yaw / 2.0);
+            odom.pose.pose.orientation.w = std::cos(yaw / 2.0);
+            odom.twist.twist.linear.x = longitudinal_velocity;
+
+            return odom;
+
+        }
 
     }
 

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -367,9 +367,9 @@ TEST(SimplePurePursuitIntegrationTest, PublishesGoalStopCommandAtTrajectoryEnd)
   // Expected 0 velocity
   EXPECT_NEAR(control->longitudinal.velocity, 0.0F, near_tol);
 
-  // Expected strong deceleration
-  // Here I already checked during development that terminal decel value is -10
-  // Seems like this module hard-coded this value. Imma freezin it here as characterization test
+  // Expected strong decelerationeration
+  // Here I already checked during development that terminal deceleration value is -10
+  // Seems like this module hard-coded this value. I will freeze it here as characterization test
   EXPECT_NEAR(control->longitudinal.acceleration, -10.0F, near_tol);
   EXPECT_TRUE(control->longitudinal.is_defined_acceleration);
 };
@@ -398,7 +398,7 @@ TEST(SimplePurePursuitIntegrationTest, PublishesZeroCommandForEmptyTrajectory)
   const auto control = harness.received_control();
   ASSERT_NE(control, nullptr);
 
-  // Expected 0 velocity and 0 accel
+  // Expected 0 velocity and 0 acceleration
   EXPECT_NEAR(control->longitudinal.velocity, 0.0F, near_tol);
   EXPECT_NEAR(control->longitudinal.acceleration, 0.0F, near_tol);
 };
@@ -432,7 +432,7 @@ TEST(SimplePurePursuitIntegrationTest, UsesExternalTargetVelocityWhenEnabled)
   // Basically ext. vel is used properly
   EXPECT_NEAR(control->longitudinal.velocity, 2.5F, near_tol);
 
-  // Car goin 0.5 m/s, target 2.5 m/s, so expect accel 2.0 m/s^2
+  // Car going at 0.5 m/s, target velocity 2.5 m/s, so expect acceleration as 2.0 m/s^2
   // Already confirmed via test run during dev
   EXPECT_NEAR(control->longitudinal.acceleration, 2.0F, near_tol);
 

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -44,6 +44,9 @@ constexpr auto output_timeout = std::chrono::seconds(5);
 constexpr auto no_output_timeout = std::chrono::milliseconds(250);
 constexpr auto spin_sleep = std::chrono::milliseconds(10);
 
+// Floating point tolerance at EXCEPT_NEAR checks (thanks Ishikawa-san for the suggestion!)
+constexpr float near_tol = 1e-4F;
+
 /**
  * @brief Create a dummy Odometry message with some given params.
  * This dummy one is a pose on the x-y plane with a yaw angle, and a longitudinal velocity.
@@ -311,9 +314,9 @@ TEST(SimplePurePursuitIntegrationTest, PublishesControlCommandForStraightTraject
 
   // Check expected values
   EXPECT_EQ(control->stamp, stamp);
-  EXPECT_FLOAT_EQ(control->longitudinal.velocity, 1.0F);
-  EXPECT_FLOAT_EQ(control->longitudinal.acceleration, 1.0F);
-  EXPECT_FLOAT_EQ(control->lateral.steering_tire_angle, 0.0F);
+  EXPECT_NEAR(control->longitudinal.velocity, 1.0F, near_tol);
+  EXPECT_NEAR(control->longitudinal.acceleration, 1.0F, near_tol);
+  EXPECT_NEAR(control->lateral.steering_tire_angle, 0.0F, near_tol);
 };
 
 // TEST 2. Synchronization safety check
@@ -361,12 +364,12 @@ TEST(SimplePurePursuitIntegrationTest, PublishesGoalStopCommandAtTrajectoryEnd)
   ASSERT_NE(control, nullptr);
 
   // Expected 0 velocity
-  EXPECT_FLOAT_EQ(control->longitudinal.velocity, 0.0F);
+  EXPECT_NEAR(control->longitudinal.velocity, 0.0F, near_tol);
 
   // Expected strong deceleration
   // Here I already checked during development that terminal decel value is -10
   // Seems like this module hard-coded this value. Imma freezin it here as characterization test
-  EXPECT_FLOAT_EQ(control->longitudinal.acceleration, -10.0F);
+  EXPECT_NEAR(control->longitudinal.acceleration, -10.0F, near_tol);
   EXPECT_TRUE(control->longitudinal.is_defined_acceleration);
 };
 
@@ -395,8 +398,8 @@ TEST(SimplePurePursuitIntegrationTest, PublishesZeroCommandForEmptyTrajectory)
   ASSERT_NE(control, nullptr);
 
   // Expected 0 velocity and 0 accel
-  EXPECT_FLOAT_EQ(control->longitudinal.velocity, 0.0F);
-  EXPECT_FLOAT_EQ(control->longitudinal.acceleration, 0.0F);
+  EXPECT_NEAR(control->longitudinal.velocity, 0.0F, near_tol);
+  EXPECT_NEAR(control->longitudinal.acceleration, 0.0F, near_tol);
 };
 
 // TEST 5. External target velocity test
@@ -426,14 +429,14 @@ TEST(SimplePurePursuitIntegrationTest, UsesExternalTargetVelocityWhenEnabled)
 
   // Expected ext. vel 2.5 m/s, not traj's 1.0 m/s or car's current 0.5 m/s
   // Basically ext. vel is used properly
-  EXPECT_FLOAT_EQ(control->longitudinal.velocity, 2.5F);
+  EXPECT_NEAR(control->longitudinal.velocity, 2.5F, near_tol);
 
   // Car goin 0.5 m/s, target 2.5 m/s, so expect accel 2.0 m/s^2
   // Already confirmed via test run during dev
-  EXPECT_FLOAT_EQ(control->longitudinal.acceleration, 2.0F);
+  EXPECT_NEAR(control->longitudinal.acceleration, 2.0F, near_tol);
 
   // Expected 0 steering angle for straight traj
-  EXPECT_FLOAT_EQ(control->lateral.steering_tire_angle, 0.0F);
+  EXPECT_NEAR(control->lateral.steering_tire_angle, 0.0F, near_tol);
 };
 
 // TEST 6. Lateral offset check
@@ -460,7 +463,7 @@ TEST(SimplePurePursuitIntegrationTest, PublishesNonZeroSteeringForLateralOffset)
 
   // Expected negative steering angle to correct 1 m lateral offset to the right, not 0
   // Already confirmed via test run during dev
-  EXPECT_NEAR(control->lateral.steering_tire_angle, -0.82152F, 1e-2F);
+  EXPECT_NEAR(control->lateral.steering_tire_angle, -0.82152F, near_tol);
 
 };
 

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -73,7 +73,7 @@ Odometry make_odometry(
   odom.twist.twist.linear.x = longitudinal_velocity;
 
   return odom;
-};
+}
 
 /**
  * @brief Create a dummy Trajectory message with some given params.

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -145,132 +145,170 @@ namespace autoware::control::simple_pure_pursuit
             
             public:
 
-            /**
-            * @brief Construct a new SimplePurePursuitIntegrationHarness object, 
-                     which sets up test env for integration testing of SimplePurePursuitNode.
-            *
-            * @param node_options NodeOptions to construct target SimplePurePursuitNode, 
-                                  can be used to override some default params if needed.
-            */
-            explicit SimplePurePursuitIntegrationHarness(
-                const rclcpp::NodeOptions & node_options
-            ) {
-                
-                executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+                /**
+                * @brief Construct a new SimplePurePursuitIntegrationHarness object, 
+                        which sets up test env for integration testing of SimplePurePursuitNode.
+                *
+                * @param node_options NodeOptions to construct target SimplePurePursuitNode, 
+                                    can be used to override some default params if needed.
+                */
+                explicit SimplePurePursuitIntegrationHarness(
+                    const rclcpp::NodeOptions & node_options
+                ) {
+                    
+                    executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
 
-                target_node = std::make_shared<SimplePurePursuitNode>(node_options);
-                input_pub_node = rclcpp::Node::make_shared("simple_pure_pursuit_test_input_publisher");
-                output_sub_node = rclcpp::Node::make_shared("simple_pure_pursuit_test_output_subscriber");
+                    target_node = std::make_shared<SimplePurePursuitNode>(node_options);
+                    input_pub_node = rclcpp::Node::make_shared("simple_pure_pursuit_test_input_publisher");
+                    output_sub_node = rclcpp::Node::make_shared("simple_pure_pursuit_test_output_subscriber");
 
-                odom_pub = input_pub_node -> create_publisher<Odometry>(
-                    "/simple_pure_pursuit/input/odometry", 
-                    rclcpp::QoS{1}
-                );
-                traj_pub = input_pub_node -> create_publisher<Trajectory>(
-                    "/simple_pure_pursuit/input/trajectory", 
-                    rclcpp::QoS{1}
-                );
-                control_sub = output_sub_node -> create_subscription<Control>(
-                    "/simple_pure_pursuit/output/control_command", 
-                    rclcpp::QoS{1}.transient_local(),
-                    [this](const Control::SharedPtr msg) {
-                        {
-                        std::scoped_lock lock(received_control_mutex);
-                        received_control = msg;
+                    odom_pub = input_pub_node -> create_publisher<Odometry>(
+                        "/simple_pure_pursuit/input/odometry", 
+                        rclcpp::QoS{1}
+                    );
+                    traj_pub = input_pub_node -> create_publisher<Trajectory>(
+                        "/simple_pure_pursuit/input/trajectory", 
+                        rclcpp::QoS{1}
+                    );
+                    control_sub = output_sub_node -> create_subscription<Control>(
+                        "/simple_pure_pursuit/output/control_command", 
+                        rclcpp::QoS{1}.transient_local(),
+                        [this](const Control::SharedPtr msg) {
+                            {
+                            std::scoped_lock lock(received_control_mutex);
+                            received_control = msg;
+                            }
+                            is_received_.store(true);
                         }
-                        is_received_.store(true);
+                    );
+
+                    executor -> add_node(target_node);
+                    executor -> add_node(input_pub_node);
+                    executor -> add_node(output_sub_node);
+
+                    // Spin it up!
+                    executor_thread = std::thread([this]() { executor -> spin(); });
+                    (void)wait_for_connections(connection_timeout);
+
+                };
+
+                // Delete copy and move constructors/assignment operators
+                SimplePurePursuitIntegrationHarness(const SimplePurePursuitIntegrationHarness &) = delete;
+                SimplePurePursuitIntegrationHarness & operator=(const SimplePurePursuitIntegrationHarness &) = delete;
+                SimplePurePursuitIntegrationHarness(SimplePurePursuitIntegrationHarness &&) = delete;
+                SimplePurePursuitIntegrationHarness & operator=(SimplePurePursuitIntegrationHarness &&) = delete;
+
+                // Just simple destructor to clean up env resources
+                ~SimplePurePursuitIntegrationHarness()
+                {
+                    
+                    executor -> cancel();
+                    if (executor_thread.joinable()) {
+                        executor_thread.join();
                     }
-                );
 
-                executor -> add_node(target_node);
-                executor -> add_node(input_pub_node);
-                executor -> add_node(output_sub_node);
+                    control_sub.reset();
+                    traj_pub.reset();
+                    odom_pub.reset();
+                    output_sub_node.reset();
+                    input_pub_node.reset();
+                    target_node.reset();
+                    executor.reset();
 
-                // Spin it up!
-                executor_thread = std::thread([this]() { executor -> spin(); });
-                (void)wait_for_connections(connection_timeout);
+                };
 
-            };
+                // Get time now from input_pub_node's clock
+                [[nodiscard]] builtin_interfaces::msg::Time now() const
+                {
+                    return input_pub_node -> get_clock() -> now();
+                };
 
-            // Delete copy and move constructors/assignment operators
-            SimplePurePursuitIntegrationHarness(const SimplePurePursuitIntegrationHarness &) = delete;
-            SimplePurePursuitIntegrationHarness & operator=(const SimplePurePursuitIntegrationHarness &) = delete;
-            SimplePurePursuitIntegrationHarness(SimplePurePursuitIntegrationHarness &&) = delete;
-            SimplePurePursuitIntegrationHarness & operator=(SimplePurePursuitIntegrationHarness &&) = delete;
+                // Funcs to publish odometry, trajectory or both as inputs to target node
+                void publish_odometry(
+                    const Odometry & odom
+                ) {
+                    clear_received_control();
+                    odom_pub -> publish(odom);
+                };
 
-            // Just simple destructor to clean up env resources
-            ~SimplePurePursuitIntegrationHarness()
-            {
-                
-                executor -> cancel();
-                if (executor_thread.joinable()) {
-                    executor_thread.join();
-                }
+                void publish_trajectory(
+                    const Trajectory & traj
+                ) {
+                    clear_received_control();
+                    traj_pub -> publish(traj);
+                };
 
-                control_sub.reset();
-                traj_pub.reset();
-                odom_pub.reset();
-                output_sub_node.reset();
-                input_pub_node.reset();
-                target_node.reset();
-                executor.reset();
+                void publish_inputs(
+                    const Odometry & odom, 
+                    const Trajectory & traj
+                ) {
+                    clear_received_control();
+                    odom_pub -> publish(odom);
+                    traj_pub -> publish(traj);
+                };
 
-            };
+                // Return true if received control command within timeout, false otherwise
+                [[nodiscard]] bool wait_for_output(
+                    const std::chrono::milliseconds timeout
+                ) const {
+                    
+                    const auto start = std::chrono::steady_clock::now();
 
-            // Get time now from input_pub_node's clock
-            [[nodiscard]] builtin_interfaces::msg::Time now() const
-            {
-                return input_pub_node -> get_clock() -> now();
-            };
-
-            // Funcs to publish odometry, trajectory or both as inputs to target node
-            void publish_odometry(
-                const Odometry & odom
-            ) {
-                clear_received_control();
-                odom_pub -> publish(odom);
-            };
-
-            void publish_trajectory(
-                const Trajectory & traj
-            ) {
-                clear_received_control();
-                traj_pub -> publish(traj);
-            };
-
-            void publish_inputs(
-                const Odometry & odom, 
-                const Trajectory & traj
-            ) {
-                clear_received_control();
-                odom_pub -> publish(odom);
-                traj_pub -> publish(traj);
-            };
-
-            // Return true if received control command within timeout, false otherwise
-            [[nodiscard]] bool wait_for_output(
-                const std::chrono::milliseconds timeout
-            ) const {
-                
-                const auto start = std::chrono::steady_clock::now();
-
-                while (!is_received_.load()) {
-                    if (std::chrono::steady_clock::now() - start > timeout) {
-                        return false;
+                    while (!is_received_.load()) {
+                        if (std::chrono::steady_clock::now() - start > timeout) {
+                            return false;
+                        }
+                        std::this_thread::sleep_for(spin_sleep);
                     }
-                    std::this_thread::sleep_for(spin_sleep);
-                }
 
-                return true;
+                    return true;
+                    
+                };
+
+                // Return true if control command received
+                [[nodiscard]] Control::SharedPtr received_control() const
+                {
+                    std::scoped_lock lock(received_control_mutex);
+                    return received_control;
+                };
+
+            private:
                 
-            };
+                // Simple nuke received control command to prepare for next test case
+                void clear_received_control()
+                {
+                    is_received.store(false);
+                    std::scoped_lock lock(received_control_mutex);
+                    received_control.reset();
+                };
 
-            // Return true if control command received
-            [[nodiscard]] Control::SharedPtr received_control() const
-            {
-                std::scoped_lock lock(received_control_mutex);
-                return received_control;
-            };
+                // Wait until all publishers and subscribers are connected or timeout happens, 
+                // return true if all connected, false otherwise
+                bool wait_for_connections(
+                    const std::chrono::milliseconds timeout
+                ) {
+                    
+                    const auto start = std::chrono::steady_clock::now();
+                    // Wait until all connections are established or timeout happens
+                    while (
+                        (
+                            (odom_pub -> get_subscription_count() == 0U) || 
+                            (traj_pub -> get_subscription_count() == 0U) ||
+                            (control_sub -> get_publisher_count() == 0U)
+                        ) && (
+                            (std::chrono::steady_clock::now() - start <= timeout)
+                        )
+                    ) {
+                        std::this_thread::sleep_for(spin_sleep);
+                    }
+
+                    return (
+                        (odom_pub -> get_subscription_count() > 0U) && 
+                        (traj_pub -> get_subscription_count() > 0U) &&
+                        (control_sub_->get_publisher_count() > 0U)
+                    );
+
+                };
 
     }; // namespace
 

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -217,6 +217,38 @@ namespace autoware::control::simple_pure_pursuit
 
             };
 
+            // Some helper functions for testing
+
+            // Get time now from input_pub_node's clock
+            [[nodiscard]] builtin_interfaces::msg::Time now() const
+            {
+                return input_pub_node -> get_clock() -> now();
+            };
+
+            // Funcs to publish odometry, trajectory or both as inputs to target node
+            void publish_odometry(
+                const Odometry & odom
+            ) {
+                clear_received_control();
+                odom_pub -> publish(odom);
+            };
+
+            void publish_trajectory(
+                const Trajectory & traj
+            ) {
+                clear_received_control();
+                traj_pub -> publish(traj);
+            };
+
+            void publish_inputs(
+                const Odometry & odom, 
+                const Trajectory & traj
+            ) {
+                clear_received_control();
+                odom_pub -> publish(odom);
+                traj_pub -> publish(traj);
+            };
+
     }; // namespace
 
 }; // namespace autoware::control::simple_pure_pursuit

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -40,6 +40,12 @@ namespace autoware::control::simple_pure_pursuit
     namespace
     {
 
+        constexpr auto connection_timeout = std::chrono::seconds(3);
+        constexpr auto output_timeout = std::chrono::seconds(5);
+        constexpr auto no_output_timeout = std::chrono::milliseconds(250);
+        constexpr auto spin_sleep = std::chrono::milliseconds(10);
+
+
         /**
         * @brief Create a dummy Odometry message with some given params.
         * This dummy one is a pose on the x-y plane with a yaw angle, and a longitudinal velocity.
@@ -325,8 +331,68 @@ namespace autoware::control::simple_pure_pursuit
                 std::atomic_bool is_received{false};
                 Control::SharedPtr received_control;
 
+            // ================== TESTING AREA HERE ==================
 
-            
+            // Standard happy case test:
+            // - Straight trajectory
+            // - Vehicle starts at beginning, 0 yaw, 1 m/s velocity
+            // => Expect to receive 1 m/s velocity, and 0 steering angle within timeout
+            TEST(
+                SimplePurePursuitIntegrationTest, 
+                PublishesControlCommandForStraightTrajectory
+            ) {
+
+                SimplePurePursuitIntegrationHarness harness(make_node_options());
+
+                const auto stamp = harness.now();
+                const auto odom = make_odometry(
+                    0.0, 0.0, 0.0, 0.0, 
+                    stamp
+                );
+                const auto traj = make_straight_trajectory(
+                    {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0}, 
+                    1.0, 
+                    stamp
+                );
+
+                harness.publish_inputs(
+                    odom, 
+                    traj
+                );
+
+                // Receive control command within timeout
+                ASSERT_TRUE(
+                    harness.wait_for_output(
+                        std::chrono::duration_cast<std::chrono::milliseconds>(output_timeout)
+                    )
+                );
+                
+                // Check non-nullptr and expected values 
+                const auto control = harness.received_control();
+                ASSERT_NE(
+                    control, 
+                    nullptr
+                );
+
+                // Check expected values
+                EXPECT_EQ(
+                    control->stamp, 
+                    stamp
+                );
+                EXPECT_FLOAT_EQ(
+                    control->longitudinal.velocity, 
+                    1.0F
+                );
+                EXPECT_FLOAT_EQ(
+                    control->longitudinal.acceleration, 
+                    1.0F
+                );
+                EXPECT_FLOAT_EQ(
+                    control->lateral.steering_tire_angle, 
+                    0.0F
+                );
+
+            };
 
     }; // namespace
 

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -532,8 +532,69 @@ namespace autoware::control::simple_pure_pursuit
                     control->longitudinal.acceleration, 
                     0.0F
                 );
+
+            };
+
+            // TEST 5. External target velocity test
+            // Same straight traj and vehicle state as TEST 1, but with external target velocity enabled at 2.5 m/s
+            // Expect to receive 2.5 m/s velocity command within timeout (that ext. vel is used properly)
+            TEST(
+                SimplePurePursuitIntegrationTest, 
+                UsesExternalTargetVelocityWhenEnabled
+            ) {
                 
-            }
+                SimplePurePursuitIntegrationHarness harness(
+                    make_node_options({
+                        {"use_external_target_vel", rclcpp::ParameterValue{true}},
+                        {"external_target_vel", rclcpp::ParameterValue{2.5}},
+                    })
+                );
+
+                const auto stamp = harness.now();
+                const auto odom = make_odometry(
+                    0.0, 0.0, 0.0, 0.5, 
+                    stamp
+                );
+                const auto traj = make_straight_trajectory(
+                    {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0}, 
+                    1.0, 
+                    stamp
+                );
+
+                harness.publish_inputs(odom, traj);
+
+                // Check receiving control command within timeout
+                ASSERT_TRUE(
+                    harness.wait_for_output(
+                        std::chrono::duration_cast<std::chrono::milliseconds>(output_timeout)
+                    )
+                );
+
+                const auto control = harness.received_control();
+
+                // Check non-nullptr and expected values
+                ASSERT_NE(control, nullptr);
+
+                // Expected ext. vel 2.5 m/s, not traj's 1.0 m/s
+                EXPECT_FLOAT_EQ(
+                    control->longitudinal.velocity, 
+                    2.5F
+                );
+
+                // Car goin 0.5 m/s, target 2.5 m/s, so expect accel 2.0 m/s^2
+                // Already confirmed via test run during dev
+                EXPECT_FLOAT_EQ(
+                    control->longitudinal.acceleration, 
+                    2.0F
+                );
+
+                // Expected 0 steering angle for straight traj
+                EXPECT_FLOAT_EQ(
+                    control->lateral.steering_tire_angle, 
+                    0.0F
+                );
+
+            };
 
     }; // namespace
 

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -42,6 +42,7 @@ namespace autoware::control::simple_pure_pursuit
 
         /**
         * @brief Create a dummy Odometry message with some given params.
+        * This dummy one is a pose on the x-y plane with a yaw angle, and a longitudinal velocity.
         *
         * @param x dummy odometry's x position.
         * @param y dummy odometry's y position.
@@ -70,8 +71,41 @@ namespace autoware::control::simple_pure_pursuit
 
             return odom;
 
-        }
+        };
 
-    }
+        /**
+        * @brief Create a dummy Trajectory message with some given params.
+        * This dummy one is a straight line along x-axis,
+        * so all y's are 0.0 and all yaw angles are 0.0.
+        *
+        * @param x_positions dummy trajectory's x positions.
+        * @param longitudinal_velocity dummy trajectory's longitudinal velocity.
+        * @param stamp dummy trajectory's timestamp.
+        *
+        * @return Trajectory dummy message.
+        */
+        Trajectory make_straight_trajectory(
+            const std::vector<double> & x_positions,
+            const double longitudinal_velocity,
+            const builtin_interfaces::msg::Time & stamp
+        ) {
 
-}
+            Trajectory traj;
+            traj.header.frame_id = "map";
+            traj.header.stamp = stamp;
+
+            for (const auto x : x_positions) {
+                TrajectoryPoint point;
+                point.pose.position.x = x;
+                point.pose.position.y = 0.0;
+                point.longitudinal_velocity_mps = static_cast<float>(longitudinal_velocity);
+                traj.points.push_back(point);
+            }
+
+            return traj;
+
+        };
+
+    }; // namespace
+
+}; // namespace autoware::control::simple_pure_pursuit

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -106,6 +106,39 @@ namespace autoware::control::simple_pure_pursuit
 
         };
 
+        /**
+        * @brief Create a NodeOptions with some given overrides and some default config files.
+        *
+        * @param overrides a vector of pairs of <param name, param value> to override default ones.
+        *
+        * @return NodeOptions with given overrides and default config files.
+        */
+        rclcpp::NodeOptions make_node_options(
+            const std::vector<std::pair<std::string, rclcpp::ParameterValue>> & overrides = {}
+        ) {
+            
+            const auto autoware_test_utils_dir =
+                ament_index_cpp::get_package_share_directory("autoware_test_utils");
+            const auto autoware_simple_pure_pursuit_dir =
+                ament_index_cpp::get_package_share_directory("autoware_simple_pure_pursuit");
+
+            auto node_options = rclcpp::NodeOptions{};
+            autoware::test_utils::updateNodeOptions(
+                node_options,
+                {
+                    autoware_test_utils_dir + "/config/test_vehicle_info.param.yaml",
+                    autoware_simple_pure_pursuit_dir + "/config/simple_pure_pursuit.param.yaml"
+                }
+            );
+
+            for (const auto & [name, value] : overrides) {
+                node_options.append_parameter_override(name, value);
+            }
+
+            return node_options;
+
+        };
+
     }; // namespace
 
 }; // namespace autoware::control::simple_pure_pursuit

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -192,6 +192,31 @@ namespace autoware::control::simple_pure_pursuit
 
             };
 
+            // Delete copy and move constructors/assignment operators
+            SimplePurePursuitIntegrationHarness(const SimplePurePursuitIntegrationHarness &) = delete;
+            SimplePurePursuitIntegrationHarness & operator=(const SimplePurePursuitIntegrationHarness &) = delete;
+            SimplePurePursuitIntegrationHarness(SimplePurePursuitIntegrationHarness &&) = delete;
+            SimplePurePursuitIntegrationHarness & operator=(SimplePurePursuitIntegrationHarness &&) = delete;
+
+            // Just simple destructor to clean up env resources
+            ~SimplePurePursuitIntegrationHarness()
+            {
+                
+                executor -> cancel();
+                if (executor_thread_.joinable()) {
+                    executor_thread_.join();
+                }
+
+                control_sub_.reset();
+                traj_pub_.reset();
+                odom_pub_.reset();
+                output_sub_node_.reset();
+                input_pub_node_.reset();
+                target_node_.reset();
+                executor_.reset();
+
+            };
+
     }; // namespace
 
 }; // namespace autoware::control::simple_pure_pursuit

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -436,6 +436,34 @@ TEST(SimplePurePursuitIntegrationTest, UsesExternalTargetVelocityWhenEnabled)
   EXPECT_FLOAT_EQ(control->lateral.steering_tire_angle, 0.0F);
 };
 
+// TEST 6. Lateral offset check
+// Straight traj along Y=0, but vehicle starts at Y=1.0 (1 m offset to the left of traj), facing +X, stopped
+// Expect to receive control command with negative steering angle (right turn) within timeout
+// (that it can calculate correct steering for lateral offset and not just output 0)
+TEST(SimplePurePursuitIntegrationTest, PublishesNonZeroSteeringForLateralOffset)
+{
+  SimplePurePursuitIntegrationHarness harness(make_node_options());
+
+  const auto stamp = harness.now();
+  const auto odom = make_odometry(0.0, 1.0, 0.0, 0.0, stamp);
+  const auto traj = make_straight_trajectory({0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0}, 1.0, stamp);
+
+  harness.publish_inputs(odom, traj);
+
+  // Check receiving control command within timeout
+  ASSERT_TRUE(
+    harness.wait_for_output(std::chrono::duration_cast<std::chrono::milliseconds>(output_timeout)));
+
+  // Check non-nullptr and expected values
+  const auto control = harness.received_control();
+  ASSERT_NE(control, nullptr);
+
+  // Expected negative steering angle to correct 1 m lateral offset to the right, not 0
+  // Already confirmed via test run during dev
+  EXPECT_NEAR(control->lateral.steering_tire_angle, -0.82152F, 1e-2F);
+
+};
+
 };  // namespace
 
 };  // namespace autoware::control::simple_pure_pursuit

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -575,7 +575,8 @@ namespace autoware::control::simple_pure_pursuit
                 // Check non-nullptr and expected values
                 ASSERT_NE(control, nullptr);
 
-                // Expected ext. vel 2.5 m/s, not traj's 1.0 m/s
+                // Expected ext. vel 2.5 m/s, not traj's 1.0 m/s or car's current 0.5 m/s
+                // Basically ext. vel is used properly
                 EXPECT_FLOAT_EQ(
                     control->longitudinal.velocity, 
                     2.5F

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -164,36 +164,36 @@ namespace autoware::control::simple_pure_pursuit
                     
                     executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
 
-                    target_node = std::make_shared<SimplePurePursuitNode>(node_options);
-                    input_pub_node = rclcpp::Node::make_shared("simple_pure_pursuit_test_input_publisher");
-                    output_sub_node = rclcpp::Node::make_shared("simple_pure_pursuit_test_output_subscriber");
+                    target_node_ = std::make_shared<SimplePurePursuitNode>(node_options);
+                    input_pub_node_ = rclcpp::Node::make_shared("simple_pure_pursuit_test_input_publisher");
+                    output_sub_node_ = rclcpp::Node::make_shared("simple_pure_pursuit_test_output_subscriber");
 
-                    odom_pub = input_pub_node -> create_publisher<Odometry>(
+                    odom_pub_ = input_pub_node_ -> create_publisher<Odometry>(
                         "/simple_pure_pursuit/input/odometry", 
                         rclcpp::QoS{1}
                     );
-                    traj_pub = input_pub_node -> create_publisher<Trajectory>(
+                    traj_pub_ = input_pub_node_ -> create_publisher<Trajectory>(
                         "/simple_pure_pursuit/input/trajectory", 
                         rclcpp::QoS{1}
                     );
-                    control_sub = output_sub_node -> create_subscription<Control>(
+                    control_sub_ = output_sub_node_ -> create_subscription<Control>(
                         "/simple_pure_pursuit/output/control_command", 
                         rclcpp::QoS{1}.transient_local(),
                         [this](const Control::SharedPtr msg) {
                             {
-                            std::scoped_lock lock(received_control_mutex);
-                            received_control = msg;
+                            std::scoped_lock lock(received_control_mutex_);
+                            received_control_ = msg;
                             }
                             is_received_.store(true);
                         }
                     );
 
-                    executor -> add_node(target_node);
-                    executor -> add_node(input_pub_node);
-                    executor -> add_node(output_sub_node);
+                    executor_ -> add_node(target_node_);
+                    executor_ -> add_node(input_pub_node_);
+                    executor_ -> add_node(output_sub_node_);
 
                     // Spin it up!
-                    executor_thread = std::thread([this]() { executor -> spin(); });
+                    executor_thread_ = std::thread([this]() { executor_ -> spin(); });
                     (void)wait_for_connections(connection_timeout);
 
                 };
@@ -208,25 +208,25 @@ namespace autoware::control::simple_pure_pursuit
                 ~SimplePurePursuitIntegrationHarness()
                 {
                     
-                    executor -> cancel();
-                    if (executor_thread.joinable()) {
-                        executor_thread.join();
+                    executor_ -> cancel();
+                    if (executor_thread_.joinable()) {
+                        executor_thread_.join();
                     }
 
-                    control_sub.reset();
-                    traj_pub.reset();
-                    odom_pub.reset();
-                    output_sub_node.reset();
-                    input_pub_node.reset();
-                    target_node.reset();
-                    executor.reset();
+                    control_sub_.reset();
+                    traj_pub_.reset();
+                    odom_pub_.reset();
+                    output_sub_node_.reset();
+                    input_pub_node_.reset();
+                    target_node_.reset();
+                    executor_.reset();
 
                 };
 
                 // Get time now from input_pub_node's clock
                 [[nodiscard]] builtin_interfaces::msg::Time now() const
                 {
-                    return input_pub_node -> get_clock() -> now();
+                    return input_pub_node_ -> get_clock() -> now();
                 };
 
                 // Funcs to publish odometry, trajectory or both as inputs to target node
@@ -234,14 +234,14 @@ namespace autoware::control::simple_pure_pursuit
                     const Odometry & odom
                 ) {
                     clear_received_control();
-                    odom_pub -> publish(odom);
+                    odom_pub_ -> publish(odom);
                 };
 
                 void publish_trajectory(
                     const Trajectory & traj
                 ) {
                     clear_received_control();
-                    traj_pub -> publish(traj);
+                    traj_pub_ -> publish(traj);
                 };
 
                 void publish_inputs(
@@ -249,8 +249,8 @@ namespace autoware::control::simple_pure_pursuit
                     const Trajectory & traj
                 ) {
                     clear_received_control();
-                    odom_pub -> publish(odom);
-                    traj_pub -> publish(traj);
+                    odom_pub_ -> publish(odom);
+                    traj_pub_ -> publish(traj);
                 };
 
                 // Return true if received control command within timeout, false otherwise
@@ -274,8 +274,8 @@ namespace autoware::control::simple_pure_pursuit
                 // Return true if control command received
                 [[nodiscard]] Control::SharedPtr received_control() const
                 {
-                    std::scoped_lock lock(received_control_mutex);
-                    return received_control;
+                    std::scoped_lock lock(received_control_mutex_);
+                    return received_control_;
                 };
 
             private:
@@ -283,9 +283,9 @@ namespace autoware::control::simple_pure_pursuit
                 // Simple nuke received control command to prepare for next test case
                 void clear_received_control()
                 {
-                    is_received.store(false);
-                    std::scoped_lock lock(received_control_mutex);
-                    received_control.reset();
+                    is_received_.store(false);
+                    std::scoped_lock lock(received_control_mutex_);
+                    received_control_.reset();
                 };
 
                 // Wait until all publishers and subscribers are connected or timeout happens, 
@@ -298,9 +298,9 @@ namespace autoware::control::simple_pure_pursuit
                     // Wait until all connections are established or timeout happens
                     while (
                         (
-                            (odom_pub -> get_subscription_count() == 0U) || 
-                            (traj_pub -> get_subscription_count() == 0U) ||
-                            (control_sub -> get_publisher_count() == 0U)
+                            (odom_pub_ -> get_subscription_count() == 0U) || 
+                            (traj_pub_ -> get_subscription_count() == 0U) ||
+                            (control_sub_ -> get_publisher_count() == 0U)
                         ) && (
                             (std::chrono::steady_clock::now() - start <= timeout)
                         )
@@ -309,27 +309,29 @@ namespace autoware::control::simple_pure_pursuit
                     }
 
                     return (
-                        (odom_pub -> get_subscription_count() > 0U) && 
-                        (traj_pub -> get_subscription_count() > 0U) &&
+                        (odom_pub_ -> get_subscription_count() > 0U) && 
+                        (traj_pub_ -> get_subscription_count() > 0U) &&
                         (control_sub_->get_publisher_count() > 0U)
                     );
 
                 };
 
                 // Consts for connection and receiving timeouts and spin sleep duration
-                std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor{nullptr};
-                std::thread executor_thread;
+                std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor_{nullptr};
+                std::thread executor_thread_;
 
-                std::shared_ptr<SimplePurePursuitNode> target_node{nullptr};
-                rclcpp::Node::SharedPtr input_pub_node{nullptr};
-                rclcpp::Node::SharedPtr output_sub_node{nullptr};
-                rclcpp::Publisher<Odometry>::SharedPtr odom_pub{nullptr};
-                rclcpp::Publisher<Trajectory>::SharedPtr traj_pub{nullptr};
-                rclcpp::Subscription<Control>::SharedPtr control_sub{nullptr};
+                std::shared_ptr<SimplePurePursuitNode> target_node_{nullptr};
+                rclcpp::Node::SharedPtr input_pub_node_{nullptr};
+                rclcpp::Node::SharedPtr output_sub_node_{nullptr};
+                rclcpp::Publisher<Odometry>::SharedPtr odom_pub_{nullptr};
+                rclcpp::Publisher<Trajectory>::SharedPtr traj_pub_{nullptr};
+                rclcpp::Subscription<Control>::SharedPtr control_sub_{nullptr};
 
-                mutable std::mutex received_control_mutex;
-                std::atomic_bool is_received{false};
-                Control::SharedPtr received_control;
+                mutable std::mutex received_control_mutex_;
+                std::atomic_bool is_received_{false};
+                Control::SharedPtr received_control_;
+
+            };
 
             // ================== TESTING AREA HERE ==================
 
@@ -437,6 +439,67 @@ namespace autoware::control::simple_pure_pursuit
 
             };
 
+            // Goal stop command test
+            // Same straight traj, vehicle starts at traj end
+            // Expected 0 velocity
+            TEST(
+                SimplePurePursuitIntegrationTest, 
+                PublishesGoalStopCommandAtTrajectoryEnd
+            ) {
+            
+                SimplePurePursuitIntegrationHarness harness(make_node_options());
+
+                const auto stamp = harness.now();
+                const auto odom = make_odometry(
+                    6.0, 0.0, 0.0, 0.0, 
+                    stamp
+                );
+                const auto traj = make_straight_trajectory(
+                    {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0}, 
+                    1.0, 
+                    stamp
+                );
+
+                harness.publish_inputs(odom, traj);
+
+                // Receive control command within timeout
+                ASSERT_TRUE(
+                    harness.wait_for_output(
+                        std::chrono::duration_cast<std::chrono::milliseconds>(output_timeout)
+                    )
+                );
+
+                // Check non-nullptr and expected values
+                const auto control = harness.received_control();
+                ASSERT_NE(control, nullptr);
+
+                // // Expected 0 velocity
+                // EXPECT_FLOAT_EQ(
+                //     control->longitudinal.velocity, 
+                //     0.0F
+                // );
+
+                // // Expected strong deceleration
+                // EXPECT_FLOAT_EQ(control->longitudinal.acceleration, -10.0F);
+                // EXPECT_TRUE(control->longitudinal.is_defined_acceleration);
+
+                std::cout << "GOLDEN MASTER TERMINAL VELOCITY: " << control->longitudinal.velocity << std::endl;
+                std::cout << "GOLDEN MASTER TERMINAL ACCELERATION: " << control->longitudinal.acceleration << std::endl;
+
+            }
+
     }; // namespace
 
 }; // namespace autoware::control::simple_pure_pursuit
+
+int main(int argc, char ** argv) {
+
+    rclcpp::init(argc, argv);
+    testing::InitGoogleTest(&argc, argv);
+
+    const auto result = RUN_ALL_TESTS();
+
+    rclcpp::shutdown();
+    return result;
+
+}

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -473,18 +473,20 @@ namespace autoware::control::simple_pure_pursuit
                 const auto control = harness.received_control();
                 ASSERT_NE(control, nullptr);
 
-                // // Expected 0 velocity
-                // EXPECT_FLOAT_EQ(
-                //     control->longitudinal.velocity, 
-                //     0.0F
-                // );
+                // Expected 0 velocity
+                EXPECT_FLOAT_EQ(
+                    control->longitudinal.velocity, 
+                    0.0F
+                );
 
-                // // Expected strong deceleration
-                // EXPECT_FLOAT_EQ(control->longitudinal.acceleration, -10.0F);
-                // EXPECT_TRUE(control->longitudinal.is_defined_acceleration);
-
-                std::cout << "GOLDEN MASTER TERMINAL VELOCITY: " << control->longitudinal.velocity << std::endl;
-                std::cout << "GOLDEN MASTER TERMINAL ACCELERATION: " << control->longitudinal.acceleration << std::endl;
+                // Expected strong deceleration
+                // Here I already checked during development that terminal decel value is -10
+                // Seems like this module hard-coded this value. Imma freezin it here as characterization test
+                EXPECT_FLOAT_EQ(
+                    control->longitudinal.acceleration, 
+                    -10.0F
+                );
+                EXPECT_TRUE(control->longitudinal.is_defined_acceleration);
 
             }
 

--- a/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
+++ b/control/autoware_simple_pure_pursuit/test/test_simple_pure_pursuit_integration.cpp
@@ -28,3 +28,20 @@
 #include <cmath>
 #include <memory>
 
+
+namespace autoware::control::simple_pure_pursuit
+{
+
+    using autoware_control_msgs::msg::Control;
+    using autoware_planning_msgs::msg::Trajectory;
+    using autoware_planning_msgs::msg::TrajectoryPoint;
+    using nav_msgs::msg::Odometry;
+
+    namespace
+    {
+
+        
+
+    }
+
+}


### PR DESCRIPTION
## Description

This PR adds characterization test for the `autoware_core` node of [simple_pure_pursuit](https://github.com/autowarefoundation/autoware_core/blob/main/control/autoware_simple_pure_pursuit/src/simple_pure_pursuit.cpp).

### 1. What this is

Basically for now, what I'm doing is the first step of our 4-step refactoring protocol - characterization test. Here I treat the node as a black box. The goal is not to verify if the math is theoretically correct, instead it is to freeze the current behavior - bugs and all. By doing this, later on when I extract the pure pursuit math into a ROS-independent C++ class (step 2 of the protocol), this test will be the absolute benchmark to ensure I don't mess up the original logic flow between input and output.

### 2. What I did

#### a. The tests

There are 5 tests:

1. `PublishesControlCommandForStraightTrajectory` : very simple basic happy case: trajectory is straight line along X-axis (`0.0` to `6.0`), odometry at origin `(0,0` facing straight ahaed (`yaw = 0`), completely stopped (`vel = 0`). Assert message publish availability, vel, accel and steering angle.
2. `DoesNotPublishUntilBothInputsAreAvailable` : same scenario as test 1, but `odometry` arrives first without `trajectory`, which expects output node to not output anything yet. After that when `trajectory` finally arrives, it outputs as normal.
3. `PublishesGoalStopCommandAtTrajectoryEnd` : same trajectory as test 1 but omodetry now at the very end of trajectory. Expects 0 velocity and strong negative `acel = -10` (hardcoded value checked during dev via spinning the node).
4. `PublishesZeroCommandForEmptyTrajectory` : same scenario as test 1 but `trajectory` messag eis empty. Expects `vel = 0`, `accel = 0` instead of crashing.
5. `UsesExternalTargetVelocityWhenEnabled` : same trajectory as test 1, the car is moving at `0.5 m/s`, external velocity injected with `ext.vel = 2.5`. Expects the node to use that `2.5 m/s` value, with `accel = 2.0 m/s2`.

## Related links

- This PR is inspired by [Sasaki-san's PR on integration test for voxel_grid_downsample_filter node](https://github.com/autowarefoundation/autoware_core/pull/1103). Thank you so much.

## How was this PR tested?

1. `colcon build --packages-select autoware_simple_pure_pursuit --cmake-args -DBUILD_TESTING=ON`
2. `colcon test --packages-select autoware_simple_pure_pursuit --event-handlers console_direct+`

All test cases passed successfully.

<img width="1262" height="289" alt="Screenshot from 2026-06-13 19-30-35" src="https://github.com/user-attachments/assets/b299f6b2-8be3-4f21-833e-26ffad8ef1dd" />

## Notes for reviewers

~~I'm not yet sure how to spin up the local `lcov` to observe the code coverage. Will do it now.~~ Got it thank you @interimadd san.