### PR TITLE
fix(autoware_agnocast_wrapper): fix for `take_data`

### DIFF
--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -641,9 +641,6 @@ class ROS2PollingSubscriber : public PollingSubscriber<MessageT, PollingPolicy>
   static constexpr bool default_allow_same_message =
     polling_default_allow_same_message_v<MessageT, PollingPolicy>;
 
-  // autoware_utils_rclcpp's polling policies (Latest/Newest) expose take_data() with no argument;
-  // allow_same_message has no equivalent there, so it is accepted for API parity with the
-  // agnocast-backed subscriber but otherwise ignored.
   AUTOWARE_MESSAGE_SHARED_PTR(const MessageT) take_data_impl(bool allow_same_message)
   {
     (void)allow_same_message;

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -641,17 +641,13 @@ class ROS2PollingSubscriber : public PollingSubscriber<MessageT, PollingPolicy>
   static constexpr bool default_allow_same_message =
     polling_default_allow_same_message_v<MessageT, PollingPolicy>;
 
-  // The Newest policy exposes take_data() with no argument; Latest exposes take_data(bool).
-  // Dispatch to the matching signature so allow_same_message is honored where it applies.
+  // autoware_utils_rclcpp's polling policies (Latest/Newest) expose take_data() with no argument;
+  // allow_same_message has no equivalent there, so it is accepted for API parity with the
+  // agnocast-backed subscriber but otherwise ignored.
   AUTOWARE_MESSAGE_SHARED_PTR(const MessageT) take_data_impl(bool allow_same_message)
   {
-    if constexpr (std::is_same_v<PollingPolicy<MessageT>, polling_policy::Newest<MessageT>>) {
-      (void)allow_same_message;
-      return AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)(std::move(subscriber_->take_data()));
-    } else {
-      return AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)(
-        std::move(subscriber_->take_data(allow_same_message)));
-    }
+    (void)allow_same_message;
+    return AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)(std::move(subscriber_->take_data()));
   }
 
 public:


### PR DESCRIPTION
## Description
`ROS2PollingSubscriber::take_data_impl` called `subscriber_->take_data(allow_same_message)` on the `Latest` policy, but `autoware_utils_rclcpp`'s polling policies (`Latest`/`Newest`) only expose a no-argument `take_data()`. This caused a build failure with `ENABLE_AGNOCAST=1` for any package using `polling_policy::Latest` (e.g. `autoware_map_based_prediction`).

Fixed `take_data_impl` to always call the no-argument `take_data()`, since `allow_same_message` has no equivalent on the `autoware_utils_rclcpp` side.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Built `autoware_map_based_prediction` with `ENABLE_ANGOCAST` ==1 and ==0.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
