### PR TITLE
test(autoware_motion_utils): add more tests for calculate_stop_distance

### DIFF
--- a/common/autoware_motion_utils/src/distance/distance.cpp
+++ b/common/autoware_motion_utils/src/distance/distance.cpp
@@ -299,8 +299,8 @@ std::optional<double> calcDecelDistWithJerkAndAccConstraints(
 
   // Phase 2: jerk-limited braking
   // Calculate what the velocity (v2) would be exactly when the acceleration reaches acc_limit
-  const double v2 =
-    v1 + (negative_decel_limit * negative_decel_limit - a1 * a1) / (2.0 * negative_jerk_limit);
+  const double t_ramp = (negative_decel_limit - a1) / negative_jerk_limit;
+  const double v2 = v1 + a1 * t_ramp + 0.5 * negative_jerk_limit * t_ramp * t_ramp;
 
   if (v2 <= 0.0) {
     // The vehicle reaches v = 0 before hitting the maximum deceleration limit.

--- a/common/autoware_motion_utils/test/src/distance/test_distance.cpp
+++ b/common/autoware_motion_utils/test/src/distance/test_distance.cpp
@@ -214,4 +214,84 @@ TEST(CalculateStopDistanceTest, HandlesAlreadyExceedingDecelerationLimit)
   EXPECT_NEAR(result.value(), 8.3333, epsilon);
 }
 
+TEST(CalculateStopDistanceTest, PositiveVelocityPositiveAcceleration_StandardStop)
+{
+  // v0 = 10.0, a0 = 2.0, delay = 0.0. Limits: a = -2.0, j = -2.0.
+  // Phase 2 (Jerk): t = 2.0s to reach a=-2.0. x2 = 21.3333m, v2 = 10.0m/s.
+  // Phase 3 (Decel): from v2=10.0 down to 0 at a=-2.0. x3 = 25.0m.
+  // Total Expected: 21.3333 + 25.0 = 46.3333 m.
+  auto result = calculate_stop_distance(10.0, 2.0, -2.0, -2.0, 0.0);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_NEAR(result.value(), 46.3333, epsilon);
+}
+
+TEST(CalculateStopDistanceTest, PositiveVelocityPositiveAcceleration_StopDuringJerkPhase)
+{
+  // v0 = 2.0, a0 = 2.0, delay = 0.0. Limits: a = -5.0, j = -2.0.
+  // Stays in Phase 2 because it reaches v=0 before reaching a=-5.0.
+  // Solve: 2.0 + 2.0*t - t^2 = 0 -> t = 1 + sqrt(3) ~ 2.732s.
+  // x = 2*t + t^2 - 1/3*t^3 ~ 6.1308m.
+  auto result = calculate_stop_distance(2.0, 2.0, -5.0, -2.0, 0.0);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_NEAR(result.value(), 6.1308, epsilon);
+}
+
+TEST(CalculateStopDistanceTest, PositiveVelocityNegativeAcceleration_StandardStop)
+{
+  // v0 = 10.0, a0 = -1.0, delay = 0.0. Limits: a = -2.0, j = -2.0.
+  // Phase 2 (Jerk): t = 0.5s to reach a=-2.0. x2 = 4.8333m, v2 = 9.25m/s.
+  // Phase 3 (Decel): from v2=9.25 down to 0 at a=-2.0. x3 = 21.3906m.
+  // Total Expected: 4.8333 + 21.3906 = 26.2239 m.
+  auto result = calculate_stop_distance(10.0, -1.0, -2.0, -2.0, 0.0);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_NEAR(result.value(), 26.2239, epsilon);
+}
+
+TEST(CalculateStopDistanceTest, ZeroVelocityPositiveAcceleration)
+{
+  // Vehicle is already stopped, should return 0 regardless of acceleration.
+  auto result = calculate_stop_distance(0.0, 2.0, -4.0, -10.0, 0.0);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_DOUBLE_EQ(result.value(), 0.0);
+}
+
+TEST(CalculateStopDistanceTest, NegativeVelocityPositiveAcceleration)
+{
+  // Vehicle is reversing, should return 0.
+  auto result = calculate_stop_distance(-2.0, 2.0, -4.0, -10.0, 0.0);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_DOUBLE_EQ(result.value(), 0.0);
+}
+
+TEST(CalculateStopDistanceTest, NegativeVelocityNegativeAcceleration)
+{
+  // Vehicle is reversing, should return 0.
+  auto result = calculate_stop_distance(-2.0, -2.0, -4.0, -10.0, 0.0);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_DOUBLE_EQ(result.value(), 0.0);
+}
+
+TEST(CalculateStopDistanceTest, PositiveVelocityNegativeAcceleration_NaturalStopDuringDelay)
+{
+  // v0 = 5.0, a0 = -2.0, delay = 5.0s.
+  // t_stop = 2.5s < delay. Natural stop.
+  // x = 5.0*2.5 + 0.5*(-2.0)*2.5^2 = 6.25m.
+  auto result = calculate_stop_distance(5.0, -2.0, -4.0, -10.0, 5.0);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_NEAR(result.value(), 6.25, epsilon);
+}
+
+TEST(CalculateStopDistanceTest, Robustness_HandlesPositiveLimitInputs)
+{
+  // Limits passed as positive magnitudes should be handled by internal std::abs.
+  // Same as Phase3Stop_StandardThreePhaseStop test.
+  auto result = calculate_stop_distance(10.0, 0.0, 2.0, 2.0, 1.0);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_NEAR(result.value(), 39.9166, epsilon);
+}
+
 }  // namespace


### PR DESCRIPTION
## Description

Add unit tests for the `calculate_stop_distance` function to cover additional use cases.

## How was this PR tested?

`./build/autoware_motion_utils/test_autoware_motion_utils --gtest_filter=CalculateStopDistanceTest\*`

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
