### PR TITLE
feat: add setAllowArea method in route handler for downstream module route validation

### DIFF
--- a/planning/autoware_route_handler/CMakeLists.txt
+++ b/planning/autoware_route_handler/CMakeLists.txt
@@ -24,11 +24,13 @@ if(BUILD_TESTING)
   ament_add_ros_isolated_gtest(test_autoware_route_handler
     test/test_main.cpp
     test/test_route_handler.cpp
+    test/test_allow_area_route_handler.cpp
     test/test_getCenterLinePath.cpp
     test/test_getCenterLinePath_vm_10_spec.cpp
     test/test_getCenterLinePath_vm_10_spec_invalid.cpp)
 
   ament_target_dependencies(test_autoware_route_handler
+    autoware_lanelet2_utils
     autoware_test_utils
     autoware_pyplot
     fmt

--- a/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
+++ b/planning/autoware_route_handler/include/autoware/route_handler/route_handler.hpp
@@ -91,6 +91,8 @@ public:
   void setRoute(const LaneletRoute & route_msg);
   void setRouteLanelets(const lanelet::ConstLanelets & path_lanelets);
   void clearRoute();
+  void setAllowArea(const bool allow_area);
+  bool allowArea() const;
 
   // const methods
 
@@ -382,6 +384,7 @@ private:
 
   bool is_map_msg_ready_{false};
   bool is_handler_ready_{false};
+  bool allow_area_{false};
 
   // save original(not modified) route start pose for start planer execution
   Pose original_start_pose_;
@@ -416,6 +419,17 @@ private:
   lanelet::ConstLanelets getPreviousLaneletSequence(
     const lanelet::ConstLanelets & lanelet_sequence) const;
   lanelet::ConstLanelets getNeighborsWithinRoute(const lanelet::ConstLanelet & lanelet) const;
+
+  // Experimental / debug for direction_change: walk mission route segment order when
+  // RoutingGraph::following() cannot cross route areas (allow_area routes).
+  std::optional<size_t> findRouteSegmentIndexForLanelet(int64_t lanelet_id) const;
+  std::optional<size_t> findNextLaneSegmentIndex(size_t from_index) const;
+  std::optional<size_t> findPreviousLaneSegmentIndex(size_t from_index) const;
+  lanelet::ConstLanelets laneletsFromRouteSegment(size_t segment_index) const;
+  bool getNextLaneletsFromRouteOrder(
+    const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelets * next_lanelets) const;
+  bool getPreviousLaneletsFromRouteOrder(
+    const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelets * prev_lanelets) const;
 
   // for path
 

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -53,7 +53,6 @@
 
 #include <algorithm>
 #include <functional>
-#include <iostream>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -517,6 +516,16 @@ void RouteHandler::clearRoute()
   is_handler_ready_ = false;
 }
 
