### PR TITLE
refactor(autoware_agnocast_wrapper): move set_period/polling_policy after the non-Agnocast macro block

### DIFF
--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -1321,41 +1321,6 @@ inline void set_period(const Timer::SharedPtr & timer, std::chrono::nanoseconds 
 
 #else
 
-namespace autoware::agnocast_wrapper
-{
-
-// Mirror the Agnocast-build alias so node code can name the polling policy the same way in both
-// builds (e.g. autoware::agnocast_wrapper::polling_policy::Newest).
-namespace polling_policy = autoware_utils_rclcpp::polling_policy;
-
-/// @brief Set the timer period (non-Agnocast build).
-///
-/// rclcpp::TimerBase has no set_period member, so we provide a free overload
-/// that falls back to the rcl C API. Mirrors the Agnocast-build overload on
-/// Timer::SharedPtr so the same call site works in both builds.
-///
-/// @throws std::invalid_argument if period is negative or equal to
-///   std::chrono::nanoseconds::max() (mirrors rclcpp::create_wall_timer's
-///   precondition 0 <= period < nanoseconds::max()).
-/// @throws rclcpp::exceptions::RCLError on rcl-level failure.
-inline void set_period(const rclcpp::TimerBase::SharedPtr & timer, std::chrono::nanoseconds period)
-{
-  if (period < std::chrono::nanoseconds::zero()) {
-    throw std::invalid_argument{"timer period cannot be negative"};
-  }
-  if (period == std::chrono::nanoseconds::max()) {
-    throw std::invalid_argument{"timer period must be less than std::chrono::nanoseconds::max()"};
-  }
-  int64_t old_period = 0;
-  const rcl_ret_t ret =
-    rcl_timer_exchange_period(timer->get_timer_handle().get(), period.count(), &old_period);
-  if (ret != RCL_RET_OK) {
-    rclcpp::exceptions::throw_from_rcl_error(ret, "Failed to set timer period");
-  }
-}
-
-}  // namespace autoware::agnocast_wrapper
-
 #define AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) std::unique_ptr<MessageT>
 // For publisher (mutable message)
 #define AUTOWARE_MESSAGE_SHARED_PTR(MessageT) std::shared_ptr<MessageT>
@@ -1467,5 +1432,40 @@ inline void set_period(const rclcpp::TimerBase::SharedPtr & timer, std::chrono::
   std::make_shared<typename std::remove_reference<decltype(*publisher)>::type::ROSMessageType>()
 #define ALLOCATE_OUTPUT_SERVICE_REQUEST(client) \
   std::make_shared<typename std::remove_reference<decltype(*client)>::type::Request>()
+
+namespace autoware::agnocast_wrapper
+{
+
+// Mirror the Agnocast-build alias so node code can name the polling policy the same way in both
+// builds (e.g. autoware::agnocast_wrapper::polling_policy::Newest).
+namespace polling_policy = autoware_utils_rclcpp::polling_policy;
+
+/// @brief Set the timer period (non-Agnocast build).
+///
+/// rclcpp::TimerBase has no set_period member, so we provide a free overload
+/// that falls back to the rcl C API. Mirrors the Agnocast-build overload on
+/// Timer::SharedPtr so the same call site works in both builds.
+///
+/// @throws std::invalid_argument if period is negative or equal to
+///   std::chrono::nanoseconds::max() (mirrors rclcpp::create_wall_timer's
+///   precondition 0 <= period < nanoseconds::max()).
+/// @throws rclcpp::exceptions::RCLError on rcl-level failure.
+inline void set_period(const rclcpp::TimerBase::SharedPtr & timer, std::chrono::nanoseconds period)
+{
+  if (period < std::chrono::nanoseconds::zero()) {
+    throw std::invalid_argument{"timer period cannot be negative"};
+  }
+  if (period == std::chrono::nanoseconds::max()) {
+    throw std::invalid_argument{"timer period must be less than std::chrono::nanoseconds::max()"};
+  }
+  int64_t old_period = 0;
+  const rcl_ret_t ret =
+    rcl_timer_exchange_period(timer->get_timer_handle().get(), period.count(), &old_period);
+  if (ret != RCL_RET_OK) {
+    rclcpp::exceptions::throw_from_rcl_error(ret, "Failed to set timer period");
+  }
+}
+
+}  // namespace autoware::agnocast_wrapper
 
 #endif


### PR DESCRIPTION
## Description
As in the title. This is the pre-refactoring before service/client API unification between `ENABLE_AGNOCAST`=0/1.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Built with both `ENABLE_AGNOCAST`=0/1.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
