### PR TITLE
refactor(autoware_twist2accel): arrange class interface

### DIFF
--- a/localization/autoware_twist2accel/src/accel_estimator.cpp
+++ b/localization/autoware_twist2accel/src/accel_estimator.cpp
@@ -15,6 +15,7 @@
 #include "accel_estimator.hpp"
 
 #include <autoware_utils_geometry/msg/covariance.hpp>
+#include <rclcpp/time.hpp>
 
 #include <algorithm>
 
@@ -32,22 +33,34 @@ AccelEstimator::AccelEstimator(const double lowpass_gain)
 {
 }
 
-geometry_msgs::msg::AccelWithCovariance AccelEstimator::estimate(
-  const geometry_msgs::msg::Twist & prev_twist, const geometry_msgs::msg::Twist & curr_twist,
-  const double dt)
+geometry_msgs::msg::AccelWithCovarianceStamped AccelEstimator::estimate(
+  const geometry_msgs::msg::TwistStamped & curr_twist)
 {
+  geometry_msgs::msg::AccelWithCovarianceStamped accel_msg;
+  accel_msg.header = curr_twist.header;
+
+  // The first call has no previous sample to difference against: store the
+  // current sample as the baseline and report a zero acceleration (with zero
+  // covariance).
+  if (!prev_twist_.has_value()) {
+    prev_twist_ = curr_twist;
+    return accel_msg;
+  }
+
+  const double dt =
+    (rclcpp::Time(curr_twist.header.stamp) - rclcpp::Time(prev_twist_->header.stamp)).seconds();
   const double clamped_dt = std::max(dt, g_min_dt);
 
-  geometry_msgs::msg::AccelWithCovariance accel;
-  accel.accel.linear.x = lpf_alx_.filter((curr_twist.linear.x - prev_twist.linear.x) / clamped_dt);
-  accel.accel.linear.y = lpf_aly_.filter((curr_twist.linear.y - prev_twist.linear.y) / clamped_dt);
-  accel.accel.linear.z = lpf_alz_.filter((curr_twist.linear.z - prev_twist.linear.z) / clamped_dt);
-  accel.accel.angular.x =
-    lpf_aax_.filter((curr_twist.angular.x - prev_twist.angular.x) / clamped_dt);
-  accel.accel.angular.y =
-    lpf_aay_.filter((curr_twist.angular.y - prev_twist.angular.y) / clamped_dt);
-  accel.accel.angular.z =
-    lpf_aaz_.filter((curr_twist.angular.z - prev_twist.angular.z) / clamped_dt);
+  const geometry_msgs::msg::Twist & prev = prev_twist_->twist;
+  const geometry_msgs::msg::Twist & curr = curr_twist.twist;
+
+  geometry_msgs::msg::AccelWithCovariance & accel = accel_msg.accel;
+  accel.accel.linear.x = lpf_alx_.filter((curr.linear.x - prev.linear.x) / clamped_dt);
+  accel.accel.linear.y = lpf_aly_.filter((curr.linear.y - prev.linear.y) / clamped_dt);
+  accel.accel.linear.z = lpf_alz_.filter((curr.linear.z - prev.linear.z) / clamped_dt);
+  accel.accel.angular.x = lpf_aax_.filter((curr.angular.x - prev.angular.x) / clamped_dt);
+  accel.accel.angular.y = lpf_aay_.filter((curr.angular.y - prev.angular.y) / clamped_dt);
+  accel.accel.angular.z = lpf_aaz_.filter((curr.angular.z - prev.angular.z) / clamped_dt);
 
   // Ideally speaking, this covariance should be properly estimated. Until that
   // is done, report constant diagonal variances; off-diagonal terms stay at the
@@ -59,6 +72,25 @@ geometry_msgs::msg::AccelWithCovariance AccelEstimator::estimate(
   accel.covariance[XYZRPY_COV_IDX::PITCH_PITCH] = g_angular_accel_variance;
   accel.covariance[XYZRPY_COV_IDX::YAW_YAW] = g_angular_accel_variance;
 
-  return accel;
+  prev_twist_ = curr_twist;
+  return accel_msg;
+}
+
+geometry_msgs::msg::AccelWithCovarianceStamped AccelEstimator::estimate(
+  const geometry_msgs::msg::TwistWithCovarianceStamped & curr_twist)
+{
+  geometry_msgs::msg::TwistStamped twist;
+  twist.header = curr_twist.header;
+  twist.twist = curr_twist.twist.twist;
+  return estimate(twist);
+}
+
+geometry_msgs::msg::AccelWithCovarianceStamped AccelEstimator::estimate(
+  const nav_msgs::msg::Odometry & curr_odom)
+{
+  geometry_msgs::msg::TwistStamped twist;
+  twist.header = curr_odom.header;
+  twist.twist = curr_odom.twist.twist;
+  return estimate(twist);
 }
 }  // namespace autoware::twist2accel