+void RouteHandler::setAllowArea(const bool allow_area)
+{
+  allow_area_ = allow_area;
+}
+
+bool RouteHandler::allowArea() const
+{
+  return allow_area_;
+}
+
 void RouteHandler::setLaneletsFromRouteMsg()
 {
   if (!route_ptr_ || !is_map_msg_ready_) {
@@ -526,7 +535,8 @@ void RouteHandler::setLaneletsFromRouteMsg()
   route_areas_.clear();
   route_lanelets_rtree_.clear();
   preferred_lanelets_.clear();
-  const bool is_route_valid = lanelet::utils::route::isRouteValid(*route_ptr_, lanelet_map_ptr_);
+  const bool is_route_valid =
+    lanelet::utils::route::isRouteValid(*route_ptr_, lanelet_map_ptr_, allow_area_);
   if (!is_route_valid) {
     return;
   }
@@ -1243,10 +1253,177 @@ bool RouteHandler::getClosestRouteLaneletFromLanelet(
   return false;
 }
 
+namespace
+{
+using autoware_planning_msgs::msg::LaneletPrimitive;
+using autoware_planning_msgs::msg::LaneletSegment;
+
+bool is_area_route_segment(const LaneletSegment & segment)
+{
+  return segment.preferred_primitive.primitive_type == "area";
+}
+
+bool is_lane_route_primitive(const LaneletPrimitive & primitive)
+{
+  return primitive.primitive_type != "area";
+}
+}  // namespace
+
+std::optional<size_t> RouteHandler::findRouteSegmentIndexForLanelet(const int64_t lanelet_id) const
+{
+  if (!route_ptr_ || route_ptr_->segments.empty()) {
+    return std::nullopt;
+  }
+
+  std::optional<size_t> preferred_match;
+  std::optional<size_t> any_match;
+  for (size_t i = 0; i < route_ptr_->segments.size(); ++i) {
+    const auto & segment = route_ptr_->segments.at(i);
+    if (is_area_route_segment(segment)) {
+      continue;
+    }
+    if (
+      segment.preferred_primitive.id == lanelet_id &&
+      is_lane_route_primitive(segment.preferred_primitive)) {
+      preferred_match = i;
+    }
+    if (exists(segment.primitives, lanelet_id)) {
+      for (const auto & primitive : segment.primitives) {
+        if (primitive.id == lanelet_id && is_lane_route_primitive(primitive)) {
+          any_match = i;
+          break;
+        }
+      }
+    }
+  }
+  if (preferred_match.has_value()) {
+    return preferred_match;
+  }
+  return any_match;
+}
+
+std::optional<size_t> RouteHandler::findNextLaneSegmentIndex(const size_t from_index) const
+{
+  if (!route_ptr_ || from_index + 1 >= route_ptr_->segments.size()) {
+    return std::nullopt;
+  }
+
+  size_t index = from_index + 1;
+  while (index < route_ptr_->segments.size() && is_area_route_segment(route_ptr_->segments.at(index))) {
+    ++index;
+  }
+  if (index >= route_ptr_->segments.size() || is_area_route_segment(route_ptr_->segments.at(index))) {
+    return std::nullopt;
+  }
+  return index;
+}
+
+std::optional<size_t> RouteHandler::findPreviousLaneSegmentIndex(const size_t from_index) const
+{
+  if (!route_ptr_ || from_index == 0) {
+    return std::nullopt;
+  }
+
+  size_t index = from_index;
+  while (index > 0) {
+    --index;
+    if (!is_area_route_segment(route_ptr_->segments.at(index))) {
+      return index;
+    }
+  }
+  return std::nullopt;
+}
+
+lanelet::ConstLanelets RouteHandler::laneletsFromRouteSegment(const size_t segment_index) const
+{
+  lanelet::ConstLanelets lanelets;
+  if (!route_ptr_ || segment_index >= route_ptr_->segments.size()) {
+    return lanelets;
+  }
+
+  const auto & segment = route_ptr_->segments.at(segment_index);
+  if (is_area_route_segment(segment)) {
+    return lanelets;
+  }
+
+  const auto & preferred = segment.preferred_primitive;
+  if (is_lane_route_primitive(preferred)) {
+    const auto preferred_lanelet = lanelet_map_ptr_->laneletLayer.get(preferred.id);
+    if (exists(route_lanelets_, preferred_lanelet)) {
+      lanelets.push_back(preferred_lanelet);
+    }
+  }
+
+  for (const auto & primitive : segment.primitives) {
+    if (!is_lane_route_primitive(primitive) || primitive.id == preferred.id) {
+      continue;
+    }
+    const auto candidate = lanelet_map_ptr_->laneletLayer.get(primitive.id);
+    if (exists(route_lanelets_, candidate)) {
+      lanelets.push_back(candidate);
+    }
+  }
+  return lanelets;
+}
+
+bool RouteHandler::getNextLaneletsFromRouteOrder(
+  const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelets * next_lanelets) const
+{
+  next_lanelets->clear();
+  if (!allow_area_ || route_areas_.empty() || !route_ptr_ || route_ptr_->segments.empty()) {
+    return false;
+  }
+
+  const auto segment_index = findRouteSegmentIndexForLanelet(lanelet.id());
+  if (!segment_index.has_value()) {
+    return false;
+  }
+
+  const auto next_segment_index = findNextLaneSegmentIndex(segment_index.value());
+  if (!next_segment_index.has_value()) {
+    return false;
+  }
+
+  *next_lanelets = laneletsFromRouteSegment(next_segment_index.value());
+  const auto start_lane_id = route_ptr_->segments.front().preferred_primitive.id;
+  next_lanelets->erase(
+    std::remove_if(
+      next_lanelets->begin(), next_lanelets->end(),
+      [start_lane_id](const lanelet::ConstLanelet & llt) { return llt.id() == start_lane_id; }),
+    next_lanelets->end());
+  return !next_lanelets->empty();
+}
+
+bool RouteHandler::getPreviousLaneletsFromRouteOrder(
+  const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelets * prev_lanelets) const
+{
+  prev_lanelets->clear();
+  if (!allow_area_ || route_areas_.empty() || !route_ptr_ || route_ptr_->segments.empty()) {
+    return false;
+  }
+
+  const auto segment_index = findRouteSegmentIndexForLanelet(lanelet.id());
+  if (!segment_index.has_value()) {
+    return false;
+  }
+
+  const auto previous_segment_index = findPreviousLaneSegmentIndex(segment_index.value());
+  if (!previous_segment_index.has_value()) {
+    return false;
+  }
+
+  *prev_lanelets = laneletsFromRouteSegment(previous_segment_index.value());
+  return !prev_lanelets->empty();
+}
+
 bool RouteHandler::getNextLaneletsWithinRoute(
   const lanelet::ConstLanelet & lanelet, lanelet::ConstLanelets * next_lanelets) const
 {
   if (exists(goal_lanelets_, lanelet)) {
+    return false;
+  }
+
+  if (!route_ptr_ || route_ptr_->segments.empty()) {
     return false;
   }
 
@@ -1259,6 +1436,12 @@ bool RouteHandler::getNextLaneletsWithinRoute(
       next_lanelets->push_back(llt);
     }
   }
+
+  // Experimental / debug for direction_change: graph following() stops at route-area boundaries.
+  if (next_lanelets->empty()) {
+    getNextLaneletsFromRouteOrder(lanelet, next_lanelets);
+  }
+
   return !(next_lanelets->empty());
 }
 
@@ -1291,6 +1474,12 @@ bool RouteHandler::getPreviousLaneletsWithinRoute(
       prev_lanelets->push_back(llt);
     }
   }
