### PR TITLE
feat: [codecov/refactoring] [lanelet2_map_loader] implement characterization test

### DIFF
--- a/map/autoware_map_loader/CMakeLists.txt
+++ b/map/autoware_map_loader/CMakeLists.txt
@@ -73,6 +73,7 @@ if(BUILD_TESTING)
   add_testcase(test/lanelet2_map_loader/test_lanelet2_map_loader_utils.cpp)
   add_testcase(test/lanelet2_map_loader/test_lanelet2_map_cell_metadata.cpp)
   add_testcase(test/lanelet2_map_loader/test_lanelet2_selected_map_loader_module.cpp)
+  add_testcase(test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp)
 endif()
 
 install(PROGRAMS

--- a/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp
+++ b/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp
@@ -40,14 +40,7 @@ protected:
 
   static void TearDownTestSuite() { rclcpp::shutdown(); }
 
-  // Runs before each test
-  void SetUp() override
-  {
-    test_node_ = std::make_shared<rclcpp::Node>("test_lanelet2_map_loader_client");
-
-    projector_pub_ = test_node_->create_publisher<MapProjectorInfo::Message>(
-      MapProjectorInfo::name, autoware::component_interface_specs::get_qos<MapProjectorInfo>());
-  }
+  void SetUp() override {}
 
   void TearDown() override { test_node_.reset(); }
 
@@ -59,8 +52,64 @@ protected:
     }
   }
 
+  struct ReceivedMessages
+  {
+    rclcpp::Node::SharedPtr target_node;
+    autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr map_msg;
+    autoware_map_msgs::msg::LaneletMapMetaData::ConstSharedPtr meta_msg;
+  };
+
+  ReceivedMessages receive_map_and_metadata(
+    const rclcpp::NodeOptions & options, std::chrono::seconds timeout = std::chrono::seconds(3))
+  {
+    auto target_node = std::make_shared<autoware::map_loader::Lanelet2MapLoaderNode>(options);
+
+    // Must reset executor each time to prevent zombie nodes
+    executor_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
+    executor_->add_node(target_node);
+
+    test_node_ = std::make_shared<rclcpp::Node>("test_lanelet2_map_loader_client");
+    projector_pub_ = test_node_->create_publisher<MapProjectorInfo::Message>(
+      MapProjectorInfo::name, autoware::component_interface_specs::get_qos<MapProjectorInfo>());
+    executor_->add_node(test_node_);
+
+    autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr map_msg;
+    auto map_sub = test_node_->create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
+      "/map/vector_map", rclcpp::QoS{1}.transient_local(),
+      [&map_msg](const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg) {
+        map_msg = msg;
+      });
+
+    autoware_map_msgs::msg::LaneletMapMetaData::ConstSharedPtr meta_msg;
+    auto meta_sub = test_node_->create_subscription<autoware_map_msgs::msg::LaneletMapMetaData>(
+      "output/lanelet2_map_metadata", rclcpp::QoS{1}.transient_local(),
+      [&meta_msg](const autoware_map_msgs::msg::LaneletMapMetaData::ConstSharedPtr msg) {
+        meta_msg = msg;
+      });
+
+    wait_for_discovery();
+
+    autoware_map_msgs::msg::MapProjectorInfo projector_info;
+    projector_info.projector_type = autoware_map_msgs::msg::MapProjectorInfo::MGRS;
+    projector_info.mgrs_grid = "54SUE";
+    projector_pub_->publish(projector_info);
+
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (!map_msg && std::chrono::steady_clock::now() < deadline) {
+      executor_->spin_some();
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    return {target_node, map_msg, meta_msg};
+  }
+
+  std::unique_ptr<rclcpp::executors::SingleThreadedExecutor> executor_;
   rclcpp::Node::SharedPtr test_node_;
   rclcpp::Publisher<MapProjectorInfo::Message>::SharedPtr projector_pub_;
+
+  // Standard test map
+  const std::string map_path_ =
+    ament_index_cpp::get_package_share_directory("autoware_map_loader") + "/test/data/test_map.osm";
 };
 
 // TEST 1. Main integration test to see if Lanelet2MapLoaderNode can load test map and work properly
@@ -83,43 +132,12 @@ TEST_F(Lanelet2MapLoaderIntegrationHarness, VerifiesNormalMapLoadingAndReading)
   options.append_parameter_override("enable_selected_map_loading", false);
   options.append_parameter_override("lanelet2_map_metadata_path", "");
 
