### PR TITLE
fix(ndt): correct sign of pitch^2 term in NDT angle Hessian (h_ang d1)

### DIFF
--- a/localization/autoware_ndt_scan_matcher/src/ndt_omp/multigrid_ndt_omp_impl.hpp
+++ b/localization/autoware_ndt_scan_matcher/src/ndt_omp/multigrid_ndt_omp_impl.hpp
@@ -596,7 +596,7 @@ void MultiGridNormalDistributionsTransform<PointSource, PointTarget>::computeAng
     h_ang_.row(4) << (-sx * cz - cx * sy * sz), (sx * sz - cx * sy * cz), 0.0f, 0.0f;  // c2
     h_ang_.row(5) << (cx * cz - sx * sy * sz), (-sx * sy * cz - cx * sz), 0.0f, 0.0f;  // c3
 
-    h_ang_.row(6) << (-cy * cz), (cy * sz), (sy), 0.0f;                  // d1
+    h_ang_.row(6) << (-cy * cz), (cy * sz), (-sy), 0.0f;                 // d1
     h_ang_.row(7) << (-sx * sy * cz), (sx * sy * sz), (sx * cy), 0.0f;   // d2
     h_ang_.row(8) << (cx * sy * cz), (-cx * sy * sz), (-cx * cy), 0.0f;  // d3
 


### PR DESCRIPTION
## Description

`MultiGridNormalDistributionsTransform::computeAngleDerivatives()` precomputes the angular Hessian table `h_ang_`. Row 6 (`d1`), which forms the **x-component of ∂²(R·x)/∂pitch²**, uses `+sy` where the exact second derivative is `-sy`.

Derivation with `R = Rx(roll)·Ry(pitch)·Rz(yaw)` applied to a point `x`:

```
(R x)_x     =  cy*cz*x0 - cy*sz*x1 + sy*x2
d/dpitch    = -sy*cz*x0 + sy*sz*x1 + cy*x2
d2/dpitch^2 = -cy*cz*x0 + cy*sz*x1 - sy*x2     =>  d1 = (-cy*cz, cy*sz, -sy)
```

So the third coefficient must be `-sy`. The one-line fix:

```diff
- h_ang_.row(6) << (-cy * cz), (cy * sz), (sy), 0.0f;   // d1
+ h_ang_.row(6) << (-cy * cz), (cy * sz), (-sy), 0.0f;  // d1
```

The gradient (`j_ang_`) is already exact, and every other `h_ang_` block was re-derived and confirmed correct (roll², roll·pitch, roll·yaw, the y/z components of pitch², pitch·yaw, yaw²); `d1`'s x-component is the only incorrect entry. This makes the analytic Hessian match the true second derivative of the NDT score.

## Related links

None.

## How was this PR tested?

- Verified analytically by re-deriving ∂²(R·x)/∂p² for every angle pair and comparing against `h_ang_` (only `d1` differed).
- A finite-difference check of the NDT score's Hessian confirms the corrected `-sy` matches the numerical second derivative, while the original `+sy` does not.
- A full colcon build / regression run is still pending (this is a Draft) — reviewers can validate against the existing `standard_sequence_*` localization tests.

## Notes for reviewers

Single-character change. It affects only the Hessian used for the Newton search direction in `computeStepLengthMT()` / `computeTransformation()`; the converged pose (where the gradient is zero) is mathematically unchanged, so any behavior change is limited to the optimization path / iteration count. A finite-difference Hessian unit test would be a good follow-up.

## Interface changes

None.

## Effects on system behavior

The corrected Hessian only changes the NDT Newton step direction; the optimum (gradient = 0) is unchanged. In practice this may slightly alter the convergence path / iteration count for scan matching. No API, topic, or parameter changes.