### PR TITLE
feat(pointcloud_map_loader): apply `agnocast_wrapper::Node` to  `pointcloud_ map_loader`

### DIFF
--- a/map/autoware_map_loader/CMakeLists.txt
+++ b/map/autoware_map_loader/CMakeLists.txt
@@ -22,9 +22,11 @@ target_include_directories(pointcloud_map_loader_node
   ${PCL_INCLUDE_DIRS}
 )
 
-rclcpp_components_register_node(pointcloud_map_loader_node
+autoware_agnocast_wrapper_register_node(pointcloud_map_loader_node
   PLUGIN "autoware::map_loader::PointCloudMapLoaderNode"
   EXECUTABLE autoware_pointcloud_map_loader
+  ROS2_EXECUTOR SingleThreadedExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )
 
 ament_auto_add_library(lanelet2_map_loader_node SHARED
@@ -65,11 +67,13 @@ if(BUILD_TESTING)
   add_testcase(test/pointcloud_map_loader/test_cylinder_box_overlap.cpp)
   add_testcase(test/pointcloud_map_loader/test_replace_with_absolute_path.cpp)
   add_testcase(test/pointcloud_map_loader/test_load_pcd_metadata.cpp)
-  add_testcase(test/pointcloud_map_loader/test_pointcloud_map_loader_node.cpp)
   add_testcase(test/pointcloud_map_loader/test_pointcloud_map_loader.cpp)
   add_testcase(test/pointcloud_map_loader/test_partial_map_loader.cpp)
   add_testcase(test/pointcloud_map_loader/test_differential_map_loader.cpp)
   add_testcase(test/pointcloud_map_loader/test_selected_map_loader.cpp)
+  if(NOT "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
+    add_testcase(test/pointcloud_map_loader/test_pointcloud_map_loader_node.cpp)
+  endif()
   add_testcase(test/lanelet2_map_loader/test_lanelet2_map_loader_utils.cpp)
   add_testcase(test/lanelet2_map_loader/test_lanelet2_map_cell_metadata.cpp)
   add_testcase(test/lanelet2_map_loader/test_lanelet2_selected_map_loader_module.cpp)

--- a/map/autoware_map_loader/package.xml
+++ b/map/autoware_map_loader/package.xml
@@ -16,6 +16,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_component_interface_specs</depend>
   <depend>autoware_geography_utils</depend>
   <depend>autoware_lanelet2_extension</depend>

--- a/map/autoware_map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
+++ b/map/autoware_map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
@@ -21,6 +21,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::map_loader
@@ -58,7 +59,10 @@ PointCloudMapLoaderNode::PointCloudMapLoaderNode(const rclcpp::NodeOptions & opt
     if (loaded_pcd.width == 0) {
       RCLCPP_ERROR(get_logger(), "No PCD was loaded: pcd_paths.size() = %zu", pcd_paths.size());
     } else {
-      pub_pointcloud_map_->publish(loaded_pcd);
+      AUTOWARE_MESSAGE_UNIQUE_PTR(sensor_msgs::msg::PointCloud2)
+      out = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_pointcloud_map_);
+      *out = loaded_pcd;
+      pub_pointcloud_map_->publish(std::move(out));
     }
   }
 
@@ -77,7 +81,10 @@ PointCloudMapLoaderNode::PointCloudMapLoaderNode(const rclcpp::NodeOptions & opt
     if (loaded_pcd.width == 0) {
       RCLCPP_ERROR(get_logger(), "No PCD was loaded: pcd_paths.size() = %zu", pcd_paths.size());
     } else {
-      pub_downsampled_pointcloud_map_->publish(loaded_pcd);
+      AUTOWARE_MESSAGE_UNIQUE_PTR(sensor_msgs::msg::PointCloud2)
+      out = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_downsampled_pointcloud_map_);
+      *out = loaded_pcd;
+      pub_downsampled_pointcloud_map_->publish(std::move(out));
     }
   }
 
@@ -121,7 +128,10 @@ PointCloudMapLoaderNode::PointCloudMapLoaderNode(const rclcpp::NodeOptions & opt
     durable_qos.transient_local();
     pub_metadata_ = create_publisher<autoware_map_msgs::msg::PointCloudMapMetaData>(
       "output/pointcloud_map_metadata", durable_qos);
-    pub_metadata_->publish(create_metadata(pcd_metadata_dict));
+    AUTOWARE_MESSAGE_UNIQUE_PTR(autoware_map_msgs::msg::PointCloudMapMetaData)
+    metadata_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_metadata_);
+    *metadata_msg = create_metadata(pcd_metadata_dict);
+    pub_metadata_->publish(std::move(metadata_msg));
   }
 }
 }  // namespace autoware::map_loader