-  auto target_node = std::make_shared<autoware::map_loader::Lanelet2MapLoaderNode>(options);
-
-  // Prepare to catch map
-  std::promise<autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr> map_promise;
-  auto map_future = map_promise.get_future();
-
-  auto map_sub = test_node_->create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
-    "/map/vector_map", rclcpp::QoS{1}.transient_local(),
-    [&map_promise](const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg) {
-      map_promise.set_value(msg);
-    });
-
-  rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(test_node_);
-  executor.add_node(target_node);
-
-  wait_for_discovery();
-
-  autoware_map_msgs::msg::MapProjectorInfo projector_info;
-  projector_info.projector_type = autoware_map_msgs::msg::MapProjectorInfo::MGRS;
-  projector_info.mgrs_grid = "54SUE";
-  projector_pub_->publish(projector_info);
-
-  auto status = executor.spin_until_future_complete(map_future, std::chrono::seconds(3));
-
-  // Expected message published
-  ASSERT_EQ(status, rclcpp::FutureReturnCode::SUCCESS)
+  auto received = receive_map_and_metadata(options);
+  ASSERT_NE(received.map_msg, nullptr)
     << "Target node failed to publish LaneletMapBin within timeout.";
-  auto map_bin_msg = map_future.get();
-  ASSERT_NE(map_bin_msg, nullptr);
 
-  // Expected proper ROS metadata
-  EXPECT_EQ(map_bin_msg->header.frame_id, "map");
-  EXPECT_EQ(map_bin_msg->version_map_format, "1");
-  EXPECT_EQ(map_bin_msg->version_map, "2");
-
-  auto decoded_map = autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*map_bin_msg);
+  auto decoded_map =
+    autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*received.map_msg);
 
   // Expected 4 lanelets
   ASSERT_EQ(decoded_map->laneletLayer.size(), 4U);
@@ -150,36 +168,11 @@ TEST_F(Lanelet2MapLoaderIntegrationHarness, VerifiesStandardCenterlineInjection)
   // TEST TARGET use_waypoints = false
   options.append_parameter_override("use_waypoints", false);
 
-  // Node + pub/sub spinups
-  auto target_node = std::make_shared<autoware::map_loader::Lanelet2MapLoaderNode>(options);
+  auto received = receive_map_and_metadata(options);
+  ASSERT_NE(received.map_msg, nullptr);
 
-  std::promise<autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr> map_promise;
-  auto map_future = map_promise.get_future();
-  auto map_sub = test_node_->create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
-    "/map/vector_map", rclcpp::QoS{1}.transient_local(),
-    [&map_promise](const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg) {
-      map_promise.set_value(msg);
-    });
-
-  autoware_map_msgs::msg::MapProjectorInfo projector_info;
-  projector_info.projector_type = autoware_map_msgs::msg::MapProjectorInfo::MGRS;
-  projector_pub_->publish(projector_info);
-
-  rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(test_node_);
-  executor.add_node(target_node);
-
-  wait_for_discovery();
-
-  auto status = executor.spin_until_future_complete(map_future, std::chrono::seconds(3));
-
-  // Expected message published
-  ASSERT_EQ(status, rclcpp::FutureReturnCode::SUCCESS)
-    << "Target node failed to publish LaneletMapBin within timeout.";
-  auto map_bin_msg = map_future.get();
-  ASSERT_NE(map_bin_msg, nullptr);
-
-  auto decoded_map = autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*map_bin_msg);
+  auto decoded_map =
+    autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*received.map_msg);
 
   // Standard overwriteLaneletsCenterline is used.
   ASSERT_EQ(decoded_map->laneletLayer.size(), 4U);
@@ -214,36 +207,14 @@ TEST_F(Lanelet2MapLoaderIntegrationHarness, VerifiesMetadataPublishedWhenSelecte
   // TEST TARGET enable_selected_map_loading = true
   options.append_parameter_override("enable_selected_map_loading", true);
 
-  auto target_node = std::make_shared<autoware::map_loader::Lanelet2MapLoaderNode>(options);
-
-  std::promise<autoware_map_msgs::msg::LaneletMapMetaData::ConstSharedPtr> meta_promise;
-  auto meta_future = meta_promise.get_future();
-  auto meta_sub = test_node_->create_subscription<autoware_map_msgs::msg::LaneletMapMetaData>(
-    "output/lanelet2_map_metadata", rclcpp::QoS{1}.transient_local(),
-    [&meta_promise](const autoware_map_msgs::msg::LaneletMapMetaData::ConstSharedPtr msg) {
-      meta_promise.set_value(msg);
-    });
-
-  autoware_map_msgs::msg::MapProjectorInfo projector_info;
-  projector_info.projector_type = autoware_map_msgs::msg::MapProjectorInfo::MGRS;
-  projector_pub_->publish(projector_info);
-
-  rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(test_node_);
-  executor.add_node(target_node);
-
-  wait_for_discovery();
-
-  auto status = executor.spin_until_future_complete(meta_future, std::chrono::seconds(3));
+  auto received = receive_map_and_metadata(options);
 
   // Expected message published
-  ASSERT_EQ(status, rclcpp::FutureReturnCode::SUCCESS)
-    << "Metadata was not published upon initialization.";
+  ASSERT_NE(received.meta_msg, nullptr) << "Metadata was not published upon initialization.";
 
   // Expects 1 metadata entry with cell_id matching test map
-  auto meta_msg = meta_future.get();
-  ASSERT_EQ(meta_msg->metadata_list.size(), 1U);
-  EXPECT_EQ(meta_msg->metadata_list[0].cell_id, map_path);
+  ASSERT_EQ(received.meta_msg->metadata_list.size(), 1U);
+  EXPECT_EQ(received.meta_msg->metadata_list[0].cell_id, map_path);
 }
 
 // TEST 4. Confirms when allow_unsupported_version = false and loading a map with an unsupported
