### PR TITLE
feat(twist2accel): apply `agnocast_wrapper::Node` to `twist2accel`

### DIFF
--- a/localization/autoware_twist2accel/CMakeLists.txt
+++ b/localization/autoware_twist2accel/CMakeLists.txt
@@ -23,11 +23,13 @@ if(BUILD_TESTING)
   target_link_libraries(test_accel_estimator ${PROJECT_NAME})
   target_include_directories(test_accel_estimator PRIVATE src)
 
-  ament_add_ros_isolated_gtest(test_twist2accel_node
-    test/test_twist2accel_node.cpp
-  )
-  target_link_libraries(test_twist2accel_node ${PROJECT_NAME})
-  target_include_directories(test_twist2accel_node PRIVATE src)
+  if(NOT (DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1"))
+    ament_add_ros_isolated_gtest(test_twist2accel_node
+      test/test_twist2accel_node.cpp
+    )
+    target_link_libraries(test_twist2accel_node ${PROJECT_NAME})
+    target_include_directories(test_twist2accel_node PRIVATE src)
+  endif()
 endif()
 
 autoware_ament_auto_package(

--- a/localization/autoware_twist2accel/CMakeLists.txt
+++ b/localization/autoware_twist2accel/CMakeLists.txt
@@ -4,13 +4,10 @@ project(autoware_twist2accel)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
-find_package(autoware_agnocast_wrapper REQUIRED)
-
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/accel_estimator.cpp
   src/twist2accel.cpp
 )
-ament_target_dependencies(${PROJECT_NAME} autoware_agnocast_wrapper)
 
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::twist2accel::Twist2Accel"

--- a/localization/autoware_twist2accel/CMakeLists.txt
+++ b/localization/autoware_twist2accel/CMakeLists.txt
@@ -4,15 +4,18 @@ project(autoware_twist2accel)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
+find_package(autoware_agnocast_wrapper REQUIRED)
+
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/accel_estimator.cpp
   src/twist2accel.cpp
 )
+ament_target_dependencies(${PROJECT_NAME} autoware_agnocast_wrapper)
 
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::twist2accel::Twist2Accel"
   EXECUTABLE ${PROJECT_NAME}_node
-  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
   ROS2_EXECUTOR SingleThreadedExecutor
 )
 

--- a/localization/autoware_twist2accel/launch/twist2accel.launch.xml
+++ b/localization/autoware_twist2accel/launch/twist2accel.launch.xml
@@ -1,10 +1,14 @@
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
   <arg name="param_file" default="$(find-pkg-share autoware_twist2accel)/config/twist2accel.param.yaml"/>
 
   <arg name="in_odom" default="in_odom"/>
   <arg name="in_twist" default="in_twist"/>
   <arg name="out_accel" default="out_accel"/>
   <node pkg="autoware_twist2accel" exec="autoware_twist2accel_node" output="both">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
+
     <remap from="input/odom" to="$(var in_odom)"/>
     <remap from="input/twist" to="$(var in_twist)"/>
     <remap from="output/accel" to="$(var out_accel)"/>

--- a/localization/autoware_twist2accel/src/twist2accel.cpp
+++ b/localization/autoware_twist2accel/src/twist2accel.cpp
@@ -26,7 +26,7 @@ namespace autoware::twist2accel
 using std::placeholders::_1;
 
 Twist2Accel::Twist2Accel(const rclcpp::NodeOptions & node_options)
-: rclcpp::Node("twist2accel", node_options)
+: autoware::agnocast_wrapper::Node("twist2accel", node_options)
 {
   sub_odom_ = create_subscription<nav_msgs::msg::Odometry>(
     "input/odom", 1, std::bind(&Twist2Accel::callback_odometry, this, _1));
@@ -41,7 +41,8 @@ Twist2Accel::Twist2Accel(const rclcpp::NodeOptions & node_options)
   accel_estimator_ = std::make_unique<AccelEstimator>(accel_lowpass_gain);
 }
 
-void Twist2Accel::callback_odometry(const nav_msgs::msg::Odometry::SharedPtr msg)
+void Twist2Accel::callback_odometry(
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(nav_msgs::msg::Odometry) msg)
 {
   if (!use_odom_) return;
 
@@ -52,7 +53,7 @@ void Twist2Accel::callback_odometry(const nav_msgs::msg::Odometry::SharedPtr msg
 }
 
 void Twist2Accel::callback_twist_with_covariance(
-  const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::TwistWithCovarianceStamped) msg)
 {
   if (use_odom_) return;
 
@@ -64,17 +65,17 @@ void Twist2Accel::callback_twist_with_covariance(
 
 void Twist2Accel::estimate_accel(const geometry_msgs::msg::TwistStamped & twist)
 {
-  geometry_msgs::msg::AccelWithCovarianceStamped accel_msg;
-  accel_msg.header = twist.header;
+  auto accel_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_accel_);
+  accel_msg->header = twist.header;
 
   if (prev_twist_.has_value()) {
     const double dt =
       (rclcpp::Time(twist.header.stamp) - rclcpp::Time(prev_twist_->header.stamp)).seconds();
 
-    accel_msg.accel = accel_estimator_->estimate(prev_twist_->twist, twist.twist, dt);
+    accel_msg->accel = accel_estimator_->estimate(prev_twist_->twist, twist.twist, dt);
   }
 
-  pub_accel_->publish(accel_msg);
+  pub_accel_->publish(std::move(accel_msg));
   prev_twist_ = twist;
 }
 }  // namespace autoware::twist2accel

