### PR TITLE
feat(autoware_agnocast_wrapper): support policy as `autoware_utils_rclcpp` for polling subscriber

### DIFF
--- a/common/autoware_agnocast_wrapper/docs/review_guide.md
+++ b/common/autoware_agnocast_wrapper/docs/review_guide.md
@@ -415,11 +415,11 @@ All macros below are defined in [`autoware_agnocast_wrapper.hpp`](https://github
 
 ### Publisher/Subscriber Creation
 
-| Macro                                                                   | ENABLE_AGNOCAST=1 (Agnocast)                                 | ENABLE_AGNOCAST=0 (ROS 2)                                 |
-| ----------------------------------------------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------- |
-| `AUTOWARE_CREATE_SUBSCRIPTION(msg_type, topic, qos, callback, options)` | `agnocast_wrapper::create_subscription<msg_type>(...)`       | `this->create_subscription<msg_type>(...)`                |
-| `AUTOWARE_CREATE_PUBLISHER2(msg_type, topic, qos)`                      | `agnocast_wrapper::create_publisher<msg_type>(...)`          | `this->create_publisher<msg_type>(...)`                   |
-| `AUTOWARE_CREATE_PUBLISHER3(msg_type, topic, qos, options)`             | `agnocast_wrapper::create_publisher<msg_type>(...)`          | `this->create_publisher<msg_type>(...)`                   |
+| Macro                                                                   | ENABLE_AGNOCAST=1 (Agnocast)                                         | ENABLE_AGNOCAST=0 (ROS 2)                                                   |
+| ----------------------------------------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `AUTOWARE_CREATE_SUBSCRIPTION(msg_type, topic, qos, callback, options)` | `agnocast_wrapper::create_subscription<msg_type>(...)`               | `this->create_subscription<msg_type>(...)`                                  |
+| `AUTOWARE_CREATE_PUBLISHER2(msg_type, topic, qos)`                      | `agnocast_wrapper::create_publisher<msg_type>(...)`                  | `this->create_publisher<msg_type>(...)`                                     |
+| `AUTOWARE_CREATE_PUBLISHER3(msg_type, topic, qos, options)`             | `agnocast_wrapper::create_publisher<msg_type>(...)`                  | `this->create_publisher<msg_type>(...)`                                     |
 | `AUTOWARE_CREATE_POLLING_SUBSCRIBER(msg_type, policy, topic, qos)`      | `agnocast_wrapper::create_polling_subscriber<msg_type, policy>(...)` | `InterProcessPollingSubscriber<msg_type, policy>::create_subscription(...)` |
 
 &nbsp;

--- a/common/autoware_agnocast_wrapper/docs/review_guide.md
+++ b/common/autoware_agnocast_wrapper/docs/review_guide.md
@@ -420,7 +420,7 @@ All macros below are defined in [`autoware_agnocast_wrapper.hpp`](https://github
 | `AUTOWARE_CREATE_SUBSCRIPTION(msg_type, topic, qos, callback, options)` | `agnocast_wrapper::create_subscription<msg_type>(...)`       | `this->create_subscription<msg_type>(...)`                |
 | `AUTOWARE_CREATE_PUBLISHER2(msg_type, topic, qos)`                      | `agnocast_wrapper::create_publisher<msg_type>(...)`          | `this->create_publisher<msg_type>(...)`                   |
 | `AUTOWARE_CREATE_PUBLISHER3(msg_type, topic, qos, options)`             | `agnocast_wrapper::create_publisher<msg_type>(...)`          | `this->create_publisher<msg_type>(...)`                   |
-| `AUTOWARE_CREATE_POLLING_SUBSCRIBER(msg_type, topic, qos)`              | `agnocast_wrapper::create_polling_subscriber<msg_type>(...)` | `InterProcessPollingSubscriber::create_subscription(...)` |
+| `AUTOWARE_CREATE_POLLING_SUBSCRIBER(msg_type, policy, topic, qos)`      | `agnocast_wrapper::create_polling_subscriber<msg_type, policy>(...)` | `InterProcessPollingSubscriber<msg_type, policy>::create_subscription(...)` |
 
 &nbsp;
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -604,7 +604,7 @@ public:
 template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
 class AgnocastPollingSubscriber : public PollingSubscriber<MessageT, PollingPolicy>
 {
-  typename agnocast::PollingSubscriber<MessageT>::SharedPtr subscriber_;
+  typename agnocast::TakeSubscription<MessageT>::SharedPtr subscriber_;
 
   static constexpr bool default_allow_same_message =
     polling_default_allow_same_message_v<MessageT, PollingPolicy>;
@@ -613,21 +613,21 @@ public:
   template <typename NodeT>
   explicit AgnocastPollingSubscriber(
     NodeT * node, const std::string & topic_name, const rclcpp::QoS & qos)
-  : subscriber_(agnocast::create_subscription<MessageT>(node, topic_name, qos))
+  : subscriber_(std::make_shared<agnocast::TakeSubscription<MessageT>>(node, topic_name, qos))
   {
   }
 
   AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)
   takeData(bool allow_same_message = default_allow_same_message) override
   {
-    auto data = subscriber_->take_data(allow_same_message);
+    auto data = subscriber_->take(allow_same_message);
     return AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)(std::move(data));
   }
 
   AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)
   take_data(bool allow_same_message = default_allow_same_message) override
   {
-    auto data = subscriber_->take_data(allow_same_message);
+    auto data = subscriber_->take(allow_same_message);
     return AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)(std::move(data));
   }
 };

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -63,8 +63,8 @@
   typename autoware::agnocast_wrapper::Subscription<MessageT>::SharedPtr
 #define AUTOWARE_PUBLISHER_PTR(MessageT) \
   typename autoware::agnocast_wrapper::Publisher<MessageT>::SharedPtr
