### PR TITLE
feat(PlanningFactorInterface): introduce node independent PlanningFactorInterfaceBase class

### DIFF
--- a/planning/autoware_planning_factor_interface/CMakeLists.txt
+++ b/planning/autoware_planning_factor_interface/CMakeLists.txt
@@ -9,9 +9,11 @@ ament_auto_add_library(autoware_planning_factor_interface SHARED
 )
 
 if(BUILD_TESTING)
+  find_package(autoware_agnocast_wrapper REQUIRED)
   ament_auto_add_gtest(test_${PROJECT_NAME}
     test/test_planning_factor_interface.cpp
   )
+  ament_target_dependencies(test_${PROJECT_NAME} autoware_agnocast_wrapper)
 endif()
 
 autoware_ament_auto_package()

--- a/planning/autoware_planning_factor_interface/include/autoware/planning_factor_interface/planning_factor_interface.hpp
+++ b/planning/autoware_planning_factor_interface/include/autoware/planning_factor_interface/planning_factor_interface.hpp
@@ -41,15 +41,16 @@ using autoware_internal_planning_msgs::msg::PlanningFactorArray;
 using autoware_internal_planning_msgs::msg::SafetyFactorArray;
 using geometry_msgs::msg::Pose;
 
-class PlanningFactorInterface
+template <typename NodeT>
+class PlanningFactorInterfaceT
 {
 public:
-  PlanningFactorInterface(
-    rclcpp::Node * node, const std::string & name, bool enable_console_output = false,
+  PlanningFactorInterfaceT(
+    NodeT * node, const std::string & name, bool enable_console_output = false,
     int throttle_duration_ms = 1000)
   : name_{name},
-    pub_factors_{
-      node->create_publisher<PlanningFactorArray>("/planning/planning_factors/" + name, 1)},
+    pub_factors_{node->template create_publisher<PlanningFactorArray>(
+      "/planning/planning_factors/" + name, 1)},
     clock_{node->get_clock()},
     enable_console_output_{enable_console_output},
     throttle_duration_ms_{throttle_duration_ms}
@@ -238,9 +239,13 @@ private:
     }
   }
 
+  using PublisherPtr =
+    decltype(std::declval<NodeT &>().template create_publisher<PlanningFactorArray>(
+      std::declval<const std::string &>(), 1));
+
   std::string name_;
 
-  rclcpp::Publisher<PlanningFactorArray>::SharedPtr pub_factors_;
+  PublisherPtr pub_factors_;
 
   rclcpp::Clock::SharedPtr clock_;
 
@@ -250,30 +255,36 @@ private:
   int throttle_duration_ms_{0};
 };
 
