### PR TITLE
feat(test_utils): templatize NodePtrT of test_utils

### DIFF
--- a/testing/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
+++ b/testing/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
@@ -324,8 +324,16 @@ LaneletRoute makeBehaviorGoalOnLeftSideRoute();
  * @param repeat_count The number of times to spin the nodes.
  */
 void spinSomeNodes(
-  rclcpp::Node::SharedPtr test_node, rclcpp::Node::SharedPtr target_node,
-  const int repeat_count = 1);
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr test_node,
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr target_node, const int repeat_count = 1);
+
+inline void spinSomeNodes(
+  const rclcpp::Node::SharedPtr & test_node, const rclcpp::Node::SharedPtr & target_node,
+  const int repeat_count = 1)
+{
+  spinSomeNodes(
+    test_node->get_node_base_interface(), target_node->get_node_base_interface(), repeat_count);
+}
 
 /**
  * @brief Updates node options with parameter files.
@@ -568,7 +576,8 @@ void publishToTargetNode(
   if (target_node->count_subscribers(topic_name) == 0) {
     throw std::runtime_error("No subscriber for " + topic_name);
   }
-  autoware::test_utils::spinSomeNodes(test_node, target_node, repeat_count);
+  autoware::test_utils::spinSomeNodes(
+    test_node->get_node_base_interface(), target_node->get_node_base_interface(), repeat_count);
 }
 
 /**
@@ -588,17 +597,17 @@ public:
     pub_clock_ = test_node_->create_publisher<rosgraph_msgs::msg::Clock>("/clock", 1);
   }
 
-  template <typename MessageType>
+  template <typename MessageType, typename NodePtrT>
   void test_pub_msg(
-    rclcpp::Node::SharedPtr target_node, const std::string & topic_name, MessageType & msg)
+    const NodePtrT & target_node, const std::string & topic_name, MessageType & msg)
   {
     rclcpp::QoS qos(rclcpp::KeepLast(10));
     test_pub_msg(target_node, topic_name, msg, qos);
   }
 
-  template <typename MessageType>
+  template <typename MessageType, typename NodePtrT>
   void test_pub_msg(
-    rclcpp::Node::SharedPtr target_node, const std::string & topic_name, MessageType & msg,
+    const NodePtrT & target_node, const std::string & topic_name, MessageType & msg,
     rclcpp::QoS qos)
   {
     if (publishers_.find(topic_name) == publishers_.end()) {
@@ -611,7 +620,8 @@ public:
 
     publisher->publish(msg);
     const int repeat_count = 3;
-    autoware::test_utils::spinSomeNodes(test_node_, target_node, repeat_count);
+    autoware::test_utils::spinSomeNodes(
+      test_node_->get_node_base_interface(), target_node->get_node_base_interface(), repeat_count);
     RCLCPP_INFO(test_node_->get_logger(), "Published message on topic '%s'", topic_name.c_str());
   }
 

--- a/testing/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
+++ b/testing/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp
@@ -598,8 +598,7 @@ public:
   }
 
   template <typename MessageType, typename NodePtrT>
-  void test_pub_msg(
-    const NodePtrT & target_node, const std::string & topic_name, MessageType & msg)
+  void test_pub_msg(const NodePtrT & target_node, const std::string & topic_name, MessageType & msg)
   {
     rclcpp::QoS qos(rclcpp::KeepLast(10));
     test_pub_msg(target_node, topic_name, msg, qos);

--- a/testing/autoware_test_utils/src/autoware_test_utils.cpp
+++ b/testing/autoware_test_utils/src/autoware_test_utils.cpp
@@ -334,7 +334,8 @@ LaneletRoute makeBehaviorGoalOnLeftSideRoute()
 
 // cppcheck-suppress unusedFunction
 void spinSomeNodes(
-  rclcpp::Node::SharedPtr test_node, rclcpp::Node::SharedPtr target_node, const int repeat_count)
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr test_node,
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr target_node, const int repeat_count)
 {
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(test_node);


### PR DESCRIPTION
## Description
Generalized `autoware_test_utils`' node-accepting helpers to take any node exposing `get_node_base_interface()`, so they accept both `rclcpp::Node` and `agnocast_wrapper::Node` without per-test changes.

  In autowarefoundation/autoware_core#1207, `agnocast_wrapper::Node` becomes a dedicated standalone class (not an `rclcpp::Node` alias) even at `ENABLE_AGNOCAST=0`, so the exposed API matches `ENABLE_AGNOCAST=1`. As a result it no longer derives from `rclcpp::Node`, and helpers hard-typed to `rclcpp::Node::SharedPtr` will start to reject wrapper-based nodes once #1207 lands.

  ### Changes
  - `spinSomeNodes`: now takes `NodeBaseInterface::SharedPtr`; added an inline `rclcpp::Node::SharedPtr` overload that forwards `get_node_base_interface()` for backward compatibility.
  - `AutowareTestManager::test_pub_msg`: templated on the target-node pointer type; forwards via `get_node_base_interface()`.
  - `publishToTargetNode`: forwards the base interfaces to `spinSomeNodes`.

  These use only APIs present on both `rclcpp::Node` and the wrapper, so they work **with or without #1207** and don't change behavior: existing `rclcpp::Node` callers keep compiling unchanged.

## Related links
autowarefoundation/autoware_core#1207

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
clean build and test with both ENABLE_AGNOCAST=1/0.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