-#define AUTOWARE_POLLING_SUBSCRIBER_PTR(MessageT) \
-  typename autoware::agnocast_wrapper::PollingSubscriber<MessageT>::SharedPtr
+#define AUTOWARE_POLLING_SUBSCRIBER_PTR(...) \
+  typename autoware::agnocast_wrapper::PollingSubscriber<__VA_ARGS__>::SharedPtr
 #define AUTOWARE_CLIENT_PTR(ServiceT) \
   typename autoware::agnocast_wrapper::Client<ServiceT>::SharedPtr
 #define AUTOWARE_SERVICE_PTR(ServiceT) \
@@ -538,22 +538,40 @@ typename Subscription<MessageT>::SharedPtr create_subscription(
   }
 }
 
-template <typename MessageT>
+// Reuse the polling policy tag types (Latest / Newest / All) from autoware_utils_rclcpp so that
+// node code can specify the policy by type, exactly as with the original InterProcessPollingSubscriber.
+namespace polling_policy = autoware_utils_rclcpp::polling_policy;
+
+// Default value for take_data(allow_same_message): Latest re-delivers the cached message (true),
+// Newest only delivers a message that is new since the last take (false).
+template <typename MessageT, template <typename> class PollingPolicy>
+inline constexpr bool polling_default_allow_same_message_v =
+  !std::is_same_v<PollingPolicy<MessageT>, polling_policy::Newest<MessageT>>;
+
+template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
 class PollingSubscriber
 {
 public:
-  using SharedPtr = std::shared_ptr<PollingSubscriber<MessageT>>;
+  using SharedPtr = std::shared_ptr<PollingSubscriber<MessageT, PollingPolicy>>;
+
+  static constexpr bool default_allow_same_message =
+    polling_default_allow_same_message_v<MessageT, PollingPolicy>;
 
   virtual ~PollingSubscriber() = default;
 
-  virtual AUTOWARE_MESSAGE_SHARED_PTR(const MessageT) takeData(bool allow_same_message = true) = 0;
-  virtual AUTOWARE_MESSAGE_SHARED_PTR(const MessageT) take_data(bool allow_same_message = true) = 0;
+  virtual AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)
+    takeData(bool allow_same_message = default_allow_same_message) = 0;
+  virtual AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)
+    take_data(bool allow_same_message = default_allow_same_message) = 0;
 };
 