@@ -270,17 +241,5 @@ TEST_F(Lanelet2MapLoaderIntegrationHarness, RejectsWeirdVersion)
   // TEST TARGET allow_unsupported_version = false
   options.append_parameter_override("allow_unsupported_version", false);
 
-  auto target_node = std::make_shared<autoware::map_loader::Lanelet2MapLoaderNode>(options);
-
-  rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(test_node_);
-  executor.add_node(target_node);
-
-  wait_for_discovery();
-
-  MapProjectorInfo::Message projector_info;
-  projector_info.projector_type = MapProjectorInfo::Message::MGRS;
-  projector_pub_->publish(projector_info);
-
-  EXPECT_THROW(executor.spin_some(), std::invalid_argument);
+  EXPECT_THROW(receive_map_and_metadata(options), std::invalid_argument);
 }

--- a/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp
+++ b/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp
@@ -45,9 +45,13 @@ protected:
   void TearDown() override { test_node_.reset(); }
 
   // Helper to ensure pub/sub are linked before sending data
-  void wait_for_discovery()
+  void wait_for_discovery(std::chrono::seconds timeout = std::chrono::seconds(3))
   {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
     while (projector_pub_->get_subscription_count() == 0) {
+      if (std::chrono::steady_clock::now() > deadline) {
+        FAIL() << "Discovery timed out after 5 secs.";
+      }
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
   }

--- a/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp
+++ b/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp
@@ -30,40 +30,37 @@
 #include <memory>
 #include <string>
 
+using MapProjectorInfo = autoware::component_interface_specs::map::MapProjectorInfo;
+
 class Lanelet2MapLoaderIntegrationHarness : public ::testing::Test
 {
 protected:
+  // Runs once per process, safe for death test in TEST 4
+  static void SetUpTestSuite() { rclcpp::init(0, nullptr); }
+
+  static void TearDownTestSuite() { rclcpp::shutdown(); }
+
+  // Runs before each test
   void SetUp() override
   {
-    rclcpp::init(0, nullptr);
     test_node_ = std::make_shared<rclcpp::Node>("test_lanelet2_map_loader_client");
 
-    // Params setting
-    rclcpp::NodeOptions options;
-    const std::string map_path =
-      ament_index_cpp::get_package_share_directory("autoware_map_loader") +
-      "/test/data/test_map.osm";
-
-    options.append_parameter_override("lanelet2_map_path", map_path);
-    options.append_parameter_override("center_line_resolution", 5.0);
-    options.append_parameter_override("use_waypoints", true);
-    options.append_parameter_override("allow_unsupported_version", true);
-    options.append_parameter_override("enable_selected_map_loading", false);
-    options.append_parameter_override("lanelet2_map_metadata_path", "");
-
-    // Init node
-    target_node_ = std::make_shared<autoware::map_loader::Lanelet2MapLoaderNode>(options);
-
-    // Pub/sub
-    projector_pub_ = test_node_->create_publisher<autoware_map_msgs::msg::MapProjectorInfo>(
-      "input/map_projector_info", rclcpp::QoS{1}.transient_local());
+    projector_pub_ = test_node_->create_publisher<MapProjectorInfo::Message>(
+      MapProjectorInfo::name, autoware::component_interface_specs::get_qos<MapProjectorInfo>());
   }
 
-  void TearDown() override { rclcpp::shutdown(); }
+  void TearDown() override { test_node_.reset(); }
+
+  // Helper to ensure pub/sub are linked before sending data
+  void wait_for_discovery()
+  {
+    while (projector_pub_->get_subscription_count() == 0) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
 
   rclcpp::Node::SharedPtr test_node_;
-  std::shared_ptr<autoware::map_loader::Lanelet2MapLoaderNode> target_node_;
-  rclcpp::Publisher<autoware_map_msgs::msg::MapProjectorInfo>::SharedPtr projector_pub_;
+  rclcpp::Publisher<MapProjectorInfo::Message>::SharedPtr projector_pub_;
 };
 
 // TEST 1. Main integration test to see if Lanelet2MapLoaderNode can load test map and work properly
@@ -75,6 +72,19 @@ protected:
 // - Each lanelet has a custom centerline injected via waypoints
 TEST_F(Lanelet2MapLoaderIntegrationHarness, VerifiesNormalMapLoadingAndReading)
 {
+  rclcpp::NodeOptions options;
+  const std::string map_path =
+    ament_index_cpp::get_package_share_directory("autoware_map_loader") + "/test/data/test_map.osm";
+
+  options.append_parameter_override("lanelet2_map_path", map_path);
+  options.append_parameter_override("center_line_resolution", 5.0);
+  options.append_parameter_override("use_waypoints", true);
+  options.append_parameter_override("allow_unsupported_version", true);
+  options.append_parameter_override("enable_selected_map_loading", false);
+  options.append_parameter_override("lanelet2_map_metadata_path", "");
+
+  auto target_node = std::make_shared<autoware::map_loader::Lanelet2MapLoaderNode>(options);
+
   // Prepare to catch map
   std::promise<autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr> map_promise;
   auto map_future = map_promise.get_future();
@@ -85,15 +95,16 @@ TEST_F(Lanelet2MapLoaderIntegrationHarness, VerifiesNormalMapLoadingAndReading)
       map_promise.set_value(msg);
     });
 
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(test_node_);
+  executor.add_node(target_node);
+
+  wait_for_discovery();
+
   autoware_map_msgs::msg::MapProjectorInfo projector_info;
   projector_info.projector_type = autoware_map_msgs::msg::MapProjectorInfo::MGRS;
   projector_info.mgrs_grid = "54SUE";
   projector_pub_->publish(projector_info);
-
-  // Spin both nodes to process callback
-  rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(test_node_);
-  executor.add_node(target_node_);
 
   auto status = executor.spin_until_future_complete(map_future, std::chrono::seconds(3));
 
@@ -158,6 +169,8 @@ TEST_F(Lanelet2MapLoaderIntegrationHarness, VerifiesStandardCenterlineInjection)
   executor.add_node(test_node_);
   executor.add_node(target_node);
 
+  wait_for_discovery();
+
   auto status = executor.spin_until_future_complete(map_future, std::chrono::seconds(3));
 
   // Expected message published
@@ -219,6 +232,8 @@ TEST_F(Lanelet2MapLoaderIntegrationHarness, VerifiesMetadataPublishedWhenSelecte
   executor.add_node(test_node_);
   executor.add_node(target_node);
 
+  wait_for_discovery();
+
   auto status = executor.spin_until_future_complete(meta_future, std::chrono::seconds(3));
 
   // Expected message published
@@ -244,38 +259,28 @@ TEST_F(Lanelet2MapLoaderIntegrationHarness, RejectsWeirdVersion)
       << "</osm>";
   out.close();
 
-  // EXPECT_DEATH to run node in forked process
-  EXPECT_DEATH(
-    {
-      rclcpp::init(0, nullptr);
-      auto test_node = std::make_shared<rclcpp::Node>("death_test_client");
-      auto pub = test_node->create_publisher<autoware_map_msgs::msg::MapProjectorInfo>(
-        "input/map_projector_info", rclcpp::QoS{1}.transient_local());
+  // Re-init node options with allow_unsupported_version = false
+  rclcpp::NodeOptions options;
+  options.append_parameter_override("lanelet2_map_path", incompat_map_path);
+  options.append_parameter_override("center_line_resolution", 5.0);
+  options.append_parameter_override("use_waypoints", true);
+  options.append_parameter_override("enable_selected_map_loading", false);
+  options.append_parameter_override("lanelet2_map_metadata_path", "");
 
-      // Re-init node options with allow_unsupported_version = false
-      rclcpp::NodeOptions options;
-      options.append_parameter_override("lanelet2_map_path", incompat_map_path);
-      options.append_parameter_override("center_line_resolution", 5.0);
-      options.append_parameter_override("use_waypoints", true);
-      options.append_parameter_override("enable_selected_map_loading", false);
-      options.append_parameter_override("lanelet2_map_metadata_path", "");
+  // TEST TARGET allow_unsupported_version = false
+  options.append_parameter_override("allow_unsupported_version", false);
 
-      // TEST TARGET allow_unsupported_version = false
-      options.append_parameter_override("allow_unsupported_version", false);
+  auto target_node = std::make_shared<autoware::map_loader::Lanelet2MapLoaderNode>(options);
 
-      auto target_node = std::make_shared<autoware::map_loader::Lanelet2MapLoaderNode>(options);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(test_node_);
+  executor.add_node(target_node);
 
-      autoware_map_msgs::msg::MapProjectorInfo projector_info;
-      projector_info.projector_type = autoware_map_msgs::msg::MapProjectorInfo::MGRS;
-      pub->publish(projector_info);
+  wait_for_discovery();
 
-      rclcpp::executors::SingleThreadedExecutor executor;
-      executor.add_node(test_node);
-      executor.add_node(target_node);
+  MapProjectorInfo::Message projector_info;
+  projector_info.projector_type = MapProjectorInfo::Message::MGRS;
+  projector_pub_->publish(projector_info);
 
-      executor.spin_some();
-
-      rclcpp::shutdown();
-    },
-    "allow_unsupported_version is false");
+  EXPECT_THROW(executor.spin_some(), std::invalid_argument);
 }

--- a/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp
+++ b/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp
@@ -50,7 +50,7 @@ protected:
     const auto deadline = std::chrono::steady_clock::now() + timeout;
     while (projector_pub_->get_subscription_count() == 0) {
       if (std::chrono::steady_clock::now() > deadline) {
-        FAIL() << "Discovery timed out after 5 secs.";
+        FAIL() << "Pub/sub handshake & discovery timed out.";
       }
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }

--- a/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp
+++ b/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp
@@ -133,10 +133,11 @@ TEST_F(Lanelet2MapLoaderIntegrationHarness, VerifiesStandardCenterlineInjection)
     ament_index_cpp::get_package_share_directory("autoware_map_loader") + "/test/data/test_map.osm";
   options.append_parameter_override("lanelet2_map_path", map_path);
   options.append_parameter_override("center_line_resolution", 5.0);
-  options.append_parameter_override("use_waypoints", false);
   options.append_parameter_override("allow_unsupported_version", true);
   options.append_parameter_override("enable_selected_map_loading", false);
   options.append_parameter_override("lanelet2_map_metadata_path", "");
+  // TEST TARGET use_waypoints = false
+  options.append_parameter_override("use_waypoints", false);
 
   // Node + pub/sub spinups
   auto target_node = std::make_shared<autoware::map_loader::Lanelet2MapLoaderNode>(options);
@@ -180,4 +181,52 @@ TEST_F(Lanelet2MapLoaderIntegrationHarness, VerifiesStandardCenterlineInjection)
     EXPECT_FALSE(lanelet.hasAttribute("waypoints"))
       << "Waypoints attribute should NOT exist when use_waypoints is false.";
   }
