### PR TITLE
fix(localization): fix test to use `get_node_base_interface` for `agnocast_wrapper::Node`

### DIFF
--- a/localization/autoware_stop_filter/test/test_stop_filter_node.cpp
+++ b/localization/autoware_stop_filter/test/test_stop_filter_node.cpp
@@ -60,7 +60,7 @@ TEST(StopFilterNodeTest, TestStopDetection)
 
   // Create executor and register nodes
   rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(stop_filter_node);
+  executor.add_node(stop_filter_node->get_node_base_interface());
   executor.add_node(test_control_node);
 
   // Run executor in separate thread

--- a/localization/autoware_twist2accel/test/test_twist2accel_node.cpp
+++ b/localization/autoware_twist2accel/test/test_twist2accel_node.cpp
@@ -82,7 +82,7 @@ TEST_F(Twist2AccelNodeTest, FirstMessagePublishesZeroAccelWithHeader)
   auto pub = helper->create_publisher<Odometry>("input/odom", 10);
 
   rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(node);
+  executor.add_node(node->get_node_base_interface());
   executor.add_node(helper);
 
   spin_until(executor, [&] { return pub->get_subscription_count() > 0; }, std::chrono::seconds(5));
@@ -131,7 +131,7 @@ TEST_F(Twist2AccelNodeTest, UseOdomTrueRoutesOdomAndIgnoresTwist)
   auto twist_pub = helper->create_publisher<TwistWithCovarianceStamped>("input/twist", 10);
 
   rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(node);
+  executor.add_node(node->get_node_base_interface());
   executor.add_node(helper);
 
   spin_until(
@@ -203,7 +203,7 @@ TEST_F(Twist2AccelNodeTest, UseOdomFalseRoutesTwistAndIgnoresOdom)
   auto twist_pub = helper->create_publisher<TwistWithCovarianceStamped>("input/twist", 10);
 
   rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(node);
+  executor.add_node(node->get_node_base_interface());
   executor.add_node(helper);
 
   spin_until(


### PR DESCRIPTION
## Description
Updated the localization unit tests to access their node-under-test via `get_node_base_interface()` instead of relying on it being an `rclcpp::Node`.

In autowarefoundation/autoware_core#1207, `agnocast_wrapper::Node` becomes a dedicated standalone class (not an `rclcpp::Node` alias) even at `ENABLE_AGNOCAST=0`, so the exposed API matches `ENABLE_AGNOCAST=1`. As a result it no longer derives from `rclcpp::Node`, and tests that pass the node-under-test to APIs expecting a concrete `rclcpp::Node` (e.g. `executor.add_node(node)`) will start to fail once #1207 
  lands.

  ### Changes
  - `test_stop_filter_node.cpp`: `add_node(stop_filter_node)` → `add_node(stop_filter_node->get_node_base_interface())`.
  - `test_twist2accel_node.cpp`: `add_node(node)` → `add_node(node->get_node_base_interface())` (×3).

  The helper `rclcpp::Node`s (`test_control_node`, `helper`) are left untouched. These use only APIs present on both `rclcpp::Node` and the wrapper, so they work **with or without #1207** and don't change behavior (`add_node(node)` already forwards to `get_node_base_interface()` internally).

## Related Links
autowarefoundation/autoware_core#1207


  ## How was this tested
  `colcon test` on the affected packages — the test executables build and the existing test cases pass (no behavioral change). (with ENABLE_AGNOCAST=0 and 1)

  ## Notes for reviewers

  ## Effects on system behavior

  None. Test-only change.
