### PR TITLE
feat(autoware_agnocast_wrapper): add overload for service

### DIFF
--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -1054,8 +1054,8 @@ inline constexpr bool is_message_ptr_service_callback_v = std::is_invocable_v<
 // unchanged on the wrapper Node, at the cost noted on the convenience paths below.
 template <typename Func, typename ServiceT>
 inline constexpr bool is_shared_ptr_service_callback_v = std::is_invocable_v<
-  std::decay_t<Func>, std::shared_ptr<typename ServiceT::Request>,
-  std::shared_ptr<typename ServiceT::Response>>;
+  std::decay_t<Func>, std::shared_ptr<typename ServiceT::Request> &,
+  std::shared_ptr<typename ServiceT::Response> &>;
 
 template <typename ServiceT>
 class AgnocastService : public Service<ServiceT>

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -1042,6 +1042,21 @@ public:
   virtual ~Service() = default;
 };
 
+// True when Callback takes the preferred AUTOWARE_SERVICE_REQUEST_PTR/RESPONSE_PTR (message_ptr)
+// pair, i.e. it is written against the wrapper's zero-copy service API.
+template <typename Func, typename ServiceT>
+inline constexpr bool is_message_ptr_service_callback_v = std::is_invocable_v<
+  std::decay_t<Func>, AUTOWARE_SERVICE_REQUEST_PTR(ServiceT) &&,
+  AUTOWARE_SERVICE_RESPONSE_PTR(ServiceT) &&>;
+
+// True when Callback is an rclcpp-style handler taking std::shared_ptr request/response. This lets
+// utilities written for rclcpp::Node (e.g. autoware_utils_logging's LoggerLevelConfigure) be used
+// unchanged on the wrapper Node, at the cost noted on the convenience paths below.
+template <typename Func, typename ServiceT>
+inline constexpr bool is_shared_ptr_service_callback_v = std::is_invocable_v<
+  std::decay_t<Func>, std::shared_ptr<typename ServiceT::Request>,
+  std::shared_ptr<typename ServiceT::Response>>;
+
 template <typename ServiceT>
 class AgnocastService : public Service<ServiceT>
 {
@@ -1054,9 +1069,7 @@ public:
     rclcpp::CallbackGroup::SharedPtr group)
   {
     static_assert(
-      std::is_invocable_v<
-        std::decay_t<Func>, AUTOWARE_SERVICE_REQUEST_PTR(ServiceT) &&,
-        AUTOWARE_SERVICE_RESPONSE_PTR(ServiceT) &&>,
+      is_message_ptr_service_callback_v<Func, ServiceT>,
       "Callback should be invocable with AUTOWARE_SERVICE_REQUEST_PTR and "
       "AUTOWARE_SERVICE_RESPONSE_PTR (const&, &&, or by-value)");
 
@@ -1085,9 +1098,7 @@ public:
     const rclcpp::QoS & qos, rclcpp::CallbackGroup::SharedPtr group)
   {
     static_assert(
-      std::is_invocable_v<
-        std::decay_t<Func>, AUTOWARE_SERVICE_REQUEST_PTR(ServiceT) &&,
-        AUTOWARE_SERVICE_RESPONSE_PTR(ServiceT) &&>,
+      is_message_ptr_service_callback_v<Func, ServiceT>,
       "Callback should be invocable with AUTOWARE_SERVICE_REQUEST_PTR and "
       "AUTOWARE_SERVICE_RESPONSE_PTR (const&, &&, or by-value)");
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -273,7 +273,10 @@ public:
     });
   }
 
-  template <typename ServiceT, typename Func>
+  // Service with a callback taking AUTOWARE_SERVICE_REQUEST_PTR/RESPONSE_PTR (message_ptr).
+  template <
+    typename ServiceT, typename Func,
+    std::enable_if_t<is_message_ptr_service_callback_v<Func, ServiceT>, int> = 0>
   AUTOWARE_SERVICE_PTR(ServiceT)
   create_service(
     const std::string & service_name, Func && callback,
@@ -290,6 +293,33 @@ public:
           n.get(), service_name, std::forward<Func>(callback), qos, group);
       }
     });