+
+  // Experimental / debug for direction_change: graph previous() stops at route-area boundaries.
+  if (prev_lanelets->empty()) {
+    getPreviousLaneletsFromRouteOrder(lanelet, prev_lanelets);
+  }
+
   return !(prev_lanelets->empty());
 }
 
@@ -2291,9 +2480,19 @@ std::optional<lanelet::ConstLanelet> RouteHandler::getGoalRoadLaneletForCheckpoi
   if (auto closest_lanelet = findGoalClosestPreferredLanelet()) {
     return closest_lanelet;
   }
+
+  lanelet::ConstLanelets candidates_at_goal;
+  for (const auto & candidate : candidates) {
+    if (lanelet::geometry::inside(candidate, p)) {
+      candidates_at_goal.push_back(candidate);
+    }
+  }
+  const auto & selection_pool =
+    candidates_at_goal.empty() ? candidates : candidates_at_goal;
+
   if (
     const auto closest_lanelet =
-      experimental::lanelet2_utils::get_closest_lanelet(candidates, goal_checkpoint)) {
+      experimental::lanelet2_utils::get_closest_lanelet(selection_pool, goal_checkpoint)) {
     return closest_lanelet;
   }
   return std::nullopt;

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -53,6 +53,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <iostream>
 #include <limits>
 #include <memory>
 #include <optional>