-template <typename MessageT>
-class AgnocastPollingSubscriber : public PollingSubscriber<MessageT>
+template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
+class AgnocastPollingSubscriber : public PollingSubscriber<MessageT, PollingPolicy>
 {
   typename agnocast::PollingSubscriber<MessageT>::SharedPtr subscriber_;
+
+  static constexpr bool default_allow_same_message =
+    polling_default_allow_same_message_v<MessageT, PollingPolicy>;
 
 public:
   template <typename NodeT>
@@ -563,67 +581,87 @@ public:
   {
   }
 
-  AUTOWARE_MESSAGE_SHARED_PTR(const MessageT) takeData(bool allow_same_message = true) override
+  AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)
+    takeData(bool allow_same_message = default_allow_same_message) override
   {
     auto data = subscriber_->take_data(allow_same_message);
     return AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)(std::move(data));
   }
 
-  AUTOWARE_MESSAGE_SHARED_PTR(const MessageT) take_data(bool allow_same_message = true) override
+  AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)
+    take_data(bool allow_same_message = default_allow_same_message) override
   {
     auto data = subscriber_->take_data(allow_same_message);
     return AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)(std::move(data));
   }
 };
 
-template <typename MessageT>
-class ROS2PollingSubscriber : public PollingSubscriber<MessageT>
+template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
+class ROS2PollingSubscriber : public PollingSubscriber<MessageT, PollingPolicy>
 {
-  typename autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT>::SharedPtr subscriber_;
+  typename autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT, PollingPolicy>::SharedPtr
+    subscriber_;
+
+  static constexpr bool default_allow_same_message =
+    polling_default_allow_same_message_v<MessageT, PollingPolicy>;
+
+  // The Newest policy exposes take_data() with no argument; Latest exposes take_data(bool).
+  // Dispatch to the matching signature so allow_same_message is honored where it applies.
+  AUTOWARE_MESSAGE_SHARED_PTR(const MessageT) take_data_impl(bool allow_same_message)
+  {
+    if constexpr (std::is_same_v<PollingPolicy<MessageT>, polling_policy::Newest<MessageT>>) {
+      (void)allow_same_message;
+      return AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)(std::move(subscriber_->take_data()));
+    } else {
+      return AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)(
+        std::move(subscriber_->take_data(allow_same_message)));
+    }
+  }
 
 public:
   explicit ROS2PollingSubscriber(
     rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos)
   : subscriber_(
-      autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT>::create_subscription(
-        node, topic_name, qos))
+      autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT, PollingPolicy>::
+        create_subscription(node, topic_name, qos))
   {
   }
 
-  AUTOWARE_MESSAGE_SHARED_PTR(const MessageT) takeData(bool allow_same_message = true) override
+  AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)
+    takeData(bool allow_same_message = default_allow_same_message) override
   {
-    return AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)(
-      std::move(subscriber_->take_data(allow_same_message)));
+    return take_data_impl(allow_same_message);
   }
 
-  AUTOWARE_MESSAGE_SHARED_PTR(const MessageT) take_data(bool allow_same_message = true) override
+  AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)
+    take_data(bool allow_same_message = default_allow_same_message) override
   {
-    return AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)(
-      std::move(subscriber_->take_data(allow_same_message)));
+    return take_data_impl(allow_same_message);
   }
 };
 
-template <typename MessageT>
-typename PollingSubscriber<MessageT>::SharedPtr create_polling_subscriber(
+template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
+typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_subscriber(
   rclcpp::Node * node, const std::string & topic_name, const size_t qos_history_depth)
 {
   if (use_agnocast()) {
-    return std::make_shared<AgnocastPollingSubscriber<MessageT>>(
+    return std::make_shared<AgnocastPollingSubscriber<MessageT, PollingPolicy>>(
       node, topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)));
   } else {
-    return std::make_shared<ROS2PollingSubscriber<MessageT>>(
+    return std::make_shared<ROS2PollingSubscriber<MessageT, PollingPolicy>>(
       node, topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)));
   }
 }
 
