### PR TITLE
feat(gnss_poser): apply `agnocast_wrapper::Node` to `autoware_gnss_poser`

### DIFF
--- a/sensing/autoware_gnss_poser/CMakeLists.txt
+++ b/sensing/autoware_gnss_poser/CMakeLists.txt
@@ -23,7 +23,7 @@ autoware_agnocast_wrapper_register_node(gnss_poser_node
   ROS2_EXECUTOR SingleThreadedExecutor
 )
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND NOT (DEFINED ENV{ENABLE_AGNOCAST} AND "$ENV{ENABLE_AGNOCAST}" STREQUAL "1"))
   set(TEST_SOURCES
     test/test_gnss_poser_node.cpp
   )

--- a/sensing/autoware_gnss_poser/CMakeLists.txt
+++ b/sensing/autoware_gnss_poser/CMakeLists.txt
@@ -16,9 +16,11 @@ ament_auto_add_library(gnss_poser_node SHARED
   ${GNSS_POSER_HEADERS}
 )
 
-rclcpp_components_register_node(gnss_poser_node
+autoware_agnocast_wrapper_register_node(gnss_poser_node
   PLUGIN "autoware::gnss_poser::GNSSPoser"
   EXECUTABLE gnss_poser
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 if(BUILD_TESTING)

--- a/sensing/autoware_gnss_poser/launch/gnss_poser.launch.xml
+++ b/sensing/autoware_gnss_poser/launch/gnss_poser.launch.xml
@@ -7,6 +7,8 @@
   <arg name="output_topic_gnss_pose_cov" default="gnss_pose_cov"/>
   <arg name="output_topic_gnss_fixed" default="gnss_fixed"/>
 
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
   <node pkg="autoware_gnss_poser" exec="gnss_poser" name="gnss_poser" output="both">
     <remap from="fix" to="$(var input_topic_fix)"/>
     <remap from="autoware_orientation" to="$(var input_topic_orientation)"/>
@@ -14,5 +16,6 @@
     <remap from="gnss_pose_cov" to="$(var output_topic_gnss_pose_cov)"/>
     <remap from="gnss_fixed" to="$(var output_topic_gnss_fixed)"/>
     <param from="$(var param_file)"/>
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
   </node>
 </launch>

--- a/sensing/autoware_gnss_poser/package.xml
+++ b/sensing/autoware_gnss_poser/package.xml
@@ -17,6 +17,7 @@
 
   <build_depend>libboost-dev</build_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_geography_utils</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_map_msgs</depend>

--- a/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
+++ b/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
@@ -216,7 +216,7 @@ void GNSSPoser::callback_nav_sat_fix(
 
 void GNSSPoser::callback_gnss_ins_orientation_stamped(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_sensing_msgs::msg::GnssInsOrientationStamped) &
-    msg)
+  msg)
 {
   *msg_gnss_ins_orientation_stamped_ = *msg;
 }

--- a/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
+++ b/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
@@ -27,7 +27,7 @@
 namespace autoware::gnss_poser
 {
 GNSSPoser::GNSSPoser(const rclcpp::NodeOptions & node_options)
-: rclcpp::Node("gnss_poser", node_options),
+: autoware::agnocast_wrapper::Node("gnss_poser", node_options),
   tf2_listener_(tf2_buffer_),
   tf2_broadcaster_(*this),
   base_frame_(declare_parameter<std::string>("base_frame")),
@@ -70,14 +70,14 @@ GNSSPoser::GNSSPoser(const rclcpp::NodeOptions & node_options)
 }
 
 void GNSSPoser::callback_map_projector_info(
-  const autoware_map_msgs::msg::MapProjectorInfo::ConstSharedPtr msg)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_map_msgs::msg::MapProjectorInfo) & msg)
 {
   projector_info_ = *msg;
   received_map_projector_info_ = true;
 }
 
 void GNSSPoser::callback_nav_sat_fix(
-  const sensor_msgs::msg::NavSatFix::ConstSharedPtr nav_sat_fix_msg_ptr)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::NavSatFix) & nav_sat_fix_msg_ptr)
 {
   // Return immediately if map_projector_info has not been received yet.
   if (!received_map_projector_info_) {
@@ -99,10 +99,10 @@ void GNSSPoser::callback_nav_sat_fix(
   const bool is_status_fixed = is_fixed(nav_sat_fix_msg_ptr->status);
 
   // publish is_fixed topic
-  autoware_internal_debug_msgs::msg::BoolStamped is_fixed_msg;
-  is_fixed_msg.stamp = this->now();
-  is_fixed_msg.data = is_status_fixed;
-  fixed_pub_->publish(is_fixed_msg);
+  auto is_fixed_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(fixed_pub_);
+  is_fixed_msg->stamp = this->now();
+  is_fixed_msg->data = is_status_fixed;
+  fixed_pub_->publish(std::move(is_fixed_msg));
 
   if (!is_status_fixed) {
     RCLCPP_WARN_STREAM_THROTTLE(
@@ -173,47 +173,48 @@ void GNSSPoser::callback_nav_sat_fix(
   tf2::Transform tf_map2base_link{};
   tf_map2base_link = tf_map2gnss_antenna * tf_gnss_antenna2base_link;
 
-  geometry_msgs::msg::PoseStamped gnss_base_pose_msg{};
-  gnss_base_pose_msg.header.stamp = nav_sat_fix_msg_ptr->header.stamp;
-  gnss_base_pose_msg.header.frame_id = map_frame_;
-  tf2::toMsg(tf_map2base_link, gnss_base_pose_msg.pose);
-
-  // publish gnss_base_link pose in map frame
-  pose_pub_->publish(gnss_base_pose_msg);
+  auto gnss_base_pose_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pose_pub_);
+  gnss_base_pose_msg->header.stamp = nav_sat_fix_msg_ptr->header.stamp;
+  gnss_base_pose_msg->header.frame_id = map_frame_;
+  tf2::toMsg(tf_map2base_link, gnss_base_pose_msg->pose);
 
   // publish gnss_base_link pose_cov in map frame
-  geometry_msgs::msg::PoseWithCovarianceStamped gnss_base_pose_cov_msg;
-  gnss_base_pose_cov_msg.header = gnss_base_pose_msg.header;
-  gnss_base_pose_cov_msg.pose.pose = gnss_base_pose_msg.pose;
+  auto gnss_base_pose_cov_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pose_cov_pub_);
+  gnss_base_pose_cov_msg->header = gnss_base_pose_msg->header;
+  gnss_base_pose_cov_msg->pose.pose = gnss_base_pose_msg->pose;
   constexpr std::size_t diagonal_stride = 7;
-  gnss_base_pose_cov_msg.pose.covariance[diagonal_stride * 0] =
+  gnss_base_pose_cov_msg->pose.covariance[diagonal_stride * 0] =
     can_get_covariance(*nav_sat_fix_msg_ptr) ? nav_sat_fix_msg_ptr->position_covariance[0] : 10.0;
-  gnss_base_pose_cov_msg.pose.covariance[diagonal_stride * 1] =
+  gnss_base_pose_cov_msg->pose.covariance[diagonal_stride * 1] =
     can_get_covariance(*nav_sat_fix_msg_ptr) ? nav_sat_fix_msg_ptr->position_covariance[4] : 10.0;
-  gnss_base_pose_cov_msg.pose.covariance[diagonal_stride * 2] =
+  gnss_base_pose_cov_msg->pose.covariance[diagonal_stride * 2] =
     can_get_covariance(*nav_sat_fix_msg_ptr) ? nav_sat_fix_msg_ptr->position_covariance[8] : 10.0;
 
   if (use_gnss_ins_orientation_) {
-    gnss_base_pose_cov_msg.pose.covariance[diagonal_stride * 3] =
+    gnss_base_pose_cov_msg->pose.covariance[diagonal_stride * 3] =
       std::pow(msg_gnss_ins_orientation_stamped_->orientation.rmse_rotation_x, 2);
-    gnss_base_pose_cov_msg.pose.covariance[diagonal_stride * 4] =
+    gnss_base_pose_cov_msg->pose.covariance[diagonal_stride * 4] =
       std::pow(msg_gnss_ins_orientation_stamped_->orientation.rmse_rotation_y, 2);
-    gnss_base_pose_cov_msg.pose.covariance[diagonal_stride * 5] =
+    gnss_base_pose_cov_msg->pose.covariance[diagonal_stride * 5] =
       std::pow(msg_gnss_ins_orientation_stamped_->orientation.rmse_rotation_z, 2);
   } else {
-    gnss_base_pose_cov_msg.pose.covariance[diagonal_stride * 3] = 0.1;
-    gnss_base_pose_cov_msg.pose.covariance[diagonal_stride * 4] = 0.1;
-    gnss_base_pose_cov_msg.pose.covariance[diagonal_stride * 5] = 1.0;
+    gnss_base_pose_cov_msg->pose.covariance[diagonal_stride * 3] = 0.1;
+    gnss_base_pose_cov_msg->pose.covariance[diagonal_stride * 4] = 0.1;
+    gnss_base_pose_cov_msg->pose.covariance[diagonal_stride * 5] = 1.0;
   }
 
-  pose_cov_pub_->publish(gnss_base_pose_cov_msg);
+  pose_cov_pub_->publish(std::move(gnss_base_pose_cov_msg));
 
-  // broadcast map to gnss_base_link
-  publish_tf(map_frame_, gnss_base_frame_, gnss_base_pose_msg);
+  // broadcast map to gnss_base_link (pose message is still owned and published below)
+  publish_tf(map_frame_, gnss_base_frame_, *gnss_base_pose_msg);
+
+  // publish gnss_base_link pose in map frame
+  pose_pub_->publish(std::move(gnss_base_pose_msg));
 }
 
 void GNSSPoser::callback_gnss_ins_orientation_stamped(
-  const autoware_sensing_msgs::msg::GnssInsOrientationStamped::ConstSharedPtr msg)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_sensing_msgs::msg::GnssInsOrientationStamped) &
+    msg)
 {
   *msg_gnss_ins_orientation_stamped_ = *msg;
 }

--- a/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
+++ b/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
@@ -173,15 +173,20 @@ void GNSSPoser::callback_nav_sat_fix(
   tf2::Transform tf_map2base_link{};
   tf_map2base_link = tf_map2gnss_antenna * tf_gnss_antenna2base_link;
 
-  auto gnss_base_pose_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pose_pub_);
-  gnss_base_pose_msg->header.stamp = nav_sat_fix_msg_ptr->header.stamp;
-  gnss_base_pose_msg->header.frame_id = map_frame_;
-  tf2::toMsg(tf_map2base_link, gnss_base_pose_msg->pose);
+  auto gnss_base_pose_unique = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pose_pub_);
+  gnss_base_pose_unique->header.stamp = nav_sat_fix_msg_ptr->header.stamp;
+  gnss_base_pose_unique->header.frame_id = map_frame_;
+  tf2::toMsg(tf_map2base_link, gnss_base_pose_unique->pose);
+
+  const geometry_msgs::msg::PoseStamped gnss_base_pose_msg = *gnss_base_pose_unique;
+
+  // publish gnss_base_link pose in map frame
+  pose_pub_->publish(std::move(gnss_base_pose_unique));
 
   // publish gnss_base_link pose_cov in map frame
   auto gnss_base_pose_cov_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pose_cov_pub_);
