### PR TITLE
feat(motion_velocity_planner): apply autoware_agnocast_wrapper for CIE

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/CMakeLists.txt
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/CMakeLists.txt
@@ -10,9 +10,11 @@ ament_auto_add_library(${PROJECT_NAME}_lib SHARED
   DIRECTORY src
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}_lib
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}_lib
   PLUGIN "autoware::motion_velocity_planner::MotionVelocityPlannerNode"
   EXECUTABLE ${PROJECT_NAME}_node
+  ROS2_EXECUTOR SingleThreadedExecutor
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
 )
 
 if(BUILD_TESTING)

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner/package.xml
@@ -19,6 +19,7 @@
 
   <build_depend>rosidl_default_generators</build_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_map_msgs</depend>


### PR DESCRIPTION
## Description

Apply `CallbackIsolatedAgnocastExecutor` (CIE) to `autoware_motion_velocity_planner`, as part of the CIE rollout (see related issue). By going through `autoware_agnocast_wrapper`, CIE activation is controlled by the `ENABLE_AGNOCAST` environment variable: when unset or `0`, the node runs with the standard ROS 2 executor as before; when set to `1`, it switches to `CallbackIsolatedAgnocastExecutor`.

This matches the pattern already used by other planning nodes (e.g. `autoware_scenario_selector`).

**Motivation:** `motion_velocity_planner` used to be CIE-ized implicitly by running as a composable node inside the CIE container (`agnocast_component_container_cie`). Now that it is launched as a standalone `<node>` (e.g. the [e2e diffusion planner launch](https://github.com/tier4/autoware_launch.x2/blob/d145c5f330749a619fd1623e4a6b58ac0b8afd69/autoware_launch/launch/e2e_components/diffusion_planner.launch.xml#L225)), the standalone executable built via `rclcpp_components_register_node` runs on a plain `SingleThreadedExecutor` and is no longer CIE-ized. This PR makes the standalone executable itself CIE-capable, restoring the isolation it previously had.

### Changes

- `CMakeLists.txt`: replace `rclcpp_components_register_node(...)` with `autoware_agnocast_wrapper_register_node(...)`. The generated `autoware_motion_velocity_planner_node` executable uses `CallbackIsolatedAgnocastExecutor` when built with `ENABLE_AGNOCAST=1`, and falls back to a `SingleThreadedExecutor` standalone executable (identical to the previous `rclcpp_components` behavior) otherwise.
- `package.xml`: add the `autoware_agnocast_wrapper` dependency.

No source changes. The node uses plain `rclcpp` publishers/subscriptions, so this only swaps the executor.

## Related links

**Related Issue:**

- https://github.com/autowarefoundation/autoware_core/issues/968

## How was this PR tested?

Built with `ENABLE_AGNOCAST=1` and verified by lsim:

- the node executable links the agnocast wrapper `node_main` (the binary contains the `compiled with agnocast support` marker),
- at runtime the node announces its callback groups to `agnocast_cie_thread_configurator` and is reported as CIE-ized in the CIE boundary measurement.

With `ENABLE_AGNOCAST` unset, the node builds and runs via the standard `rclcpp_components` path with no behavior change.

## Notes for reviewers

`ROS2_EXECUTOR` is set to `SingleThreadedExecutor` to preserve the node's current single-threaded standalone-executor behavior.

If the node meets **all** of the following conditions, please check for potential race conditions (see [Effects on system behavior](#effects-on-system-behavior) for the reason):
  1. The node was originally running on a `SingleThreadedExecutor`
  2. The node has multiple callback groups (the default is one)
  3. Shared variables are accessed across callback groups without proper mutex protection

  > **Note:** Nodes already running on `MultiThreadedExecutor` (or `component_container_mt`) are not affected, as their callbacks are already executed concurrently.

## Interface changes

None.

## Effects on system behavior

When `ENABLE_AGNOCAST=0` (default), there is no change in behavior at all. The node runs with the standard ROS 2 executor exactly as before.

When `ENABLE_AGNOCAST=1`, the executor switches to `CallbackIsolatedAgnocastExecutor` (CIE). Internally, CIE creates a dedicated `rclcpp::SingleThreadedExecutor` for each callback group, so the fundamental scheduling behavior within each group remains almost identical. The key difference is that, for nodes originally using `SingleThreadedExecutor`, callback groups now run in parallel across separate threads, similar to `MultiThreadedExecutor`.