+}
+
+// TEST 3. Confirms when enable_selected_map_loading is set to true, node publishes metadata upon
+// initialization. Expects:
+// - Node publishes LaneletMapMetaData message (with 3 secs)
+// - LaneletMapMetaData message has 1 metadata entry with cell_id matching the map
+TEST_F(Lanelet2MapLoaderIntegrationHarness, VerifiesMetadataPublishedWhenSelectedLoadingEnabled)
+{
+  // Re-init node options with enable_selected_map_loading = true
+  rclcpp::NodeOptions options;
+  const std::string map_path =
+    ament_index_cpp::get_package_share_directory("autoware_map_loader") + "/test/data/test_map.osm";
+  options.append_parameter_override("lanelet2_map_path", map_path);
+  options.append_parameter_override("center_line_resolution", 5.0);
+  options.append_parameter_override("use_waypoints", true);
+  options.append_parameter_override("allow_unsupported_version", true);
+  options.append_parameter_override("lanelet2_map_metadata_path", "");
+  // TEST TARGET enable_selected_map_loading = true
+  options.append_parameter_override("enable_selected_map_loading", true);
+
+  auto target_node = std::make_shared<autoware::map_loader::Lanelet2MapLoaderNode>(options);
+
+  std::promise<autoware_map_msgs::msg::LaneletMapMetaData::ConstSharedPtr> meta_promise;
+  auto meta_future = meta_promise.get_future();
+  auto meta_sub = test_node_->create_subscription<autoware_map_msgs::msg::LaneletMapMetaData>(
+    "output/lanelet2_map_metadata", rclcpp::QoS{1}.transient_local(),
+    [&meta_promise](const autoware_map_msgs::msg::LaneletMapMetaData::ConstSharedPtr msg) {
+      meta_promise.set_value(msg);
+    });
+
+  autoware_map_msgs::msg::MapProjectorInfo projector_info;
+  projector_info.projector_type = autoware_map_msgs::msg::MapProjectorInfo::MGRS;
+  projector_pub_->publish(projector_info);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(test_node_);
+  executor.add_node(target_node);
+
+  auto status = executor.spin_until_future_complete(meta_future, std::chrono::seconds(3));
+
+  // Expected message published
+  ASSERT_EQ(status, rclcpp::FutureReturnCode::SUCCESS)
+    << "Metadata was not published upon initialization.";
+
+  // Expects 1 metadata entry with cell_id matching test map
+  auto meta_msg = meta_future.get();
+  ASSERT_EQ(meta_msg->metadata_list.size(), 1U);
+  EXPECT_EQ(meta_msg->metadata_list[0].cell_id, map_path);
 }