--- a/localization/autoware_twist2accel/src/twist2accel.cpp
+++ b/localization/autoware_twist2accel/src/twist2accel.cpp
@@ -43,14 +43,18 @@ void Twist2Accel::callback_odometry(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(nav_msgs::msg::Odometry) msg)
 {
   if (!use_odom_) return;
-  pub_accel_->publish(accel_estimator_->estimate(*msg));
+  auto accel_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_accel_);
+  *accel_msg = accel_estimator_->estimate(*msg);
+  pub_accel_->publish(std::move(accel_msg));
 }
 
 void Twist2Accel::callback_twist_with_covariance(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::TwistWithCovarianceStamped) msg)
 {
   if (use_odom_) return;
-  pub_accel_->publish(accel_estimator_->estimate(*msg));
+  auto accel_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_accel_);
+  *accel_msg = accel_estimator_->estimate(*msg);
+  pub_accel_->publish(std::move(accel_msg));
 }
 }  // namespace autoware::twist2accel
 

--- a/localization/autoware_twist2accel/src/twist2accel.cpp
+++ b/localization/autoware_twist2accel/src/twist2accel.cpp
@@ -18,6 +18,7 @@
 
 #include <functional>
 #include <memory>
+#include <utility>
 
 namespace autoware::twist2accel
 {

--- a/localization/autoware_twist2accel/src/twist2accel.hpp
+++ b/localization/autoware_twist2accel/src/twist2accel.hpp
@@ -17,6 +17,7 @@
 
 #include "accel_estimator.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
@@ -29,18 +30,18 @@
 
 namespace autoware::twist2accel
 {
-class Twist2Accel : public rclcpp::Node
+class Twist2Accel : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit Twist2Accel(const rclcpp::NodeOptions & node_options);
 
 private:
-  rclcpp::Publisher<geometry_msgs::msg::AccelWithCovarianceStamped>::SharedPtr
-    pub_accel_;  //!< @brief stop flag publisher
-  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr
-    sub_odom_;  //!< @brief measurement odometry subscriber
-  rclcpp::Subscription<geometry_msgs::msg::TwistWithCovarianceStamped>::SharedPtr
-    sub_twist_;  //!< @brief measurement odometry subscriber
+  AUTOWARE_PUBLISHER_PTR(geometry_msgs::msg::AccelWithCovarianceStamped)
+  pub_accel_;  //!< @brief stop flag publisher
+  AUTOWARE_SUBSCRIPTION_PTR(nav_msgs::msg::Odometry)
+  sub_odom_;  //!< @brief measurement odometry subscriber
+  AUTOWARE_SUBSCRIPTION_PTR(geometry_msgs::msg::TwistWithCovarianceStamped)
+  sub_twist_;  //!< @brief measurement odometry subscriber
 
   std::optional<geometry_msgs::msg::TwistStamped> prev_twist_;
   bool use_odom_;
@@ -50,8 +51,8 @@ private:
    * @brief set odometry measurement
    */
   void callback_twist_with_covariance(
-    const geometry_msgs::msg::TwistWithCovarianceStamped::SharedPtr msg);
-  void callback_odometry(const nav_msgs::msg::Odometry::SharedPtr msg);
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::TwistWithCovarianceStamped) msg);
+  void callback_odometry(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(nav_msgs::msg::Odometry) msg);
   void estimate_accel(const geometry_msgs::msg::TwistStamped & twist);
 };
 }  // namespace autoware::twist2accel


### PR DESCRIPTION
## Description
Apply `agnocast_wrapper::Node` to `autoware_twist2accel`.
Please read https://github.com/autowarefoundation/autoware/issues/7007 for the context and review guidelines of `autoware_agnocast_wrapper` adoption. 
Also, please refer to https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md for the review guide of `autoware_agnocast_wrapper` application PR. FYI: This node take [Method2](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md#method-2-agnocast_wrappernode-inheritance) of two integrations methods.

## Related Links

  - https://github.com/autowarefoundation/autoware/issues/7007
  - https://github.com/orgs/autowarefoundation/discussions/6804

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
  - `colcon build` succeeds with both `ENABLE_AGNOCAST=1` and `ENABLE_AGNOCAST=0`.
  - Ran Autoware based product with this change applied and confirmed it operates without any regression.

## Notes for reviewers

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None when ENABLE_AGNOCAST is not set or set to 0 on runtime. When ENABLE_AGNOCAST=1, CPU Time used in this node for message serialization/deserialization will be reduced.