--- a/map/autoware_map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
+++ b/map/autoware_map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
@@ -21,7 +21,6 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace autoware::map_loader
@@ -122,10 +121,7 @@ PointCloudMapLoaderNode::PointCloudMapLoaderNode(const rclcpp::NodeOptions & opt
     durable_qos.transient_local();
     pub_metadata_ = create_publisher<autoware_map_msgs::msg::PointCloudMapMetaData>(
       "output/pointcloud_map_metadata", durable_qos);
-    AUTOWARE_MESSAGE_UNIQUE_PTR(autoware_map_msgs::msg::PointCloudMapMetaData)
-    metadata_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_metadata_);
-    *metadata_msg = create_metadata(pcd_metadata_dict);
-    pub_metadata_->publish(std::move(metadata_msg));
+    pub_metadata_->publish(create_metadata(pcd_metadata_dict));
   }
 }
 }  // namespace autoware::map_loader

--- a/map/autoware_map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
+++ b/map/autoware_map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
@@ -59,10 +59,7 @@ PointCloudMapLoaderNode::PointCloudMapLoaderNode(const rclcpp::NodeOptions & opt
     if (loaded_pcd.width == 0) {
       RCLCPP_ERROR(get_logger(), "No PCD was loaded: pcd_paths.size() = %zu", pcd_paths.size());
     } else {
-      AUTOWARE_MESSAGE_UNIQUE_PTR(sensor_msgs::msg::PointCloud2)
-      out = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_pointcloud_map_);
-      *out = loaded_pcd;
-      pub_pointcloud_map_->publish(std::move(out));
+      pub_pointcloud_map_->publish(loaded_pcd);
     }
   }
 
@@ -81,10 +78,7 @@ PointCloudMapLoaderNode::PointCloudMapLoaderNode(const rclcpp::NodeOptions & opt
     if (loaded_pcd.width == 0) {
       RCLCPP_ERROR(get_logger(), "No PCD was loaded: pcd_paths.size() = %zu", pcd_paths.size());
     } else {
-      AUTOWARE_MESSAGE_UNIQUE_PTR(sensor_msgs::msg::PointCloud2)
-      out = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_downsampled_pointcloud_map_);
-      *out = loaded_pcd;
-      pub_downsampled_pointcloud_map_->publish(std::move(out));
+      pub_downsampled_pointcloud_map_->publish(loaded_pcd);
     }
   }
 

--- a/map/autoware_map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.hpp
+++ b/map/autoware_map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.hpp
@@ -20,6 +20,7 @@
 #include "pointcloud_map_loader.hpp"
 #include "selected_map_loader.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_map_msgs/msg/point_cloud_map_meta_data.hpp>
@@ -38,7 +39,7 @@
 
 namespace autoware::map_loader
 {
-class PointCloudMapLoaderNode : public rclcpp::Node
+class PointCloudMapLoaderNode : public autoware::agnocast_wrapper::Node
 {
   using GetPartialPointCloudMap = autoware_map_msgs::srv::GetPartialPointCloudMap;
   using GetDifferentialPointCloudMap = autoware_map_msgs::srv::GetDifferentialPointCloudMap;
@@ -49,16 +50,16 @@ public:
 
 private:
   std::unique_ptr<PointcloudMapLoaderModule> pcd_map_loader_;
-  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_pointcloud_map_;
+  AUTOWARE_PUBLISHER_PTR(sensor_msgs::msg::PointCloud2) pub_pointcloud_map_;
   std::unique_ptr<PointcloudMapLoaderModule> downsampled_pcd_map_loader_;
-  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pub_downsampled_pointcloud_map_;
+  AUTOWARE_PUBLISHER_PTR(sensor_msgs::msg::PointCloud2) pub_downsampled_pointcloud_map_;
   std::unique_ptr<PartialMapLoaderModule> partial_map_loader_;
-  rclcpp::Service<GetPartialPointCloudMap>::SharedPtr get_partial_pcd_maps_service_;
+  AUTOWARE_SERVICE_PTR(GetPartialPointCloudMap) get_partial_pcd_maps_service_;
   std::unique_ptr<DifferentialMapLoaderModule> differential_map_loader_;
-  rclcpp::Service<GetDifferentialPointCloudMap>::SharedPtr get_differential_pcd_maps_service_;
+  AUTOWARE_SERVICE_PTR(GetDifferentialPointCloudMap) get_differential_pcd_maps_service_;
   std::unique_ptr<SelectedMapLoaderModule> selected_map_loader_;
-  rclcpp::Service<GetSelectedPointCloudMap>::SharedPtr get_selected_pcd_maps_service_;
-  rclcpp::Publisher<autoware_map_msgs::msg::PointCloudMapMetaData>::SharedPtr pub_metadata_;
+  AUTOWARE_SERVICE_PTR(GetSelectedPointCloudMap) get_selected_pcd_maps_service_;
+  AUTOWARE_PUBLISHER_PTR(autoware_map_msgs::msg::PointCloudMapMetaData) pub_metadata_;
 };
 }  // namespace autoware::map_loader
 

