### PR TITLE
feat(autoware_agnocast_wrapper): add default `qos_depth` as in `autoware_utils`

### DIFF
--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -618,7 +618,7 @@ typename PollingSubscriber<MessageT>::SharedPtr create_polling_subscriber(
 
 template <typename MessageT>
 typename PollingSubscriber<MessageT>::SharedPtr create_polling_subscriber(
-  rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos)
+  rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos = rclcpp::QoS{1})
 {
   if (use_agnocast()) {
     return std::make_shared<AgnocastPollingSubscriber<MessageT>>(node, topic_name, qos);

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -696,7 +696,8 @@ public:
   // ===== Polling Subscriber =====
   template <typename MessageT>
   typename autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT>::SharedPtr
-  create_polling_subscriber(const std::string & topic_name, const rclcpp::QoS & qos = rclcpp::QoS{1})
+  create_polling_subscriber(
+    const std::string & topic_name, const rclcpp::QoS & qos = rclcpp::QoS{1})
   {
     return autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT>::create_subscription(
       node_.get(), topic_name, qos);

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -245,7 +245,7 @@ public:
   // ===== Polling Subscriber =====
   template <typename MessageT>
   typename PollingSubscriber<MessageT>::SharedPtr create_polling_subscriber(
-    const std::string & topic_name, const rclcpp::QoS & qos)
+    const std::string & topic_name, const rclcpp::QoS & qos = rclcpp::QoS{1})
   {
     return visit_node([&](auto & n) -> typename PollingSubscriber<MessageT>::SharedPtr {
       using NodeT = std::decay_t<decltype(*n)>;
@@ -696,7 +696,7 @@ public:
   // ===== Polling Subscriber =====
   template <typename MessageT>
   typename autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT>::SharedPtr
-  create_polling_subscriber(const std::string & topic_name, const rclcpp::QoS & qos)
+  create_polling_subscriber(const std::string & topic_name, const rclcpp::QoS & qos = rclcpp::QoS{1})
   {
     return autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT>::create_subscription(
       node_.get(), topic_name, qos);


### PR DESCRIPTION
## Description
  `autoware_agnocast_wrapper`'s `create_polling_subscriber` currently requires the QoS (or history depth) argument to be passed explicitly. This PR defaults it to `rclcpp::QoS{1}` (depth 1) so the argument can be omitted.

This aligns the wrapper with `autoware_utils`, whose `InterProcessPollingSubscriber` constructor and `create_subscription` already default the QoS to depth 1:
  https://github.com/autowarefoundation/autoware_utils/blob/1a0ebbc8cb955e49ec28163a3a7953dc7fa4c312/autoware_utils_rclcpp/include/autoware_utils_rclcpp/polling_subscriber.hpp#L206-L231


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Tested by building with `ENABLE_AGNOCAST==0` and `ENABLE_AGNOCAST==1`.
## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