-  gnss_base_pose_cov_msg->header = gnss_base_pose_msg->header;
-  gnss_base_pose_cov_msg->pose.pose = gnss_base_pose_msg->pose;
+  gnss_base_pose_cov_msg->header = gnss_base_pose_msg.header;
+  gnss_base_pose_cov_msg->pose.pose = gnss_base_pose_msg.pose;
   constexpr std::size_t diagonal_stride = 7;
   gnss_base_pose_cov_msg->pose.covariance[diagonal_stride * 0] =
     can_get_covariance(*nav_sat_fix_msg_ptr) ? nav_sat_fix_msg_ptr->position_covariance[0] : 10.0;
@@ -205,11 +210,8 @@ void GNSSPoser::callback_nav_sat_fix(
 
   pose_cov_pub_->publish(std::move(gnss_base_pose_cov_msg));
 
-  // broadcast map to gnss_base_link (pose message is still owned and published below)
-  publish_tf(map_frame_, gnss_base_frame_, *gnss_base_pose_msg);
-
-  // publish gnss_base_link pose in map frame
-  pose_pub_->publish(std::move(gnss_base_pose_msg));
+  // broadcast map to gnss_base_link
+  publish_tf(map_frame_, gnss_base_frame_, gnss_base_pose_msg);
 }
 
 void GNSSPoser::callback_gnss_ins_orientation_stamped(

--- a/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
+++ b/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
@@ -28,7 +28,7 @@ namespace autoware::gnss_poser
 {
 GNSSPoser::GNSSPoser(const rclcpp::NodeOptions & node_options)
 : autoware::agnocast_wrapper::Node("gnss_poser", node_options),
-  tf2_listener_(tf2_buffer_),
+  tf2_listener_(tf2_buffer_, *this),
   tf2_broadcaster_(*this),
   base_frame_(declare_parameter<std::string>("base_frame")),
   gnss_base_frame_(declare_parameter<std::string>("gnss_base_frame")),

--- a/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
+++ b/sensing/autoware_gnss_poser/src/gnss_poser_node.cpp
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::gnss_poser

--- a/sensing/autoware_gnss_poser/src/gnss_poser_node.hpp
+++ b/sensing/autoware_gnss_poser/src/gnss_poser_node.hpp
@@ -53,7 +53,7 @@ private:
     const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::NavSatFix) & nav_sat_fix_msg_ptr);
   void callback_gnss_ins_orientation_stamped(
     const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_sensing_msgs::msg::GnssInsOrientationStamped) &