--- a/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp
+++ b/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <ament_index_cpp/get_package_share_directory.hpp>
+#include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware/map_loader/lanelet2_map_loader_node.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -20,6 +21,8 @@
 #include <autoware_map_msgs/msg/map_projector_info.hpp>
 
 #include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/Lanelet.h>
 
 #include <chrono>
 #include <memory>
@@ -60,3 +63,57 @@ protected:
   std::shared_ptr<autoware::map_loader::Lanelet2MapLoaderNode> target_node_;
   rclcpp::Publisher<autoware_map_msgs::msg::MapProjectorInfo>::SharedPtr projector_pub_;
 };
+
+// TEST 1. Main integration test to see if Lanelet2MapLoaderNode can load test map and work properly
+// as expected. Spins up pub/sub and checks normal behaviors including proper ROS metadata, lanelet
+// count, and centerline injection. Expects:
+// - Node publishes LaneletMapBin message (with 3 secs)
+// - LaneletMapBin message has proper ROS metadata (frame_id, version_map_format, version_map)
+// - LaneletMapBin message decodes to a LaneletMap with 4 lanelets
+// - Each lanelet has a custom centerline injected via waypoints
+TEST_F(CharacterizationTestLanelet2MapLoaderNode, VerifiesEndToEndMapLoadingAndCenterlineInjection)
+{
+  // Prepare to catch map
+  std::promise<autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr> map_promise;
+  auto map_future = map_promise.get_future();
+
+  auto map_sub = test_node_->create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
+    "/map/vector_map", rclcpp::QoS{1}.transient_local(),
+    [&map_promise](const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg) {
+      map_promise.set_value(msg);
+    });
+
+  autoware_map_msgs::msg::MapProjectorInfo projector_info;
+  projector_info.projector_type = autoware_map_msgs::msg::MapProjectorInfo::MGRS;
+  projector_info.mgrs_grid = "54SUE";
+  projector_pub_->publish(projector_info);
+
+  // Spin both nodes to process callback
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(test_node_);
+  executor.add_node(target_node_);
+
+  auto status = executor.spin_until_future_complete(map_future, std::chrono::seconds(3));
+
+  // Expected message published
+  ASSERT_EQ(status, rclcpp::FutureReturnCode::SUCCESS)
+    << "Target node failed to publish LaneletMapBin within timeout.";
+  auto map_bin_msg = map_future.get();
+  ASSERT_NE(map_bin_msg, nullptr);
+
+  // Expected proper ROS metadata
+  EXPECT_EQ(map_bin_msg->header.frame_id, "map");
+  EXPECT_EQ(map_bin_msg->version_map_format, "1");
+  EXPECT_EQ(map_bin_msg->version_map, "2");
+
+  auto decoded_map = autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*map_bin_msg);
+
+  // Expected 4 lanelets
+  ASSERT_EQ(decoded_map->laneletLayer.size(), 4U);
+
+  // Expected centerline injected via waypoints
+  for (const auto & lanelet : decoded_map->laneletLayer) {
+    EXPECT_TRUE(lanelet.hasCustomCenterline())
+      << "Centerline generation failed to apply to lanelet " << lanelet.id();
+  }
+}

