### PR TITLE
fix: correct message package name in autoware_pose_initializer README

### DIFF
--- a/localization/autoware_pose_initializer/README.md
+++ b/localization/autoware_pose_initializer/README.md
@@ -62,7 +62,7 @@ This `autoware_pose_initializer` is used via default AD API. For detailed descri
 ### Using the GNSS estimated position
 
 ```bash
-ros2 service call /localization/initialize autoware_internal_localization_msgs/srv/InitializeLocalization
+ros2 service call /localization/initialize autoware_localization_msgs/srv/InitializeLocalization
 ```
 
 The GNSS estimated position is used as the initial guess, and the localization algorithm automatically estimates a more accurate position.
@@ -70,7 +70,7 @@ The GNSS estimated position is used as the initial guess, and the localization a
 ### Using the input position
 
 ```bash
-ros2 service call /localization/initialize autoware_internal_localization_msgs/srv/InitializeLocalization "
+ros2 service call /localization/initialize autoware_localization_msgs/srv/InitializeLocalization "
 pose_with_covariance:
   - header:
       frame_id: map
@@ -95,7 +95,7 @@ The input position is used as the initial guess, and the localization algorithm 
 ### Direct initial position set
 
 ```bash
-ros2 service call /localization/initialize autoware_internal_localization_msgs/srv/InitializeLocalization "
+ros2 service call /localization/initialize autoware_localization_msgs/srv/InitializeLocalization "
 pose_with_covariance:
   - header:
       frame_id: map


### PR DESCRIPTION
## Description

I fixed an error in the README for `autoware_pose_initializer`.

In the "Initialize pose via CLI" section, the message type was still documented as `autoware_internal_localization_msgs`, even though it had already been renamed. As a result, the example command provided in the README did not work as expected.

This PR updates the documentation to use `autoware_localization_msgs` instead.

This change only affects the documentation. There are no code changes or behavioral changes.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