-      msg);
+    msg);
 
   static bool is_fixed(const sensor_msgs::msg::NavSatStatus & nav_sat_status_msg);
   static bool can_get_covariance(const sensor_msgs::msg::NavSatFix & nav_sat_fix_msg);
@@ -79,7 +79,7 @@ private:
   AUTOWARE_SUBSCRIPTION_PTR(autoware_map_msgs::msg::MapProjectorInfo) sub_map_projector_info_;
   AUTOWARE_SUBSCRIPTION_PTR(sensor_msgs::msg::NavSatFix) nav_sat_fix_sub_;
   AUTOWARE_SUBSCRIPTION_PTR(autoware_sensing_msgs::msg::GnssInsOrientationStamped)
-    autoware_orientation_sub_;
+  autoware_orientation_sub_;
 
   AUTOWARE_PUBLISHER_PTR(geometry_msgs::msg::PoseStamped) pose_pub_;
   AUTOWARE_PUBLISHER_PTR(geometry_msgs::msg::PoseWithCovarianceStamped) pose_cov_pub_;

--- a/sensing/autoware_gnss_poser/src/gnss_poser_node.hpp
+++ b/sensing/autoware_gnss_poser/src/gnss_poser_node.hpp
@@ -14,6 +14,7 @@
 #ifndef GNSS_POSER_NODE_HPP_
 #define GNSS_POSER_NODE_HPP_
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tf2/transform_datatypes.hpp>
 #include <tf2_ros/transform_broadcaster.hpp>
