### PR TITLE
refactor(autoware_twist2accel): shrink characterization test

### DIFF
--- a/localization/autoware_twist2accel/src/twist2accel.cpp
+++ b/localization/autoware_twist2accel/src/twist2accel.cpp
@@ -44,18 +44,14 @@ void Twist2Accel::callback_odometry(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(nav_msgs::msg::Odometry) msg)
 {
   if (!use_odom_) return;
-  auto accel_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_accel_);
-  *accel_msg = accel_estimator_->estimate(*msg);
-  pub_accel_->publish(std::move(accel_msg));
+  pub_accel_->publish(accel_estimator_->estimate(*msg));
 }
 
 void Twist2Accel::callback_twist_with_covariance(
   const AUTOWARE_MESSAGE_CONST_SHARED_PTR(geometry_msgs::msg::TwistWithCovarianceStamped) msg)
 {
   if (use_odom_) return;
-  auto accel_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_accel_);
-  *accel_msg = accel_estimator_->estimate(*msg);
-  pub_accel_->publish(std::move(accel_msg));
+  pub_accel_->publish(accel_estimator_->estimate(*msg));
 }
 }  // namespace autoware::twist2accel
 

--- a/localization/autoware_twist2accel/test/test_twist2accel_node.cpp
+++ b/localization/autoware_twist2accel/test/test_twist2accel_node.cpp
@@ -22,12 +22,9 @@
 
 #include <gtest/gtest.h>
 
-#include <array>
 #include <chrono>
-#include <cstddef>
 #include <memory>
 #include <thread>