+  }
+
+  // Convenience overload for rclcpp-style std::shared_ptr callbacks (copies in/out of shared
+  // memory under Agnocast like publish(const MessageT &); prefer the message_ptr overload).
+  template <
+    typename ServiceT, typename Func,
+    std::enable_if_t<
+      !is_message_ptr_service_callback_v<Func, ServiceT> &&
+        is_shared_ptr_service_callback_v<Func, ServiceT>,
+      int> = 0>
+  AUTOWARE_SERVICE_PTR(ServiceT)
+  create_service(
+    const std::string & service_name, Func && callback,
+    const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
+    rclcpp::CallbackGroup::SharedPtr group = nullptr)
+  {
+    return create_service<ServiceT>(
+      service_name,
+      [callback = std::forward<Func>(callback)](
+        AUTOWARE_SERVICE_REQUEST_PTR(ServiceT) && req,
+        AUTOWARE_SERVICE_RESPONSE_PTR(ServiceT) && res) {
+        auto request = std::make_shared<typename ServiceT::Request>(*req);
+        auto response = std::make_shared<typename ServiceT::Response>();
+        callback(request, response);
+        *res = *response;
+      },
+      qos, group);
   }
 
   // ===== Timer =====

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -340,8 +340,9 @@ public:
     static_assert(
       is_message_ptr_service_callback_v<Func, ServiceT> ||
         is_shared_ptr_service_callback_v<Func, ServiceT>,
-      "Service callback must take AUTOWARE_SERVICE_REQUEST_PTR/RESPONSE_PTR (message_ptr) "
-      "or std::shared_ptr<Request>/Response.");
+      "Service callback must be invocable with "
+      "(AUTOWARE_SERVICE_REQUEST_PTR(ServiceT), AUTOWARE_SERVICE_RESPONSE_PTR(ServiceT)) or with "
+      "(std::shared_ptr<ServiceT::Request>, std::shared_ptr<ServiceT::Response>).");
   }
 
   // ===== Timer =====

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -295,8 +295,9 @@ public:
     });
   }
 
-  // Convenience overload for rclcpp-style std::shared_ptr callbacks (copies in/out of shared
-  // memory under Agnocast like publish(const MessageT &); prefer the message_ptr overload).
+  // Convenience overload for rclcpp-style std::shared_ptr callbacks. Gives the callback independent
+  // owning copies of the request/response (safe to retain, like rclcpp) and copies the filled
+  // response back, so prefer the message_ptr overload above to avoid the copies on hot paths.
   template <
     typename ServiceT, typename Func,
     std::enable_if_t<
@@ -320,6 +321,27 @@ public:
         *res = *response;
       },
       qos, group);
+  }
+
+  // Fallback overload: neither callback form matched. Exists only to turn the otherwise opaque
+  // "no matching function" error into the static_assert message below.
+  template <
+    typename ServiceT, typename Func,
+    std::enable_if_t<
+      !is_message_ptr_service_callback_v<Func, ServiceT> &&
+        !is_shared_ptr_service_callback_v<Func, ServiceT>,
+      int> = 0>
+  AUTOWARE_SERVICE_PTR(ServiceT)
+  create_service(
+    const std::string & service_name, Func && callback,
+    const rclcpp::QoS & qos = rclcpp::ServicesQoS(),
+    rclcpp::CallbackGroup::SharedPtr group = nullptr)
+  {
+    static_assert(
+      is_message_ptr_service_callback_v<Func, ServiceT> ||
+        is_shared_ptr_service_callback_v<Func, ServiceT>,
+      "Service callback must take AUTOWARE_SERVICE_REQUEST_PTR/RESPONSE_PTR (message_ptr) "
+      "or std::shared_ptr<Request>/Response.");
   }
 
   // ===== Timer =====


### PR DESCRIPTION
## Description
  Add an `rclcpp`-style overload of `Node::create_service` that accepts callbacks taking `std::shared_ptr<Request/Response>`, in addition to the existing `message_ptr` (`AUTOWARE_SERVICE_REQUEST_PTR/RESPONSE_PTR`) form.

  This lets helpers written against `rclcpp::Node` (e.g. `autoware_utils_logging`'s `LoggerLevelConfigure`) compile unchanged on the wrapper `Node`. The two overloads are selected by callback type via mutually-exclusive `enable_if`, so they are never ambiguous. The convenience overload adapts the callback to the `message_ptr` form and delegates to the primary one; under Agnocast it copies the request/response
  in/out of shared memory (like `Publisher::publish(const MessageT &)`), so the `message_ptr` overload remains preferred on hot paths.

  No change to existing `message_ptr` behavior; `AgnocastService`/`ROS2Service` are untouched.

## Related links
This overload is used in https://github.com/autowarefoundation/autoware_utils/pull/113.
 Without this PR, shared helpers written for `rclcpp::Node` would need an `if constexpr` branch switching the callback signature between the `rclcpp::Node` and `agnocast_wrapper::Node` forms; this keeps them unchanged. 
**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Applied `agnocast_wrapper::Node` to `autoware_ekf_localizer`. This node uses LoggerLevelConfigure of `autoware_utils` thus, we need this overload. Tested that the node correctly works.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
