### PR TITLE
feat(MotionUtils): templatize NodeT of `MotionUtils`

### DIFF
--- a/common/autoware_motion_utils/include/autoware/motion_utils/vehicle/vehicle_state_checker.hpp
+++ b/common/autoware_motion_utils/include/autoware/motion_utils/vehicle/vehicle_state_checker.hpp
@@ -33,7 +33,11 @@ using nav_msgs::msg::Odometry;
 class VehicleStopCheckerBase
 {
 public:
-  VehicleStopCheckerBase(rclcpp::Node * node, double buffer_duration);
+  template <class NodeT>
+  VehicleStopCheckerBase(NodeT * node, double buffer_duration)
+  : clock_(node->get_clock()), logger_(node->get_logger()), buffer_duration_(buffer_duration)
+  {
+  }
   rclcpp::Logger getLogger() { return logger_; }
   void addTwist(const TwistStamped & twist);
   [[nodiscard]] bool isVehicleStopped(const double stop_duration = 0.0) const;

--- a/common/autoware_motion_utils/src/vehicle/vehicle_state_checker.cpp
+++ b/common/autoware_motion_utils/src/vehicle/vehicle_state_checker.cpp
@@ -20,12 +20,6 @@
 
 namespace autoware::motion_utils
 {
-VehicleStopCheckerBase::VehicleStopCheckerBase(rclcpp::Node * node, double buffer_duration)
-: clock_(node->get_clock()), logger_(node->get_logger())
-{
-  buffer_duration_ = buffer_duration;
-}
-
 void VehicleStopCheckerBase::addTwist(const TwistStamped & twist)
 {
   twist_buffer_.push_front(twist);


### PR DESCRIPTION
## Description
  Templatize the `VehicleStopCheckerBase` constructor on the node type so it works with any node-like object, not only `rclcpp::Node`. The constructor only uses `get_clock()` / `get_logger()`, so only the constructor signature needed changing. This unblocks agnocast migration by allowing construction from `autoware::agnocast_wrapper::Node`. Existing `rclcpp::Node` callers are unaffected, and the class itself stays non-template, so the derived `VehicleStopChecker` / `VehicleArrivalChecker` are unaffected.

## Changes
  - `vehicle_state_checker.hpp`: constructor → `template <class NodeT>`, body moved inline (logic unchanged).
  - `vehicle_state_checker.cpp`: drop the now-inline constructor definition.

  ## Related links
  - https://github.com/autowarefoundation/autoware/issues/7007
  - https://github.com/orgs/autowarefoundation/discussions/6804

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Tested clean build.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
