### PR TITLE
refactor(stop_filter): unify core logic to message conversion

### DIFF
--- a/localization/autoware_stop_filter/CMakeLists.txt
+++ b/localization/autoware_stop_filter/CMakeLists.txt
@@ -24,8 +24,13 @@ autoware_agnocast_wrapper_register_node(${PROJECT_NAME}_ros
 )
 
 if(BUILD_TESTING)
-  ament_add_ros_isolated_gtest(test_stop_filter_node
+  ament_auto_add_gtest(test_stop_filter
     test/test_stop_filter.cpp
+  )
+  target_link_libraries(test_stop_filter ${PROJECT_NAME})
+  target_include_directories(test_stop_filter PRIVATE src)
+
+  ament_add_ros_isolated_gtest(test_stop_filter_node
     test/test_stop_filter_node.cpp
   )
   target_link_libraries(test_stop_filter_node ${PROJECT_NAME} ${PROJECT_NAME}_ros)

--- a/localization/autoware_stop_filter/src/stop_filter.cpp
+++ b/localization/autoware_stop_filter/src/stop_filter.cpp
@@ -18,34 +18,47 @@
 
 namespace autoware::stop_filter
 {
-StopFilter::StopFilter(double linear_x_threshold, double angular_z_threshold)
+namespace
+{
+bool is_stopped(
+  const nav_msgs::msg::Odometry & input, const double linear_x_threshold,
+  const double angular_z_threshold)
+{
+  const bool linear_stopped = std::fabs(input.twist.twist.linear.x) < linear_x_threshold;
+  const bool angular_stopped = std::fabs(input.twist.twist.angular.z) < angular_z_threshold;
+  return linear_stopped && angular_stopped;
+}
+}  // namespace
+
+StopFilter::StopFilter(const double linear_x_threshold, const double angular_z_threshold)
 : linear_x_threshold_(linear_x_threshold), angular_z_threshold_(angular_z_threshold)
 {
 }
 
-bool StopFilter::is_stopped(
-  const Vector3D & linear_velocity, const Vector3D & angular_velocity) const
+autoware_internal_debug_msgs::msg::BoolStamped StopFilter::create_stop_flag_msg(
+  const nav_msgs::msg::Odometry::SharedPtr input) const
 {
-  const bool linear_stopped = std::fabs(linear_velocity.x) < linear_x_threshold_;
-  const bool angular_stopped = std::fabs(angular_velocity.z) < angular_z_threshold_;
-  return linear_stopped && angular_stopped;
+  autoware_internal_debug_msgs::msg::BoolStamped stop_flag_msg;
+  stop_flag_msg.stamp = input->header.stamp;
+  stop_flag_msg.data = is_stopped(*input, linear_x_threshold_, angular_z_threshold_);
+  return stop_flag_msg;
 }
 
-FilterResult StopFilter::apply_stop_filter(
-  const Vector3D & linear_velocity, const Vector3D & angular_velocity) const
+nav_msgs::msg::Odometry StopFilter::create_filtered_msg(
+  const nav_msgs::msg::Odometry::SharedPtr input) const
 {
-  FilterResult result;
-  result.was_stopped = is_stopped(linear_velocity, angular_velocity);
+  nav_msgs::msg::Odometry filtered_msg = *input;
 
-  if (result.was_stopped) {
-    result.linear_velocity = {0.0, 0.0, 0.0};
-    result.angular_velocity = {0.0, 0.0, 0.0};
-  } else {
-    result.linear_velocity = linear_velocity;
-    result.angular_velocity = angular_velocity;
+  if (is_stopped(*input, linear_x_threshold_, angular_z_threshold_)) {
+    filtered_msg.twist.twist.linear.x = 0.0;
+    filtered_msg.twist.twist.linear.y = 0.0;
+    filtered_msg.twist.twist.linear.z = 0.0;
+    filtered_msg.twist.twist.angular.x = 0.0;
+    filtered_msg.twist.twist.angular.y = 0.0;
+    filtered_msg.twist.twist.angular.z = 0.0;
   }
 
-  return result;
+  return filtered_msg;
 }
 
 }  // namespace autoware::stop_filter

--- a/localization/autoware_stop_filter/src/stop_filter.hpp
+++ b/localization/autoware_stop_filter/src/stop_filter.hpp
@@ -15,34 +15,34 @@
 #ifndef STOP_FILTER_HPP_
 #define STOP_FILTER_HPP_
 
+#include <autoware_internal_debug_msgs/msg/bool_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
 namespace autoware::stop_filter
 {
 
-struct Vector3D
-{
-  double x;
-  double y;
-  double z;
-};
-
-struct FilterResult
-{
-  Vector3D linear_velocity;
-  Vector3D angular_velocity;
-  bool was_stopped;
-};
-
+/// @brief Judges whether a vehicle is stopped from its odometry twist and, when it is, zeroes the
+/// twist. The judgement compares the linear-x and angular-z velocities against fixed thresholds.
 class StopFilter
 {
 public:
+  /// @brief Construct the filter.
+  /// @param linear_x_threshold Linear-x velocity below which the vehicle is considered stopped.
+  /// @param angular_z_threshold Angular-z velocity below which the vehicle is considered stopped.
   StopFilter(double linear_x_threshold, double angular_z_threshold);
-  FilterResult apply_stop_filter(
-    const Vector3D & linear_velocity, const Vector3D & angular_velocity) const;
+
+  /// @brief Build a stop-flag message indicating whether the input odometry represents a stop.
+  /// @return BoolStamped carrying the input timestamp and the stop judgement.
+  autoware_internal_debug_msgs::msg::BoolStamped create_stop_flag_msg(
+    const nav_msgs::msg::Odometry::SharedPtr input) const;
+
+  /// @brief Build a filtered odometry whose twist is zeroed when the vehicle is judged stopped.
+  /// @return Copy of the input odometry with a zeroed twist on a stop, otherwise unchanged.
+  nav_msgs::msg::Odometry create_filtered_msg(const nav_msgs::msg::Odometry::SharedPtr input) const;
 
 private:
   double linear_x_threshold_;
   double angular_z_threshold_;
-  bool is_stopped(const Vector3D & linear_velocity, const Vector3D & angular_velocity) const;
 };
 }  // namespace autoware::stop_filter
 #endif  // STOP_FILTER_HPP_

--- a/localization/autoware_stop_filter/src/stop_filter_node.cpp
+++ b/localization/autoware_stop_filter/src/stop_filter_node.cpp
@@ -17,53 +17,9 @@
 namespace autoware::stop_filter
 {
 
-StopFilterProcessor::StopFilterProcessor(double linear_x_threshold, double angular_z_threshold)
-: stop_filter_(linear_x_threshold, angular_z_threshold)
-{
-}
-
-FilterResult StopFilterProcessor::apply_filter(const nav_msgs::msg::Odometry::SharedPtr input) const
-{
-  Vector3D linear_velocity{
-    input->twist.twist.linear.x, input->twist.twist.linear.y, input->twist.twist.linear.z};
-  Vector3D angular_velocity{
-    input->twist.twist.angular.x, input->twist.twist.angular.y, input->twist.twist.angular.z};
-
-  return stop_filter_.apply_stop_filter(linear_velocity, angular_velocity);
-}
-
-autoware_internal_debug_msgs::msg::BoolStamped StopFilterProcessor::create_stop_flag_msg(
-  const nav_msgs::msg::Odometry::SharedPtr input) const
-{
-  autoware_internal_debug_msgs::msg::BoolStamped stop_flag_msg;
-  stop_flag_msg.stamp = input->header.stamp;
-
-  FilterResult result = apply_filter(input);
-  stop_flag_msg.data = result.was_stopped;
-
-  return stop_flag_msg;
-}
-
-nav_msgs::msg::Odometry StopFilterProcessor::create_filtered_msg(
-  const nav_msgs::msg::Odometry::SharedPtr input) const
-{
-  nav_msgs::msg::Odometry filtered_msg = *input;
-
-  FilterResult result = apply_filter(input);
-  filtered_msg.twist.twist.linear.x = result.linear_velocity.x;
-  filtered_msg.twist.twist.linear.y = result.linear_velocity.y;
-  filtered_msg.twist.twist.linear.z = result.linear_velocity.z;
-  filtered_msg.twist.twist.angular.x = result.angular_velocity.x;
-  filtered_msg.twist.twist.angular.y = result.angular_velocity.y;
-  filtered_msg.twist.twist.angular.z = result.angular_velocity.z;
-
-  return filtered_msg;
-}
-
 StopFilterNode::StopFilterNode(const rclcpp::NodeOptions & node_options)
 : rclcpp::Node("stop_filter", node_options),
-  message_processor_(
-    declare_parameter<double>("vx_threshold"), declare_parameter<double>("wz_threshold"))
+  stop_filter_(declare_parameter<double>("vx_threshold"), declare_parameter<double>("wz_threshold"))
 {
   sub_odom_ = create_subscription<nav_msgs::msg::Odometry>(
     "input/odom", 1, std::bind(&StopFilterNode::callback_odometry, this, std::placeholders::_1));
@@ -75,8 +31,8 @@ StopFilterNode::StopFilterNode(const rclcpp::NodeOptions & node_options)
 
 void StopFilterNode::callback_odometry(const nav_msgs::msg::Odometry::SharedPtr msg)
 {
-  pub_stop_flag_->publish(message_processor_.create_stop_flag_msg(msg));
-  pub_odom_->publish(message_processor_.create_filtered_msg(msg));
+  pub_stop_flag_->publish(stop_filter_.create_stop_flag_msg(msg));
+  pub_odom_->publish(stop_filter_.create_filtered_msg(msg));
 }
 }  // namespace autoware::stop_filter
 

--- a/localization/autoware_stop_filter/src/stop_filter_node.hpp
+++ b/localization/autoware_stop_filter/src/stop_filter_node.hpp
@@ -25,19 +25,6 @@
 namespace autoware::stop_filter
 {
 
-class StopFilterProcessor
-{
-public:
-  StopFilterProcessor(double linear_x_threshold, double angular_z_threshold);
-  autoware_internal_debug_msgs::msg::BoolStamped create_stop_flag_msg(
-    const nav_msgs::msg::Odometry::SharedPtr input) const;
-  nav_msgs::msg::Odometry create_filtered_msg(const nav_msgs::msg::Odometry::SharedPtr input) const;
-
-private:
-  StopFilter stop_filter_;
-  FilterResult apply_filter(const nav_msgs::msg::Odometry::SharedPtr input) const;
-};
-
 class StopFilterNode : public rclcpp::Node
 {
 public:
@@ -50,7 +37,7 @@ private:
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr
     sub_odom_;  //!< @brief measurement odometry subscriber
 
-  StopFilterProcessor message_processor_;
+  StopFilter stop_filter_;
 
   /**
    * @brief set odometry measurement

--- a/localization/autoware_stop_filter/test/test_stop_filter.cpp
+++ b/localization/autoware_stop_filter/test/test_stop_filter.cpp
@@ -16,66 +16,104 @@
 
 #include <gtest/gtest.h>
 
-using autoware::stop_filter::FilterResult;
+#include <memory>
+
 using autoware::stop_filter::StopFilter;
-using autoware::stop_filter::Vector3D;
 
-TEST(StopFilterTest, FilterStopWhenStopped)
+namespace
+{
+// Build an odometry sample from its six twist components. The stamp and frame are fixed so the
+// filter's forwarding of the header can be asserted.
+nav_msgs::msg::Odometry::SharedPtr create_odometry_message(
+  const double linear_x, const double linear_y, const double linear_z, const double angular_x,
+  const double angular_y, const double angular_z)
+{
+  auto msg = std::make_shared<nav_msgs::msg::Odometry>();
+  msg->header.frame_id = "base_link";
+  msg->header.stamp.sec = 1;
+  msg->header.stamp.nanosec = 500000000;
+  msg->twist.twist.linear.x = linear_x;
+  msg->twist.twist.linear.y = linear_y;
+  msg->twist.twist.linear.z = linear_z;
+  msg->twist.twist.angular.x = angular_x;
+  msg->twist.twist.angular.y = angular_y;
+  msg->twist.twist.angular.z = angular_z;
+  return msg;
+}
+}  // namespace
+
+// When both linear-x and angular-z exceed the thresholds the vehicle is moving, so the stop flag
+// is false. The input timestamp is forwarded onto the flag message.
+TEST(StopFilterTest, StopFlagIsFalseWhenMoving)
 {
   StopFilter filter(0.1, 0.1);
-  Vector3D linear_velocity = {0.05, 0.0, 0.0};
-  Vector3D angular_velocity = {0.0, 0.0, 0.05};
+  const auto input = create_odometry_message(0.2, 0.0, 0.0, 0.0, 0.0, 0.2);
 
-  FilterResult result = filter.apply_stop_filter(linear_velocity, angular_velocity);
+  const auto stop_flag_msg = filter.create_stop_flag_msg(input);
 
-  EXPECT_TRUE(result.was_stopped);
-  EXPECT_EQ(result.linear_velocity.x, 0.0);
-  EXPECT_EQ(result.linear_velocity.y, 0.0);
-  EXPECT_EQ(result.linear_velocity.z, 0.0);
-  EXPECT_EQ(result.angular_velocity.x, 0.0);
-  EXPECT_EQ(result.angular_velocity.y, 0.0);
-  EXPECT_EQ(result.angular_velocity.z, 0.0);
+  EXPECT_FALSE(stop_flag_msg.data);
+  EXPECT_EQ(stop_flag_msg.stamp, input->header.stamp);
 }
 
-TEST(StopFilterTest, FilterStopWhenNotStopped)
+// When both linear-x and angular-z are below the thresholds the vehicle is stopped, so the stop
+// flag is true.
+TEST(StopFilterTest, StopFlagIsTrueWhenStopped)
 {
   StopFilter filter(0.1, 0.1);
-  Vector3D linear_velocity = {0.2, 0.0, 0.0};
-  Vector3D angular_velocity = {0.0, 0.0, 0.2};
+  const auto input = create_odometry_message(0.05, 0.0, 0.0, 0.0, 0.0, 0.05);
 
-  FilterResult result = filter.apply_stop_filter(linear_velocity, angular_velocity);
+  const auto stop_flag_msg = filter.create_stop_flag_msg(input);
 
-  EXPECT_FALSE(result.was_stopped);
-  EXPECT_EQ(result.linear_velocity.x, 0.2);
-  EXPECT_EQ(result.linear_velocity.y, 0.0);
-  EXPECT_EQ(result.linear_velocity.z, 0.0);
-  EXPECT_EQ(result.angular_velocity.x, 0.0);
-  EXPECT_EQ(result.angular_velocity.y, 0.0);
-  EXPECT_EQ(result.angular_velocity.z, 0.2);
+  EXPECT_TRUE(stop_flag_msg.data);
+  EXPECT_EQ(stop_flag_msg.stamp, input->header.stamp);
 }
 
-TEST(StopFilterTest, FilterStopOnlyLinearVelocityBelowThreshold)
+// A stop requires both axes below threshold: linear-x alone below threshold is still moving, so the
+// twist is preserved.
+TEST(StopFilterTest, NotStoppedWhenOnlyLinearVelocityBelowThreshold)
 {
   StopFilter filter(0.1, 0.1);
-  Vector3D linear_velocity = {0.05, 0.0, 0.0};
-  Vector3D angular_velocity = {0.0, 0.0, 0.2};
+  const auto input = create_odometry_message(0.05, 0.0, 0.0, 0.0, 0.0, 0.2);
 
-  FilterResult result = filter.apply_stop_filter(linear_velocity, angular_velocity);
-
-  EXPECT_FALSE(result.was_stopped);
-  EXPECT_EQ(result.linear_velocity.x, 0.05);
-  EXPECT_EQ(result.angular_velocity.z, 0.2);
+  EXPECT_FALSE(filter.create_stop_flag_msg(input).data);
 }
 
-TEST(StopFilterTest, FilterStopOnlyAngularVelocityBelowThreshold)
+// Symmetrically, angular-z alone below threshold is still moving, so the twist is preserved.
+TEST(StopFilterTest, NotStoppedWhenOnlyAngularVelocityBelowThreshold)
 {
   StopFilter filter(0.1, 0.1);
-  Vector3D linear_velocity = {0.2, 0.0, 0.0};
-  Vector3D angular_velocity = {0.0, 0.0, 0.05};
+  const auto input = create_odometry_message(0.2, 0.0, 0.0, 0.0, 0.0, 0.05);
 
-  FilterResult result = filter.apply_stop_filter(linear_velocity, angular_velocity);
+  EXPECT_FALSE(filter.create_stop_flag_msg(input).data);
+}
 
-  EXPECT_FALSE(result.was_stopped);
-  EXPECT_EQ(result.linear_velocity.x, 0.2);
-  EXPECT_EQ(result.angular_velocity.z, 0.05);
+// On a stop every twist component is zeroed while the header is preserved.
+TEST(StopFilterTest, FilteredMsgZeroesTwistWhenStopped)
+{
+  StopFilter filter(0.1, 0.1);
+  const auto input = create_odometry_message(0.05, 0.02, 0.01, 0.03, 0.04, 0.05);
+
+  const auto filtered_msg = filter.create_filtered_msg(input);
+
+  EXPECT_EQ(filtered_msg.twist.twist.linear.x, 0.0);
+  EXPECT_EQ(filtered_msg.twist.twist.linear.y, 0.0);
+  EXPECT_EQ(filtered_msg.twist.twist.linear.z, 0.0);
+  EXPECT_EQ(filtered_msg.twist.twist.angular.x, 0.0);
+  EXPECT_EQ(filtered_msg.twist.twist.angular.y, 0.0);
+  EXPECT_EQ(filtered_msg.twist.twist.angular.z, 0.0);
+
+  EXPECT_EQ(filtered_msg.header.frame_id, input->header.frame_id);
+  EXPECT_EQ(filtered_msg.header.stamp, input->header.stamp);
+}
+
+// When moving the twist passes through unchanged.
+TEST(StopFilterTest, FilteredMsgPreservesTwistWhenMoving)
+{
+  StopFilter filter(0.1, 0.1);
+  const auto input = create_odometry_message(0.2, 0.0, 0.0, 0.0, 0.0, 0.2);
+
+  const auto filtered_msg = filter.create_filtered_msg(input);
+
+  EXPECT_EQ(filtered_msg.twist.twist.linear.x, 0.2);
+  EXPECT_EQ(filtered_msg.twist.twist.angular.z, 0.2);
 }

--- a/localization/autoware_stop_filter/test/test_stop_filter_node.cpp
+++ b/localization/autoware_stop_filter/test/test_stop_filter_node.cpp
@@ -16,59 +16,10 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <memory>
-
-nav_msgs::msg::Odometry::SharedPtr createOdometryMessage(
-  double linear_x, double linear_y, double linear_z, double angular_x, double angular_y,
-  double angular_z)
-{
-  auto msg = std::make_shared<nav_msgs::msg::Odometry>();
-  msg->header.frame_id = "base_link";
-  msg->header.stamp = rclcpp::Clock().now();
-  msg->twist.twist.linear.x = linear_x;
-  msg->twist.twist.linear.y = linear_y;
-  msg->twist.twist.linear.z = linear_z;
-  msg->twist.twist.angular.x = angular_x;
-  msg->twist.twist.angular.y = angular_y;
-  msg->twist.twist.angular.z = angular_z;
-  return msg;
-}
-
-TEST(StopFilterProcessorTest, TestCreateStopFlagMsgMoving)
-{
-  // Create message with velocities above threshold (moving)
-  auto message_filter_ = std::make_unique<autoware::stop_filter::StopFilterProcessor>(0.1, 0.1);
-  auto input_msg = createOdometryMessage(0.2, 0.0, 0.0, 0.0, 0.0, 0.2);
-
-  // Test stop flag creation
-  auto stop_flag_msg = message_filter_->create_stop_flag_msg(input_msg);
-
-  // Verify stop flag is false (vehicle is moving)
-  ASSERT_FALSE(stop_flag_msg.data);
-  ASSERT_EQ(stop_flag_msg.stamp, input_msg->header.stamp);
-}
-
-TEST(StopFilterProcessorTest, TestCreateFilteredMsgStopped)
-{
-  // Create message with velocities below threshold (stopped)
-  auto message_filter_ = std::make_unique<autoware::stop_filter::StopFilterProcessor>(0.1, 0.1);
-  auto input_msg = createOdometryMessage(0.05, 0.02, 0.01, 0.03, 0.04, 0.05);
-
-  // Test filtered message creation
-  auto filtered_msg = message_filter_->create_filtered_msg(input_msg);
-
-  // Verify velocities are set to zero when stopped
-  ASSERT_EQ(filtered_msg.twist.twist.linear.x, 0.0);
-  ASSERT_EQ(filtered_msg.twist.twist.linear.y, 0.0);
-  ASSERT_EQ(filtered_msg.twist.twist.linear.z, 0.0);
-  ASSERT_EQ(filtered_msg.twist.twist.angular.x, 0.0);
-  ASSERT_EQ(filtered_msg.twist.twist.angular.y, 0.0);
-  ASSERT_EQ(filtered_msg.twist.twist.angular.z, 0.0);
-
-  // Verify header is preserved
-  ASSERT_EQ(filtered_msg.header.frame_id, input_msg->header.frame_id);
-  ASSERT_EQ(filtered_msg.header.stamp, input_msg->header.stamp);
-}
+#include <mutex>
+#include <thread>
 
 // Test for stop detection in StopFilterNode
 // This test is disabled by default due to its reliance on real-time execution

--- a/localization/autoware_stop_filter/test/test_stop_filter_node.cpp
+++ b/localization/autoware_stop_filter/test/test_stop_filter_node.cpp
@@ -21,10 +21,7 @@
 #include <mutex>
 #include <thread>
 
-// Test for stop detection in StopFilterNode
-// This test is disabled by default due to its reliance on real-time execution
-// To run this test, you need to enable it manually by removing the DISABLED_ prefix
-TEST(StopFilterNodeTest, DISABLED_TestStopDetection)
+TEST(StopFilterNodeTest, TestStopDetection)
 {
   // Initialize ROS 2 context
   rclcpp::init(0, nullptr);


### PR DESCRIPTION
## Description

This PR refactors `autoware_stop_filter` so that its core logic class performs a direct ROS 2 message-to-message conversion.

Previously the package had an extra indirection layer: a pure-logic `StopFilter` operating on `Vector3D` / `FilterResult` structs, plus a `StopFilterProcessor` wrapper inside `stop_filter_node.cpp` that converted between ROS messages and those structs. This struct conversion layer added complexity without real benefit.

## Related links

https://github.com/autowarefoundation/autoware_core/pull/573

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

`colcon build --packages-select autoware_stop_filter` followed by `colcon test --packages-select autoware_stop_filter --event-handlers console_cohesion+` passes. 

All test suites pass (6/6 ctest entries), including the six `StopFilter` unit-test cases, the `StopFilterNode` integration test 

## Notes for reviewers

I'd like to refactor the integration tests later. For now, I've left them as is. I believe it's best not to change production code and test code at the same time if possible, since the existing tests ensure that the node's behavior remains unchanged.

## Interface changes

None.

## Effects on system behavior

None.