@@ -37,7 +38,7 @@ class GNSSPoserHelpersTest;
 
 namespace autoware::gnss_poser
 {
-class GNSSPoser : public rclcpp::Node
+class GNSSPoser : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit GNSSPoser(const rclcpp::NodeOptions & node_options);
@@ -47,10 +48,12 @@ private:
   friend class ::GNSSPoserHelpersTest;
 
   void callback_map_projector_info(
-    const autoware_map_msgs::msg::MapProjectorInfo::ConstSharedPtr msg);
-  void callback_nav_sat_fix(const sensor_msgs::msg::NavSatFix::ConstSharedPtr nav_sat_fix_msg_ptr);
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_map_msgs::msg::MapProjectorInfo) & msg);
+  void callback_nav_sat_fix(
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(sensor_msgs::msg::NavSatFix) & nav_sat_fix_msg_ptr);
   void callback_gnss_ins_orientation_stamped(
-    const autoware_sensing_msgs::msg::GnssInsOrientationStamped::ConstSharedPtr msg);
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_sensing_msgs::msg::GnssInsOrientationStamped) &
+      msg);
 
   static bool is_fixed(const sensor_msgs::msg::NavSatStatus & nav_sat_status_msg);
   static bool can_get_covariance(const sensor_msgs::msg::NavSatFix & nav_sat_fix_msg);