--- a/planning/autoware_route_handler/src/route_handler.cpp
+++ b/planning/autoware_route_handler/src/route_handler.cpp
@@ -1309,10 +1309,12 @@ std::optional<size_t> RouteHandler::findNextLaneSegmentIndex(const size_t from_i
   }
 
   size_t index = from_index + 1;
-  while (index < route_ptr_->segments.size() && is_area_route_segment(route_ptr_->segments.at(index))) {
+  while (index < route_ptr_->segments.size() &&
+         is_area_route_segment(route_ptr_->segments.at(index))) {
     ++index;
   }
-  if (index >= route_ptr_->segments.size() || is_area_route_segment(route_ptr_->segments.at(index))) {
+  if (
+    index >= route_ptr_->segments.size() || is_area_route_segment(route_ptr_->segments.at(index))) {
     return std::nullopt;
   }
   return index;
@@ -2487,8 +2489,7 @@ std::optional<lanelet::ConstLanelet> RouteHandler::getGoalRoadLaneletForCheckpoi
       candidates_at_goal.push_back(candidate);
     }
   }
-  const auto & selection_pool =
-    candidates_at_goal.empty() ? candidates : candidates_at_goal;
+  const auto & selection_pool = candidates_at_goal.empty() ? candidates : candidates_at_goal;
 
   if (
     const auto closest_lanelet =

--- a/planning/autoware_route_handler/test/test_allow_area_route_handler.cpp
+++ b/planning/autoware_route_handler/test/test_allow_area_route_handler.cpp
@@ -1,0 +1,233 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <autoware/lanelet2_utils/conversion.hpp>
+#include <autoware/route_handler/route_handler.hpp>
+#include <autoware_test_utils/autoware_test_utils.hpp>
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/Area.h>
+#include <lanelet2_routing/RoutingGraph.h>
+
+#include <memory>
+
+namespace autoware::route_handler::test
+{
+namespace
+{
+using autoware::experimental::lanelet2_utils::to_autoware_map_msgs;
+using autoware_planning_msgs::msg::LaneletPrimitive;
+using autoware_planning_msgs::msg::LaneletRoute;
+using autoware_planning_msgs::msg::LaneletSegment;
+
+constexpr lanelet::Id kEntryLaneId = 100;
+constexpr lanelet::Id kAreaId = 200;
+constexpr lanelet::Id kExitLaneId = 300;
+
+lanelet::Lanelet makeRoadLanelet(
+  const lanelet::Id id, const lanelet::LineString3d & left, const lanelet::LineString3d & right)
+{
+  lanelet::Lanelet lanelet(id, left, right);
+  lanelet.attributes()["subtype"] = "road";
+  lanelet.attributes()["participant:vehicle"] = "yes";
+  return lanelet;
+}
+
+lanelet::LaneletMapPtr makeLaneAreaLaneMap()
+{
+  const lanelet::Point3d entry_left_0(1, 0.0, 0.0, 0.0);
+  const lanelet::Point3d entry_left_1(2, 0.0, 10.0, 0.0);
+  const lanelet::Point3d entry_right_0(3, 1.0, 0.0, 0.0);
+  const lanelet::Point3d entry_right_1(4, 1.0, 10.0, 0.0);
+  const lanelet::LineString3d entry_left(10, {entry_left_0, entry_left_1});
+  const lanelet::LineString3d entry_right(11, {entry_right_0, entry_right_1});
+
+  const lanelet::Point3d exit_left_0(5, 0.0, 20.0, 0.0);
+  const lanelet::Point3d exit_left_1(6, 0.0, 30.0, 0.0);
+  const lanelet::Point3d exit_right_0(7, 1.0, 20.0, 0.0);
+  const lanelet::Point3d exit_right_1(8, 1.0, 30.0, 0.0);
+  const lanelet::LineString3d exit_left(12, {exit_left_0, exit_left_1});
+  const lanelet::LineString3d exit_right(13, {exit_right_0, exit_right_1});
+
+  const lanelet::Point3d area_p1(21, 0.0, 10.0, 0.0);
+  const lanelet::Point3d area_p2(22, 2.0, 10.0, 0.0);
+  const lanelet::Point3d area_p3(23, 2.0, 20.0, 0.0);
+  const lanelet::Point3d area_p4(24, 0.0, 20.0, 0.0);
+  const lanelet::LineString3d area_ring(20, {area_p1, area_p2, area_p3, area_p4, area_p1});
+  const lanelet::Area area(kAreaId, lanelet::LineStrings3d{area_ring});
+
+  auto map = std::make_shared<lanelet::LaneletMap>();
+  map->add(makeRoadLanelet(kEntryLaneId, entry_left, entry_right));
+  map->add(area);
+  map->add(makeRoadLanelet(kExitLaneId, exit_left, exit_right));
+  return map;
+}
+
+LaneletSegment makeLaneSegment(const lanelet::Id id)
+{
+  LaneletPrimitive primitive;
+  primitive.id = id;
+  primitive.primitive_type = "lane";
+
+  LaneletSegment segment;
+  segment.preferred_primitive = primitive;
+  segment.preferred_primitive.primitive_type = "";
+  segment.primitives.push_back(primitive);
+  return segment;
+}
+
+LaneletSegment makeAreaSegment(const lanelet::Id id)
+{
+  LaneletPrimitive primitive;
+  primitive.id = id;
+  primitive.primitive_type = "area";
+
+  LaneletSegment segment;
+  segment.preferred_primitive = primitive;
+  segment.primitives.push_back(primitive);
+  return segment;
+}
+
+LaneletRoute makeLaneAreaLaneRoute()
+{
+  LaneletRoute route;
+  route.header.frame_id = "map";
+  route.start_pose = autoware::test_utils::createPose(0.5, 5.0, 0.0, 0.0, 0.0, 0.0);
+  route.goal_pose = autoware::test_utils::createPose(0.5, 25.0, 0.0, 0.0, 0.0, 0.0);
+  route.segments.push_back(makeLaneSegment(kEntryLaneId));
+  route.segments.push_back(makeAreaSegment(kAreaId));
+  route.segments.push_back(makeLaneSegment(kExitLaneId));
+  return route;
+}
+
+std::shared_ptr<RouteHandler> makeRouteHandler(const bool allow_area)
+{
+  const auto map = makeLaneAreaLaneMap();
+  const auto map_bin = to_autoware_map_msgs(map);
+  auto route_handler = std::make_shared<RouteHandler>(map_bin);
+  route_handler->setAllowArea(allow_area);
+  route_handler->setRoute(makeLaneAreaLaneRoute());
+  return route_handler;
+}
+
+bool hasDirectFollowingInRoute(
+  const RouteHandler & route_handler, const lanelet::ConstLanelet & lanelet)
+{
+  const auto routing_graph = route_handler.getRoutingGraphPtr();
+  const auto following = routing_graph->following(lanelet);
+  for (const auto & candidate : following) {
+    if (route_handler.isRouteLanelet(candidate)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool hasDirectPreviousInRoute(
+  const RouteHandler & route_handler, const lanelet::ConstLanelet & lanelet)
+{
+  const auto routing_graph = route_handler.getRoutingGraphPtr();
+  const auto previous = routing_graph->previous(lanelet);
+  for (const auto & candidate : previous) {
+    if (route_handler.isRouteLanelet(candidate)) {
+      return true;
+    }
+  }
+  return false;
+}
+}  // namespace
+
+TEST(AllowAreaRouteHandler, setAllowAreaDefaultIsFalse)
+{
+  const auto map = makeLaneAreaLaneMap();
+  const RouteHandler route_handler(to_autoware_map_msgs(map));
+  EXPECT_FALSE(route_handler.allowArea());
+}
+
+TEST(AllowAreaRouteHandler, setAllowAreaUpdatesValue)
+{
+  const auto map = makeLaneAreaLaneMap();
+  RouteHandler route_handler(to_autoware_map_msgs(map));
+
+  route_handler.setAllowArea(true);
+  EXPECT_TRUE(route_handler.allowArea());
+
+  route_handler.setAllowArea(false);
+  EXPECT_FALSE(route_handler.allowArea());
+}
+
+TEST(AllowAreaRouteHandler, routeWithAreaRejectedWhenAllowAreaDisabled)
+{
+  const auto route_handler = makeRouteHandler(false);
+  EXPECT_FALSE(route_handler->isHandlerReady());
+}
+
+TEST(AllowAreaRouteHandler, routeWithAreaAcceptedWhenAllowAreaEnabled)
+{
+  const auto route_handler = makeRouteHandler(true);
+  EXPECT_TRUE(route_handler->isHandlerReady());
+}
+
+TEST(AllowAreaRouteHandler, getNextLaneletsWithinRouteCrossesAreaBoundary)
+{
+  const auto route_handler = makeRouteHandler(true);
+  ASSERT_TRUE(route_handler->isHandlerReady());
+
+  const auto entry_lanelet = route_handler->getLaneletsFromId(kEntryLaneId);
+  ASSERT_FALSE(hasDirectFollowingInRoute(*route_handler, entry_lanelet));
+
+  lanelet::ConstLanelets next_lanelets;
+  ASSERT_TRUE(route_handler->getNextLaneletsWithinRoute(entry_lanelet, &next_lanelets));
+  ASSERT_EQ(next_lanelets.size(), 1u);
+  EXPECT_EQ(next_lanelets.front().id(), kExitLaneId);
+}
+
+TEST(AllowAreaRouteHandler, getPreviousLaneletsWithinRouteCrossesAreaBoundary)
+{
+  const auto route_handler = makeRouteHandler(true);
+  ASSERT_TRUE(route_handler->isHandlerReady());
+
+  const auto exit_lanelet = route_handler->getLaneletsFromId(kExitLaneId);
+  ASSERT_FALSE(hasDirectPreviousInRoute(*route_handler, exit_lanelet));
+
+  lanelet::ConstLanelets previous_lanelets;
+  ASSERT_TRUE(route_handler->getPreviousLaneletsWithinRoute(exit_lanelet, &previous_lanelets));
+  ASSERT_EQ(previous_lanelets.size(), 1u);
+  EXPECT_EQ(previous_lanelets.front().id(), kEntryLaneId);
+}
+
+TEST(AllowAreaRouteHandler, getNextLaneletsWithinRouteReturnsFalseAtRouteEnd)
+{
+  const auto route_handler = makeRouteHandler(true);
+  ASSERT_TRUE(route_handler->isHandlerReady());
+
+  const auto exit_lanelet = route_handler->getLaneletsFromId(kExitLaneId);
+  lanelet::ConstLanelets next_lanelets;
+  EXPECT_FALSE(route_handler->getNextLaneletsWithinRoute(exit_lanelet, &next_lanelets));
+  EXPECT_TRUE(next_lanelets.empty());
+}
+
+TEST(AllowAreaRouteHandler, getPreviousLaneletsWithinRouteReturnsFalseAtRouteStart)
+{
+  const auto route_handler = makeRouteHandler(true);
+  ASSERT_TRUE(route_handler->isHandlerReady());
+
+  const auto entry_lanelet = route_handler->getLaneletsFromId(kEntryLaneId);
+  lanelet::ConstLanelets previous_lanelets;
+  EXPECT_FALSE(route_handler->getPreviousLaneletsWithinRoute(entry_lanelet, &previous_lanelets));
+  EXPECT_TRUE(previous_lanelets.empty());
+}
+
+}  // namespace autoware::route_handler::test


### PR DESCRIPTION
## Description

- Add `RouteHandler::setAllowArea()` / `allowArea()` to enable area-primitive routes
- Pass `allow_area` to `isRouteValid()` when parsing route messages
- Traverse lanelet segments across route areas via mission route segment order
- Prefer goal lanelets containing the goal point when resolving checkpoint lanelets

## Related links

- autoware_universe [related PR](https://github.com/autowarefoundation/autoware_universe/pull/12815)

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