-template <typename MessageT>
-typename PollingSubscriber<MessageT>::SharedPtr create_polling_subscriber(
+template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
+typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_subscriber(
   rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos)
 {
   if (use_agnocast()) {
-    return std::make_shared<AgnocastPollingSubscriber<MessageT>>(node, topic_name, qos);
+    return std::make_shared<AgnocastPollingSubscriber<MessageT, PollingPolicy>>(
+      node, topic_name, qos);
   } else {
-    return std::make_shared<ROS2PollingSubscriber<MessageT>>(node, topic_name, qos);
+    return std::make_shared<ROS2PollingSubscriber<MessageT, PollingPolicy>>(node, topic_name, qos);
   }
 }
 
@@ -1257,6 +1295,10 @@ inline void set_period(const Timer::SharedPtr & timer, std::chrono::nanoseconds 
 namespace autoware::agnocast_wrapper
 {
 
+// Mirror the Agnocast-build alias so node code can name the polling policy the same way in both
+// builds (e.g. autoware::agnocast_wrapper::polling_policy::Newest).
+namespace polling_policy = autoware_utils_rclcpp::polling_policy;
+
 /// @brief Set the timer period (non-Agnocast build).
 ///
 /// rclcpp::TimerBase has no set_period member, so we provide a free overload
@@ -1296,8 +1338,8 @@ inline void set_period(const rclcpp::TimerBase::SharedPtr & timer, std::chrono::
 #define AUTOWARE_CLIENT_RESPONSE_PTR(ServiceT) std::shared_ptr<const typename ServiceT::Response>
 #define AUTOWARE_SUBSCRIPTION_PTR(MessageT) typename rclcpp::Subscription<MessageT>::SharedPtr
 #define AUTOWARE_PUBLISHER_PTR(MessageT) typename rclcpp::Publisher<MessageT>::SharedPtr
-#define AUTOWARE_POLLING_SUBSCRIBER_PTR(MessageT) \
-  typename autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT>::SharedPtr
+#define AUTOWARE_POLLING_SUBSCRIBER_PTR(...) \
+  typename autoware_utils_rclcpp::InterProcessPollingSubscriber<__VA_ARGS__>::SharedPtr
 #define AUTOWARE_CLIENT_PTR(ServiceT) typename rclcpp::Client<ServiceT>::SharedPtr
 #define AUTOWARE_SERVICE_PTR(ServiceT) typename rclcpp::Service<ServiceT>::SharedPtr
 #define AUTOWARE_CLIENT_FUTURE(ServiceT) typename rclcpp::Client<ServiceT>::Future

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -548,10 +548,23 @@ template <typename MessageT, template <typename> class PollingPolicy>
 inline constexpr bool polling_default_allow_same_message_v =
   !std::is_same_v<PollingPolicy<MessageT>, polling_policy::Newest<MessageT>>;
 
+// The wrapper's PollingSubscriber interface returns a single message from take_data(), so the
+// All policy (which yields a std::vector in InterProcessPollingSubscriber, and has no equivalent
+// in agnocast's native polling subscriber) cannot be represented. Reject it at compile time.
+template <typename MessageT, template <typename> class PollingPolicy>
+inline constexpr bool polling_policy_supported_v =
+  !std::is_same_v<PollingPolicy<MessageT>, polling_policy::All<MessageT>>;
+
 template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
 class PollingSubscriber
 {
 public:
+  static_assert(
+    polling_policy_supported_v<MessageT, PollingPolicy>,
+    "polling_policy::All is not supported by autoware::agnocast_wrapper::create_polling_subscriber "
+    "(take_data() returns a single message, not a vector). Use polling_policy::Latest or "
+    "polling_policy::Newest.");
+
   using SharedPtr = std::shared_ptr<PollingSubscriber<MessageT, PollingPolicy>>;
 
   static constexpr bool default_allow_same_message =
@@ -655,7 +668,7 @@ typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_su
 
 template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
 typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_subscriber(
-  rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos)
+  rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos = rclcpp::QoS{1})
 {
   if (use_agnocast()) {
     return std::make_shared<AgnocastPollingSubscriber<MessageT, PollingPolicy>>(

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -539,7 +539,8 @@ typename Subscription<MessageT>::SharedPtr create_subscription(
 }
 
 // Reuse the polling policy tag types (Latest / Newest / All) from autoware_utils_rclcpp so that
-// node code can specify the policy by type, exactly as with the original InterProcessPollingSubscriber.
+// node code can specify the policy by type, exactly as with the original
+// InterProcessPollingSubscriber.
 namespace polling_policy = autoware_utils_rclcpp::polling_policy;
 
 // Default value for take_data(allow_same_message): Latest re-delivers the cached message (true),
@@ -582,14 +583,14 @@ public:
   }
 
   AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)
-    takeData(bool allow_same_message = default_allow_same_message) override
+  takeData(bool allow_same_message = default_allow_same_message) override
   {
     auto data = subscriber_->take_data(allow_same_message);
     return AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)(std::move(data));
   }
 
   AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)
-    take_data(bool allow_same_message = default_allow_same_message) override
+  take_data(bool allow_same_message = default_allow_same_message) override
   {
     auto data = subscriber_->take_data(allow_same_message);
     return AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)(std::move(data));
@@ -622,19 +623,19 @@ public:
   explicit ROS2PollingSubscriber(
     rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos)
   : subscriber_(
-      autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT, PollingPolicy>::
-        create_subscription(node, topic_name, qos))
+      autoware_utils_rclcpp::InterProcessPollingSubscriber<
+        MessageT, PollingPolicy>::create_subscription(node, topic_name, qos))
   {
   }
 
   AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)
-    takeData(bool allow_same_message = default_allow_same_message) override
+  takeData(bool allow_same_message = default_allow_same_message) override
   {
     return take_data_impl(allow_same_message);
   }
 
   AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)
