### PR TITLE
feat(lanelet2_map_loader): apply `agnocast_wrapper::Node` to `lanelet2_map_loader`

### DIFF
--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -20,6 +20,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <rcl/timer.h>
+#include <rclcpp/version.h>
 
 #include <chrono>
 #include <functional>

--- a/map/autoware_map_loader/CMakeLists.txt
+++ b/map/autoware_map_loader/CMakeLists.txt
@@ -34,16 +34,20 @@ ament_auto_add_library(lanelet2_map_loader_node SHARED
   src/lanelet2_map_loader/lanelet2_selected_map_loader_module.cpp
 )
 
-rclcpp_components_register_node(lanelet2_map_loader_node
+autoware_agnocast_wrapper_register_node(lanelet2_map_loader_node
   PLUGIN "autoware::map_loader::Lanelet2MapLoaderNode"
   EXECUTABLE autoware_lanelet2_map_loader
+  ROS2_EXECUTOR SingleThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )
 
 if(BUILD_TESTING)
-  add_launch_test(
-    test/lanelet2_map_loader_launch.test.py
-    TIMEOUT "30"
-  )
+  if(NOT (DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1"))
+    add_launch_test(
+      test/lanelet2_map_loader_launch.test.py
+      TIMEOUT "30"
+    )
+  endif()
   install(DIRECTORY
     test/data/
     DESTINATION share/${PROJECT_NAME}/test/data/

--- a/map/autoware_map_loader/CMakeLists.txt
+++ b/map/autoware_map_loader/CMakeLists.txt
@@ -76,8 +76,11 @@ if(BUILD_TESTING)
   add_testcase(test/pointcloud_map_loader/test_selected_map_loader.cpp)
   add_testcase(test/lanelet2_map_loader/test_lanelet2_map_loader_utils.cpp)
   add_testcase(test/lanelet2_map_loader/test_lanelet2_map_cell_metadata.cpp)
-  add_testcase(test/lanelet2_map_loader/test_lanelet2_selected_map_loader_module.cpp)
-  add_testcase(test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp)
+  # These node-based pub/sub and service tests are skipped when ENABLE_AGNOCAST=1.
+  if(NOT (DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1"))
+    add_testcase(test/lanelet2_map_loader/test_lanelet2_selected_map_loader_module.cpp)
+    add_testcase(test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp)
+  endif()
 endif()
 
 install(PROGRAMS

--- a/map/autoware_map_loader/include/autoware/map_loader/lanelet2_map_loader_node.hpp
+++ b/map/autoware_map_loader/include/autoware/map_loader/lanelet2_map_loader_node.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__MAP_LOADER__LANELET2_MAP_LOADER_NODE_HPP_
 #define AUTOWARE__MAP_LOADER__LANELET2_MAP_LOADER_NODE_HPP_
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/component_interface_specs/map.hpp>
 #include <autoware_lanelet2_extension/version.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -29,11 +30,10 @@
 
 namespace autoware::map_loader
 {
-
 // Forward declaration — full definition lives in the private source directory.
 class Lanelet2SelectedMapLoaderModule;
 
-class Lanelet2MapLoaderNode : public rclcpp::Node
+class Lanelet2MapLoaderNode : public autoware::agnocast_wrapper::Node
 {
 public:
   static constexpr lanelet::autoware::Version version = lanelet::autoware::version;
@@ -52,10 +52,11 @@ public:
 private:
   using MapProjectorInfo = autoware::component_interface_specs::map::MapProjectorInfo;
   using VectorMap = autoware::component_interface_specs::map::VectorMap;
-  void on_map_projector_info(const MapProjectorInfo::Message::ConstSharedPtr msg);
+  void on_map_projector_info(
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(MapProjectorInfo::Message) & msg);
 
-  rclcpp::Subscription<MapProjectorInfo::Message>::SharedPtr sub_map_projector_info_;
-  rclcpp::Publisher<VectorMap::Message>::SharedPtr pub_map_bin_;
+  AUTOWARE_SUBSCRIPTION_PTR(MapProjectorInfo::Message) sub_map_projector_info_;
+  AUTOWARE_PUBLISHER_PTR(VectorMap::Message) pub_map_bin_;
 
   std::unique_ptr<Lanelet2SelectedMapLoaderModule> selected_map_loader_module_;
 };

--- a/map/autoware_map_loader/launch/lanelet2_map_loader.launch.xml
+++ b/map/autoware_map_loader/launch/lanelet2_map_loader.launch.xml
@@ -1,4 +1,5 @@
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <arg name="lanelet2_map_loader_param_path" default="$(find-pkg-share autoware_map_loader)/config/lanelet2_map_loader.param.yaml"/>
   <arg name="lanelet2_map_path"/>
   <arg name="lanelet2_map_metadata_path" default="''"/>
@@ -10,6 +11,7 @@
   </node>
 
   <node pkg="autoware_map_loader" exec="autoware_lanelet2_map_loader" name="lanelet2_map_loader" output="both">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <remap from="output/lanelet2_map" to="$(var lanelet2_map_topic)"/>
     <param from="$(var lanelet2_map_loader_param_path)" allow_substs="true"/>
   </node>

--- a/map/autoware_map_loader/package.xml
+++ b/map/autoware_map_loader/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_component_interface_specs</depend>
   <depend>autoware_geography_utils</depend>
   <depend>autoware_lanelet2_extension</depend>

--- a/map/autoware_map_loader/src/lanelet2_map_loader/lanelet2_map_loader_node.cpp
+++ b/map/autoware_map_loader/src/lanelet2_map_loader/lanelet2_map_loader_node.cpp
@@ -72,7 +72,9 @@ Lanelet2MapLoaderNode::Lanelet2MapLoaderNode(const rclcpp::NodeOptions & options
   // subscription
   sub_map_projector_info_ = this->create_subscription<MapProjectorInfo::Message>(
     MapProjectorInfo::name, autoware::component_interface_specs::get_qos<MapProjectorInfo>(),
-    [this](const MapProjectorInfo::Message::ConstSharedPtr msg) { on_map_projector_info(msg); });
+    [this](const AUTOWARE_MESSAGE_CONST_SHARED_PTR(MapProjectorInfo::Message) & msg) {
+      on_map_projector_info(msg);
+    });
 
   declare_parameter<bool>("allow_unsupported_version");
   declare_parameter<std::string>("lanelet2_map_path");
@@ -87,7 +89,7 @@ Lanelet2MapLoaderNode::Lanelet2MapLoaderNode(const rclcpp::NodeOptions & options
 Lanelet2MapLoaderNode::~Lanelet2MapLoaderNode() = default;
 
 void Lanelet2MapLoaderNode::on_map_projector_info(
-  const MapProjectorInfo::Message::ConstSharedPtr msg)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(MapProjectorInfo::Message) & msg)
 {
   const auto allow_unsupported_version = get_parameter("allow_unsupported_version").as_bool();
   const auto lanelet2_map_path = get_parameter("lanelet2_map_path").as_string();

--- a/map/autoware_map_loader/src/lanelet2_map_loader/lanelet2_selected_map_loader_module.cpp
+++ b/map/autoware_map_loader/src/lanelet2_map_loader/lanelet2_selected_map_loader_module.cpp
@@ -56,7 +56,8 @@ autoware_map_msgs::msg::LaneletMapMetaData build_metadata_msg(
 }  // namespace
 
 Lanelet2SelectedMapLoaderModule::Lanelet2SelectedMapLoaderModule(
-  rclcpp::Node * node, std::map<std::string, Lanelet2FileMetaData> cell_metadata_dict,
+  autoware::agnocast_wrapper::Node * node,
+  std::map<std::string, Lanelet2FileMetaData> cell_metadata_dict,
   const autoware_map_msgs::msg::MapProjectorInfo & projector_info,
   const double center_line_resolution, const bool use_waypoints)
 : logger_(node->get_logger()),
@@ -68,7 +69,10 @@ Lanelet2SelectedMapLoaderModule::Lanelet2SelectedMapLoaderModule(
   pub_metadata_(node->create_publisher<autoware_map_msgs::msg::LaneletMapMetaData>(
     "output/lanelet2_map_metadata", rclcpp::QoS{1}.transient_local()))
 {
-  pub_metadata_->publish(build_metadata_msg(all_cell_metadata_dict_, node->now()));
+  AUTOWARE_MESSAGE_UNIQUE_PTR(autoware_map_msgs::msg::LaneletMapMetaData)
+  metadata_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_metadata_);
+  *metadata_msg = build_metadata_msg(all_cell_metadata_dict_, node->now());
+  pub_metadata_->publish(std::move(metadata_msg));
 
   service_ = node->create_service<GetSelectedLanelet2Map>(
     "service/get_selected_lanelet2_map",
@@ -78,8 +82,8 @@ Lanelet2SelectedMapLoaderModule::Lanelet2SelectedMapLoaderModule(
 }
 
 bool Lanelet2SelectedMapLoaderModule::on_service_get_selected_lanelet2_map(
-  GetSelectedLanelet2Map::Request::SharedPtr req,
-  GetSelectedLanelet2Map::Response::SharedPtr res) const
+  AUTOWARE_SERVER_REQUEST_PTR(GetSelectedLanelet2Map) req,
+  AUTOWARE_SERVER_RESPONSE_PTR(GetSelectedLanelet2Map) res) const
 {
   // Resolve requested cell IDs to file paths.
   std::vector<std::string> paths;

--- a/map/autoware_map_loader/src/lanelet2_map_loader/lanelet2_selected_map_loader_module.hpp
+++ b/map/autoware_map_loader/src/lanelet2_map_loader/lanelet2_selected_map_loader_module.hpp
@@ -17,6 +17,8 @@
 
 #include "lanelet2_map_cell_metadata.hpp"
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_map_msgs/msg/lanelet_map_meta_data.hpp>
@@ -49,7 +51,8 @@ public:
   /// @param center_line_resolution  Passed to `overwriteLaneletsCenterline`.
   /// @param use_waypoints         If true, use waypoint-based centerline overwrite.
   Lanelet2SelectedMapLoaderModule(
-    rclcpp::Node * node, std::map<std::string, Lanelet2FileMetaData> cell_metadata_dict,
+    autoware::agnocast_wrapper::Node * node,
+    std::map<std::string, Lanelet2FileMetaData> cell_metadata_dict,
     const autoware_map_msgs::msg::MapProjectorInfo & projector_info, double center_line_resolution,
     bool use_waypoints);
 
@@ -62,12 +65,12 @@ private:
   double center_line_resolution_;
   bool use_waypoints_;
 
-  rclcpp::Service<GetSelectedLanelet2Map>::SharedPtr service_;
-  rclcpp::Publisher<autoware_map_msgs::msg::LaneletMapMetaData>::SharedPtr pub_metadata_;
+  AUTOWARE_SERVICE_PTR(GetSelectedLanelet2Map) service_;
+  AUTOWARE_PUBLISHER_PTR(autoware_map_msgs::msg::LaneletMapMetaData) pub_metadata_;
 
   [[nodiscard]] bool on_service_get_selected_lanelet2_map(
-    GetSelectedLanelet2Map::Request::SharedPtr req,
-    GetSelectedLanelet2Map::Response::SharedPtr res) const;
+    AUTOWARE_SERVER_REQUEST_PTR(GetSelectedLanelet2Map) req,
+    AUTOWARE_SERVER_RESPONSE_PTR(GetSelectedLanelet2Map) res) const;
 };
 
 }  // namespace autoware::map_loader

--- a/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp
+++ b/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp
@@ -58,7 +58,7 @@ protected:
 
   struct ReceivedMessages
   {
-    rclcpp::Node::SharedPtr target_node;
+    std::shared_ptr<autoware::map_loader::Lanelet2MapLoaderNode> target_node;
     autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr map_msg;
     autoware_map_msgs::msg::LaneletMapMetaData::ConstSharedPtr meta_msg;
   };
@@ -70,7 +70,7 @@ protected:
 
     // Must reset executor each time to prevent zombie nodes
     executor_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
-    executor_->add_node(target_node);
+    executor_->add_node(target_node->get_node_base_interface());
 
     test_node_ = std::make_shared<rclcpp::Node>("test_lanelet2_map_loader_client");
     projector_pub_ = test_node_->create_publisher<MapProjectorInfo::Message>(

--- a/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_selected_map_loader_module.cpp
+++ b/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_selected_map_loader_module.cpp
@@ -144,10 +144,10 @@ TEST_F(TestLanelet2SelectedMapLoaderModule, MetadataTopicPublished)
   bool received = false;
   auto sub = node_->create_subscription<autoware_map_msgs::msg::LaneletMapMetaData>(
     "output/lanelet2_map_metadata", rclcpp::QoS{1}.transient_local(),
-    [&received, this](const autoware_map_msgs::msg::LaneletMapMetaData::SharedPtr msg) {
-      EXPECT_EQ(msg->header.frame_id, "map");
-      EXPECT_EQ(msg->metadata_list.size(), 1u);
-      EXPECT_EQ(msg->metadata_list[0].cell_id, test_map_path());
+    [&received, this](const autoware_map_msgs::msg::LaneletMapMetaData & msg) {
+      EXPECT_EQ(msg.header.frame_id, "map");
+      EXPECT_EQ(msg.metadata_list.size(), 1u);
+      EXPECT_EQ(msg.metadata_list[0].cell_id, test_map_path());
       received = true;
     });
 

--- a/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_selected_map_loader_module.cpp
+++ b/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_selected_map_loader_module.cpp
@@ -15,6 +15,8 @@
 #include "../src/lanelet2_map_loader/lanelet2_selected_map_loader_module.hpp"
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/map_loader/lanelet2_map_loader_node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -24,9 +26,11 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <chrono>
 #include <map>
 #include <memory>
 #include <string>
+#include <thread>
 #include <utility>
 
 using autoware::map_loader::Lanelet2FileMetaData;
@@ -56,8 +60,11 @@ class TestLanelet2SelectedMapLoaderModule : public ::testing::Test
 protected:
   void SetUp() override
   {
+    // This test is built and run only with ENABLE_AGNOCAST=0 (gated in CMakeLists.txt).
     rclcpp::init(0, nullptr);
-    node_ = std::make_shared<rclcpp::Node>("test_lanelet2_selected_map_loader_module");
+
+    node_ = std::make_shared<autoware::agnocast_wrapper::Node>(
+      "test_lanelet2_selected_map_loader_module");
 
     const std::string path = test_map_path();
     const auto projector_info = mgrs_projector_info();
@@ -77,6 +84,7 @@ protected:
     }
 
     std::map<std::string, Lanelet2FileMetaData> metadata_dict{{path, meta}};
+
     module_ = std::make_shared<Lanelet2SelectedMapLoaderModule>(
       node_.get(), std::move(metadata_dict), projector_info,
       /*center_line_resolution=*/5.0, /*use_waypoints=*/true);
@@ -86,9 +94,9 @@ protected:
 
   void TearDown() override { rclcpp::shutdown(); }
 
-  rclcpp::Node::SharedPtr node_;
+  autoware::agnocast_wrapper::Node::SharedPtr node_;
   std::shared_ptr<Lanelet2SelectedMapLoaderModule> module_;
-  rclcpp::Client<GetSelectedLanelet2Map>::SharedPtr client_;
+  autoware::agnocast_wrapper::Client<GetSelectedLanelet2Map>::SharedPtr client_;
 };
 
 TEST_F(TestLanelet2SelectedMapLoaderModule, ServiceIsAvailable)
@@ -100,11 +108,13 @@ TEST_F(TestLanelet2SelectedMapLoaderModule, LoadKnownCellReturnsNonEmptyMap)
 {
   ASSERT_TRUE(client_->wait_for_service(std::chrono::seconds(3)));
 
-  auto request = std::make_shared<GetSelectedLanelet2Map::Request>();
+  auto request = client_->allocate_output_service_request();
   request->cell_ids = {test_map_path()};
 
-  auto future = client_->async_send_request(request);
-  ASSERT_EQ(rclcpp::spin_until_future_complete(node_, future), rclcpp::FutureReturnCode::SUCCESS);
+  auto future = client_->async_send_request(std::move(request));
+  ASSERT_EQ(
+    rclcpp::spin_until_future_complete(node_->get_node_base_interface(), future),
+    rclcpp::FutureReturnCode::SUCCESS);
 
   const auto response = future.get();
   EXPECT_EQ(response->header.frame_id, "map");
@@ -116,11 +126,13 @@ TEST_F(TestLanelet2SelectedMapLoaderModule, LoadUnknownCellReturnsFalse)
 {
   ASSERT_TRUE(client_->wait_for_service(std::chrono::seconds(3)));
 
-  auto request = std::make_shared<GetSelectedLanelet2Map::Request>();
+  auto request = client_->allocate_output_service_request();
   request->cell_ids = {"/nonexistent/path/map.osm"};
 
-  auto future = client_->async_send_request(request);
-  ASSERT_EQ(rclcpp::spin_until_future_complete(node_, future), rclcpp::FutureReturnCode::SUCCESS);
+  auto future = client_->async_send_request(std::move(request));
+  ASSERT_EQ(
+    rclcpp::spin_until_future_complete(node_->get_node_base_interface(), future),
+    rclcpp::FutureReturnCode::SUCCESS);
 
   // Service returns false for unknown IDs; lanelet2_cells should be empty.
   const auto response = future.get();
@@ -139,7 +151,14 @@ TEST_F(TestLanelet2SelectedMapLoaderModule, MetadataTopicPublished)
       received = true;
     });
 
-  rclcpp::spin_some(node_);
+  // transient_local delivers the latched sample eventually, not synchronously: discovery/matching
+  // must finish first, so a single spin_some() right after subscribing can miss it. Spin with a
+  // deadline.
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+  while (!received && std::chrono::steady_clock::now() < deadline) {
+    rclcpp::spin_some(node_->get_node_base_interface());
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
   EXPECT_TRUE(received) << "LaneletMapMetaData was not received on output/lanelet2_map_metadata";
 }
 


### PR DESCRIPTION
## Description
Apply `agnocast_wrapper::Node` to `autoware_lanelet2_map_loader`.
Please read https://github.com/autowarefoundation/autoware/issues/7007 for the context and review guidelines of `autoware_agnocast_wrapper` adoption. 
Also, please refer to https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md for the review guide of `autoware_agnocast_wrapper` application PR. FYI: This node take [Method2](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md#method-2-agnocast_wrappernode-inheritance) of two integrations methods.

**AgnocastOnlyCallbackIsolatedExecutor:**
When built and run with `ENABLE_AGNOCAST=1`, the node runs on a `AgnocastOnlyCallbackIsolatedExecutor` (CIE), the standard executor for `agnocast_wrapper::Node`. Please check for potential race conditions only if the node meets **all** of the following:

1. It was originally running on a `SingleThreadedExecutor`.
2. It has multiple callback groups (the default is one).
3. Shared variables are accessed across those callback groups without mutex protection.

**Nodes already running on `MultiThreadedExecutor` are unaffected**, since their callbacks already run concurrently.

## Related Links

  - https://github.com/autowarefoundation/autoware/issues/7007
  - https://github.com/orgs/autowarefoundation/discussions/6804

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
  - `colcon build` succeeds with both `ENABLE_AGNOCAST=1` and `ENABLE_AGNOCAST=0`.
  - Ran Autoware based product with this change applied and confirmed it operates without any regression.

## Notes for reviewers
This PR depends to https://github.com/autowarefoundation/autoware_launch/pull/1898. Please wait for this PR to be merged before this PR.

`test_lanelet2_selected_map_loader_module.cpp` now runs the module on a single `agnocast_wrapper::Node`, matching how the production `Lanelet2MapLoaderNode` hosts the module. The service client and topic subscriber live on that same node, so the test keeps upstream's per-test `rclcpp::init`/`shutdown` in `SetUp`/`TearDown` (no shared member executor is needed). `MetadataTopicPublished` spins until the `transient_local` (latched) sample is received or a short deadline (3s) elapses, instead of a single `spin_some()`, since the latched sample is delivered only after pub/sub discovery completes.


## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None when ENABLE_AGNOCAST is not set or set to 0 on runtime. When ENABLE_AGNOCAST=1, CPU Time used in this node for message serialization/deserialization will be reduced.