@@ -73,14 +76,14 @@ private:
   tf2_ros::TransformListener tf2_listener_;
   tf2_ros::TransformBroadcaster tf2_broadcaster_;
 
-  rclcpp::Subscription<autoware_map_msgs::msg::MapProjectorInfo>::SharedPtr sub_map_projector_info_;
-  rclcpp::Subscription<sensor_msgs::msg::NavSatFix>::SharedPtr nav_sat_fix_sub_;
-  rclcpp::Subscription<autoware_sensing_msgs::msg::GnssInsOrientationStamped>::SharedPtr
+  AUTOWARE_SUBSCRIPTION_PTR(autoware_map_msgs::msg::MapProjectorInfo) sub_map_projector_info_;
+  AUTOWARE_SUBSCRIPTION_PTR(sensor_msgs::msg::NavSatFix) nav_sat_fix_sub_;
+  AUTOWARE_SUBSCRIPTION_PTR(autoware_sensing_msgs::msg::GnssInsOrientationStamped)
     autoware_orientation_sub_;
 
-  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr pose_pub_;
-  rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pose_cov_pub_;
-  rclcpp::Publisher<autoware_internal_debug_msgs::msg::BoolStamped>::SharedPtr fixed_pub_;
+  AUTOWARE_PUBLISHER_PTR(geometry_msgs::msg::PoseStamped) pose_pub_;
+  AUTOWARE_PUBLISHER_PTR(geometry_msgs::msg::PoseWithCovarianceStamped) pose_cov_pub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_internal_debug_msgs::msg::BoolStamped) fixed_pub_;
 
   autoware_map_msgs::msg::MapProjectorInfo projector_info_;
   const std::string base_frame_;

--- a/sensing/autoware_gnss_poser/src/gnss_poser_node.hpp
+++ b/sensing/autoware_gnss_poser/src/gnss_poser_node.hpp
@@ -15,10 +15,9 @@
 #define GNSS_POSER_NODE_HPP_
 
 #include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/tf2.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tf2/transform_datatypes.hpp>
-#include <tf2_ros/transform_broadcaster.hpp>
-#include <tf2_ros/transform_listener.hpp>
 
 #include <autoware_internal_debug_msgs/msg/bool_stamped.hpp>
 #include <autoware_map_msgs/msg/map_projector_info.hpp>
@@ -73,8 +72,8 @@ private:
     const geometry_msgs::msg::PoseStamped & pose_msg);
 
   tf2::BufferCore tf2_buffer_;