-    take_data(bool allow_same_message = default_allow_same_message) override
+  take_data(bool allow_same_message = default_allow_same_message) override
   {
     return take_data_impl(allow_same_message);
   }

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -93,10 +93,10 @@
 #define AUTOWARE_CREATE_PUBLISHER3_ON_NODE(message_type, node, arg1, arg2, arg3) \
   autoware::agnocast_wrapper::create_publisher<message_type>(node, arg1, arg2, arg3)
 
-#define AUTOWARE_CREATE_POLLING_SUBSCRIBER(message_type, topic, qos) \
-  autoware::agnocast_wrapper::create_polling_subscriber<message_type>(this, topic, qos)
-#define AUTOWARE_CREATE_POLLING_SUBSCRIBER_ON_NODE(message_type, node, topic, qos) \
-  autoware::agnocast_wrapper::create_polling_subscriber<message_type>(node, topic, qos)
+#define AUTOWARE_CREATE_POLLING_SUBSCRIBER(message_type, policy, topic, qos) \
+  autoware::agnocast_wrapper::create_polling_subscriber<message_type, policy>(this, topic, qos)
+#define AUTOWARE_CREATE_POLLING_SUBSCRIBER_ON_NODE(message_type, policy, node, topic, qos) \
+  autoware::agnocast_wrapper::create_polling_subscriber<message_type, policy>(node, topic, qos)
 
 #define AUTOWARE_CREATE_CLIENT1(service_type, service_name) \
   autoware::agnocast_wrapper::create_client<service_type>(this, service_name)
