### PR TITLE
feat(VehicleInfoUtils): templatize NodeT of `VehicleInfoUtils`

### DIFF
--- a/common/autoware_vehicle_info_utils/include/autoware/vehicle_info_utils/vehicle_info_utils.hpp
+++ b/common/autoware_vehicle_info_utils/include/autoware/vehicle_info_utils/vehicle_info_utils.hpp
@@ -20,30 +20,18 @@
 #include <autoware_utils_rclcpp/parameter.hpp>
 #include <rclcpp/node.hpp>
 
-#include <type_traits>
-
 namespace autoware::vehicle_info_utils
 {
 /// This is a convenience class for saving you from declaring all parameters
 /// manually and calculating derived parameters.
 /// This class supposes that necessary parameters are set when the node is launched.
-///
 class VehicleInfoUtils
 {
 public:
   /// Constructor
   // NOTE(soblin): this throws which should be replaced with a factory
   template <typename NodeT>
-  explicit VehicleInfoUtils(NodeT & node) : vehicle_info_(create_from_node(node))
-  {
-  }
-
-  /// Get vehicle info
-  [[nodiscard]] VehicleInfo getVehicleInfo() const;
-
-private:
-  template <typename NodeT>
-  static VehicleInfo create_from_node(NodeT & node)
+  explicit VehicleInfoUtils(NodeT & node)
   {
     static constexpr const char * WHEEL_RADIUS = "wheel_radius";
     static constexpr const char * WHEEL_WIDTH = "wheel_width";
@@ -68,11 +56,15 @@ private:
     const auto vehicle_height_m = get_or_declare_parameter<double>(node, VEHICLE_HEIGHT);
     const auto max_steer_angle_rad = get_or_declare_parameter<double>(node, MAX_STEER_ANGLE);
 
-    return createVehicleInfo(
+    vehicle_info_ = createVehicleInfo(
       wheel_radius_m, wheel_width_m, wheel_base_m, wheel_tread_m, front_overhang_m, rear_overhang_m,
       left_overhang_m, right_overhang_m, vehicle_height_m, max_steer_angle_rad);
   }
 
+  /// Get vehicle info
+  [[nodiscard]] VehicleInfo getVehicleInfo() const;
+
+private:
   /// Buffer for base parameters
   VehicleInfo vehicle_info_;
 };

--- a/common/autoware_vehicle_info_utils/include/autoware/vehicle_info_utils/vehicle_info_utils.hpp
+++ b/common/autoware_vehicle_info_utils/include/autoware/vehicle_info_utils/vehicle_info_utils.hpp
@@ -17,24 +17,62 @@
 
 #include "autoware/vehicle_info_utils/vehicle_info.hpp"
 
+#include <autoware_utils_rclcpp/parameter.hpp>
 #include <rclcpp/node.hpp>
+
+#include <type_traits>
 
 namespace autoware::vehicle_info_utils
 {
 /// This is a convenience class for saving you from declaring all parameters
 /// manually and calculating derived parameters.
 /// This class supposes that necessary parameters are set when the node is launched.
+///
 class VehicleInfoUtils
 {
 public:
   /// Constructor
   // NOTE(soblin): this throws which should be replaced with a factory
-  explicit VehicleInfoUtils(rclcpp::Node & node);
+  template <typename NodeT>
+  explicit VehicleInfoUtils(NodeT & node) : vehicle_info_(create_from_node(node))
+  {
+  }
 
   /// Get vehicle info
   [[nodiscard]] VehicleInfo getVehicleInfo() const;
 
 private:
+  template <typename NodeT>
+  static VehicleInfo create_from_node(NodeT & node)
+  {
+    static constexpr const char * WHEEL_RADIUS = "wheel_radius";
+    static constexpr const char * WHEEL_WIDTH = "wheel_width";
+    static constexpr const char * WHEEL_BASE = "wheel_base";
+    static constexpr const char * WHEEL_TREAD = "wheel_tread";
+    static constexpr const char * FRONT_OVERHANG = "front_overhang";
+    static constexpr const char * REAR_OVERHANG = "rear_overhang";
+    static constexpr const char * LEFT_OVERHANG = "left_overhang";
+    static constexpr const char * RIGHT_OVERHANG = "right_overhang";
+    static constexpr const char * VEHICLE_HEIGHT = "vehicle_height";
+    static constexpr const char * MAX_STEER_ANGLE = "max_steer_angle";
+
+    using autoware_utils_rclcpp::get_or_declare_parameter;
+    const auto wheel_radius_m = get_or_declare_parameter<double>(node, WHEEL_RADIUS);
+    const auto wheel_width_m = get_or_declare_parameter<double>(node, WHEEL_WIDTH);
+    const auto wheel_base_m = get_or_declare_parameter<double>(node, WHEEL_BASE);
+    const auto wheel_tread_m = get_or_declare_parameter<double>(node, WHEEL_TREAD);
+    const auto front_overhang_m = get_or_declare_parameter<double>(node, FRONT_OVERHANG);
+    const auto rear_overhang_m = get_or_declare_parameter<double>(node, REAR_OVERHANG);
+    const auto left_overhang_m = get_or_declare_parameter<double>(node, LEFT_OVERHANG);
+    const auto right_overhang_m = get_or_declare_parameter<double>(node, RIGHT_OVERHANG);
+    const auto vehicle_height_m = get_or_declare_parameter<double>(node, VEHICLE_HEIGHT);
+    const auto max_steer_angle_rad = get_or_declare_parameter<double>(node, MAX_STEER_ANGLE);
+
+    return createVehicleInfo(
+      wheel_radius_m, wheel_width_m, wheel_base_m, wheel_tread_m, front_overhang_m, rear_overhang_m,
+      left_overhang_m, right_overhang_m, vehicle_height_m, max_steer_angle_rad);
+  }
+
   /// Buffer for base parameters
   VehicleInfo vehicle_info_;
 };

--- a/common/autoware_vehicle_info_utils/src/vehicle_info_utils.cpp
+++ b/common/autoware_vehicle_info_utils/src/vehicle_info_utils.cpp
@@ -14,40 +14,8 @@
 
 #include "autoware/vehicle_info_utils/vehicle_info_utils.hpp"
 
-#include <autoware_utils_rclcpp/parameter.hpp>
-
 namespace autoware::vehicle_info_utils
 {
-VehicleInfoUtils::VehicleInfoUtils(rclcpp::Node & node)
-{
-  static constexpr const char * WHEEL_RADIUS = "wheel_radius";
-  static constexpr const char * WHEEL_WIDTH = "wheel_width";
-  static constexpr const char * WHEEL_BASE = "wheel_base";
-  static constexpr const char * WHEEL_TREAD = "wheel_tread";
-  static constexpr const char * FRONT_OVERHANG = "front_overhang";
-  static constexpr const char * REAR_OVERHANG = "rear_overhang";
-  static constexpr const char * LEFT_OVERHANG = "left_overhang";
-  static constexpr const char * RIGHT_OVERHANG = "right_overhang";
-  static constexpr const char * VEHICLE_HEIGHT = "vehicle_height";
-  static constexpr const char * MAX_STEER_ANGLE = "max_steer_angle";
-
-  using autoware_utils_rclcpp::get_or_declare_parameter;
-  const auto wheel_radius_m = get_or_declare_parameter<double>(node, WHEEL_RADIUS);
-  const auto wheel_width_m = get_or_declare_parameter<double>(node, WHEEL_WIDTH);
-  const auto wheel_base_m = get_or_declare_parameter<double>(node, WHEEL_BASE);
-  const auto wheel_tread_m = get_or_declare_parameter<double>(node, WHEEL_TREAD);
-  const auto front_overhang_m = get_or_declare_parameter<double>(node, FRONT_OVERHANG);
-  const auto rear_overhang_m = get_or_declare_parameter<double>(node, REAR_OVERHANG);
-  const auto left_overhang_m = get_or_declare_parameter<double>(node, LEFT_OVERHANG);
-  const auto right_overhang_m = get_or_declare_parameter<double>(node, RIGHT_OVERHANG);
-  const auto vehicle_height_m = get_or_declare_parameter<double>(node, VEHICLE_HEIGHT);
-  const auto max_steer_angle_rad = get_or_declare_parameter<double>(node, MAX_STEER_ANGLE);
-
-  vehicle_info_ = createVehicleInfo(
-    wheel_radius_m, wheel_width_m, wheel_base_m, wheel_tread_m, front_overhang_m, rear_overhang_m,
-    left_overhang_m, right_overhang_m, vehicle_height_m, max_steer_angle_rad);
-}
-
 VehicleInfo VehicleInfoUtils::getVehicleInfo() const
 {
   return vehicle_info_;


### PR DESCRIPTION
## Description
Templatize `VehicleInfoUtils` constructor on the node type so it works with any node-like object, not only `rclcpp::Node`. The body only uses `get_or_declare_parameter`, so only the constructor signature needed changing. This unblocks agnocast migration by allowing construction from `autoware::agnocast_wrapper::Node`. Existing `rclcpp::Node` callers are unaffected (template argument deduced).

## Changes
  - `vehicle_info_utils.hpp`: constructor → `template <typename NodeT>`, body moved inline (logic unchanged).
  - `vehicle_info_utils.cpp`: drop the now-inline constructor definition.

## Related links
  - https://github.com/autowarefoundation/autoware/issues/7007
  - https://github.com/orgs/autowarefoundation/discussions/6804


**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Tested clean build.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