-  tf2_ros::TransformListener tf2_listener_;
-  tf2_ros::TransformBroadcaster tf2_broadcaster_;
+  autoware::agnocast_wrapper::TransformListener tf2_listener_;
+  autoware::agnocast_wrapper::TransformBroadcaster tf2_broadcaster_;
 
   AUTOWARE_SUBSCRIPTION_PTR(autoware_map_msgs::msg::MapProjectorInfo) sub_map_projector_info_;
   AUTOWARE_SUBSCRIPTION_PTR(sensor_msgs::msg::NavSatFix) nav_sat_fix_sub_;

--- a/sensing/autoware_gnss_poser/test/test_gnss_poser_node.cpp
+++ b/sensing/autoware_gnss_poser/test/test_gnss_poser_node.cpp
@@ -149,7 +149,7 @@ protected:
 
     // Create single executor for both nodes
     executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
-    executor_->add_node(gnss_poser_node_);
+    executor_->add_node(gnss_poser_node_->get_node_base_interface());
     executor_->add_node(publisher_node_);
 
     createTestSubscriptions();
@@ -175,14 +175,14 @@ protected:
     pose_cov_received_ = false;
     fixed_status_received_ = false;
 
-    pose_sub_ = gnss_poser_node_->create_subscription<geometry_msgs::msg::PoseStamped>(
+    pose_sub_ = publisher_node_->create_subscription<geometry_msgs::msg::PoseStamped>(
       "gnss_pose", rclcpp::QoS(1), [this](const geometry_msgs::msg::PoseStamped::SharedPtr msg) {
         last_pose_ = *msg;
         pose_received_ = true;
       });
 
     pose_cov_sub_ =
-      gnss_poser_node_->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
+      publisher_node_->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
         "gnss_pose_cov", rclcpp::QoS(1),
         [this](const geometry_msgs::msg::PoseWithCovarianceStamped::SharedPtr msg) {
           last_pose_cov_ = *msg;
@@ -190,7 +190,7 @@ protected:
         });
 
     fixed_sub_ =
-      gnss_poser_node_->create_subscription<autoware_internal_debug_msgs::msg::BoolStamped>(
+      publisher_node_->create_subscription<autoware_internal_debug_msgs::msg::BoolStamped>(
         "gnss_fixed", rclcpp::QoS(1),
         [this](const autoware_internal_debug_msgs::msg::BoolStamped::SharedPtr msg) {
           last_fixed_status_ = *msg;
@@ -221,12 +221,12 @@ protected:
     fixed_sub_.reset();
 
     // Remove old node from executor, then destroy it
-    executor_->remove_node(gnss_poser_node_);
+    executor_->remove_node(gnss_poser_node_->get_node_base_interface());
     gnss_poser_node_.reset();
 
     // Create new node and add to the same executor
     gnss_poser_node_ = std::make_shared<autoware::gnss_poser::GNSSPoser>(options);
-    executor_->add_node(gnss_poser_node_);
+    executor_->add_node(gnss_poser_node_->get_node_base_interface());
 
     // Re-create test subscriptions on the new node
     createTestSubscriptions();


### PR DESCRIPTION
## Description
Apply `agnocast_wrapper::Node` to `autoware_gnss_poser`.
Please read https://github.com/autowarefoundation/autoware/issues/7007 for the context and review guidelines of `autoware_agnocast_wrapper` adoption. 
Also, please refer to https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md for the review guide of `autoware_agnocast_wrapper` application PR. FYI: This node take [Method2](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/docs/review_guide.md#method-2-agnocast_wrappernode-inheritance) of two integrations methods.

## Related Links

  - https://github.com/autowarefoundation/autoware/issues/7007
  - https://github.com/orgs/autowarefoundation/discussions/6804

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
  - `colcon build` succeeds with both `ENABLE_AGNOCAST=1` and `ENABLE_AGNOCAST=0`.
  - Ran Lsim with sample rosbag. 

## Notes for reviewers

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None when ENABLE_AGNOCAST is not set or set to 0 on runtime. When ENABLE_AGNOCAST=1, CPU Time used in this node for message serialization/deserialization will be reduced.