--- a/map/autoware_map_loader/test/pointcloud_map_loader/test_pointcloud_map_loader_node.cpp
+++ b/map/autoware_map_loader/test/pointcloud_map_loader/test_pointcloud_map_loader_node.cpp
@@ -28,6 +28,7 @@
 #include <chrono>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 using autoware_map_msgs::srv::GetDifferentialPointCloudMap;
@@ -94,7 +95,7 @@ TEST_F(TestPointcloudMapLoaderNode, LoadPCDFilesNoDownsampleTest)
 
   // Spin until pointcloud is received or timeout occurs
   rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(map_loader_node_);
+  executor.add_node(map_loader_node_->get_node_base_interface());
   auto start_time = map_loader_node_->now();
   while (!*pointcloud_received && (map_loader_node_->now() - start_time).seconds() < 3) {
     executor.spin_some(50ms);
@@ -131,9 +132,9 @@ TEST_F(TestPointcloudMapLoaderNode, LoadDifferentialPCDFiles)
   request->area.radius = 2;
   request->cached_ids.clear();
 
-  auto result_future = client->async_send_request(request);
+  auto result_future = client->async_send_request(std::move(request));
   ASSERT_EQ(
-    rclcpp::spin_until_future_complete(map_loader_node_, result_future),
+    rclcpp::spin_until_future_complete(map_loader_node_->get_node_base_interface(), result_future),
     rclcpp::FutureReturnCode::SUCCESS);
 
   auto result = result_future.get();
@@ -178,9 +179,9 @@ TEST(PointcloudMapLoaderNodePartial, LoadPartialPCDFiles)
   request->area.center_y = 0;
   request->area.radius = 2;
 
-  auto result_future = client->async_send_request(request);
+  auto result_future = client->async_send_request(std::move(request));
   ASSERT_EQ(
-    rclcpp::spin_until_future_complete(map_loader_node, result_future),
+    rclcpp::spin_until_future_complete(map_loader_node->get_node_base_interface(), result_future),
     rclcpp::FutureReturnCode::SUCCESS);
 
   auto result = result_future.get();


### PR DESCRIPTION
## Description
Apply `agnocast_wrapper::Node` to `autoware_pointcloud_map_loader`.
Please read https://github.com/autowarefoundation/autoware/issues/7007 for the context and review guidelines of `autoware_agnocast_wrapper` adoption. 
Also, please refer to https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md for the review guide of `autoware_agnocast_wrapper` application PR. FYI: This node take [Method2](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md#method-2-agnocast_wrappernode-inheritance) of two integrations methods.

**AgnocastOnlyCallbackIsolatedExecutor:**
When built and run with `ENABLE_AGNOCAST=1`, the node runs on a `AgnocastOnlyCallbackIsolatedExecutor` (CIE), the standard executor for `agnocast_wrapper::Node`. Please check for potential race conditions only if the node meets **all** of the following:

1. It was originally running on a `SingleThreadedExecutor`.
2. It has multiple callback groups (the default is one).
3. Shared variables are accessed across those callback groups without mutex protection.

**Nodes already running on `MultiThreadedExecutor` are unaffected**, since their callbacks already run concurrently.
## Related Links

  - https://github.com/autowarefoundation/autoware/issues/7007
  - https://github.com/orgs/autowarefoundation/discussions/6804

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
  - `colcon build` succeeds with both `ENABLE_AGNOCAST=1` and `ENABLE_AGNOCAST=0`.
  - Ran Autoware based product with this change applied and confirmed it operates without any regression.

## Notes for reviewers
- This PR depends to https://github.com/autowarefoundation/autoware_launch/pull/1898. Please wait for this PR to be merged before this PR.
- The whole-map / downsampled-map / metadata publishers use `ALLOCATE_OUTPUT_MESSAGE_UNIQUE()` -> copy -> `publish()` rather than building the message directly in the loaned buffer. This is intentional: these are one-time publishes in the constructor. If this startup copy ever becomes a concern for large maps, we can switch to building directly into the loaned buffer at that point.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None when ENABLE_AGNOCAST is not set or set to 0 on runtime. When ENABLE_AGNOCAST=1, CPU Time used in this node for message serialization/deserialization will be reduced.

