### PR TITLE
feat(autoware_agnocast_wrapper): support const reference subscription callbacks

### DIFF
--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -235,6 +235,16 @@ void onPointCloud(AUTOWARE_MESSAGE_UNIQUE_PTR(const PointCloud2) && input_msg) {
 }
 ```
 
+Subscription callbacks that only read the message inside the callback can also keep the plain rclcpp `const MessageT &` signature:
+
+```cpp
+void onPointCloud(const PointCloud2 & input_msg) {
+  ...
+}
+```
+
+Zero-copy is preserved on the Agnocast path: the subscription dereferences the received pointer before invoking the callback, so the reference points directly into shared memory. Use `AUTOWARE_MESSAGE_CONST_SHARED_PTR` instead when the callback needs to keep the message alive beyond the callback without a copy.
+
 To use the macros provided by this package in your own package, include the following lines in your `CMakeLists.txt`:
 
 ```cmake

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -243,7 +243,7 @@ void onPointCloud(const PointCloud2 & input_msg) {
 }
 ```
 
-Zero-copy is preserved on the Agnocast path: the subscription dereferences the received pointer before invoking the callback, so the reference points directly into shared memory. Use `AUTOWARE_MESSAGE_CONST_SHARED_PTR` instead when the callback needs to keep the message alive beyond the callback without a copy.
+Zero-copy is preserved on the Agnocast path: the subscription dereferences the received pointer before invoking the callback, so the reference points directly into shared memory. The referenced entry is kept alive only while the callback runs: the reference is valid for the duration of the callback and must not be stored or used after the callback returns. Use `AUTOWARE_MESSAGE_CONST_SHARED_PTR` instead when the callback needs to keep the message alive beyond the callback without a copy.
 
 To use the macros provided by this package in your own package, include the following lines in your `CMakeLists.txt`:
 

--- a/common/autoware_agnocast_wrapper/docs/review_guide.md
+++ b/common/autoware_agnocast_wrapper/docs/review_guide.md
@@ -148,7 +148,7 @@ Once identified, proceed to the corresponding review procedure below.
 
 - [ ] Creation: `this->create_publisher` → `AUTOWARE_CREATE_PUBLISHER2` / `AUTOWARE_CREATE_PUBLISHER3` etc.
 
-- [ ] Callback arguments: `const SharedPtr` / `UniquePtr` → `AUTOWARE_MESSAGE_CONST_SHARED_PTR` / `AUTOWARE_MESSAGE_UNIQUE_PTR`
+- [ ] Callback arguments: `const SharedPtr` / `UniquePtr` → `AUTOWARE_MESSAGE_CONST_SHARED_PTR` / `AUTOWARE_MESSAGE_UNIQUE_PTR` (callbacks taking `const MessageT &` can keep their signature unchanged)
 
 - [ ] Message allocation (if publisher exists): `std::make_unique<M>()` → `ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_)`
 
@@ -303,7 +303,7 @@ Node-wide migration to `agnocast_wrapper::Node` (see Part 2 Section 4 Method 2).
 
 - [ ] Creation: Use `agnocast_wrapper::Node` member functions `create_publisher` / `create_subscription` directly (**`AUTOWARE_CREATE_*` macros are not needed**)
 
-- [ ] Callback arguments: `const SharedPtr` / `UniquePtr` → `AUTOWARE_MESSAGE_CONST_SHARED_PTR` / `AUTOWARE_MESSAGE_UNIQUE_PTR`
+- [ ] Callback arguments: `const SharedPtr` / `UniquePtr` → `AUTOWARE_MESSAGE_CONST_SHARED_PTR` / `AUTOWARE_MESSAGE_UNIQUE_PTR` (callbacks taking `const MessageT &` can keep their signature unchanged)
 
 - [ ] Message allocation (if publisher exists): `std::make_unique<M>()` → `ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_)`
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -445,10 +445,15 @@ public:
     // CudaPointcloudPreprocessorNode which uses UNIQUE_PTR callbacks.
     static_assert(
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
-        std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>,
+        std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&> ||
+        std::is_invocable_v<std::decay_t<Func>, const MessageT &>,
       "callback should be invocable with an rvalue reference to either "
-      "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR");
+      "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, or with a "
+      "const reference to the message type");
 
+    constexpr bool is_message_ptr_callback =
+      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
+      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>;
     constexpr auto ownership =
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>
         ? OwnershipType::Unique
@@ -457,7 +462,11 @@ public:
     subscription_ = agnocast::create_subscription<MessageT>(
       node, topic_name, qos,
       [callback = std::forward<Func>(callback)](agnocast::ipc_shared_ptr<MessageT> && msg) {
-        if constexpr (ownership == OwnershipType::Unique) {
+        if constexpr (!is_message_ptr_callback) {
+          // msg keeps the shared-memory entry alive while the callback runs, so the
+          // reference stays valid and no copy is made.
+          callback(*msg);
+        } else if constexpr (ownership == OwnershipType::Unique) {
           callback(message_ptr<MessageT, ownership>(std::move(msg)));
         } else {
           callback(
@@ -482,10 +491,15 @@ public:
   {
     static_assert(
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
-        std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>,
+        std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&> ||
+        std::is_invocable_v<std::decay_t<Func>, const MessageT &>,
       "callback should be invocable with an rvalue reference to either "
-      "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR");
+      "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, or with a "
+      "const reference to the message type");
 
+    constexpr bool is_message_ptr_callback =
+      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
+      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>;
     constexpr auto ownership =
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>
         ? OwnershipType::Unique
@@ -496,7 +510,9 @@ public:
     subscription_ = node->create_subscription<MessageT>(
       topic_name, qos,
       [callback = std::forward<Func>(callback)](std::unique_ptr<MessageT> msg) {
-        if constexpr (ownership == OwnershipType::Unique) {
+        if constexpr (!is_message_ptr_callback) {
+          callback(*msg);
+        } else if constexpr (ownership == OwnershipType::Unique) {
           callback(message_ptr<MessageT, ownership>(std::move(msg)));
         } else {
           callback(

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -428,23 +428,6 @@ public:
   virtual ~Subscription() = default;
 };
 
-template <typename Func, typename MessageT>
-inline constexpr bool is_unique_ptr_subscription_callback_v =
-  std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>;
-
-// True when Callback takes one of the wrapper's message_ptr types (AUTOWARE_MESSAGE_UNIQUE_PTR /
-// AUTOWARE_MESSAGE_CONST_SHARED_PTR), i.e. it is written against the wrapper's zero-copy
-// subscription API.
-template <typename Func, typename MessageT>
-inline constexpr bool is_message_ptr_subscription_callback_v =
-  is_unique_ptr_subscription_callback_v<Func, MessageT> ||
-  std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>;
-
-// True when Callback is an rclcpp-style read-only handler taking const MessageT &.
-template <typename Func, typename MessageT>
-inline constexpr bool is_const_ref_subscription_callback_v =
-  std::is_invocable_v<std::decay_t<Func>, const MessageT &>;
-
 template <typename MessageT>
 class AgnocastSubscription : public Subscription<MessageT>
 {
@@ -461,16 +444,20 @@ public:
     // risks corrupting data read by other subscribers. Currently kept for compatibility with
     // CudaPointcloudPreprocessorNode which uses UNIQUE_PTR callbacks.
     static_assert(
-      is_message_ptr_subscription_callback_v<Func, MessageT> ||
-        is_const_ref_subscription_callback_v<Func, MessageT>,
+      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
+        std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&> ||
+        std::is_invocable_v<std::decay_t<Func>, const MessageT &>,
       "callback should be invocable with an rvalue reference to either "
       "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, or with a "
       "const reference to the message type");
 
-    constexpr bool is_message_ptr_callback = is_message_ptr_subscription_callback_v<Func, MessageT>;
-    constexpr auto ownership = is_unique_ptr_subscription_callback_v<Func, MessageT>
-                                 ? OwnershipType::Unique
-                                 : OwnershipType::Shared;
+    constexpr bool is_message_ptr_callback =
+      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
+      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>;
+    constexpr auto ownership =
+      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>
+        ? OwnershipType::Unique
+        : OwnershipType::Shared;
 
     subscription_ = agnocast::create_subscription<MessageT>(
       node, topic_name, qos,
@@ -507,16 +494,20 @@ public:
     const agnocast::SubscriptionOptions & options)
   {
     static_assert(
-      is_message_ptr_subscription_callback_v<Func, MessageT> ||
-        is_const_ref_subscription_callback_v<Func, MessageT>,
+      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
+        std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&> ||
+        std::is_invocable_v<std::decay_t<Func>, const MessageT &>,
       "callback should be invocable with an rvalue reference to either "
       "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, or with a "
       "const reference to the message type");
 
-    constexpr bool is_message_ptr_callback = is_message_ptr_subscription_callback_v<Func, MessageT>;
-    constexpr auto ownership = is_unique_ptr_subscription_callback_v<Func, MessageT>
-                                 ? OwnershipType::Unique
-                                 : OwnershipType::Shared;
+    constexpr bool is_message_ptr_callback =
+      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
+      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>;
+    constexpr auto ownership =
+      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>
+        ? OwnershipType::Unique
+        : OwnershipType::Shared;
 
     rclcpp::SubscriptionOptions ros2_options;
     ros2_options.callback_group = options.callback_group;

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -428,6 +428,23 @@ public:
   virtual ~Subscription() = default;
 };
 
+template <typename Func, typename MessageT>
+inline constexpr bool is_unique_ptr_subscription_callback_v =
+  std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>;
+
+// True when Callback takes one of the wrapper's message_ptr types (AUTOWARE_MESSAGE_UNIQUE_PTR /
+// AUTOWARE_MESSAGE_CONST_SHARED_PTR), i.e. it is written against the wrapper's zero-copy
+// subscription API.
+template <typename Func, typename MessageT>
+inline constexpr bool is_message_ptr_subscription_callback_v =
+  is_unique_ptr_subscription_callback_v<Func, MessageT> ||
+  std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>;
+
+// True when Callback is an rclcpp-style read-only handler taking const MessageT &.
+template <typename Func, typename MessageT>
+inline constexpr bool is_const_ref_subscription_callback_v =
+  std::is_invocable_v<std::decay_t<Func>, const MessageT &>;
+
 template <typename MessageT>
 class AgnocastSubscription : public Subscription<MessageT>
 {
@@ -444,28 +461,29 @@ public:
     // risks corrupting data read by other subscribers. Currently kept for compatibility with
     // CudaPointcloudPreprocessorNode which uses UNIQUE_PTR callbacks.
     static_assert(
-      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
-        std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&> ||
-        std::is_invocable_v<std::decay_t<Func>, const MessageT &>,
+      is_message_ptr_subscription_callback_v<Func, MessageT> ||
+        is_const_ref_subscription_callback_v<Func, MessageT>,
       "callback should be invocable with an rvalue reference to either "
       "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, or with a "
       "const reference to the message type");
 
     constexpr bool is_message_ptr_callback =
-      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
-      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>;
-    constexpr auto ownership =
-      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>
-        ? OwnershipType::Unique
-        : OwnershipType::Shared;
+      is_message_ptr_subscription_callback_v<Func, MessageT>;
+    constexpr auto ownership = is_unique_ptr_subscription_callback_v<Func, MessageT>
+                                 ? OwnershipType::Unique
+                                 : OwnershipType::Shared;
 
     subscription_ = agnocast::create_subscription<MessageT>(
       node, topic_name, qos,
       [callback = std::forward<Func>(callback)](agnocast::ipc_shared_ptr<MessageT> && msg) {
         if constexpr (!is_message_ptr_callback) {
-          // msg keeps the shared-memory entry alive while the callback runs, so the
-          // reference stays valid and no copy is made.
-          callback(*msg);
+          // msg keeps the shared-memory entry alive only while the callback runs: the
+          // reference is valid for the duration of the callback and no copy is made, but
+          // it must not be stored or used after the callback returns. Callbacks that need
+          // to extend the message lifetime should take AUTOWARE_MESSAGE_CONST_SHARED_PTR.
+          // as_const prevents generic callbacks from mutating the shared-memory entry,
+          // which other processes may be reading concurrently.
+          callback(std::as_const(*msg));
         } else if constexpr (ownership == OwnershipType::Unique) {
           callback(message_ptr<MessageT, ownership>(std::move(msg)));
         } else {
@@ -490,20 +508,17 @@ public:
     const agnocast::SubscriptionOptions & options)
   {
     static_assert(
-      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
-        std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&> ||
-        std::is_invocable_v<std::decay_t<Func>, const MessageT &>,
+      is_message_ptr_subscription_callback_v<Func, MessageT> ||
+        is_const_ref_subscription_callback_v<Func, MessageT>,
       "callback should be invocable with an rvalue reference to either "
       "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, or with a "
       "const reference to the message type");
 
     constexpr bool is_message_ptr_callback =
-      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
-      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>;
-    constexpr auto ownership =
-      std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>
-        ? OwnershipType::Unique
-        : OwnershipType::Shared;
+      is_message_ptr_subscription_callback_v<Func, MessageT>;
+    constexpr auto ownership = is_unique_ptr_subscription_callback_v<Func, MessageT>
+                                 ? OwnershipType::Unique
+                                 : OwnershipType::Shared;
 
     rclcpp::SubscriptionOptions ros2_options;
     ros2_options.callback_group = options.callback_group;
@@ -511,7 +526,9 @@ public:
       topic_name, qos,
       [callback = std::forward<Func>(callback)](std::unique_ptr<MessageT> msg) {
         if constexpr (!is_message_ptr_callback) {
-          callback(*msg);
+          // as_const keeps this fallback consistent with the Agnocast path: generic
+          // callbacks must not observe a mutable reference on either path.
+          callback(std::as_const(*msg));
         } else if constexpr (ownership == OwnershipType::Unique) {
           callback(message_ptr<MessageT, ownership>(std::move(msg)));
         } else {

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -467,8 +467,7 @@ public:
       "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, or with a "
       "const reference to the message type");
 
-    constexpr bool is_message_ptr_callback =
-      is_message_ptr_subscription_callback_v<Func, MessageT>;
+    constexpr bool is_message_ptr_callback = is_message_ptr_subscription_callback_v<Func, MessageT>;
     constexpr auto ownership = is_unique_ptr_subscription_callback_v<Func, MessageT>
                                  ? OwnershipType::Unique
                                  : OwnershipType::Shared;
@@ -514,8 +513,7 @@ public:
       "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, or with a "
       "const reference to the message type");
 
-    constexpr bool is_message_ptr_callback =
-      is_message_ptr_subscription_callback_v<Func, MessageT>;
+    constexpr bool is_message_ptr_callback = is_message_ptr_subscription_callback_v<Func, MessageT>;
     constexpr auto ownership = is_unique_ptr_subscription_callback_v<Func, MessageT>
                                  ? OwnershipType::Unique
                                  : OwnershipType::Shared;


### PR DESCRIPTION
## Description

`create_subscription` in `autoware_agnocast_wrapper` currently accepts only callbacks invocable with `AUTOWARE_MESSAGE_UNIQUE_PTR &&` or `AUTOWARE_MESSAGE_CONST_SHARED_PTR &&`. As a result, nodes whose callbacks take a plain `const MessageT &` (a signature rclcpp supports natively) must rewrite their callback signatures with wrapper-specific types even when they only read the message inside the callback. This was pointed out in [this review discussion](https://github.com/autowarefoundation/autoware_universe/pull/12843#discussion_r3517024152): application code should avoid wrapper-specific syntax wherever possible.

This PR makes `create_subscription` also accept rclcpp-style `const MessageT &` callbacks:

- The subscription dereferences the received pointer and invokes the callback through `std::as_const`, so the callback observes a `const` reference. On the Agnocast path the reference points directly into shared memory and the received `ipc_shared_ptr` stays alive for the duration of the callback, so zero-copy is fully preserved. Passing the message as `const` also guarantees that generic callbacks (e.g. `[](auto & msg)`) cannot mutate the shared-memory entry, which other processes may be reading concurrently.
- Dispatch priority is unchanged for existing code: `message_ptr` signatures win over `const MessageT &` when a callback (e.g. a generic lambda) matches both. `std::bind` expressions and `std::function` are classified correctly because their call operators are SFINAE-friendly.
- The `ENABLE_AGNOCAST=0` build needs no change since it maps directly to `rclcpp::Node::create_subscription`, which already supports `const MessageT &`.

The reference passed to the callback is only valid for the duration of the callback; callbacks that need to extend the message lifetime beyond the callback without a copy should keep using `AUTOWARE_MESSAGE_CONST_SHARED_PTR`. README and the review guide are updated accordingly.

## Related links

- https://github.com/autowarefoundation/autoware_universe/pull/12843#discussion_r3517024152

## How was this PR tested?

- Built the package with both `ENABLE_AGNOCAST=1` and `ENABLE_AGNOCAST=0`.
- Verified the ROS 2 runtime fallback path (built with `ENABLE_AGNOCAST=1`, run without it) with a pub/sub program whose subscription callbacks take `const MessageT &`, both as a `std::bind`-wrapped member function and as a lambda: messages are delivered to both.
- Verified the real Agnocast runtime path with a standalone single-process pub/sub program (Agnocast executor, `LD_PRELOAD` heaphook, kernel module loaded): the `const MessageT &` callback fires, and the address of the referenced message equals the publisher-side loaned-message address for every message, confirming zero-copy:

  ```text
  [pub] publishing from 0x40a00000020
  [sub] received x=42.0 at 0x40a00000020
  RESULT received=3 pub_addr=0x40a00000020 sub_addr=0x40a00000020 ZERO_COPY_CONFIRMED
  ```

- Compile-only checks after the `std::as_const` hardening: all accepted callback forms (`const MessageT &` function, `AUTOWARE_MESSAGE_CONST_SHARED_PTR &&`, `AUTOWARE_MESSAGE_UNIQUE_PTR &&`, and a read-only generic lambda) still instantiate, and a generic lambda that mutates the message now fails to compile as intended.

## Notes for reviewers

None.

## Interface changes

None. The new callback signature is additive; existing `message_ptr` callbacks behave exactly as before.

## Effects on system behavior

None.