### PR TITLE
feat(stop_filter): apply `agnocast_wrapper::Node` to `stop_filter`

### DIFF
--- a/localization/autoware_stop_filter/CMakeLists.txt
+++ b/localization/autoware_stop_filter/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(${PROJECT_NAME}_ros
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}_ros
   PLUGIN "autoware::stop_filter::StopFilterNode"
   EXECUTABLE ${PROJECT_NAME}_node
-  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
   ROS2_EXECUTOR SingleThreadedExecutor
 )
 
@@ -30,11 +30,13 @@ if(BUILD_TESTING)
   target_link_libraries(test_stop_filter ${PROJECT_NAME})
   target_include_directories(test_stop_filter PRIVATE src)
 
-  ament_add_ros_isolated_gtest(test_stop_filter_node
-    test/test_stop_filter_node.cpp
-  )
-  target_link_libraries(test_stop_filter_node ${PROJECT_NAME} ${PROJECT_NAME}_ros)
-  target_include_directories(test_stop_filter_node PRIVATE src)
+  if(NOT (DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1"))
+    ament_add_ros_isolated_gtest(test_stop_filter_node
+      test/test_stop_filter_node.cpp
+    )
+    target_link_libraries(test_stop_filter_node ${PROJECT_NAME} ${PROJECT_NAME}_ros)
+    target_include_directories(test_stop_filter_node PRIVATE src)
+  endif()
 endif()
 
 autoware_ament_auto_package(

--- a/localization/autoware_stop_filter/launch/stop_filter.launch.xml
+++ b/localization/autoware_stop_filter/launch/stop_filter.launch.xml
@@ -1,9 +1,11 @@
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <arg name="param_path" default="$(find-pkg-share autoware_stop_filter)/config/stop_filter.param.yaml"/>
   <arg name="input_odom_name" default="ekf_odom"/>
   <arg name="output_odom_name" default="stop_filter_odom"/>
   <arg name="debug_stop_flag" default="debug/stop_flag"/>
   <node pkg="autoware_stop_filter" exec="autoware_stop_filter_node" output="both">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <remap from="input/odom" to="$(var input_odom_name)"/>
 
     <remap from="output/odom" to="$(var output_odom_name)"/>

--- a/localization/autoware_stop_filter/src/stop_filter.cpp
+++ b/localization/autoware_stop_filter/src/stop_filter.cpp
@@ -36,20 +36,20 @@ StopFilter::StopFilter(const double linear_x_threshold, const double angular_z_t
 }
 
 autoware_internal_debug_msgs::msg::BoolStamped StopFilter::create_stop_flag_msg(
-  const nav_msgs::msg::Odometry::SharedPtr input) const
+  const nav_msgs::msg::Odometry & input) const
 {
   autoware_internal_debug_msgs::msg::BoolStamped stop_flag_msg;
-  stop_flag_msg.stamp = input->header.stamp;
-  stop_flag_msg.data = is_stopped(*input, linear_x_threshold_, angular_z_threshold_);
+  stop_flag_msg.stamp = input.header.stamp;
+  stop_flag_msg.data = is_stopped(input, linear_x_threshold_, angular_z_threshold_);
   return stop_flag_msg;
 }
 
 nav_msgs::msg::Odometry StopFilter::create_filtered_msg(
-  const nav_msgs::msg::Odometry::SharedPtr input) const
+  const nav_msgs::msg::Odometry & input) const
 {
-  nav_msgs::msg::Odometry filtered_msg = *input;
+  nav_msgs::msg::Odometry filtered_msg = input;
 
-  if (is_stopped(*input, linear_x_threshold_, angular_z_threshold_)) {
+  if (is_stopped(input, linear_x_threshold_, angular_z_threshold_)) {
     filtered_msg.twist.twist.linear.x = 0.0;
     filtered_msg.twist.twist.linear.y = 0.0;
     filtered_msg.twist.twist.linear.z = 0.0;

--- a/localization/autoware_stop_filter/src/stop_filter.cpp
+++ b/localization/autoware_stop_filter/src/stop_filter.cpp
@@ -44,8 +44,7 @@ autoware_internal_debug_msgs::msg::BoolStamped StopFilter::create_stop_flag_msg(
   return stop_flag_msg;
 }
 
-nav_msgs::msg::Odometry StopFilter::create_filtered_msg(
-  const nav_msgs::msg::Odometry & input) const
+nav_msgs::msg::Odometry StopFilter::create_filtered_msg(const nav_msgs::msg::Odometry & input) const
 {
   nav_msgs::msg::Odometry filtered_msg = input;
 

--- a/localization/autoware_stop_filter/src/stop_filter.hpp
+++ b/localization/autoware_stop_filter/src/stop_filter.hpp
@@ -34,11 +34,11 @@ public:
   /// @brief Build a stop-flag message indicating whether the input odometry represents a stop.
   /// @return BoolStamped carrying the input timestamp and the stop judgement.
   autoware_internal_debug_msgs::msg::BoolStamped create_stop_flag_msg(
-    const nav_msgs::msg::Odometry::SharedPtr input) const;
+    const nav_msgs::msg::Odometry & input) const;
 
   /// @brief Build a filtered odometry whose twist is zeroed when the vehicle is judged stopped.
   /// @return Copy of the input odometry with a zeroed twist on a stop, otherwise unchanged.
-  nav_msgs::msg::Odometry create_filtered_msg(const nav_msgs::msg::Odometry::SharedPtr input) const;
+  nav_msgs::msg::Odometry create_filtered_msg(const nav_msgs::msg::Odometry & input) const;
 
 private:
   double linear_x_threshold_;

--- a/localization/autoware_stop_filter/src/stop_filter_node.cpp
+++ b/localization/autoware_stop_filter/src/stop_filter_node.cpp
@@ -18,7 +18,7 @@ namespace autoware::stop_filter
 {
 
 StopFilterNode::StopFilterNode(const rclcpp::NodeOptions & node_options)
-: rclcpp::Node("stop_filter", node_options),
+: autoware::agnocast_wrapper::Node("stop_filter", node_options),
   stop_filter_(declare_parameter<double>("vx_threshold"), declare_parameter<double>("wz_threshold"))
 {
   sub_odom_ = create_subscription<nav_msgs::msg::Odometry>(
@@ -29,10 +29,16 @@ StopFilterNode::StopFilterNode(const rclcpp::NodeOptions & node_options)
     create_publisher<autoware_internal_debug_msgs::msg::BoolStamped>("debug/stop_flag", 1);
 }
 
-void StopFilterNode::callback_odometry(const nav_msgs::msg::Odometry::SharedPtr msg)
+void StopFilterNode::callback_odometry(
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(nav_msgs::msg::Odometry) & msg)
 {
-  pub_stop_flag_->publish(stop_filter_.create_stop_flag_msg(msg));
-  pub_odom_->publish(stop_filter_.create_filtered_msg(msg));
+  auto stop_flag_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_stop_flag_);
+  *stop_flag_msg = stop_filter_.create_stop_flag_msg(*msg);
+  pub_stop_flag_->publish(std::move(stop_flag_msg));
+
+  auto filtered_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_odom_);
+  *filtered_msg = stop_filter_.create_filtered_msg(*msg);
+  pub_odom_->publish(std::move(filtered_msg));
 }
 }  // namespace autoware::stop_filter
 

--- a/localization/autoware_stop_filter/src/stop_filter_node.cpp
+++ b/localization/autoware_stop_filter/src/stop_filter_node.cpp
@@ -14,6 +14,8 @@
 
 #include "stop_filter_node.hpp"
 
+#include <utility>
+
 namespace autoware::stop_filter
 {
 

--- a/localization/autoware_stop_filter/src/stop_filter_node.hpp
+++ b/localization/autoware_stop_filter/src/stop_filter_node.hpp
@@ -17,6 +17,7 @@
 
 #include "stop_filter.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_internal_debug_msgs/msg/bool_stamped.hpp>
@@ -25,24 +26,24 @@
 namespace autoware::stop_filter
 {
 
-class StopFilterNode : public rclcpp::Node
+class StopFilterNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit StopFilterNode(const rclcpp::NodeOptions & node_options);
 
 private:
-  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr pub_odom_;  //!< @brief odom publisher
-  rclcpp::Publisher<autoware_internal_debug_msgs::msg::BoolStamped>::SharedPtr
-    pub_stop_flag_;  //!< @brief stop flag publisher
-  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr
-    sub_odom_;  //!< @brief measurement odometry subscriber
+  AUTOWARE_PUBLISHER_PTR(nav_msgs::msg::Odometry) pub_odom_;  //!< @brief odom publisher
+  AUTOWARE_PUBLISHER_PTR(autoware_internal_debug_msgs::msg::BoolStamped)
+  pub_stop_flag_;  //!< @brief stop flag publisher
+  AUTOWARE_SUBSCRIPTION_PTR(nav_msgs::msg::Odometry)
+  sub_odom_;  //!< @brief measurement odometry subscriber
 
   StopFilter stop_filter_;
 
   /**
    * @brief set odometry measurement
    */
-  void callback_odometry(const nav_msgs::msg::Odometry::SharedPtr msg);
+  void callback_odometry(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(nav_msgs::msg::Odometry) & msg);
 };
 }  // namespace autoware::stop_filter
 #endif  // STOP_FILTER_NODE_HPP_

--- a/localization/autoware_stop_filter/test/test_stop_filter.cpp
+++ b/localization/autoware_stop_filter/test/test_stop_filter.cpp
@@ -49,7 +49,7 @@ TEST(StopFilterTest, StopFlagIsFalseWhenMoving)
   StopFilter filter(0.1, 0.1);
   const auto input = create_odometry_message(0.2, 0.0, 0.0, 0.0, 0.0, 0.2);
 
-  const auto stop_flag_msg = filter.create_stop_flag_msg(input);
+  const auto stop_flag_msg = filter.create_stop_flag_msg(*input);
 
   EXPECT_FALSE(stop_flag_msg.data);
   EXPECT_EQ(stop_flag_msg.stamp, input->header.stamp);
@@ -62,7 +62,7 @@ TEST(StopFilterTest, StopFlagIsTrueWhenStopped)
   StopFilter filter(0.1, 0.1);
   const auto input = create_odometry_message(0.05, 0.0, 0.0, 0.0, 0.0, 0.05);
 
-  const auto stop_flag_msg = filter.create_stop_flag_msg(input);
+  const auto stop_flag_msg = filter.create_stop_flag_msg(*input);
 
   EXPECT_TRUE(stop_flag_msg.data);
   EXPECT_EQ(stop_flag_msg.stamp, input->header.stamp);
@@ -75,7 +75,7 @@ TEST(StopFilterTest, NotStoppedWhenOnlyLinearVelocityBelowThreshold)
   StopFilter filter(0.1, 0.1);
   const auto input = create_odometry_message(0.05, 0.0, 0.0, 0.0, 0.0, 0.2);
 
-  EXPECT_FALSE(filter.create_stop_flag_msg(input).data);
+  EXPECT_FALSE(filter.create_stop_flag_msg(*input).data);
 }
 
 // Symmetrically, angular-z alone below threshold is still moving, so the twist is preserved.
@@ -84,7 +84,7 @@ TEST(StopFilterTest, NotStoppedWhenOnlyAngularVelocityBelowThreshold)
   StopFilter filter(0.1, 0.1);
   const auto input = create_odometry_message(0.2, 0.0, 0.0, 0.0, 0.0, 0.05);
 
-  EXPECT_FALSE(filter.create_stop_flag_msg(input).data);
+  EXPECT_FALSE(filter.create_stop_flag_msg(*input).data);
 }
 
 // On a stop every twist component is zeroed while the header is preserved.
@@ -93,7 +93,7 @@ TEST(StopFilterTest, FilteredMsgZeroesTwistWhenStopped)
   StopFilter filter(0.1, 0.1);
   const auto input = create_odometry_message(0.05, 0.02, 0.01, 0.03, 0.04, 0.05);
 
-  const auto filtered_msg = filter.create_filtered_msg(input);
+  const auto filtered_msg = filter.create_filtered_msg(*input);
 
   EXPECT_EQ(filtered_msg.twist.twist.linear.x, 0.0);
   EXPECT_EQ(filtered_msg.twist.twist.linear.y, 0.0);
@@ -112,7 +112,7 @@ TEST(StopFilterTest, FilteredMsgPreservesTwistWhenMoving)
   StopFilter filter(0.1, 0.1);
   const auto input = create_odometry_message(0.2, 0.0, 0.0, 0.0, 0.0, 0.2);
 
-  const auto filtered_msg = filter.create_filtered_msg(input);
+  const auto filtered_msg = filter.create_filtered_msg(*input);
 
   EXPECT_EQ(filtered_msg.twist.twist.linear.x, 0.2);
   EXPECT_EQ(filtered_msg.twist.twist.angular.z, 0.2);


### PR DESCRIPTION
## Description
Apply `agnocast_wrapper::Node` to `autoware_stop_filter`.
Please read https://github.com/autowarefoundation/autoware/issues/7007 for the context and review guidelines of `autoware_agnocast_wrapper` adoption. 
Also, please refer to https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md for the review guide of `autoware_agnocast_wrapper` application PR. FYI: This node take [Method2](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md#method-2-agnocast_wrappernode-inheritance) of two integrations methods.

## Related Links

  - https://github.com/autowarefoundation/autoware/issues/7007
  - https://github.com/orgs/autowarefoundation/discussions/6804

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
  - `colcon build` succeeds with both `ENABLE_AGNOCAST=1` and `ENABLE_AGNOCAST=0`.
  - Ran Autoware based product with this change applied and confirmed it operates without any regression.

## Notes for reviewers

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None when ENABLE_AGNOCAST is not set or set to 0 on runtime. When ENABLE_AGNOCAST=1, CPU Time used in this node for message serialization/deserialization will be reduced.