--- a/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp
+++ b/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp
@@ -1,0 +1,62 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <autoware/map_loader/lanelet2_map_loader_node.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_map_msgs/msg/map_projector_info.hpp>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+class CharacterizationTestLanelet2MapLoaderNode : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+    test_node_ = std::make_shared<rclcpp::Node>("test_lanelet2_map_loader_client");
+
+    // Params setting
+    rclcpp::NodeOptions options;
+    const std::string map_path =
+      ament_index_cpp::get_package_share_directory("autoware_map_loader") +
+      "/test/data/test_map.osm";
+
+    options.append_parameter_override("lanelet2_map_path", map_path);
+    options.append_parameter_override("center_line_resolution", 5.0);
+    options.append_parameter_override("use_waypoints", true);
+    options.append_parameter_override("allow_unsupported_version", true);
+    options.append_parameter_override("enable_selected_map_loading", false);
+    options.append_parameter_override("lanelet2_map_metadata_path", "");
+
+    // Init node
+    target_node_ = std::make_shared<autoware::map_loader::Lanelet2MapLoaderNode>(options);
+
+    // Pub/sub
+    projector_pub_ = test_node_->create_publisher<autoware_map_msgs::msg::MapProjectorInfo>(
+      "input/map_projector_info", rclcpp::QoS{1}.transient_local());
+  }
+
+  void TearDown() override { rclcpp::shutdown(); }
+
+  rclcpp::Node::SharedPtr test_node_;
+  std::shared_ptr<autoware::map_loader::Lanelet2MapLoaderNode> target_node_;
+  rclcpp::Publisher<autoware_map_msgs::msg::MapProjectorInfo>::SharedPtr projector_pub_;
+};

--- a/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp
+++ b/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp
@@ -230,3 +230,52 @@ TEST_F(Lanelet2MapLoaderIntegrationHarness, VerifiesMetadataPublishedWhenSelecte
   ASSERT_EQ(meta_msg->metadata_list.size(), 1U);
   EXPECT_EQ(meta_msg->metadata_list[0].cell_id, map_path);
 }