@@ -1400,11 +1400,11 @@ inline void set_period(const rclcpp::TimerBase::SharedPtr & timer, std::chrono::
 #define AUTOWARE_CREATE_PUBLISHER3_ON_NODE(message_type, node, arg1, arg2, arg3) \
   node->create_publisher<message_type>(arg1, arg2, arg3)
 
-#define AUTOWARE_CREATE_POLLING_SUBSCRIBER(message_type, topic, qos)                       \
-  autoware_utils_rclcpp::InterProcessPollingSubscriber<message_type>::create_subscription( \
+#define AUTOWARE_CREATE_POLLING_SUBSCRIBER(message_type, policy, topic, qos)                       \
+  autoware_utils_rclcpp::InterProcessPollingSubscriber<message_type, policy>::create_subscription( \
     this, topic, qos)
-#define AUTOWARE_CREATE_POLLING_SUBSCRIBER_ON_NODE(message_type, node, topic, qos)         \
-  autoware_utils_rclcpp::InterProcessPollingSubscriber<message_type>::create_subscription( \
+#define AUTOWARE_CREATE_POLLING_SUBSCRIBER_ON_NODE(message_type, policy, node, topic, qos)         \
+  autoware_utils_rclcpp::InterProcessPollingSubscriber<message_type, policy>::create_subscription( \
     node, topic, qos)
 
 #if RCLCPP_VERSION_MAJOR >= 28

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -701,7 +701,8 @@ public:
     typename MessageT,
     template <typename> class PollingPolicy = autoware_utils_rclcpp::polling_policy::Latest>
   typename autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT, PollingPolicy>::SharedPtr
-  create_polling_subscriber(const std::string & topic_name, const rclcpp::QoS & qos = rclcpp::QoS{1})
+  create_polling_subscriber(
+    const std::string & topic_name, const rclcpp::QoS & qos = rclcpp::QoS{1})
   {
     static_assert(
       !std::is_same_v<

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -247,17 +247,17 @@ public:
   typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_subscriber(
     const std::string & topic_name, const rclcpp::QoS & qos)
   {
-    return visit_node([&](auto & n) ->
-                      typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr {
-      using NodeT = std::decay_t<decltype(*n)>;
-      if constexpr (std::is_same_v<NodeT, agnocast::Node>) {
-        return std::make_shared<AgnocastPollingSubscriber<MessageT, PollingPolicy>>(
-          n.get(), topic_name, qos);
-      } else {
-        return std::make_shared<ROS2PollingSubscriber<MessageT, PollingPolicy>>(
-          n.get(), topic_name, qos);
-      }
-    });
+    return visit_node(
+      [&](auto & n) -> typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr {
+        using NodeT = std::decay_t<decltype(*n)>;
+        if constexpr (std::is_same_v<NodeT, agnocast::Node>) {
+          return std::make_shared<AgnocastPollingSubscriber<MessageT, PollingPolicy>>(
+            n.get(), topic_name, qos);
+        } else {
+          return std::make_shared<ROS2PollingSubscriber<MessageT, PollingPolicy>>(
+            n.get(), topic_name, qos);
+        }
+      });
   }
 
   template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -245,7 +245,7 @@ public:
   // ===== Polling Subscriber =====
   template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
   typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_subscriber(
-    const std::string & topic_name, const rclcpp::QoS & qos)
+    const std::string & topic_name, const rclcpp::QoS & qos = rclcpp::QoS{1})
   {
     return visit_node([&](auto & n) ->
                       typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr {
@@ -701,8 +701,14 @@ public:
     typename MessageT,
     template <typename> class PollingPolicy = autoware_utils_rclcpp::polling_policy::Latest>
   typename autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT, PollingPolicy>::SharedPtr
-  create_polling_subscriber(const std::string & topic_name, const rclcpp::QoS & qos)
+  create_polling_subscriber(const std::string & topic_name, const rclcpp::QoS & qos = rclcpp::QoS{1})
   {
+    static_assert(
+      !std::is_same_v<
+        PollingPolicy<MessageT>, autoware_utils_rclcpp::polling_policy::All<MessageT>>,
+      "polling_policy::All is not supported by "
+      "autoware::agnocast_wrapper::Node::create_polling_subscriber; use polling_policy::Latest or "
+      "polling_policy::Newest (or use InterProcessPollingSubscriber directly for the All policy).");
     return autoware_utils_rclcpp::InterProcessPollingSubscriber<
       MessageT, PollingPolicy>::create_subscription(node_.get(), topic_name, qos);
   }

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -243,25 +243,28 @@ public:
   }
 
   // ===== Polling Subscriber =====
-  template <typename MessageT>
-  typename PollingSubscriber<MessageT>::SharedPtr create_polling_subscriber(
+  template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
+  typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_subscriber(
     const std::string & topic_name, const rclcpp::QoS & qos)
   {
-    return visit_node([&](auto & n) -> typename PollingSubscriber<MessageT>::SharedPtr {
+    return visit_node([&](auto & n) ->
+                      typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr {
       using NodeT = std::decay_t<decltype(*n)>;
       if constexpr (std::is_same_v<NodeT, agnocast::Node>) {
-        return std::make_shared<AgnocastPollingSubscriber<MessageT>>(n.get(), topic_name, qos);
+        return std::make_shared<AgnocastPollingSubscriber<MessageT, PollingPolicy>>(
+          n.get(), topic_name, qos);
       } else {
-        return std::make_shared<ROS2PollingSubscriber<MessageT>>(n.get(), topic_name, qos);
+        return std::make_shared<ROS2PollingSubscriber<MessageT, PollingPolicy>>(
+          n.get(), topic_name, qos);
       }
     });
   }
 
-  template <typename MessageT>
-  typename PollingSubscriber<MessageT>::SharedPtr create_polling_subscriber(
+  template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
+  typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_subscriber(
     const std::string & topic_name, size_t qos_history_depth)
   {
-    return create_polling_subscriber<MessageT>(
+    return create_polling_subscriber<MessageT, PollingPolicy>(
       topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)));
   }
 
@@ -694,19 +697,23 @@ public:
   }
 
   // ===== Polling Subscriber =====
-  template <typename MessageT>
-  typename autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT>::SharedPtr
+  template <
+    typename MessageT,
+    template <typename> class PollingPolicy = autoware_utils_rclcpp::polling_policy::Latest>
+  typename autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT, PollingPolicy>::SharedPtr
   create_polling_subscriber(const std::string & topic_name, const rclcpp::QoS & qos)
   {
-    return autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT>::create_subscription(
-      node_.get(), topic_name, qos);
+    return autoware_utils_rclcpp::InterProcessPollingSubscriber<
+      MessageT, PollingPolicy>::create_subscription(node_.get(), topic_name, qos);
   }
 
-  template <typename MessageT>
-  typename autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT>::SharedPtr
+  template <
+    typename MessageT,
+    template <typename> class PollingPolicy = autoware_utils_rclcpp::polling_policy::Latest>
+  typename autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT, PollingPolicy>::SharedPtr
   create_polling_subscriber(const std::string & topic_name, size_t qos_history_depth)
   {
-    return create_polling_subscriber<MessageT>(
+    return create_polling_subscriber<MessageT, PollingPolicy>(
       topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)));
   }
 


### PR DESCRIPTION
## Description
Add polling-policy support to `autoware_agnocast_wrapper`'s polling subscriber, mirroring `autoware_utils_rclcpp::InterProcessPollingSubscriber`. `PollingSubscriber` / `AgnocastPollingSubscriber` / `ROS2PollingSubscriber` are now templated on `PollingPolicy` (`Latest` / `Newest`), so node code can select the policy by type exactly as before.

  - ROS 2 backend: the policy is forwarded to `InterProcessPollingSubscriber<MessageT, PollingPolicy>` (policy encoded in the type).
  - Agnocast backend: the policy is mapped to `allow_same_message` (`Latest` → `true`, `Newest` → `false`) and passed down via `agnocast::TakeSubscription::take(allow_same_message)`.
  - `polling_policy::All` is rejected at compile time (`take_data()` returns a single message, not a vector).
  - `AUTOWARE_CREATE_POLLING_SUBSCRIBER{,_ON_NODE}` now take `policy` as a required argument
(right after `message_type`, matching `AUTOWARE_POLLING_SUBSCRIBER_PTR`), so both builds
can select the policy via macro without dropping to explicit template calls. This is a breaking change, but safe: these macros have no call sites yet, so nothing needs migrating.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
 Built and ran with both `ENABLE_AGNOCAST=0` and `ENABLE_AGNOCAST=1`, confirming polling subscribers behave identically across backends.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