--- a/localization/autoware_twist2accel/src/accel_estimator.cpp
+++ b/localization/autoware_twist2accel/src/accel_estimator.cpp
@@ -39,9 +39,6 @@ geometry_msgs::msg::AccelWithCovarianceStamped AccelEstimator::estimate(
   geometry_msgs::msg::AccelWithCovarianceStamped accel_msg;
   accel_msg.header = curr_twist.header;
 
-  // The first call has no previous sample to difference against: store the
-  // current sample as the baseline and report a zero acceleration (with zero
-  // covariance).
   if (!prev_twist_.has_value()) {
     prev_twist_ = curr_twist;
     return accel_msg;
@@ -62,9 +59,6 @@ geometry_msgs::msg::AccelWithCovarianceStamped AccelEstimator::estimate(
   accel.accel.angular.y = lpf_aay_.filter((curr.angular.y - prev.angular.y) / clamped_dt);
   accel.accel.angular.z = lpf_aaz_.filter((curr.angular.z - prev.angular.z) / clamped_dt);
 
-  // Ideally speaking, this covariance should be properly estimated. Until that
-  // is done, report constant diagonal variances; off-diagonal terms stay at the
-  // default zero.
   accel.covariance[XYZRPY_COV_IDX::X_X] = g_linear_accel_variance;
   accel.covariance[XYZRPY_COV_IDX::Y_Y] = g_linear_accel_variance;
   accel.covariance[XYZRPY_COV_IDX::Z_Z] = g_linear_accel_variance;

--- a/localization/autoware_twist2accel/src/accel_estimator.hpp
+++ b/localization/autoware_twist2accel/src/accel_estimator.hpp
@@ -27,74 +27,31 @@
 namespace autoware::twist2accel
 {
 
-/// Lower bound applied to the time delta between successive twist samples to
-/// avoid division by (near-)zero when stamps are equal or out of order.
 constexpr double g_min_dt = 1.0e-3;
-
-/// Fixed covariance assigned to the estimated acceleration. The current
-/// estimator does not propagate the input twist covariance through the
-/// finite-difference / low-pass smoothing, so it reports these constant
-/// diagonal variances (off-diagonal terms stay zero):
-/// - linear x/y/z variance = g_linear_accel_variance
-/// - angular roll/pitch/yaw variance = g_angular_accel_variance
 constexpr double g_linear_accel_variance = 1.0;
 constexpr double g_angular_accel_variance = 0.05;
 
-/// @brief Pure acceleration estimator with no rclcpp::Node / spinning dependency.
-///
-/// Estimates acceleration by finite-differencing two successive twist samples
-/// and smoothing each of the six components with a first-order low-pass filter.
-/// It keeps the previous twist sample as internal state, so the caller only
-/// supplies the current sample; the time delta is derived from the difference
-/// between the current and previous header stamps. It also owns the six
-/// LowpassFilter1d instances so the filter state persists across calls,
-/// mirroring the per-component smoothing performed by the node.
-///
-/// In addition to the acceleration values it fills in the acceleration
-/// covariance and copies the input header onto the output, keeping the full
-/// estimation contract (stamp + value + uncertainty) in one pure place instead
-/// of splitting it between the core and the node.
-///
-/// It operates directly on the plain geometry_msgs TwistStamped /
-/// AccelWithCovarianceStamped data structs: those are header-only value types
-/// that need no running ROS node, so the estimator stays unit-testable while
-/// avoiding any conversion layer.
+/// @brief Estimates acceleration by differentiating consecutive twist (velocity) samples over time
+/// and low-pass filtering the result.
 class AccelEstimator
 {
 public:
+  /// @brief Construct the estimator.
+  /// @param lowpass_gain Gain applied to every per-axis low-pass filter (0: no smoothing,
+  /// closer to 1: stronger smoothing).
   explicit AccelEstimator(double lowpass_gain);
 
-  /// @brief Estimate acceleration and its covariance from the finite difference
-  ///   between the current twist sample and the previously supplied one.
-  ///
-  /// The previous twist sample is held as internal state and the time delta is
-  /// computed from the difference between the current and previous header
-  /// stamps; deltas below g_min_dt (including zero or negative ones from equal
-  /// or out-of-order stamps) are clamped up to g_min_dt before the division.
-  ///
-  /// On the first call there is no previous sample to difference against, so the
-  /// estimator reports a zero acceleration with a zero covariance and just
-  /// stores the current sample as the baseline for the next call.
-  ///
-  /// @param curr_twist stamped twist sample at the current time step
-  /// @return stamped acceleration whose header is copied from @p curr_twist and
-  ///   whose value is the per-component, low-pass-filtered acceleration together
-  ///   with its covariance (constant diagonal variances, see
-  ///   g_linear_accel_variance / g_angular_accel_variance)
+  /// @brief Estimate acceleration from the current twist.
+  /// @param curr_twist Current velocity sample with timestamp.
+  /// @return Estimated acceleration; zero on the first call since no previous sample exists yet.
   geometry_msgs::msg::AccelWithCovarianceStamped estimate(
     const geometry_msgs::msg::TwistStamped & curr_twist);
 
-  /// @brief Convenience overload that estimates from a TwistWithCovarianceStamped.
-  ///
-  /// The input covariance is not propagated; only the header and the nested
-  /// twist are used before delegating to estimate(const TwistStamped &).
+  /// @brief Estimate acceleration from a twist-with-covariance sample (covariance is ignored).
   geometry_msgs::msg::AccelWithCovarianceStamped estimate(
     const geometry_msgs::msg::TwistWithCovarianceStamped & curr_twist);
 
-  /// @brief Convenience overload that estimates from an Odometry message.
-  ///
-  /// Only the header and the nested twist are used (the pose is ignored) before
-  /// delegating to estimate(const TwistStamped &).
+  /// @brief Estimate acceleration from the twist field of an odometry sample.
   geometry_msgs::msg::AccelWithCovarianceStamped estimate(
     const nav_msgs::msg::Odometry & curr_odom);
 

--- a/localization/autoware_twist2accel/src/accel_estimator.hpp
+++ b/localization/autoware_twist2accel/src/accel_estimator.hpp
@@ -17,8 +17,12 @@
 
 #include "autoware/signal_processing/lowpass_filter_1d.hpp"
 
-#include <geometry_msgs/msg/accel_with_covariance.hpp>
-#include <geometry_msgs/msg/twist.hpp>
+#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+#include <optional>
 
 namespace autoware::twist2accel
 {
@@ -40,36 +44,62 @@ constexpr double g_angular_accel_variance = 0.05;
 ///
 /// Estimates acceleration by finite-differencing two successive twist samples
 /// and smoothing each of the six components with a first-order low-pass filter.
-/// Owns the six LowpassFilter1d instances so the filter state persists across
-/// calls, mirroring the per-component smoothing performed by the node.
+/// It keeps the previous twist sample as internal state, so the caller only
+/// supplies the current sample; the time delta is derived from the difference
+/// between the current and previous header stamps. It also owns the six
+/// LowpassFilter1d instances so the filter state persists across calls,
+/// mirroring the per-component smoothing performed by the node.
 ///
 /// In addition to the acceleration values it fills in the acceleration
-/// covariance, keeping the full estimation contract (value + uncertainty) in
-/// one pure place instead of splitting it between the core and the node.
+/// covariance and copies the input header onto the output, keeping the full
+/// estimation contract (stamp + value + uncertainty) in one pure place instead
+/// of splitting it between the core and the node.
 ///
-/// It operates directly on the plain geometry_msgs Twist/AccelWithCovariance
-/// data structs: those are header-only value types that need no running ROS
-/// node, so the estimator stays unit-testable while avoiding any conversion
-/// layer.
+/// It operates directly on the plain geometry_msgs TwistStamped /
+/// AccelWithCovarianceStamped data structs: those are header-only value types
+/// that need no running ROS node, so the estimator stays unit-testable while
+/// avoiding any conversion layer.
 class AccelEstimator
 {
 public:
   explicit AccelEstimator(double lowpass_gain);
 
-  /// @brief Estimate acceleration and its covariance from a finite difference
-  ///   of two twists.
-  /// @param prev_twist twist sample at the previous time step
-  /// @param curr_twist twist sample at the current time step
-  /// @param dt time delta in seconds between the two samples; values below
-  ///   g_min_dt are clamped up to g_min_dt before the division
-  /// @return per-component, low-pass-filtered acceleration together with its
-  ///   covariance (constant diagonal variances, see g_linear_accel_variance /
-  ///   g_angular_accel_variance)
-  geometry_msgs::msg::AccelWithCovariance estimate(
-    const geometry_msgs::msg::Twist & prev_twist, const geometry_msgs::msg::Twist & curr_twist,
-    double dt);
+  /// @brief Estimate acceleration and its covariance from the finite difference
+  ///   between the current twist sample and the previously supplied one.
+  ///
+  /// The previous twist sample is held as internal state and the time delta is
+  /// computed from the difference between the current and previous header
+  /// stamps; deltas below g_min_dt (including zero or negative ones from equal
+  /// or out-of-order stamps) are clamped up to g_min_dt before the division.
+  ///
+  /// On the first call there is no previous sample to difference against, so the
+  /// estimator reports a zero acceleration with a zero covariance and just
+  /// stores the current sample as the baseline for the next call.
+  ///
+  /// @param curr_twist stamped twist sample at the current time step
+  /// @return stamped acceleration whose header is copied from @p curr_twist and
+  ///   whose value is the per-component, low-pass-filtered acceleration together
+  ///   with its covariance (constant diagonal variances, see
+  ///   g_linear_accel_variance / g_angular_accel_variance)
+  geometry_msgs::msg::AccelWithCovarianceStamped estimate(
+    const geometry_msgs::msg::TwistStamped & curr_twist);
+
+  /// @brief Convenience overload that estimates from a TwistWithCovarianceStamped.
+  ///
+  /// The input covariance is not propagated; only the header and the nested
+  /// twist are used before delegating to estimate(const TwistStamped &).
+  geometry_msgs::msg::AccelWithCovarianceStamped estimate(
+    const geometry_msgs::msg::TwistWithCovarianceStamped & curr_twist);
+
+  /// @brief Convenience overload that estimates from an Odometry message.
+  ///
+  /// Only the header and the nested twist are used (the pose is ignored) before
+  /// delegating to estimate(const TwistStamped &).
+  geometry_msgs::msg::AccelWithCovarianceStamped estimate(
+    const nav_msgs::msg::Odometry & curr_odom);
 
 private:
+  std::optional<geometry_msgs::msg::TwistStamped> prev_twist_;
   autoware::signal_processing::LowpassFilter1d lpf_alx_;
   autoware::signal_processing::LowpassFilter1d lpf_aly_;
   autoware::signal_processing::LowpassFilter1d lpf_alz_;

--- a/localization/autoware_twist2accel/src/twist2accel.cpp
+++ b/localization/autoware_twist2accel/src/twist2accel.cpp
@@ -16,8 +16,6 @@
 
 #include "accel_estimator.hpp"
 
-#include <rclcpp/logging.hpp>
-
 #include <functional>
 #include <memory>
 
@@ -44,38 +42,14 @@ Twist2Accel::Twist2Accel(const rclcpp::NodeOptions & node_options)
 void Twist2Accel::callback_odometry(const nav_msgs::msg::Odometry::SharedPtr msg)
 {
   if (!use_odom_) return;
-
-  geometry_msgs::msg::TwistStamped twist;
-  twist.header = msg->header;
-  twist.twist = msg->twist.twist;
-  estimate_accel(twist);
+  pub_accel_->publish(accel_estimator_->estimate(*msg));
 }
 
 void Twist2Accel::callback_twist_with_covariance(
   const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg)
 {
   if (use_odom_) return;
-
-  geometry_msgs::msg::TwistStamped twist;
-  twist.header = msg->header;
-  twist.twist = msg->twist.twist;
-  estimate_accel(twist);
-}
-
-void Twist2Accel::estimate_accel(const geometry_msgs::msg::TwistStamped & twist)
-{
-  geometry_msgs::msg::AccelWithCovarianceStamped accel_msg;
-  accel_msg.header = twist.header;
-
-  if (prev_twist_.has_value()) {
-    const double dt =
-      (rclcpp::Time(twist.header.stamp) - rclcpp::Time(prev_twist_->header.stamp)).seconds();
-
-    accel_msg.accel = accel_estimator_->estimate(prev_twist_->twist, twist.twist, dt);
-  }
-
-  pub_accel_->publish(accel_msg);
-  prev_twist_ = twist;
+  pub_accel_->publish(accel_estimator_->estimate(*msg));
 }
 }  // namespace autoware::twist2accel
 

--- a/localization/autoware_twist2accel/src/twist2accel.hpp
+++ b/localization/autoware_twist2accel/src/twist2accel.hpp
@@ -20,12 +20,10 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
-#include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 
 #include <memory>
-#include <optional>
 
 namespace autoware::twist2accel
 {
@@ -42,7 +40,6 @@ private:
   rclcpp::Subscription<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr
     sub_twist_;  //!< @brief measurement odometry subscriber
 
-  std::optional<geometry_msgs::msg::TwistStamped> prev_twist_;
   bool use_odom_;
   std::unique_ptr<AccelEstimator> accel_estimator_;
 
@@ -52,7 +49,6 @@ private:
   void callback_twist_with_covariance(
     const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg);
   void callback_odometry(const nav_msgs::msg::Odometry::SharedPtr msg);
-  void estimate_accel(const geometry_msgs::msg::TwistStamped & twist);
 };
 }  // namespace autoware::twist2accel
 #endif  // TWIST2ACCEL_HPP_

--- a/localization/autoware_twist2accel/test/test_accel_estimator.cpp
+++ b/localization/autoware_twist2accel/test/test_accel_estimator.cpp
@@ -15,12 +15,15 @@
 #include "../src/accel_estimator.hpp"
 
 #include <geometry_msgs/msg/accel_with_covariance.hpp>
-#include <geometry_msgs/msg/twist.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
 
 #include <gtest/gtest.h>
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 
 using autoware::twist2accel::AccelEstimator;
 using autoware::twist2accel::g_angular_accel_variance;
@@ -31,33 +34,38 @@ namespace
 {
 constexpr double kTol = 1e-9;
 
-// Build a geometry_msgs Twist from its six scalar components for concise tests.
-geometry_msgs::msg::Twist make_twist(
-  const double linear_x, const double linear_y, const double linear_z, const double angular_x,
-  const double angular_y, const double angular_z)
+// Build a stamped geometry_msgs Twist from a timestamp (seconds) and its six
+// scalar components. The estimator derives dt from successive header stamps, so
+// each sample carries its own timestamp.
+geometry_msgs::msg::TwistStamped make_twist(
+  const double stamp_sec, const double linear_x, const double linear_y, const double linear_z,
+  const double angular_x, const double angular_y, const double angular_z)
 {
-  geometry_msgs::msg::Twist twist;
-  twist.linear.x = linear_x;
-  twist.linear.y = linear_y;
-  twist.linear.z = linear_z;
-  twist.angular.x = angular_x;
-  twist.angular.y = angular_y;
-  twist.angular.z = angular_z;
+  geometry_msgs::msg::TwistStamped twist;
+  const auto whole_sec = static_cast<int32_t>(stamp_sec);
+  twist.header.stamp.sec = whole_sec;
+  twist.header.stamp.nanosec = static_cast<uint32_t>((stamp_sec - whole_sec) * 1e9);
+  twist.twist.linear.x = linear_x;
+  twist.twist.linear.y = linear_y;
+  twist.twist.linear.z = linear_z;
+  twist.twist.angular.x = angular_x;
+  twist.twist.angular.y = angular_y;
+  twist.twist.angular.z = angular_z;
   return twist;
 }
 }  // namespace
 
-// On the very first sample the per-component low-pass filters are uninitialized,
-// so filter(u) returns u unchanged. The estimator therefore reports the raw
-// finite difference (curr - prev) / dt on every channel.
+// On the first computed estimate the per-component low-pass filters are
+// uninitialized, so filter(u) returns u unchanged. The estimator therefore
+// reports the raw finite difference (curr - prev) / dt on every channel.
 TEST(AccelEstimatorTest, FiniteDifferenceNoSmoothingOnFirstSample)
 {
   AccelEstimator estimator(0.9);
-  const auto prev = make_twist(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-  const auto curr = make_twist(2.0, 4.0, 6.0, 0.2, 0.4, 0.6);
-  const double dt = 0.5;
+  const auto prev = make_twist(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+  const auto curr = make_twist(0.5, 2.0, 4.0, 6.0, 0.2, 0.4, 0.6);
 
-  const geometry_msgs::msg::AccelWithCovariance accel = estimator.estimate(prev, curr, dt);
+  estimator.estimate(prev);
+  const geometry_msgs::msg::AccelWithCovariance accel = estimator.estimate(curr).accel;
 
   EXPECT_NEAR(accel.accel.linear.x, 4.0, kTol);   // (2.0 - 0.0) / 0.5
   EXPECT_NEAR(accel.accel.linear.y, 8.0, kTol);   // (4.0 - 0.0) / 0.5
@@ -72,9 +80,11 @@ TEST(AccelEstimatorTest, FiniteDifferenceNoSmoothingOnFirstSample)
 TEST(AccelEstimatorTest, ZeroVelocityChangeYieldsZeroAccel)
 {
   AccelEstimator estimator(0.5);
-  const auto twist = make_twist(1.0, -2.0, 3.0, 0.1, -0.2, 0.3);
+  const auto prev = make_twist(0.0, 1.0, -2.0, 3.0, 0.1, -0.2, 0.3);
+  const auto curr = make_twist(0.1, 1.0, -2.0, 3.0, 0.1, -0.2, 0.3);
 
-  const geometry_msgs::msg::AccelWithCovariance accel = estimator.estimate(twist, twist, 0.1);
+  estimator.estimate(prev);
+  const geometry_msgs::msg::AccelWithCovariance accel = estimator.estimate(curr).accel;
 
   EXPECT_NEAR(accel.accel.linear.x, 0.0, kTol);
   EXPECT_NEAR(accel.accel.linear.y, 0.0, kTol);
@@ -90,24 +100,26 @@ TEST(AccelEstimatorTest, LowPassSmoothingAcrossSamples)
 {
   const double gain = 0.9;
   AccelEstimator estimator(gain);
-  const double dt = 1.0;
+
+  // Establish the previous sample at t = 0; subsequent samples are 1 s apart.
+  estimator.estimate(make_twist(0.0, 0, 0, 0, 0, 0, 0));
 
   // First sample: linear_x ramps 0 -> 1, raw accel = 1.0, LPF returns it as-is.
   const geometry_msgs::msg::AccelWithCovariance first =
-    estimator.estimate(make_twist(0.0, 0, 0, 0, 0, 0), make_twist(1.0, 0, 0, 0, 0, 0), dt);
+    estimator.estimate(make_twist(1.0, 1.0, 0, 0, 0, 0, 0)).accel;
   EXPECT_NEAR(first.accel.linear.x, 1.0, kTol);
 
   // Second sample: linear_x ramps 1 -> 3, raw accel = 2.0.
   // Smoothed: 0.9 * 1.0 + 0.1 * 2.0 = 1.1.
   const geometry_msgs::msg::AccelWithCovariance second =
-    estimator.estimate(make_twist(1.0, 0, 0, 0, 0, 0), make_twist(3.0, 0, 0, 0, 0, 0), dt);
+    estimator.estimate(make_twist(2.0, 3.0, 0, 0, 0, 0, 0)).accel;
   EXPECT_NEAR(second.accel.linear.x, gain * 1.0 + (1.0 - gain) * 2.0, kTol);
   EXPECT_NEAR(second.accel.linear.x, 1.1, kTol);
 
   // Third sample: linear_x ramps 3 -> 3, raw accel = 0.0.
   // Smoothed: 0.9 * 1.1 + 0.1 * 0.0 = 0.99.
   const geometry_msgs::msg::AccelWithCovariance third =
-    estimator.estimate(make_twist(3.0, 0, 0, 0, 0, 0), make_twist(3.0, 0, 0, 0, 0, 0), dt);
+    estimator.estimate(make_twist(3.0, 3.0, 0, 0, 0, 0, 0)).accel;
   EXPECT_NEAR(third.accel.linear.x, gain * 1.1 + (1.0 - gain) * 0.0, kTol);
   EXPECT_NEAR(third.accel.linear.x, 0.99, kTol);
 }
@@ -117,25 +129,25 @@ TEST(AccelEstimatorTest, LowPassSmoothingAcrossSamples)
 // estimator never divides by zero or flips sign.
 TEST(AccelEstimatorTest, DtClampForNearSimultaneousStamps)
 {
-  const auto prev = make_twist(0.0, 0, 0, 0, 0, 0);
-  const auto curr = make_twist(1.0, 0, 0, 0, 0, 0);
-
-  // dt == 0 is clamped to g_min_dt: accel = 1.0 / g_min_dt.
+  // dt == 0 (equal stamps) is clamped to g_min_dt: accel = 1.0 / g_min_dt.
   AccelEstimator zero_dt_estimator(0.0);  // gain 0 -> filter passes raw value through
+  zero_dt_estimator.estimate(make_twist(1.0, 0, 0, 0, 0, 0, 0));
   const geometry_msgs::msg::AccelWithCovariance zero_dt =
-    zero_dt_estimator.estimate(prev, curr, 0.0);
+    zero_dt_estimator.estimate(make_twist(1.0, 1.0, 0, 0, 0, 0, 0)).accel;
   EXPECT_NEAR(zero_dt.accel.linear.x, 1.0 / g_min_dt, kTol);
 
-  // Negative dt is also clamped to g_min_dt, not used directly.
+  // Negative dt (out-of-order stamps) is also clamped to g_min_dt, not used directly.
   AccelEstimator negative_dt_estimator(0.0);
+  negative_dt_estimator.estimate(make_twist(5.0, 0, 0, 0, 0, 0, 0));
   const geometry_msgs::msg::AccelWithCovariance negative_dt =
-    negative_dt_estimator.estimate(prev, curr, -5.0);
+    negative_dt_estimator.estimate(make_twist(1.0, 1.0, 0, 0, 0, 0, 0)).accel;
   EXPECT_NEAR(negative_dt.accel.linear.x, 1.0 / g_min_dt, kTol);
 
   // dt above the threshold is used unchanged.
   AccelEstimator large_dt_estimator(0.0);
+  large_dt_estimator.estimate(make_twist(0.0, 0, 0, 0, 0, 0, 0));
   const geometry_msgs::msg::AccelWithCovariance large_dt =
-    large_dt_estimator.estimate(prev, curr, 2.0);
+    large_dt_estimator.estimate(make_twist(2.0, 1.0, 0, 0, 0, 0, 0)).accel;
   EXPECT_NEAR(large_dt.accel.linear.x, 1.0 / 2.0, kTol);
 }
 
@@ -144,14 +156,16 @@ TEST(AccelEstimatorTest, DtClampForNearSimultaneousStamps)
 TEST(AccelEstimatorTest, ChannelsAreIndependent)
 {
   AccelEstimator estimator(0.5);
-  const double dt = 1.0;
+
+  // Establish the previous sample at t = 0; subsequent samples are 1 s apart.
+  estimator.estimate(make_twist(0.0, 0, 0, 0, 0, 0, 0));
 
   // Prime only linear_x with a non-zero history.
-  estimator.estimate(make_twist(0, 0, 0, 0, 0, 0), make_twist(2.0, 0, 0, 0, 0, 0), dt);
+  estimator.estimate(make_twist(1.0, 2.0, 0, 0, 0, 0, 0));
 
   // Now move only angular_z; linear_x sees raw accel 0 but retains its history.
   const geometry_msgs::msg::AccelWithCovariance accel =
-    estimator.estimate(make_twist(2.0, 0, 0, 0, 0, 0), make_twist(2.0, 0, 0, 0, 0, 1.0), dt);
+    estimator.estimate(make_twist(2.0, 2.0, 0, 0, 0, 0, 1.0)).accel;
 
   // linear_x: 0.5 * 2.0 (history) + 0.5 * 0.0 (raw) = 1.0. Its history is
   // preserved independently of the other channels.
@@ -175,10 +189,11 @@ TEST(AccelEstimatorTest, ChannelsAreIndependent)
 TEST(AccelEstimatorTest, CovarianceIsConstantDiagonal)
 {
   AccelEstimator estimator(0.9);
-  const auto prev = make_twist(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
-  const auto curr = make_twist(2.0, 4.0, 6.0, 0.2, 0.4, 0.6);
+  const auto prev = make_twist(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+  const auto curr = make_twist(0.5, 2.0, 4.0, 6.0, 0.2, 0.4, 0.6);
 
-  const geometry_msgs::msg::AccelWithCovariance accel = estimator.estimate(prev, curr, 0.5);
+  estimator.estimate(prev);
+  const geometry_msgs::msg::AccelWithCovariance accel = estimator.estimate(curr).accel;
 
   // Expected: a 36-entry array that is zero everywhere except the six diagonal
   // variances, set to the named public constants. The diagonal of a row-major
@@ -194,4 +209,77 @@ TEST(AccelEstimatorTest, CovarianceIsConstantDiagonal)
   for (std::size_t i = 0; i < expected.size(); ++i) {
     EXPECT_NEAR(accel.covariance[i], expected[i], kTol) << "covariance index " << i;
   }
+}
+
+// The first call has no previous sample to difference against, so it primes the
+// internal state and reports a zero acceleration with a zero covariance.
+TEST(AccelEstimatorTest, FirstCallReturnsZeroAccel)
+{
+  AccelEstimator estimator(0.9);
+
+  const geometry_msgs::msg::AccelWithCovariance accel =
+    estimator.estimate(make_twist(0.0, 1.0, 2.0, 3.0, 0.1, 0.2, 0.3)).accel;
+
+  EXPECT_NEAR(accel.accel.linear.x, 0.0, kTol);
+  EXPECT_NEAR(accel.accel.linear.y, 0.0, kTol);
+  EXPECT_NEAR(accel.accel.linear.z, 0.0, kTol);
+  EXPECT_NEAR(accel.accel.angular.x, 0.0, kTol);
+  EXPECT_NEAR(accel.accel.angular.y, 0.0, kTol);
+  EXPECT_NEAR(accel.accel.angular.z, 0.0, kTol);
+  for (const auto & covariance_entry : accel.covariance) {
+    EXPECT_NEAR(covariance_entry, 0.0, kTol);
+  }
+}
+
+// The TwistWithCovarianceStamped overload uses only the header and the nested
+// twist (the input covariance is dropped) before delegating to the primary
+// estimate(). Two samples 1 s apart on linear_x must yield the same raw finite
+// difference as the TwistStamped path, with the output header forwarded.
+TEST(AccelEstimatorTest, EstimateFromTwistWithCovarianceUsesHeaderAndTwist)
+{
+  AccelEstimator estimator(0.9);
+
+  geometry_msgs::msg::TwistWithCovarianceStamped prev_twist;
+  prev_twist.header.stamp.sec = 0;
+  prev_twist.twist.twist.linear.x = 0.0;
+  estimator.estimate(prev_twist);
+
+  geometry_msgs::msg::TwistWithCovarianceStamped curr_twist;
+  curr_twist.header.frame_id = "base_link";
+  curr_twist.header.stamp.sec = 1;
+  curr_twist.twist.twist.linear.x = 2.0;
+
+  const auto accel_msg = estimator.estimate(curr_twist);
+
+  // dt = 1 s, raw accel = (2.0 - 0.0) / 1.0 = 2.0, first LPF passes it through.
+  EXPECT_NEAR(accel_msg.accel.accel.linear.x, 2.0, kTol);
+  // The header is forwarded from the input message.
+  EXPECT_EQ(accel_msg.header.frame_id, "base_link");
+  EXPECT_EQ(accel_msg.header.stamp.sec, 1);
+}
+
+// The Odometry overload uses only the header and the nested twist (the pose is
+// ignored) before delegating to the primary estimate().
+TEST(AccelEstimatorTest, EstimateFromOdometryUsesHeaderAndTwistIgnoringPose)
+{
+  AccelEstimator estimator(0.9);
+
+  nav_msgs::msg::Odometry prev_odom;
+  prev_odom.header.stamp.sec = 0;
+  prev_odom.twist.twist.linear.x = 0.0;
+  estimator.estimate(prev_odom);
+
+  nav_msgs::msg::Odometry curr_odom;
+  curr_odom.header.frame_id = "base_link";
+  curr_odom.header.stamp.sec = 1;
+  curr_odom.twist.twist.linear.x = 2.0;
+  curr_odom.pose.pose.position.x = 123.0;  // pose must not affect the estimate
+
+  const auto accel_msg = estimator.estimate(curr_odom);
+
+  // dt = 1 s, raw accel = (2.0 - 0.0) / 1.0 = 2.0, first LPF passes it through.
+  EXPECT_NEAR(accel_msg.accel.accel.linear.x, 2.0, kTol);
+  // The header is forwarded from the input message.
+  EXPECT_EQ(accel_msg.header.frame_id, "base_link");
+  EXPECT_EQ(accel_msg.header.stamp.sec, 1);
 }


### PR DESCRIPTION
## Description

This PR refactors `autoware_twist2accel` so that `AccelEstimator` owns the per-call estimation state previously maintained in the `Twist2Accel` node.

Since the logic for managing previous twist data and calculating time differences is part of the core logic, it belongs in the core logic class.

This change simplifies the core logic class interface as follows:
```cpp
// before
void Twist2Accel::estimate_accel(const geometry_msgs::msg::TwistStamped & twist)
{
  geometry_msgs::msg::AccelWithCovarianceStamped accel_msg;
  accel_msg.header = twist.header;

  if (prev_twist_.has_value()) {
    const double dt =
      (rclcpp::Time(twist.header.stamp) - rclcpp::Time(prev_twist_->header.stamp)).seconds();

    accel_msg.accel = accel_estimator_->estimate(prev_twist_->twist, twist.twist, dt);
  }

  pub_accel_->publish(accel_msg);
  prev_twist_ = twist;
}

// after
void Twist2Accel::callback_odometry(const nav_msgs::msg::Odometry::SharedPtr msg)
{
  if (!use_odom_) return;
  pub_accel_->publish(accel_estimator_->estimate(*msg));
}
```


## Related links

https://github.com/autowarefoundation/autoware_core/pull/1111

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- `colcon test --packages-select autoware_twist2accel` passes.
- Updated the existing `AccelEstimator` unit tests to support the new stamp-based API (each sample now carries its own timestamp, and `dt` is derived from successive stamps).
- Integration tests for the `autoware_twist2accel` node also pass successfully without any modifications, as this PR does not change the node's behavior.

## Notes for reviewers

None

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None. This is a pure internal refactor: the public ROS interface (subscribed/published topics and parameters) is unchanged.