+
+// TEST 4. Confirms when allow_unsupported_version = false and loading a map with an unsupported
+// version, node will throw an error and terminate.
+TEST_F(Lanelet2MapLoaderIntegrationHarness, RejectsWeirdVersion)
+{
+  // Dummy file map with wrong version number
+  const std::string incompat_map_path = "/tmp/stupid_version_map.osm";
+  std::ofstream out(incompat_map_path);
+  out << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+      << "<osm generator=\"VMB\">\n"
+      << "  <MetaInfo format_version=\"69\" map_version=\"1\"/>\n"
+      << "</osm>";
+  out.close();
+
+  // EXPECT_DEATH to run node in forked process
+  EXPECT_DEATH(
+    {
+      rclcpp::init(0, nullptr);
+      auto test_node = std::make_shared<rclcpp::Node>("death_test_client");
+      auto pub = test_node->create_publisher<autoware_map_msgs::msg::MapProjectorInfo>(
+        "input/map_projector_info", rclcpp::QoS{1}.transient_local());
+
+      // Re-init node options with allow_unsupported_version = false
+      rclcpp::NodeOptions options;
+      options.append_parameter_override("lanelet2_map_path", incompat_map_path);
+      options.append_parameter_override("center_line_resolution", 5.0);
+      options.append_parameter_override("use_waypoints", true);
+      options.append_parameter_override("enable_selected_map_loading", false);
+      options.append_parameter_override("lanelet2_map_metadata_path", "");
+
+      // TEST TARGET allow_unsupported_version = false
+      options.append_parameter_override("allow_unsupported_version", false);
+
+      auto target_node = std::make_shared<autoware::map_loader::Lanelet2MapLoaderNode>(options);
+
+      autoware_map_msgs::msg::MapProjectorInfo projector_info;
+      projector_info.projector_type = autoware_map_msgs::msg::MapProjectorInfo::MGRS;
+      pub->publish(projector_info);
+
+      rclcpp::executors::SingleThreadedExecutor executor;
+      executor.add_node(test_node);
+      executor.add_node(target_node);
+
+      executor.spin_some();
+
+      rclcpp::shutdown();
+    },
+    "allow_unsupported_version is false");
+}

--- a/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp
+++ b/map/autoware_map_loader/test/lanelet2_map_loader/test_lanelet2_map_loader_integration.cpp
@@ -18,6 +18,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_map_msgs/msg/lanelet_map_meta_data.hpp>
 #include <autoware_map_msgs/msg/map_projector_info.hpp>
 
 #include <gtest/gtest.h>
@@ -25,10 +26,11 @@
 #include <lanelet2_core/primitives/Lanelet.h>
 
 #include <chrono>
+#include <fstream>
 #include <memory>
 #include <string>
 
-class CharacterizationTestLanelet2MapLoaderNode : public ::testing::Test
+class Lanelet2MapLoaderIntegrationHarness : public ::testing::Test
 {
 protected:
   void SetUp() override
@@ -71,7 +73,7 @@ protected:
 // - LaneletMapBin message has proper ROS metadata (frame_id, version_map_format, version_map)
 // - LaneletMapBin message decodes to a LaneletMap with 4 lanelets
 // - Each lanelet has a custom centerline injected via waypoints
-TEST_F(CharacterizationTestLanelet2MapLoaderNode, VerifiesEndToEndMapLoadingAndCenterlineInjection)
+TEST_F(Lanelet2MapLoaderIntegrationHarness, VerifiesNormalMapLoadingAndReading)
 {
   // Prepare to catch map
   std::promise<autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr> map_promise;
@@ -115,5 +117,67 @@ TEST_F(CharacterizationTestLanelet2MapLoaderNode, VerifiesEndToEndMapLoadingAndC
   for (const auto & lanelet : decoded_map->laneletLayer) {
     EXPECT_TRUE(lanelet.hasCustomCenterline())
       << "Centerline generation failed to apply to lanelet " << lanelet.id();
+  }
+}
+
+// TEST 2. Confirms that when use_waypoints is set to false, standard overwriteLaneletsCenterline is
+// used instead of custom centerline injection. Expects:
+// - Node publishes LaneletMapBin message (with 3 secs)
+// - LaneletMapBin message decodes to a LaneletMap with 4 lanelets
+// - Each lanelet has a standard centerline injected via overwriteLaneletsCenterline
+TEST_F(Lanelet2MapLoaderIntegrationHarness, VerifiesStandardCenterlineInjection)
+{
+  // Re-init node options with use_waypoints = false
+  rclcpp::NodeOptions options;
+  const std::string map_path =
+    ament_index_cpp::get_package_share_directory("autoware_map_loader") + "/test/data/test_map.osm";
+  options.append_parameter_override("lanelet2_map_path", map_path);
+  options.append_parameter_override("center_line_resolution", 5.0);
+  options.append_parameter_override("use_waypoints", false);
+  options.append_parameter_override("allow_unsupported_version", true);
+  options.append_parameter_override("enable_selected_map_loading", false);
+  options.append_parameter_override("lanelet2_map_metadata_path", "");
+
+  // Node + pub/sub spinups
+  auto target_node = std::make_shared<autoware::map_loader::Lanelet2MapLoaderNode>(options);
+
+  std::promise<autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr> map_promise;
+  auto map_future = map_promise.get_future();
+  auto map_sub = test_node_->create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
+    "/map/vector_map", rclcpp::QoS{1}.transient_local(),
+    [&map_promise](const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg) {
+      map_promise.set_value(msg);
+    });
+
+  autoware_map_msgs::msg::MapProjectorInfo projector_info;
+  projector_info.projector_type = autoware_map_msgs::msg::MapProjectorInfo::MGRS;
+  projector_pub_->publish(projector_info);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(test_node_);
+  executor.add_node(target_node);
+
+  auto status = executor.spin_until_future_complete(map_future, std::chrono::seconds(3));
+
+  // Expected message published
+  ASSERT_EQ(status, rclcpp::FutureReturnCode::SUCCESS)
+    << "Target node failed to publish LaneletMapBin within timeout.";
+  auto map_bin_msg = map_future.get();
+  ASSERT_NE(map_bin_msg, nullptr);
+
+  auto decoded_map = autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*map_bin_msg);
+
+  // Standard overwriteLaneletsCenterline is used.
+  ASSERT_EQ(decoded_map->laneletLayer.size(), 4U);
+
+  // Each lanelet has a standard centerline injected via overwriteLaneletsCenterline
+  for (const auto & lanelet : decoded_map->laneletLayer) {
+    // Standard centerline exists with points
+    EXPECT_FALSE(lanelet.centerline().empty())
+      << "Standard centerline should be populated when use_waypoints is false.";
+
+    // No custom waypoints generated
+    EXPECT_FALSE(lanelet.hasAttribute("waypoints"))
+      << "Waypoints attribute should NOT exist when use_waypoints is false.";
   }
 }