-#include <vector>
 
 namespace
 {
@@ -36,209 +33,88 @@ using geometry_msgs::msg::AccelWithCovarianceStamped;
 using geometry_msgs::msg::TwistWithCovarianceStamped;
 using nav_msgs::msg::Odometry;
 
-// Spin both nodes until `predicate` holds or the timeout elapses, so the tests
-// stay deterministic instead of relying on a fixed sleep.
-template <typename Predicate>
-void spin_until(
-  rclcpp::executors::SingleThreadedExecutor & executor, const Predicate & predicate,
-  std::chrono::milliseconds timeout)
-{
-  const auto deadline = std::chrono::steady_clock::now() + timeout;
-  while (!predicate() && std::chrono::steady_clock::now() < deadline) {
-    executor.spin_some(std::chrono::milliseconds(10));
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-  }
-}
-
 class Twist2AccelNodeTest : public ::testing::Test
 {
 protected:
   void SetUp() override { rclcpp::init(0, nullptr); }
   void TearDown() override { rclcpp::shutdown(); }
 
-  // Build the node under test with the given use_odom routing and spin it
-  // together with a helper node that publishes inputs and captures outputs.
-  std::shared_ptr<Twist2Accel> make_node(bool use_odom)
+  void create_nodes(bool use_odom)
   {
     rclcpp::NodeOptions options;
     options.parameter_overrides({{"use_odom", use_odom}, {"accel_lowpass_gain", 0.9}});
-    return std::make_shared<Twist2Accel>(options);
+    node_ = std::make_shared<Twist2Accel>(options);
+    helper_ = std::make_shared<rclcpp::Node>("twist2accel_test_helper");
+
+    sub_ = helper_->create_subscription<AccelWithCovarianceStamped>(
+      "output/accel", 10,
+      [this](const AccelWithCovarianceStamped::SharedPtr) { ++received_count_; });
+    odom_pub_ = helper_->create_publisher<Odometry>("input/odom", 10);
+    twist_pub_ = helper_->create_publisher<TwistWithCovarianceStamped>("input/twist", 10);
+
+    executor_ = std::make_unique<rclcpp::executors::SingleThreadedExecutor>();
+    executor_->add_node(node_->get_node_base_interface());
+    executor_->add_node(helper_);
+
+    wait_for_discovery();
   }
+
+  void wait_for_discovery()
+  {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (
+      (odom_pub_->get_subscription_count() == 0 || twist_pub_->get_subscription_count() == 0) &&
+      std::chrono::steady_clock::now() < deadline) {
+      executor_->spin_some(std::chrono::milliseconds(10));
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  }
+
+  void wait_for_receive_output(std::chrono::milliseconds timeout)
+  {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (received_count_ < 1u && std::chrono::steady_clock::now() < deadline) {
+      executor_->spin_some(std::chrono::milliseconds(10));
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  }
+
+  std::shared_ptr<Twist2Accel> node_;
+  std::shared_ptr<rclcpp::Node> helper_;
+  rclcpp::Publisher<Odometry>::SharedPtr odom_pub_;
+  rclcpp::Publisher<TwistWithCovarianceStamped>::SharedPtr twist_pub_;
+  rclcpp::Subscription<AccelWithCovarianceStamped>::SharedPtr sub_;
+  std::unique_ptr<rclcpp::executors::SingleThreadedExecutor> executor_;
+  std::size_t received_count_ = 0;
 };
 
-// First message (prev_twist_ == nullopt): the node publishes an
-// AccelWithCovarianceStamped whose header is copied from the input but whose
-// accel and covariance are left at their default zeros -- no estimate is run
-// because there is no previous sample to difference against.
-TEST_F(Twist2AccelNodeTest, FirstMessagePublishesZeroAccelWithHeader)
+TEST_F(Twist2AccelNodeTest, TwistInputProducesOutput)
 {
-  auto node = make_node(/*use_odom=*/true);
-  auto helper = std::make_shared<rclcpp::Node>("twist2accel_test_helper");
+  create_nodes(/*use_odom=*/false);
 
-  std::vector<AccelWithCovarianceStamped> received;
-  auto sub = helper->create_subscription<AccelWithCovarianceStamped>(
-    "output/accel", 10,
-    [&received](const AccelWithCovarianceStamped::SharedPtr msg) { received.push_back(*msg); });
-  auto pub = helper->create_publisher<Odometry>("input/odom", 10);
+  twist_pub_->publish(TwistWithCovarianceStamped{});
+  wait_for_receive_output(std::chrono::seconds(1));
 
-  rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(node->get_node_base_interface());
-  executor.add_node(helper);
-
-  spin_until(executor, [&] { return pub->get_subscription_count() > 0; }, std::chrono::seconds(5));
-
-  Odometry odom;
-  odom.header.frame_id = "base_link";
-  odom.header.stamp = rclcpp::Time(123, 456, RCL_ROS_TIME);
-  odom.twist.twist.linear.x = 5.0;
-  odom.twist.twist.angular.z = 1.0;
-  pub->publish(odom);
-
-  spin_until(executor, [&] { return !received.empty(); }, std::chrono::seconds(5));
-
-  ASSERT_EQ(received.size(), 1u);
-  const auto & out = received.front();
-  // Header is forwarded from the input message.
-  EXPECT_EQ(out.header.frame_id, "base_link");
-  EXPECT_EQ(rclcpp::Time(out.header.stamp), rclcpp::Time(123, 456, RCL_ROS_TIME));
-  // No estimate ran, so accel is all zeros ...
-  EXPECT_DOUBLE_EQ(out.accel.accel.linear.x, 0.0);
-  EXPECT_DOUBLE_EQ(out.accel.accel.linear.y, 0.0);
-  EXPECT_DOUBLE_EQ(out.accel.accel.linear.z, 0.0);
-  EXPECT_DOUBLE_EQ(out.accel.accel.angular.x, 0.0);
-  EXPECT_DOUBLE_EQ(out.accel.accel.angular.y, 0.0);
-  EXPECT_DOUBLE_EQ(out.accel.accel.angular.z, 0.0);
-  // ... and the covariance is left untouched (all zeros).
-  for (const auto & c : out.accel.covariance) {
-    EXPECT_DOUBLE_EQ(c, 0.0);
-  }
+  EXPECT_EQ(received_count_, 1u);
 }
 
-// With use_odom=true the odom callback drives estimation while the twist
-// callback early-returns. The second odom sample (now that prev_twist_ is set)
-// produces a non-zero accel, and the interleaved twist message produces no
-// extra output.
-TEST_F(Twist2AccelNodeTest, UseOdomTrueRoutesOdomAndIgnoresTwist)
+TEST_F(Twist2AccelNodeTest, OdomInputProducesOutputWhenUseOdomTrue)
 {
-  auto node = make_node(/*use_odom=*/true);
-  auto helper = std::make_shared<rclcpp::Node>("twist2accel_test_helper");
+  create_nodes(/*use_odom=*/true);
 
-  std::vector<AccelWithCovarianceStamped> received;
-  auto sub = helper->create_subscription<AccelWithCovarianceStamped>(
-    "output/accel", 10,
-    [&received](const AccelWithCovarianceStamped::SharedPtr msg) { received.push_back(*msg); });
-  auto odom_pub = helper->create_publisher<Odometry>("input/odom", 10);
-  auto twist_pub = helper->create_publisher<TwistWithCovarianceStamped>("input/twist", 10);
+  odom_pub_->publish(Odometry{});
+  wait_for_receive_output(std::chrono::seconds(1));
 
-  rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(node->get_node_base_interface());
-  executor.add_node(helper);
-
-  spin_until(
-    executor,
-    [&] {
-      return odom_pub->get_subscription_count() > 0 && twist_pub->get_subscription_count() > 0;
-    },
-    std::chrono::seconds(5));
-
-  // First odom: linear.x = 0 at t = 0. Primes prev_twist_, publishes zero accel.
-  Odometry odom0;
-  odom0.header.frame_id = "base_link";
-  odom0.header.stamp = rclcpp::Time(0, 0, RCL_ROS_TIME);
-  odom0.twist.twist.linear.x = 0.0;
-  odom_pub->publish(odom0);
-  spin_until(executor, [&] { return received.size() >= 1u; }, std::chrono::seconds(5));
-
-  // A twist message must be ignored while use_odom=true: no new output.
-  TwistWithCovarianceStamped twist;
-  twist.header.frame_id = "base_link";
-  twist.header.stamp = rclcpp::Time(0, 500000000, RCL_ROS_TIME);
-  twist.twist.twist.linear.x = 100.0;
-  twist_pub->publish(twist);
-  spin_until(executor, [&] { return false; }, std::chrono::milliseconds(300));
-  EXPECT_EQ(received.size(), 1u) << "twist input must be ignored when use_odom=true";
-
-  // Second odom: linear.x = 1 at t = 1 s. dt = 1 s, raw accel = 1.0, first LPF
-  // sample returns it unchanged -> linear.x accel == 1.0.
-  Odometry odom1;
-  odom1.header.frame_id = "base_link";
-  odom1.header.stamp = rclcpp::Time(1, 0, RCL_ROS_TIME);
-  odom1.twist.twist.linear.x = 1.0;
-  odom_pub->publish(odom1);
-  spin_until(executor, [&] { return received.size() >= 2u; }, std::chrono::seconds(5));
-
-  ASSERT_EQ(received.size(), 2u);
-  EXPECT_DOUBLE_EQ(received.back().accel.accel.linear.x, 1.0);
-
-  // Characterization: the published covariance must stay byte-for-byte what the
-  // node emitted before the covariance logic moved into the pure core, i.e. a
-  // constant diagonal (linear variance 1.0, angular variance 0.05) with all
-  // off-diagonal terms zero. The literals below are hand-written, not read back
-  // from the estimator. Diagonal of a row-major 6x6 lives at row * 6 + row.
-  const auto & cov = received.back().accel.covariance;
-  std::array<double, 36> expected{};  // value-initialized to all zeros
-  expected[0] = 1.0;                  // linear x variance
-  expected[7] = 1.0;                  // linear y variance
-  expected[14] = 1.0;                 // linear z variance
-  expected[21] = 0.05;                // roll variance
-  expected[28] = 0.05;                // pitch variance
-  expected[35] = 0.05;                // yaw variance
-  for (std::size_t i = 0; i < expected.size(); ++i) {
-    EXPECT_DOUBLE_EQ(cov[i], expected[i]) << "covariance index " << i;
-  }
+  EXPECT_EQ(received_count_, 1u);
 }
 
-// With use_odom=false the twist callback drives estimation while the odom
-// callback early-returns. Symmetric to the use_odom=true case.
-TEST_F(Twist2AccelNodeTest, UseOdomFalseRoutesTwistAndIgnoresOdom)
+TEST_F(Twist2AccelNodeTest, OdomInputIgnoredWhenUseOdomFalse)
 {
-  auto node = make_node(/*use_odom=*/false);
-  auto helper = std::make_shared<rclcpp::Node>("twist2accel_test_helper");
+  create_nodes(/*use_odom=*/false);
 
-  std::vector<AccelWithCovarianceStamped> received;
-  auto sub = helper->create_subscription<AccelWithCovarianceStamped>(
-    "output/accel", 10,
-    [&received](const AccelWithCovarianceStamped::SharedPtr msg) { received.push_back(*msg); });
-  auto odom_pub = helper->create_publisher<Odometry>("input/odom", 10);
-  auto twist_pub = helper->create_publisher<TwistWithCovarianceStamped>("input/twist", 10);
+  odom_pub_->publish(Odometry{});
+  wait_for_receive_output(std::chrono::milliseconds(200));
 
-  rclcpp::executors::SingleThreadedExecutor executor;
-  executor.add_node(node->get_node_base_interface());
-  executor.add_node(helper);
-
-  spin_until(
-    executor,
-    [&] {
-      return odom_pub->get_subscription_count() > 0 && twist_pub->get_subscription_count() > 0;
-    },
-    std::chrono::seconds(5));
-
-  // First twist: linear.x = 0 at t = 0. Primes prev_twist_, publishes zero accel.
-  TwistWithCovarianceStamped twist0;
-  twist0.header.frame_id = "base_link";
-  twist0.header.stamp = rclcpp::Time(0, 0, RCL_ROS_TIME);
-  twist0.twist.twist.linear.x = 0.0;
-  twist_pub->publish(twist0);
-  spin_until(executor, [&] { return received.size() >= 1u; }, std::chrono::seconds(5));
-
-  // An odom message must be ignored while use_odom=false: no new output.
-  Odometry odom;
-  odom.header.frame_id = "base_link";
-  odom.header.stamp = rclcpp::Time(0, 500000000, RCL_ROS_TIME);
-  odom.twist.twist.linear.x = 100.0;
-  odom_pub->publish(odom);
-  spin_until(executor, [&] { return false; }, std::chrono::milliseconds(300));
-  EXPECT_EQ(received.size(), 1u) << "odom input must be ignored when use_odom=false";
-
-  // Second twist: linear.x = 1 at t = 1 s. dt = 1 s, raw accel = 1.0.
-  TwistWithCovarianceStamped twist1;
-  twist1.header.frame_id = "base_link";
-  twist1.header.stamp = rclcpp::Time(1, 0, RCL_ROS_TIME);
-  twist1.twist.twist.linear.x = 1.0;
-  twist_pub->publish(twist1);
-  spin_until(executor, [&] { return received.size() >= 2u; }, std::chrono::seconds(5));
-
-  ASSERT_EQ(received.size(), 2u);
-  EXPECT_DOUBLE_EQ(received.back().accel.accel.linear.x, 1.0);
+  EXPECT_EQ(received_count_, 0u);
 }
 }  // namespace


### PR DESCRIPTION
## Description

Refactors `autoware_twist2accel`'s publishing code and shrinks its node-level characterization test to a simple integration test.

- **`twist2accel.cpp`**: Reverted change in https://github.com/autowarefoundation/autoware_core/pull/1209. Please note the intermediate allocation and assignment are unnecessary since `estimate()` already returns an `AccelWithCovarianceStamped` by value.
- **`test_twist2accel_node.cpp`**: The estimation math is already covered by `test_accel_estimator.cpp` unit tests, so the node-level test is reduced to verifying only the node's own routing logic.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

- `colcon test --packages-select autoware_traffic_light_selector` passes (7/7 tests, including the shrunk `autoware_traffic_light_selector_node_test`).
- Measured line/function coverage of `traffic_light_selector_node.cpp` with `lcov` before and after the change: unchanged at 100.0% lines (29/29) and 100.0% functions (3/3).

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