-extern template void
-PlanningFactorInterface::add<autoware_internal_planning_msgs::msg::PathPointWithLaneId>(
+using PlanningFactorInterface = PlanningFactorInterfaceT<rclcpp::Node>;
+
+extern template void PlanningFactorInterfaceT<rclcpp::Node>::add<
+  autoware_internal_planning_msgs::msg::PathPointWithLaneId>(
   const std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> &, const Pose &,
   const Pose &, const uint16_t behavior, const SafetyFactorArray &, const bool, const double,
   const double, const std::string &);
-extern template void PlanningFactorInterface::add<autoware_planning_msgs::msg::PathPoint>(
+extern template void
+PlanningFactorInterfaceT<rclcpp::Node>::add<autoware_planning_msgs::msg::PathPoint>(
   const std::vector<autoware_planning_msgs::msg::PathPoint> &, const Pose &, const Pose &,
   const uint16_t behavior, const SafetyFactorArray &, const bool, const double, const double,
   const std::string &);
-extern template void PlanningFactorInterface::add<autoware_planning_msgs::msg::TrajectoryPoint>(
+extern template void
+PlanningFactorInterfaceT<rclcpp::Node>::add<autoware_planning_msgs::msg::TrajectoryPoint>(
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> &, const Pose &, const Pose &,
   const uint16_t behavior, const SafetyFactorArray &, const bool, const double, const double,
   const std::string &);
 
-extern template void
-PlanningFactorInterface::add<autoware_internal_planning_msgs::msg::PathPointWithLaneId>(
+extern template void PlanningFactorInterfaceT<rclcpp::Node>::add<
+  autoware_internal_planning_msgs::msg::PathPointWithLaneId>(
   const std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> &, const Pose &,
   const Pose &, const Pose &, const uint16_t behavior, const SafetyFactorArray &, const bool,
   const double, const double, const double, const double, const std::string &);
-extern template void PlanningFactorInterface::add<autoware_planning_msgs::msg::PathPoint>(
+extern template void
+PlanningFactorInterfaceT<rclcpp::Node>::add<autoware_planning_msgs::msg::PathPoint>(
   const std::vector<autoware_planning_msgs::msg::PathPoint> &, const Pose &, const Pose &,
   const Pose &, const uint16_t behavior, const SafetyFactorArray &, const bool, const double,
   const double, const double, const double, const std::string &);
-extern template void PlanningFactorInterface::add<autoware_planning_msgs::msg::TrajectoryPoint>(
+extern template void
+PlanningFactorInterfaceT<rclcpp::Node>::add<autoware_planning_msgs::msg::TrajectoryPoint>(
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> &, const Pose &, const Pose &,
   const Pose &, const uint16_t behavior, const SafetyFactorArray &, const bool, const double,
   const double, const double, const double, const std::string &);

--- a/planning/autoware_planning_factor_interface/package.xml
+++ b/planning/autoware_planning_factor_interface/package.xml
@@ -20,6 +20,7 @@
 
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_agnocast_wrapper</test_depend>
   <test_depend>autoware_lint_common</test_depend>
   <test_depend>autoware_utils_geometry</test_depend>
 

--- a/planning/autoware_planning_factor_interface/src/planing_factor_interface.cpp
+++ b/planning/autoware_planning_factor_interface/src/planing_factor_interface.cpp
@@ -19,30 +19,32 @@
 
 namespace autoware::planning_factor_interface
 {
-template void
-PlanningFactorInterface::add<autoware_internal_planning_msgs::msg::PathPointWithLaneId>(
+template void PlanningFactorInterfaceT<rclcpp::Node>::add<
+  autoware_internal_planning_msgs::msg::PathPointWithLaneId>(
   const std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> &, const Pose &,
   const Pose &, const uint16_t behavior, const SafetyFactorArray &, const bool, const double,
   const double, const std::string &);
-template void PlanningFactorInterface::add<autoware_planning_msgs::msg::PathPoint>(
+template void PlanningFactorInterfaceT<rclcpp::Node>::add<autoware_planning_msgs::msg::PathPoint>(
   const std::vector<autoware_planning_msgs::msg::PathPoint> &, const Pose &, const Pose &,
   const uint16_t behavior, const SafetyFactorArray &, const bool, const double, const double,
   const std::string &);
-template void PlanningFactorInterface::add<autoware_planning_msgs::msg::TrajectoryPoint>(
+template void
+PlanningFactorInterfaceT<rclcpp::Node>::add<autoware_planning_msgs::msg::TrajectoryPoint>(
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> &, const Pose &, const Pose &,
   const uint16_t behavior, const SafetyFactorArray &, const bool, const double, const double,
   const std::string &);
 
-template void
-PlanningFactorInterface::add<autoware_internal_planning_msgs::msg::PathPointWithLaneId>(
+template void PlanningFactorInterfaceT<rclcpp::Node>::add<
+  autoware_internal_planning_msgs::msg::PathPointWithLaneId>(
   const std::vector<autoware_internal_planning_msgs::msg::PathPointWithLaneId> &, const Pose &,
   const Pose &, const Pose &, const uint16_t behavior, const SafetyFactorArray &, const bool,
   const double, const double, const double, const double, const std::string &);
-template void PlanningFactorInterface::add<autoware_planning_msgs::msg::PathPoint>(
+template void PlanningFactorInterfaceT<rclcpp::Node>::add<autoware_planning_msgs::msg::PathPoint>(
   const std::vector<autoware_planning_msgs::msg::PathPoint> &, const Pose &, const Pose &,
   const Pose &, const uint16_t behavior, const SafetyFactorArray &, const bool, const double,
   const double, const double, const double, const std::string &);
-template void PlanningFactorInterface::add<autoware_planning_msgs::msg::TrajectoryPoint>(
+template void
+PlanningFactorInterfaceT<rclcpp::Node>::add<autoware_planning_msgs::msg::TrajectoryPoint>(
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> &, const Pose &, const Pose &,
   const Pose &, const uint16_t behavior, const SafetyFactorArray &, const bool, const double,
   const double, const double, const double, const std::string &);

--- a/planning/autoware_planning_factor_interface/test/test_planning_factor_interface.cpp
+++ b/planning/autoware_planning_factor_interface/test/test_planning_factor_interface.cpp
@@ -63,17 +63,16 @@ std::vector<TrajectoryPoint> make_straight_trajectory(const size_t num_points)
 }
 }  // namespace
 
-// Run the suite over the agnocast wrapper node PlanningFactorInterfaceT is instantiated with.
 class PlanningFactorInterfaceTest : public ::testing::Test
 {
 protected:
-  using NodeT = autoware::agnocast_wrapper::Node;
-  using InterfaceT = PlanningFactorInterfaceT<NodeT>;
+  using InterfaceT = PlanningFactorInterfaceT<autoware::agnocast_wrapper::Node>;
 
   void SetUp() override
   {
     rclcpp::init(0, nullptr);
-    node_ = std::make_shared<NodeT>("planning_factor_interface_test_node");
+    node_ =
+      std::make_shared<autoware::agnocast_wrapper::Node>("planning_factor_interface_test_node");
     interface_ = std::make_unique<InterfaceT>(node_.get(), "test_module");
   }
 
@@ -84,7 +83,7 @@ protected:
     rclcpp::shutdown();
   }
 
-  std::shared_ptr<NodeT> node_;
+  std::shared_ptr<autoware::agnocast_wrapper::Node> node_;
   std::unique_ptr<InterfaceT> interface_;
 };
 

--- a/planning/autoware_planning_factor_interface/test/test_planning_factor_interface.cpp
+++ b/planning/autoware_planning_factor_interface/test/test_planning_factor_interface.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/planning_factor_interface/planning_factor_interface.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -62,14 +63,19 @@ std::vector<TrajectoryPoint> make_straight_trajectory(const size_t num_points)
 }
 }  // namespace
 
+// Run the suite over both node types PlanningFactorInterfaceT is instantiated with:
+// rclcpp::Node and the agnocast wrapper node.
+template <typename NodeT>
 class PlanningFactorInterfaceTest : public ::testing::Test
 {
 protected:
+  using InterfaceT = PlanningFactorInterfaceT<NodeT>;
+
   void SetUp() override
   {
     rclcpp::init(0, nullptr);
-    node_ = std::make_shared<rclcpp::Node>("planning_factor_interface_test_node");
-    interface_ = std::make_unique<PlanningFactorInterface>(node_.get(), "test_module");
+    node_ = std::make_shared<NodeT>("planning_factor_interface_test_node");
+    interface_ = std::make_unique<InterfaceT>(node_.get(), "test_module");
   }
 
   void TearDown() override
@@ -79,23 +85,26 @@ protected:
     rclcpp::shutdown();
   }
 
-  std::shared_ptr<rclcpp::Node> node_;
-  std::unique_ptr<PlanningFactorInterface> interface_;
+  std::shared_ptr<NodeT> node_;
+  std::unique_ptr<InterfaceT> interface_;
 };
+
+using NodeTypes = ::testing::Types<rclcpp::Node, autoware::agnocast_wrapper::Node>;
+TYPED_TEST_SUITE(PlanningFactorInterfaceTest, NodeTypes);
 
 // add(distance, ...) populates exactly one ControlPoint with the supplied fields and
 // the PlanningFactor metadata (module name, behavior, detail, driving direction).
-TEST_F(PlanningFactorInterfaceTest, AddSingleControlPoint)
+TYPED_TEST(PlanningFactorInterfaceTest, AddSingleControlPoint)
 {
   const auto control_pose = make_pose(3.0, 4.0);
   SafetyFactorArray safety_factors;
   safety_factors.is_safe = true;
 
-  interface_->add(
+  this->interface_->add(
     /*distance=*/12.5, control_pose, PlanningFactor::STOP, safety_factors,
     /*is_driving_forward=*/false, /*velocity=*/2.0, /*shift_length=*/-1.5, "detail-text");
 
-  const auto & factors = interface_->get_factors();
+  const auto & factors = this->interface_->get_factors();
   ASSERT_EQ(factors.size(), 1u);
 
   const auto & factor = factors.front();
@@ -115,18 +124,18 @@ TEST_F(PlanningFactorInterfaceTest, AddSingleControlPoint)
 }
 
 // add(start_distance, end_distance, ...) populates two ControlPoints in start->end order.
-TEST_F(PlanningFactorInterfaceTest, AddTwoControlPoints)
+TYPED_TEST(PlanningFactorInterfaceTest, AddTwoControlPoints)
 {
   const auto start_pose = make_pose(1.0, 0.0);
   const auto end_pose = make_pose(5.0, 0.0);
   const SafetyFactorArray safety_factors;
 
-  interface_->add(
+  this->interface_->add(
     /*start_distance=*/1.0, /*end_distance=*/5.0, start_pose, end_pose, PlanningFactor::SLOW_DOWN,
     safety_factors, /*is_driving_forward=*/true, /*start_velocity=*/3.0, /*end_velocity=*/4.0,
     /*start_shift_length=*/0.5, /*end_shift_length=*/0.7, "section");
 
-  const auto & factors = interface_->get_factors();
+  const auto & factors = this->interface_->get_factors();
   ASSERT_EQ(factors.size(), 1u);
 
   const auto & factor = factors.front();
@@ -152,23 +161,23 @@ TEST_F(PlanningFactorInterfaceTest, AddTwoControlPoints)
 // The templated single-point add() forwards the calcSignedArcLength result into
 // ControlPoint.distance. With a 1 m-spaced straight trajectory the signed arc length
 // from the origin to (x, 0) is exactly x.
-TEST_F(PlanningFactorInterfaceTest, AddTemplatedSinglePointForwardsArcLength)
+TYPED_TEST(PlanningFactorInterfaceTest, AddTemplatedSinglePointForwardsArcLength)
 {
   const auto points = make_straight_trajectory(6);
   const auto ego_pose = make_pose(0.0, 0.0);
   const auto control_pose = make_pose(4.0, 0.0);
   const SafetyFactorArray safety_factors;
 
-  interface_->add(points, ego_pose, control_pose, PlanningFactor::STOP, safety_factors);
+  this->interface_->add(points, ego_pose, control_pose, PlanningFactor::STOP, safety_factors);
 
-  const auto & factors = interface_->get_factors();
+  const auto & factors = this->interface_->get_factors();
   ASSERT_EQ(factors.size(), 1u);
   ASSERT_EQ(factors.front().control_points.size(), 1u);
   EXPECT_FLOAT_EQ(factors.front().control_points.front().distance, 4.0f);
 }
 
 // The templated two-point add() forwards both calcSignedArcLength results in order.
-TEST_F(PlanningFactorInterfaceTest, AddTemplatedTwoPointsForwardsArcLength)
+TYPED_TEST(PlanningFactorInterfaceTest, AddTemplatedTwoPointsForwardsArcLength)
 {
   const auto points = make_straight_trajectory(8);
   const auto ego_pose = make_pose(0.0, 0.0);
@@ -176,10 +185,10 @@ TEST_F(PlanningFactorInterfaceTest, AddTemplatedTwoPointsForwardsArcLength)
   const auto end_pose = make_pose(6.0, 0.0);
   const SafetyFactorArray safety_factors;
 
-  interface_->add(
+  this->interface_->add(
     points, ego_pose, start_pose, end_pose, PlanningFactor::SLOW_DOWN, safety_factors);
 
-  const auto & factors = interface_->get_factors();
+  const auto & factors = this->interface_->get_factors();
   ASSERT_EQ(factors.size(), 1u);
   ASSERT_EQ(factors.front().control_points.size(), 2u);
   EXPECT_FLOAT_EQ(factors.front().control_points.at(0).distance, 2.0f);
@@ -187,14 +196,14 @@ TEST_F(PlanningFactorInterfaceTest, AddTemplatedTwoPointsForwardsArcLength)
 }
 
 // Multiple add() calls accumulate into factors_ in insertion order.
-TEST_F(PlanningFactorInterfaceTest, MultipleAddAccumulates)
+TYPED_TEST(PlanningFactorInterfaceTest, MultipleAddAccumulates)
 {
   const SafetyFactorArray safety_factors;
-  interface_->add(1.0, make_pose(1.0, 0.0), PlanningFactor::STOP, safety_factors);
-  interface_->add(2.0, make_pose(2.0, 0.0), PlanningFactor::SLOW_DOWN, safety_factors);
-  interface_->add(3.0, make_pose(3.0, 0.0), PlanningFactor::NONE, safety_factors);
+  this->interface_->add(1.0, make_pose(1.0, 0.0), PlanningFactor::STOP, safety_factors);
+  this->interface_->add(2.0, make_pose(2.0, 0.0), PlanningFactor::SLOW_DOWN, safety_factors);
+  this->interface_->add(3.0, make_pose(3.0, 0.0), PlanningFactor::NONE, safety_factors);
 
-  const auto & factors = interface_->get_factors();
+  const auto & factors = this->interface_->get_factors();
   ASSERT_EQ(factors.size(), 3u);
   EXPECT_EQ(factors.at(0).behavior, PlanningFactor::STOP);
   EXPECT_EQ(factors.at(1).behavior, PlanningFactor::SLOW_DOWN);
@@ -206,26 +215,27 @@ TEST_F(PlanningFactorInterfaceTest, MultipleAddAccumulates)
 
 // publish() stamps frame_id='map', forwards the accumulated factors into the message,
 // and clears the internal buffer afterwards.
-TEST_F(PlanningFactorInterfaceTest, PublishStampsAndForwardsFactors)
+TYPED_TEST(PlanningFactorInterfaceTest, PublishStampsAndForwardsFactors)
 {
   const SafetyFactorArray safety_factors;
-  interface_->add(7.0, make_pose(7.0, 0.0), PlanningFactor::STOP, safety_factors, true, 1.0, 0.0);
+  this->interface_->add(
+    7.0, make_pose(7.0, 0.0), PlanningFactor::STOP, safety_factors, true, 1.0, 0.0);
 
   PlanningFactorArray received;
   bool got_msg = false;
-  auto sub = node_->create_subscription<PlanningFactorArray>(
+  auto sub = this->node_->template create_subscription<PlanningFactorArray>(
     "/planning/planning_factors/test_module", rclcpp::QoS{1},
     [&](const PlanningFactorArray::ConstSharedPtr msg) {
       received = *msg;
       got_msg = true;
     });
 
-  interface_->publish();
+  this->interface_->publish();
 
   // Spin until the subscription receives the published message (bounded wait).
   const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
   while (!got_msg && std::chrono::steady_clock::now() < deadline) {
-    rclcpp::spin_some(node_);
+    rclcpp::spin_some(this->node_->get_node_base_interface());
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
 
@@ -239,19 +249,19 @@ TEST_F(PlanningFactorInterfaceTest, PublishStampsAndForwardsFactors)
 
 // publish() clears the internal factor buffer so the next cycle starts empty
 // (the clear-after-publish contract).
-TEST_F(PlanningFactorInterfaceTest, PublishClearsFactors)
+TYPED_TEST(PlanningFactorInterfaceTest, PublishClearsFactors)
 {
   const SafetyFactorArray safety_factors;
-  interface_->add(1.0, make_pose(1.0, 0.0), PlanningFactor::STOP, safety_factors);
-  ASSERT_EQ(interface_->get_factors().size(), 1u);
+  this->interface_->add(1.0, make_pose(1.0, 0.0), PlanningFactor::STOP, safety_factors);
+  ASSERT_EQ(this->interface_->get_factors().size(), 1u);
 
-  interface_->publish();
+  this->interface_->publish();
 
-  EXPECT_TRUE(interface_->get_factors().empty());
+  EXPECT_TRUE(this->interface_->get_factors().empty());
 
   // A subsequent add starts from an empty buffer.
-  interface_->add(2.0, make_pose(2.0, 0.0), PlanningFactor::SLOW_DOWN, safety_factors);
-  EXPECT_EQ(interface_->get_factors().size(), 1u);
+  this->interface_->add(2.0, make_pose(2.0, 0.0), PlanningFactor::SLOW_DOWN, safety_factors);
+  EXPECT_EQ(this->interface_->get_factors().size(), 1u);
 }
 
 }  // namespace autoware::planning_factor_interface

--- a/planning/autoware_planning_factor_interface/test/test_planning_factor_interface.cpp
+++ b/planning/autoware_planning_factor_interface/test/test_planning_factor_interface.cpp
@@ -63,12 +63,11 @@ std::vector<TrajectoryPoint> make_straight_trajectory(const size_t num_points)
 }
 }  // namespace
 
-// Run the suite over both node types PlanningFactorInterfaceT is instantiated with:
-// rclcpp::Node and the agnocast wrapper node.
-template <typename NodeT>
+// Run the suite over the agnocast wrapper node PlanningFactorInterfaceT is instantiated with.
 class PlanningFactorInterfaceTest : public ::testing::Test
 {
 protected:
+  using NodeT = autoware::agnocast_wrapper::Node;
   using InterfaceT = PlanningFactorInterfaceT<NodeT>;
 
   void SetUp() override
@@ -89,22 +88,19 @@ protected:
   std::unique_ptr<InterfaceT> interface_;
 };
 
-using NodeTypes = ::testing::Types<rclcpp::Node, autoware::agnocast_wrapper::Node>;
-TYPED_TEST_SUITE(PlanningFactorInterfaceTest, NodeTypes);
-
 // add(distance, ...) populates exactly one ControlPoint with the supplied fields and
 // the PlanningFactor metadata (module name, behavior, detail, driving direction).
-TYPED_TEST(PlanningFactorInterfaceTest, AddSingleControlPoint)
+TEST_F(PlanningFactorInterfaceTest, AddSingleControlPoint)
 {
   const auto control_pose = make_pose(3.0, 4.0);
   SafetyFactorArray safety_factors;
   safety_factors.is_safe = true;
 
-  this->interface_->add(
+  interface_->add(
     /*distance=*/12.5, control_pose, PlanningFactor::STOP, safety_factors,
     /*is_driving_forward=*/false, /*velocity=*/2.0, /*shift_length=*/-1.5, "detail-text");
 
-  const auto & factors = this->interface_->get_factors();
+  const auto & factors = interface_->get_factors();
   ASSERT_EQ(factors.size(), 1u);
 
   const auto & factor = factors.front();
@@ -124,18 +120,18 @@ TYPED_TEST(PlanningFactorInterfaceTest, AddSingleControlPoint)
 }
 
 // add(start_distance, end_distance, ...) populates two ControlPoints in start->end order.
-TYPED_TEST(PlanningFactorInterfaceTest, AddTwoControlPoints)
+TEST_F(PlanningFactorInterfaceTest, AddTwoControlPoints)
 {
   const auto start_pose = make_pose(1.0, 0.0);
   const auto end_pose = make_pose(5.0, 0.0);
   const SafetyFactorArray safety_factors;
 
-  this->interface_->add(
+  interface_->add(
     /*start_distance=*/1.0, /*end_distance=*/5.0, start_pose, end_pose, PlanningFactor::SLOW_DOWN,
     safety_factors, /*is_driving_forward=*/true, /*start_velocity=*/3.0, /*end_velocity=*/4.0,
     /*start_shift_length=*/0.5, /*end_shift_length=*/0.7, "section");
 
-  const auto & factors = this->interface_->get_factors();
+  const auto & factors = interface_->get_factors();
   ASSERT_EQ(factors.size(), 1u);
 
   const auto & factor = factors.front();
@@ -161,23 +157,23 @@ TYPED_TEST(PlanningFactorInterfaceTest, AddTwoControlPoints)
 // The templated single-point add() forwards the calcSignedArcLength result into
 // ControlPoint.distance. With a 1 m-spaced straight trajectory the signed arc length
 // from the origin to (x, 0) is exactly x.
-TYPED_TEST(PlanningFactorInterfaceTest, AddTemplatedSinglePointForwardsArcLength)
+TEST_F(PlanningFactorInterfaceTest, AddTemplatedSinglePointForwardsArcLength)
 {
   const auto points = make_straight_trajectory(6);
   const auto ego_pose = make_pose(0.0, 0.0);
   const auto control_pose = make_pose(4.0, 0.0);
   const SafetyFactorArray safety_factors;
 
-  this->interface_->add(points, ego_pose, control_pose, PlanningFactor::STOP, safety_factors);
+  interface_->add(points, ego_pose, control_pose, PlanningFactor::STOP, safety_factors);
 
-  const auto & factors = this->interface_->get_factors();
+  const auto & factors = interface_->get_factors();
   ASSERT_EQ(factors.size(), 1u);
   ASSERT_EQ(factors.front().control_points.size(), 1u);
   EXPECT_FLOAT_EQ(factors.front().control_points.front().distance, 4.0f);
 }
 
 // The templated two-point add() forwards both calcSignedArcLength results in order.
-TYPED_TEST(PlanningFactorInterfaceTest, AddTemplatedTwoPointsForwardsArcLength)
+TEST_F(PlanningFactorInterfaceTest, AddTemplatedTwoPointsForwardsArcLength)
 {
   const auto points = make_straight_trajectory(8);
   const auto ego_pose = make_pose(0.0, 0.0);
@@ -185,10 +181,10 @@ TYPED_TEST(PlanningFactorInterfaceTest, AddTemplatedTwoPointsForwardsArcLength)
   const auto end_pose = make_pose(6.0, 0.0);
   const SafetyFactorArray safety_factors;
 
-  this->interface_->add(
+  interface_->add(
     points, ego_pose, start_pose, end_pose, PlanningFactor::SLOW_DOWN, safety_factors);
 
-  const auto & factors = this->interface_->get_factors();
+  const auto & factors = interface_->get_factors();
   ASSERT_EQ(factors.size(), 1u);
   ASSERT_EQ(factors.front().control_points.size(), 2u);
   EXPECT_FLOAT_EQ(factors.front().control_points.at(0).distance, 2.0f);
@@ -196,14 +192,14 @@ TYPED_TEST(PlanningFactorInterfaceTest, AddTemplatedTwoPointsForwardsArcLength)
 }
 
 // Multiple add() calls accumulate into factors_ in insertion order.
-TYPED_TEST(PlanningFactorInterfaceTest, MultipleAddAccumulates)
+TEST_F(PlanningFactorInterfaceTest, MultipleAddAccumulates)
 {
   const SafetyFactorArray safety_factors;
-  this->interface_->add(1.0, make_pose(1.0, 0.0), PlanningFactor::STOP, safety_factors);
-  this->interface_->add(2.0, make_pose(2.0, 0.0), PlanningFactor::SLOW_DOWN, safety_factors);
-  this->interface_->add(3.0, make_pose(3.0, 0.0), PlanningFactor::NONE, safety_factors);
+  interface_->add(1.0, make_pose(1.0, 0.0), PlanningFactor::STOP, safety_factors);
+  interface_->add(2.0, make_pose(2.0, 0.0), PlanningFactor::SLOW_DOWN, safety_factors);
+  interface_->add(3.0, make_pose(3.0, 0.0), PlanningFactor::NONE, safety_factors);
 
-  const auto & factors = this->interface_->get_factors();
+  const auto & factors = interface_->get_factors();
   ASSERT_EQ(factors.size(), 3u);
   EXPECT_EQ(factors.at(0).behavior, PlanningFactor::STOP);
   EXPECT_EQ(factors.at(1).behavior, PlanningFactor::SLOW_DOWN);
@@ -215,27 +211,26 @@ TYPED_TEST(PlanningFactorInterfaceTest, MultipleAddAccumulates)
 
 // publish() stamps frame_id='map', forwards the accumulated factors into the message,
 // and clears the internal buffer afterwards.
-TYPED_TEST(PlanningFactorInterfaceTest, PublishStampsAndForwardsFactors)
+TEST_F(PlanningFactorInterfaceTest, PublishStampsAndForwardsFactors)
 {
   const SafetyFactorArray safety_factors;
-  this->interface_->add(
-    7.0, make_pose(7.0, 0.0), PlanningFactor::STOP, safety_factors, true, 1.0, 0.0);
+  interface_->add(7.0, make_pose(7.0, 0.0), PlanningFactor::STOP, safety_factors, true, 1.0, 0.0);
 
   PlanningFactorArray received;
   bool got_msg = false;
-  auto sub = this->node_->template create_subscription<PlanningFactorArray>(
+  auto sub = node_->create_subscription<PlanningFactorArray>(
     "/planning/planning_factors/test_module", rclcpp::QoS{1},
     [&](const PlanningFactorArray::ConstSharedPtr msg) {
       received = *msg;
       got_msg = true;
     });
 
-  this->interface_->publish();
+  interface_->publish();
 
   // Spin until the subscription receives the published message (bounded wait).
   const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
   while (!got_msg && std::chrono::steady_clock::now() < deadline) {
-    rclcpp::spin_some(this->node_->get_node_base_interface());
+    rclcpp::spin_some(node_->get_node_base_interface());
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
 
@@ -249,19 +244,19 @@ TYPED_TEST(PlanningFactorInterfaceTest, PublishStampsAndForwardsFactors)
 
 // publish() clears the internal factor buffer so the next cycle starts empty
 // (the clear-after-publish contract).
-TYPED_TEST(PlanningFactorInterfaceTest, PublishClearsFactors)
+TEST_F(PlanningFactorInterfaceTest, PublishClearsFactors)
 {
   const SafetyFactorArray safety_factors;
-  this->interface_->add(1.0, make_pose(1.0, 0.0), PlanningFactor::STOP, safety_factors);
-  ASSERT_EQ(this->interface_->get_factors().size(), 1u);
+  interface_->add(1.0, make_pose(1.0, 0.0), PlanningFactor::STOP, safety_factors);
+  ASSERT_EQ(interface_->get_factors().size(), 1u);
 
-  this->interface_->publish();
+  interface_->publish();
 
-  EXPECT_TRUE(this->interface_->get_factors().empty());
+  EXPECT_TRUE(interface_->get_factors().empty());
 
   // A subsequent add starts from an empty buffer.
-  this->interface_->add(2.0, make_pose(2.0, 0.0), PlanningFactor::SLOW_DOWN, safety_factors);
-  EXPECT_EQ(this->interface_->get_factors().size(), 1u);
+  interface_->add(2.0, make_pose(2.0, 0.0), PlanningFactor::SLOW_DOWN, safety_factors);
+  EXPECT_EQ(interface_->get_factors().size(), 1u);
 }
 
 }  // namespace autoware::planning_factor_interface


### PR DESCRIPTION
## Description
Make `PlanningFactorInterface` node-type agnostic so a node that owns its publisher can reuse the factor-accumulation logic and publish planning factors through its own node.

Instead of splitting out a base class, the class is generalized over the node type: `PlanningFactorInterface` becomes `PlanningFactorInterfaceT<NodeT>`, the publisher is created through `NodeT`, and its type is deduced from `NodeT::create_publisher(...)` via `decltype`. `using PlanningFactorInterface = PlanningFactorInterfaceT<rclcpp::Node>;` keeps the historic name and public contract, and the explicit `PlanningFactorInterface::add<T>` instantiations are re-emitted for `PlanningFactorInterfaceT<rclcpp::Node>` so the ABI of the existing type is unchanged.

This is required so the `autoware_trajectory_modifier` node can own its own planning-factor publisher instead of relying on the rclcpp publisher embedded in `PlanningFactorInterface`.

## Related links
https://github.com/autowarefoundation/autoware_universe/pull/12980

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- `test/test_planning_factor_interface.cpp` is converted to a `TYPED_TEST` over both node types the class is instantiated with in production: `rclcpp::Node` and `autoware::agnocast_wrapper::Node`. The whole suite (single/two control points, templated arc-length forwarding, accumulation, publish stamping/forwarding, clear-after-publish) runs against both instantiations, so the templatization is exercised for the agnocast wrapper node and not only the historic `rclcpp::Node` path.
- Verified with `ENABLE_AGNOCAST=0`: the full suite passes for both node types (14/14).

## Notes for reviewers
The core library gains no rclcpp/agnocast publishing dependency of its own: the publisher type is delegated entirely to `NodeT`. Downstream users of the `PlanningFactorInterface` alias are unaffected (same public API and ABI).

## Interface changes

None. `PlanningFactorInterface` keeps the same public API and ABI.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