### PR DESCRIPTION
## Description

### 1. Introduction

This PR adds characterization test for the `lanelet2_map_loader` node of [autoware_map_loader](https://github.com/autowarefoundation/autoware_core/tree/main/map/autoware_map_loader).

Step 2 (core logic isolation) and step 3 (revamped unit tests) will be available very very soon (I'm kinda out of time now...)

### 2. Current test suite

Currently the test suite comprises of:

- `test_lanelet2_map_cell_metadata.cpp` : tests bounding-box computation and parsing utilities.
- `test_lanelet2_map_loader_utils.cpp` : tests primitive map merging and filesystem handling.
- `test_lanelet2_selected_map_loader_module.cpp` : tests service-based dynamic cell loading.
- `lanelet2_map_loader_launch.test.py` : tests end-to-end integration with a high-level integration smoke test.

As you can see, current test suite provides good coverage for isolated low-level utility functions & the dynamic selection service module. However there are NO coverage for the main pipeline, besides a high-level Python integration test.

Perfect! I'm gonna do it now, in this PR.

### 3. What I did

Similar to what I did at [simple_pure_pursuit](https://github.com/autowarefoundation/autoware_core/pull/1179) and [ground_filter](https://github.com/autowarefoundation/autoware_core/pull/1196), I implemented an integration harness test class to support the integration test suite, with these 4 new test cases:

- TEST 1. VerifiesNormalMapLoadingAndReading 
  Main integration test to see if `Lanelet2MapLoaderNode` can load test map and work properly as expected. Spins up pub/sub and checks normal behaviors including proper ROS metadata, lanelet count, and centerline injection. 
  Expects:
    - Node publishes `LaneletMapBin` message (with 3 secs)
    - `LaneletMapBin` message has proper ROS metadata (`frame_id`, `version_map_format`, `version_map`)
    - `LaneletMapBin` message decodes to a `LaneletMap` with 4 lanelets
    - Each lanelet has a custom centerline injected via waypoints
- TEST 2. VerifiesStandardCenterlineInjection
  Confirms that when `use_waypoints` is set to false, standard `overwriteLaneletsCenterline` is used instead of custom centerline injection. 
  Expects:
    - Node publishes `LaneletMapBin` message (with 3 secs)
    - `LaneletMapBin` message decodes to a `LaneletMap` with 4 lanelets
    - Each lanelet has a standard centerline injected via `overwriteLaneletsCenterline`
- TEST 3. VerifiesMetadataPublishedWhenSelectedLoadingEnabled
  Confirms when `enable_selected_map_loading` is set to true, node publishes metadata upon initialization. 
  Expects:
    - Node publishes `LaneletMapMetaData` message (with 3 secs)
    - `LaneletMapMetaData` message has 1 metadata entry with `cell_id` matching the map
- TEST 4. RejectsWeirdVersion
  Confirms when allow_unsupported_version = false and loading a map with an unsupported version, node will throw an error and terminate. For this I spawned a sample map with totally nonavailable version number `69`. It should expect throwing error.

## How was this PR tested?

### 1. Commands

```bash
rm -rf build/autoware_map_loader/ install/autoware_map_loader/

colcon build --packages-select autoware_map_loader --cmake-clean-cache --cmake-args -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS=--coverage -DCMAKE_CXX_FLAGS=--coverage --allow-overriding autoware_map_loader

colcon test --event-handlers console_cohesion+ --packages-select autoware_map_loader --allow-overriding autoware_map_loader

colcon lcov-result --packages-select autoware_map_loader --filter "/test/" --allow-overriding autoware_map_loader
```

### 2. Codecov results

<img width="1842" height="353" alt="image" src="https://github.com/user-attachments/assets/a736c091-5e1a-4694-b50f-1cf731d229f4" />

<img width="1842" height="353" alt="image" src="https://github.com/user-attachments/assets/94dcff8a-b9f6-4913-826c-7d4f139c620d" />

<img width="1842" height="330" alt="image" src="https://github.com/user-attachments/assets/36f817e0-4245-4861-aeae-6a285489ded0" />

Somehow `lanelet2_local_projector.hpp` does not have coverage. Gonna inspect them in next steps of core logic isolation + unit tests.