### PR TITLE
feat(autoware_component_interface_specs): add per-domain versioning foundation

### DIFF
--- a/common/autoware_component_interface_specs/CMakeLists.txt
+++ b/common/autoware_component_interface_specs/CMakeLists.txt
@@ -5,6 +5,17 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 if(BUILD_TESTING)
+  # Build-time tool that emits the committed interface_manifest.json. It walks the
+  # per-domain Specs tuples, so it needs C++20 (concepts + tuple iteration). It is
+  # a producer-side/CI tool only (the manifest freshness test drives it), so it is
+  # gated behind BUILD_TESTING: this keeps the C++20 build off the default consumer
+  # dependency build, so it can never break the header-only package for the C++17
+  # consumers that include the domain headers.
+  ament_auto_add_executable(generate_interface_manifest
+    src/generate_interface_manifest.cpp
+  )
+  target_compile_features(generate_interface_manifest PRIVATE cxx_std_20)
+
   ament_auto_add_gtest(gtest_${PROJECT_NAME}
     test/gtest_main.cpp
     test/test_planning.cpp
@@ -14,7 +25,14 @@ if(BUILD_TESTING)
     test/test_perception.cpp
     test/test_system.cpp
     test/test_vehicle.cpp
+    test/test_version.cpp
+    test/test_concepts.cpp
+    test/test_manifest.cpp
   )
+  # test_concepts.cpp exercises the C++20 concepts header.
+  target_compile_features(gtest_${PROJECT_NAME} PRIVATE cxx_std_20)
+  target_compile_definitions(gtest_${PROJECT_NAME}
+    PRIVATE GENERATE_TOOL="$<TARGET_FILE:generate_interface_manifest>")
 endif()
 
 autoware_ament_auto_package(

--- a/common/autoware_component_interface_specs/CMakeLists.txt
+++ b/common/autoware_component_interface_specs/CMakeLists.txt
@@ -28,11 +28,28 @@ if(BUILD_TESTING)
     test/test_version.cpp
     test/test_concepts.cpp
     test/test_manifest.cpp
+    test/test_service_qos.cpp
   )
   # test_concepts.cpp exercises the C++20 concepts header.
   target_compile_features(gtest_${PROJECT_NAME} PRIVATE cxx_std_20)
+  # COMMITTED_MANIFEST lets test_manifest.cpp diff the generator's output against the file
+  # that is actually checked in, which is the copy consumers read.
   target_compile_definitions(gtest_${PROJECT_NAME}
-    PRIVATE GENERATE_TOOL="$<TARGET_FILE:generate_interface_manifest>")
+    PRIVATE
+      GENERATE_TOOL="$<TARGET_FILE:generate_interface_manifest>"
+      COMMITTED_MANIFEST="${CMAKE_CURRENT_SOURCE_DIR}/interface_manifest.json")
+
+  # Consumers of the domain headers get the C++17 that autoware_package() sets, so keep one
+  # target on it. Pinned with the property rather than target_compile_features(cxx_std_17),
+  # which only asks for *at least* C++17 and would silently follow a raised global default.
+  ament_auto_add_gtest(gtest_${PROJECT_NAME}_cxx17
+    test/gtest_main.cpp
+    test/test_cxx17_compat.cpp
+  )
+  set_target_properties(gtest_${PROJECT_NAME}_cxx17 PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED ON
+    CXX_EXTENSIONS OFF)
 endif()
 
 autoware_ament_auto_package(

--- a/common/autoware_component_interface_specs/CMakeLists.txt
+++ b/common/autoware_component_interface_specs/CMakeLists.txt
@@ -5,43 +5,64 @@ find_package(autoware_cmake REQUIRED)
 autoware_package()
 
 if(BUILD_TESTING)
-  # Build-time tool that emits the committed interface_manifest.json. It walks the
-  # per-domain Specs tuples, so it needs C++20 (concepts + tuple iteration). It is
-  # a producer-side/CI tool only (the manifest freshness test drives it), so it is
-  # gated behind BUILD_TESTING: this keeps the C++20 build off the default consumer
-  # dependency build, so it can never break the header-only package for the C++17
-  # consumers that include the domain headers.
-  ament_auto_add_executable(generate_interface_manifest
-    src/generate_interface_manifest.cpp
-  )
-  target_compile_features(generate_interface_manifest PRIVATE cxx_std_20)
+  # The manifest generator and the concepts test compile real C++20: the
+  # `concept X = requires { ... }` syntax in concepts.hpp and tuple iteration. GCC ships
+  # standard C++20 concepts only from GCC 10 -- GCC 8/9 have the older Concepts TS
+  # (`concept bool`), not this syntax. The Humble RHEL-8 binary buildfarm job runs GCC 8.5
+  # and compiles BUILD_TESTING targets (unlike the Jazzy release jobs, it does not set
+  # run_package_tests:false), so these targets would fail to build there. Gate them on a
+  # capable compiler so BUILD_TESTING degrades gracefully instead of FTBFS-ing.
+  set(AUTOWARE_COMPONENT_INTERFACE_SPECS_HAS_CXX20 TRUE)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10)
+    set(AUTOWARE_COMPONENT_INTERFACE_SPECS_HAS_CXX20 FALSE)
+  endif()
 
-  ament_auto_add_gtest(gtest_${PROJECT_NAME}
-    test/gtest_main.cpp
-    test/test_planning.cpp
-    test/test_control.cpp
-    test/test_localization.cpp
-    test/test_map.cpp
-    test/test_perception.cpp
-    test/test_system.cpp
-    test/test_vehicle.cpp
-    test/test_version.cpp
-    test/test_concepts.cpp
-    test/test_manifest.cpp
-    test/test_service_qos.cpp
-  )
-  # test_concepts.cpp exercises the C++20 concepts header.
-  target_compile_features(gtest_${PROJECT_NAME} PRIVATE cxx_std_20)
-  # COMMITTED_MANIFEST lets test_manifest.cpp diff the generator's output against the file
-  # that is actually checked in, which is the copy consumers read.
-  target_compile_definitions(gtest_${PROJECT_NAME}
-    PRIVATE
-      GENERATE_TOOL="$<TARGET_FILE:generate_interface_manifest>"
-      COMMITTED_MANIFEST="${CMAKE_CURRENT_SOURCE_DIR}/interface_manifest.json")
+  if(AUTOWARE_COMPONENT_INTERFACE_SPECS_HAS_CXX20)
+    # Build-time tool that emits the committed interface_manifest.json. It walks the
+    # per-domain Specs tuples, so it needs C++20 (concepts + tuple iteration). It is
+    # a producer-side/CI tool only (the manifest freshness test drives it), so it is
+    # gated behind BUILD_TESTING: this keeps the C++20 build off the default consumer
+    # dependency build, so it can never break the header-only package for the C++17
+    # consumers that include the domain headers.
+    ament_auto_add_executable(generate_interface_manifest
+      src/generate_interface_manifest.cpp
+    )
+    target_compile_features(generate_interface_manifest PRIVATE cxx_std_20)
+
+    # This gtest bundles the C++20-only tests (test_concepts, and test_manifest which drives
+    # the generator above) with the plain domain value tests. On GCC 8.5 it is skipped
+    # wholesale: the value tests assert compile-time constants identical on every compiler
+    # and run on all other jobs, and the C++17 consumer-surface test below still compiles
+    # every domain header on the RHEL-8 job.
+    ament_auto_add_gtest(gtest_${PROJECT_NAME}
+      test/gtest_main.cpp
+      test/test_planning.cpp
+      test/test_control.cpp
+      test/test_localization.cpp
+      test/test_map.cpp
+      test/test_perception.cpp
+      test/test_system.cpp
+      test/test_vehicle.cpp
+      test/test_version.cpp
+      test/test_concepts.cpp
+      test/test_manifest.cpp
+      test/test_service_qos.cpp
+    )
+    # test_concepts.cpp exercises the C++20 concepts header.
+    target_compile_features(gtest_${PROJECT_NAME} PRIVATE cxx_std_20)
+    # COMMITTED_MANIFEST lets test_manifest.cpp diff the generator's output against the file
+    # that is actually checked in, which is the copy consumers read.
+    target_compile_definitions(gtest_${PROJECT_NAME}
+      PRIVATE
+        GENERATE_TOOL="$<TARGET_FILE:generate_interface_manifest>"
+        COMMITTED_MANIFEST="${CMAKE_CURRENT_SOURCE_DIR}/interface_manifest.json")
+  endif()
 
   # Consumers of the domain headers get the C++17 that autoware_package() sets, so keep one
   # target on it. Pinned with the property rather than target_compile_features(cxx_std_17),
   # which only asks for *at least* C++17 and would silently follow a raised global default.
+  # Deliberately outside the C++20 guard above: this is the surface the RHEL-8 GCC 8.5
+  # buildfarm job still exercises, so the domain headers stay compile-tested there.
   ament_auto_add_gtest(gtest_${PROJECT_NAME}_cxx17
     test/gtest_main.cpp
     test/test_cxx17_compat.cpp

--- a/common/autoware_component_interface_specs/CMakeLists.txt
+++ b/common/autoware_component_interface_specs/CMakeLists.txt
@@ -8,10 +8,10 @@ if(BUILD_TESTING)
   # The manifest generator and the concepts test compile real C++20: the
   # `concept X = requires { ... }` syntax in concepts.hpp and tuple iteration. GCC ships
   # standard C++20 concepts only from GCC 10 -- GCC 8/9 have the older Concepts TS
-  # (`concept bool`), not this syntax. The Humble RHEL-8 binary buildfarm job runs GCC 8.5
+  # (`concept bool`), not this syntax. The Humble RHEL-8 binary build farm job runs GCC 8.5
   # and compiles BUILD_TESTING targets (unlike the Jazzy release jobs, it does not set
   # run_package_tests:false), so these targets would fail to build there. Gate them on a
-  # capable compiler so BUILD_TESTING degrades gracefully instead of FTBFS-ing.
+  # capable compiler so BUILD_TESTING degrades gracefully instead of breaking the build.
   set(AUTOWARE_COMPONENT_INTERFACE_SPECS_HAS_CXX20 TRUE)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10)
     set(AUTOWARE_COMPONENT_INTERFACE_SPECS_HAS_CXX20 FALSE)
@@ -62,7 +62,7 @@ if(BUILD_TESTING)
   # target on it. Pinned with the property rather than target_compile_features(cxx_std_17),
   # which only asks for *at least* C++17 and would silently follow a raised global default.
   # Deliberately outside the C++20 guard above: this is the surface the RHEL-8 GCC 8.5
-  # buildfarm job still exercises, so the domain headers stay compile-tested there.
+  # build farm job still exercises, so the domain headers stay compile-tested there.
   ament_auto_add_gtest(gtest_${PROJECT_NAME}_cxx17
     test/gtest_main.cpp
     test/test_cxx17_compat.cpp

--- a/common/autoware_component_interface_specs/README.md
+++ b/common/autoware_component_interface_specs/README.md
@@ -50,11 +50,60 @@ To use these interface specifications in your component:
 
 Each domain namespace declares a semantic `Version` (`version.hpp`) and a `Specs` tuple listing every interface it owns. `0.x` denotes an unstable interface while the standard is stabilizing. Compatibility is decided on the `MAJOR` field only; `is_compatible` is the reference encoding of that rule for consumers that compile against this package. The deploy-time admission gate in `autoware_component_interface_admission` is a no-dependency leaf package, so it restates the same relation rather than calling `is_compatible` — the two must be changed together.
 
+A domain declares its version, its `Specs` registry, and the ADL hook that `spec_version<Spec>()` resolves through in one macro, so the three cannot drift apart:
+
+```cpp
+namespace autoware::component_interface_specs::control
+{
+struct ControlCommand { /* ... */ };
+
+AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(0, 1, 0, ControlCommand)
+}  // namespace autoware::component_interface_specs::control
+```
+
+## Quality of service
+
+Topic specs carry the QoS their endpoints are created with (`depth`, `reliability`, `durability`); `get_qos<Spec>()` turns that into an `rclcpp::QoS`.
+
+Services have a QoS profile too, but not a per-spec one. Every `create_service` and `create_client` call takes ROS 2's `rmw_qos_profile_services_default` — `KEEP_LAST(10)`, `RELIABLE`, `VOLATILE` — unmodified, so all services really do run under identical conditions. Rather than repeat that profile on every `ServiceSpec`, it is declared once as `service_qos` in `utils.hpp` and returned by `get_service_qos()`. `test_service_qos.cpp` asserts it still equals the RMW default it mirrors, so a change to that default surfaces as a test failure instead of as silent drift between the specs and the wire.
+
+## C++ standard
+
+The domain headers, `version.hpp` and `utils.hpp` are C++17, matching the `CMAKE_CXX_STANDARD 17` that `autoware_package()` gives every Autoware target.
+
+`concepts.hpp` needs C++20, because the standard library only exposes `<concepts>` in C++20 mode. A target that wants it opts in:
+
+```cmake
+target_compile_features(<target> PRIVATE cxx_std_20)
+```
+
+CMake raises that one target to `-std=c++20` and leaves every other target — and every C++17 consumer of the domain headers — on `-std=c++17`. This is what the package's own `generate_interface_manifest` and gtest targets do, and it builds on Humble / gcc-11 (Ubuntu 22.04) as well as on Jazzy. Both targets are `BUILD_TESTING`-gated, so a C++20 compile failure in either could never break the header-only package for its C++17 consumers.
+
+Below C++20, `concepts.hpp` is an empty header rather than a hard error, so including it is always safe. Test `AUTOWARE_COMPONENT_INTERFACE_SPECS_HAS_CONCEPTS` before naming anything it declares.
+
 ## Interface manifest
 
-`interface_manifest.json` is a machine-readable list of every registered interface (domain, interface name, message/service type, kind, and version). It is generated from the `Specs` tuples by the `generate_interface_manifest` tool and committed to the repository as the source of truth.
+`interface_manifest.json` is a machine-readable list of every registered interface: its domain, interface name, message or service type, kind, version, and the QoS its endpoints are created with. It is generated from the `Specs` tuples by the `generate_interface_manifest` tool and committed to the repository as the source of truth.
 
-Regenerate it by hand after changing any domain's specs or versions:
+```json
+{
+  "domain": "control",
+  "interface": "/control/command/control_cmd",
+  "type": "autoware_control_msgs/msg/Control",
+  "kind": "topic",
+  "version": "0.1.0",
+  "qos": {
+    "history": "keep_last",
+    "depth": 1,
+    "reliability": "reliable",
+    "durability": "volatile"
+  }
+}
+```
+
+`reliability` and `durability` are the two axes ROS 2 checks when it decides whether a publisher and a subscription may talk at all, which is why a deploy-time gate needs them alongside the type and the version. Service entries carry the shared `service_qos` profile.
+
+Regenerate the manifest by hand after changing any domain's specs, QoS or versions:
 
 ```bash
 colcon build --symlink-install --packages-select autoware_component_interface_specs
@@ -62,4 +111,4 @@ colcon build --symlink-install --packages-select autoware_component_interface_sp
   src/autoware_component_interface_specs/interface_manifest.json
 ```
 
-The generator emits the same layout Prettier produces, so the committed file is stable across regenerations. Adjust the output path to match where the package lives in your workspace.
+The generator emits the same layout Prettier produces, so the committed file is stable across regenerations. Adjust the output path to match where the package lives in your workspace. `test_manifest.cpp` diffs the generator's output against the committed file, so a stale manifest fails the build rather than reaching consumers.

--- a/common/autoware_component_interface_specs/README.md
+++ b/common/autoware_component_interface_specs/README.md
@@ -45,3 +45,21 @@ To use these interface specifications in your component:
    autoware::component_interface_specs::get_qos<KinematicState>(),
    std::bind(&YourClass::callback, this, std::placeholders::1));
    ```
+
+## Versioning
+
+Each domain namespace declares a semantic `Version` (`version.hpp`) and a `Specs` tuple listing every interface it owns. `0.x` denotes an unstable interface while the standard is stabilizing. Compatibility is decided on the `MAJOR` field only; `is_compatible` is the reference encoding of that rule for consumers that compile against this package. The deploy-time admission gate in `autoware_component_interface_admission` is a no-dependency leaf package, so it restates the same relation rather than calling `is_compatible` — the two must be changed together.
+
+## Interface manifest
+
+`interface_manifest.json` is a machine-readable list of every registered interface (domain, interface name, message/service type, kind, and version). It is generated from the `Specs` tuples by the `generate_interface_manifest` tool and committed to the repository as the source of truth.
+
+Regenerate it by hand after changing any domain's specs or versions:
+
+```bash
+colcon build --symlink-install --packages-select autoware_component_interface_specs
+./build/autoware_component_interface_specs/generate_interface_manifest \
+  src/autoware_component_interface_specs/interface_manifest.json
+```
+
+The generator emits the same layout Prettier produces, so the committed file is stable across regenerations. Adjust the output path to match where the package lives in your workspace.

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/concepts.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/concepts.hpp
@@ -17,7 +17,29 @@
 
 #include "autoware/component_interface_specs/version.hpp"
 
+/// 1 when this header declares the concepts, 0 when it expands to nothing.
+///
+/// The concepts need C++20: the standard library only exposes `<concepts>` -- and the
+/// `std::convertible_to` these build on -- in C++20 mode. `autoware_package()` leaves
+/// every target at `CMAKE_CXX_STANDARD 17`, so a target that wants the concepts opts in
+/// with
+///
+///     target_compile_features(<target> PRIVATE cxx_std_20)
+///
+/// CMake raises that one target to `-std=c++20` and leaves every other target -- and
+/// every C++17 consumer of the domain headers -- on `-std=c++17`. This is what the
+/// package's own `generate_interface_manifest` and gtest targets do, on Humble/gcc-11
+/// (Ubuntu 22.04) as well as Jazzy.
+///
+/// A target left at C++17 gets an empty header rather than a hard error, so including it
+/// is always safe. Test this macro before naming anything the header declares.
 #if __cplusplus >= 202002L
+#define AUTOWARE_COMPONENT_INTERFACE_SPECS_HAS_CONCEPTS 1
+#else
+#define AUTOWARE_COMPONENT_INTERFACE_SPECS_HAS_CONCEPTS 0
+#endif
+
+#if AUTOWARE_COMPONENT_INTERFACE_SPECS_HAS_CONCEPTS
 
 #include <rmw/qos_profiles.h>
 
@@ -39,7 +61,9 @@ concept InterfaceSpec = requires {
   { T::durability } -> std::convertible_to<rmw_qos_durability_policy_t>;
 };
 
-/// A service interface spec: service type + name.
+/// A service interface spec: service type + name. Services carry no QoS of their own
+/// because there is exactly one service profile and no call site varies it; see
+/// `service_qos` in utils.hpp.
 template <class T>
 concept ServiceSpec = requires {
   typename T::Service;
@@ -63,5 +87,5 @@ constexpr bool all_specs_valid()
 
 }  // namespace autoware::component_interface_specs
 
-#endif  // __cplusplus >= 202002L
+#endif  // AUTOWARE_COMPONENT_INTERFACE_SPECS_HAS_CONCEPTS
 #endif  // AUTOWARE__COMPONENT_INTERFACE_SPECS__CONCEPTS_HPP_

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/concepts.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/concepts.hpp
@@ -1,0 +1,67 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__COMPONENT_INTERFACE_SPECS__CONCEPTS_HPP_
+#define AUTOWARE__COMPONENT_INTERFACE_SPECS__CONCEPTS_HPP_
+
+#include "autoware/component_interface_specs/version.hpp"
+
+#if __cplusplus >= 202002L
+
+#include <rmw/qos_profiles.h>
+
+#include <concepts>
+#include <cstddef>
+#include <tuple>
+#include <utility>
+
+namespace autoware::component_interface_specs
+{
+
+/// A topic interface spec: message type + name + QoS triple.
+template <class T>
+concept InterfaceSpec = requires {
+  typename T::Message;
+  { T::name } -> std::convertible_to<const char *>;
+  { T::depth } -> std::convertible_to<std::size_t>;
+  { T::reliability } -> std::convertible_to<rmw_qos_reliability_policy_t>;
+  { T::durability } -> std::convertible_to<rmw_qos_durability_policy_t>;
+};
+
+/// A service interface spec: service type + name.
+template <class T>
+concept ServiceSpec = requires {
+  typename T::Service;
+  { T::name } -> std::convertible_to<const char *>;
+};
+
+template <class T>
+concept AnySpec = InterfaceSpec<T> || ServiceSpec<T>;
+
+template <class Tuple, std::size_t... Is>
+constexpr bool all_specs_valid_impl(std::index_sequence<Is...>)
+{
+  return (AnySpec<std::tuple_element_t<Is, Tuple>> && ...);
+}
+
+template <class Tuple>
+constexpr bool all_specs_valid()
+{
+  return all_specs_valid_impl<Tuple>(std::make_index_sequence<std::tuple_size_v<Tuple>>{});
+}
+
+}  // namespace autoware::component_interface_specs
+
+#endif  // __cplusplus >= 202002L
+#endif  // AUTOWARE__COMPONENT_INTERFACE_SPECS__CONCEPTS_HPP_

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/control.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/control.hpp
@@ -16,9 +16,12 @@
 #define AUTOWARE__COMPONENT_INTERFACE_SPECS__CONTROL_HPP_
 
 #include <autoware/component_interface_specs/utils.hpp>
+#include <autoware/component_interface_specs/version.hpp>
 #include <rclcpp/qos.hpp>
 
 #include <autoware_control_msgs/msg/control.hpp>
+
+#include <tuple>
 
 namespace autoware::component_interface_specs::control
 {
@@ -31,6 +34,18 @@ struct ControlCommand
   static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
 };
+
+static constexpr Version version{0, 1, 0};
+
+using Specs = std::tuple<ControlCommand>;
+
+/// ADL hook: lets consumers resolve this domain's version from any spec type
+/// defined in this namespace (used by spec_version<Spec>()).
+template <class Spec>
+constexpr Version resolve_domain_version(const Spec &) noexcept
+{
+  return version;
+}
 
 }  // namespace autoware::component_interface_specs::control
 

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/control.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/control.hpp
@@ -21,8 +21,6 @@
 
 #include <autoware_control_msgs/msg/control.hpp>
 
-#include <tuple>
-
 namespace autoware::component_interface_specs::control
 {
 
@@ -35,17 +33,7 @@ struct ControlCommand
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
 };
 
-static constexpr Version version{0, 1, 0};
-
-using Specs = std::tuple<ControlCommand>;
-
-/// ADL hook: lets consumers resolve this domain's version from any spec type
-/// defined in this namespace (used by spec_version<Spec>()).
-template <class Spec>
-constexpr Version resolve_domain_version(const Spec &) noexcept
-{
-  return version;
-}
+AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(0, 1, 0, ControlCommand)
 
 }  // namespace autoware::component_interface_specs::control
 

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/control.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/control.hpp
@@ -17,9 +17,10 @@
 
 #include <autoware/component_interface_specs/utils.hpp>
 #include <autoware/component_interface_specs/version.hpp>
-#include <rclcpp/qos.hpp>
 
 #include <autoware_control_msgs/msg/control.hpp>
+
+#include <rmw/qos_profiles.h>
 
 namespace autoware::component_interface_specs::control
 {

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/localization.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/localization.hpp
@@ -16,12 +16,15 @@
 #define AUTOWARE__COMPONENT_INTERFACE_SPECS__LOCALIZATION_HPP_
 
 #include <autoware/component_interface_specs/utils.hpp>
+#include <autoware/component_interface_specs/version.hpp>
 #include <rclcpp/qos.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/localization_initialization_state.hpp>
 #include <autoware_localization_msgs/srv/initialize_localization.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
+
+#include <tuple>
 
 namespace autoware::component_interface_specs::localization
 {
@@ -58,6 +61,18 @@ struct Acceleration
   static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
 };
+
+static constexpr Version version{0, 1, 0};
+
+using Specs = std::tuple<Initialize, InitializationState, KinematicState, Acceleration>;
+
+/// ADL hook: lets consumers resolve this domain's version from any spec type
+/// defined in this namespace (used by spec_version<Spec>()).
+template <class Spec>
+constexpr Version resolve_domain_version(const Spec &) noexcept
+{
+  return version;
+}
 
 }  // namespace autoware::component_interface_specs::localization
 

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/localization.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/localization.hpp
@@ -24,8 +24,6 @@
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 
-#include <tuple>
-
 namespace autoware::component_interface_specs::localization
 {
 
@@ -62,17 +60,8 @@ struct Acceleration
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
 };
 
-static constexpr Version version{0, 1, 0};
-
-using Specs = std::tuple<Initialize, InitializationState, KinematicState, Acceleration>;
-
-/// ADL hook: lets consumers resolve this domain's version from any spec type
-/// defined in this namespace (used by spec_version<Spec>()).
-template <class Spec>
-constexpr Version resolve_domain_version(const Spec &) noexcept
-{
-  return version;
-}
+AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(
+  0, 1, 0, Initialize, InitializationState, KinematicState, Acceleration)
 
 }  // namespace autoware::component_interface_specs::localization
 

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/localization.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/localization.hpp
@@ -17,12 +17,13 @@
 
 #include <autoware/component_interface_specs/utils.hpp>
 #include <autoware/component_interface_specs/version.hpp>
-#include <rclcpp/qos.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/localization_initialization_state.hpp>
 #include <autoware_localization_msgs/srv/initialize_localization.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
+
+#include <rmw/qos_profiles.h>
 
 namespace autoware::component_interface_specs::localization
 {

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/map.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/map.hpp
@@ -16,11 +16,14 @@
 #define AUTOWARE__COMPONENT_INTERFACE_SPECS__MAP_HPP_
 
 #include <autoware/component_interface_specs/utils.hpp>
+#include <autoware/component_interface_specs/version.hpp>
 #include <rclcpp/qos.hpp>
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_map_msgs/msg/map_projector_info.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
+
+#include <tuple>
 
 namespace autoware::component_interface_specs::map
 {
@@ -51,6 +54,18 @@ struct VectorMap
   static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
 };
+
+static constexpr Version version{0, 1, 0};
+
+using Specs = std::tuple<MapProjectorInfo, PointCloudMap, VectorMap>;
+
+/// ADL hook: lets consumers resolve this domain's version from any spec type
+/// defined in this namespace (used by spec_version<Spec>()).
+template <class Spec>
+constexpr Version resolve_domain_version(const Spec &) noexcept
+{
+  return version;
+}
 
 }  // namespace autoware::component_interface_specs::map
 

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/map.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/map.hpp
@@ -23,8 +23,6 @@
 #include <autoware_map_msgs/msg/map_projector_info.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
-#include <tuple>
-
 namespace autoware::component_interface_specs::map
 {
 
@@ -55,17 +53,8 @@ struct VectorMap
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
 };
 
-static constexpr Version version{0, 1, 0};
-
-using Specs = std::tuple<MapProjectorInfo, PointCloudMap, VectorMap>;
-
-/// ADL hook: lets consumers resolve this domain's version from any spec type
-/// defined in this namespace (used by spec_version<Spec>()).
-template <class Spec>
-constexpr Version resolve_domain_version(const Spec &) noexcept
-{
-  return version;
-}
+AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(
+  0, 1, 0, MapProjectorInfo, PointCloudMap, VectorMap)
 
 }  // namespace autoware::component_interface_specs::map
 

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/map.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/map.hpp
@@ -17,11 +17,12 @@
 
 #include <autoware/component_interface_specs/utils.hpp>
 #include <autoware/component_interface_specs/version.hpp>
-#include <rclcpp/qos.hpp>
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_map_msgs/msg/map_projector_info.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
+
+#include <rmw/qos_profiles.h>
 
 namespace autoware::component_interface_specs::map
 {

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/perception.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/perception.hpp
@@ -21,8 +21,6 @@
 
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 
-#include <tuple>
-
 namespace autoware::component_interface_specs::perception
 {
 
@@ -35,17 +33,7 @@ struct ObjectRecognition
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
 };
 
-static constexpr Version version{0, 1, 0};
-
-using Specs = std::tuple<ObjectRecognition>;
-
-/// ADL hook: lets consumers resolve this domain's version from any spec type
-/// defined in this namespace (used by spec_version<Spec>()).
-template <class Spec>
-constexpr Version resolve_domain_version(const Spec &) noexcept
-{
-  return version;
-}
+AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(0, 1, 0, ObjectRecognition)
 
 }  // namespace autoware::component_interface_specs::perception
 

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/perception.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/perception.hpp
@@ -16,9 +16,12 @@
 #define AUTOWARE__COMPONENT_INTERFACE_SPECS__PERCEPTION_HPP_
 
 #include <autoware/component_interface_specs/utils.hpp>
+#include <autoware/component_interface_specs/version.hpp>
 #include <rclcpp/qos.hpp>
 
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
+
+#include <tuple>
 
 namespace autoware::component_interface_specs::perception
 {
@@ -31,6 +34,18 @@ struct ObjectRecognition
   static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
 };
+
+static constexpr Version version{0, 1, 0};
+
+using Specs = std::tuple<ObjectRecognition>;
+
+/// ADL hook: lets consumers resolve this domain's version from any spec type
+/// defined in this namespace (used by spec_version<Spec>()).
+template <class Spec>
+constexpr Version resolve_domain_version(const Spec &) noexcept
+{
+  return version;
+}
 
 }  // namespace autoware::component_interface_specs::perception
 

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/perception.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/perception.hpp
@@ -17,9 +17,10 @@
 
 #include <autoware/component_interface_specs/utils.hpp>
 #include <autoware/component_interface_specs/version.hpp>
-#include <rclcpp/qos.hpp>
 
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
+
+#include <rmw/qos_profiles.h>
 
 namespace autoware::component_interface_specs::perception
 {

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/planning.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/planning.hpp
@@ -16,6 +16,7 @@
 #define AUTOWARE__COMPONENT_INTERFACE_SPECS__PLANNING_HPP_
 
 #include <autoware/component_interface_specs/utils.hpp>
+#include <autoware/component_interface_specs/version.hpp>
 #include <rclcpp/qos.hpp>
 
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
@@ -24,6 +25,8 @@
 #include <autoware_planning_msgs/srv/clear_route.hpp>
 #include <autoware_planning_msgs/srv/set_lanelet_route.hpp>
 #include <autoware_planning_msgs/srv/set_waypoint_route.hpp>
+
+#include <tuple>
 
 namespace autoware::component_interface_specs::planning
 {
@@ -72,6 +75,19 @@ struct Trajectory
   static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
 };
+
+static constexpr Version version{0, 1, 0};
+
+using Specs =
+  std::tuple<SetLaneletRoute, SetWaypointRoute, ClearRoute, RouteState, LaneletRoute, Trajectory>;
+
+/// ADL hook: lets consumers resolve this domain's version from any spec type
+/// defined in this namespace (used by spec_version<Spec>()).
+template <class Spec>
+constexpr Version resolve_domain_version(const Spec &) noexcept
+{
+  return version;
+}
 
 }  // namespace autoware::component_interface_specs::planning
 

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/planning.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/planning.hpp
@@ -26,8 +26,6 @@
 #include <autoware_planning_msgs/srv/set_lanelet_route.hpp>
 #include <autoware_planning_msgs/srv/set_waypoint_route.hpp>
 
-#include <tuple>
-
 namespace autoware::component_interface_specs::planning
 {
 
@@ -76,18 +74,8 @@ struct Trajectory
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
 };
 
-static constexpr Version version{0, 1, 0};
-
-using Specs =
-  std::tuple<SetLaneletRoute, SetWaypointRoute, ClearRoute, RouteState, LaneletRoute, Trajectory>;
-
-/// ADL hook: lets consumers resolve this domain's version from any spec type
-/// defined in this namespace (used by spec_version<Spec>()).
-template <class Spec>
-constexpr Version resolve_domain_version(const Spec &) noexcept
-{
-  return version;
-}
+AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(
+  0, 1, 0, SetLaneletRoute, SetWaypointRoute, ClearRoute, RouteState, LaneletRoute, Trajectory)
 
 }  // namespace autoware::component_interface_specs::planning
 

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/planning.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/planning.hpp
@@ -17,7 +17,6 @@
 
 #include <autoware/component_interface_specs/utils.hpp>
 #include <autoware/component_interface_specs/version.hpp>
-#include <rclcpp/qos.hpp>
 
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <autoware_planning_msgs/msg/route_state.hpp>
@@ -25,6 +24,8 @@
 #include <autoware_planning_msgs/srv/clear_route.hpp>
 #include <autoware_planning_msgs/srv/set_lanelet_route.hpp>
 #include <autoware_planning_msgs/srv/set_waypoint_route.hpp>
+
+#include <rmw/qos_profiles.h>
 
 namespace autoware::component_interface_specs::planning
 {

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/system.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/system.hpp
@@ -15,12 +15,15 @@
 #ifndef AUTOWARE__COMPONENT_INTERFACE_SPECS__SYSTEM_HPP_
 #define AUTOWARE__COMPONENT_INTERFACE_SPECS__SYSTEM_HPP_
 
+#include <autoware/component_interface_specs/version.hpp>
 #include <rclcpp/qos.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
 #include <autoware_system_msgs/srv/change_autoware_control.hpp>
 #include <autoware_system_msgs/srv/change_operation_mode.hpp>
+
+#include <tuple>
 
 namespace autoware::component_interface_specs::system
 {
@@ -45,6 +48,18 @@ struct OperationModeState
   static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
 };
+
+static constexpr Version version{0, 1, 0};
+
+using Specs = std::tuple<ChangeAutowareControl, ChangeOperationMode, OperationModeState>;
+
+/// ADL hook: lets consumers resolve this domain's version from any spec type
+/// defined in this namespace (used by spec_version<Spec>()).
+template <class Spec>
+constexpr Version resolve_domain_version(const Spec &) noexcept
+{
+  return version;
+}
 
 }  // namespace autoware::component_interface_specs::system
 

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/system.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/system.hpp
@@ -23,8 +23,6 @@
 #include <autoware_system_msgs/srv/change_autoware_control.hpp>
 #include <autoware_system_msgs/srv/change_operation_mode.hpp>
 
-#include <tuple>
-
 namespace autoware::component_interface_specs::system
 {
 
@@ -49,17 +47,8 @@ struct OperationModeState
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
 };
 
-static constexpr Version version{0, 1, 0};
-
-using Specs = std::tuple<ChangeAutowareControl, ChangeOperationMode, OperationModeState>;
-
-/// ADL hook: lets consumers resolve this domain's version from any spec type
-/// defined in this namespace (used by spec_version<Spec>()).
-template <class Spec>
-constexpr Version resolve_domain_version(const Spec &) noexcept
-{
-  return version;
-}
+AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(
+  0, 1, 0, ChangeAutowareControl, ChangeOperationMode, OperationModeState)
 
 }  // namespace autoware::component_interface_specs::system
 

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/system.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/system.hpp
@@ -16,12 +16,13 @@
 #define AUTOWARE__COMPONENT_INTERFACE_SPECS__SYSTEM_HPP_
 
 #include <autoware/component_interface_specs/version.hpp>
-#include <rclcpp/qos.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
 #include <autoware_system_msgs/srv/change_autoware_control.hpp>
 #include <autoware_system_msgs/srv/change_operation_mode.hpp>
+
+#include <rmw/qos_profiles.h>
 
 namespace autoware::component_interface_specs::system
 {

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/utils.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/utils.hpp
@@ -21,6 +21,10 @@
 #include <autoware_map_msgs/msg/map_projector_info.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
+#include <rmw/qos_profiles.h>
+
+#include <cstddef>
+
 namespace autoware::component_interface_specs
 {
 
@@ -28,6 +32,29 @@ template <typename T>
 rclcpp::QoS get_qos()
 {
   return rclcpp::QoS{T::depth}.reliability(T::reliability).durability(T::durability);
+}
+
+/// ROS 2 gives services a QoS profile just like topics: `rmw_qos_profile_services_default`,
+/// which is what every `create_service` / `create_client` call in Autoware takes. No call
+/// site overrides it, so all services do run under identical conditions. Service specs
+/// therefore carry no QoS members of their own -- the one profile they all share is
+/// declared here instead, and `test_service_qos.cpp` asserts it still equals the RMW
+/// default it mirrors, so a change to that default surfaces as a test failure rather than
+/// as silent drift between the specs and the wire.
+namespace service_qos
+{
+static constexpr std::size_t depth = 10;
+static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+}  // namespace service_qos
+
+/// The QoS every service in this package runs on, as the topic-side `get_qos<T>()` returns
+/// the QoS of a single topic spec.
+inline rclcpp::QoS get_service_qos()
+{
+  return rclcpp::QoS{service_qos::depth}
+    .reliability(service_qos::reliability)
+    .durability(service_qos::durability);
 }
 
 }  // namespace autoware::component_interface_specs

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/vehicle.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/vehicle.hpp
@@ -18,12 +18,15 @@
 #include "utils.hpp"
 
 #include <autoware/component_interface_specs/utils.hpp>
+#include <autoware/component_interface_specs/version.hpp>
 #include <rclcpp/qos.hpp>
 
 #include <autoware_vehicle_msgs/msg/gear_report.hpp>
 #include <autoware_vehicle_msgs/msg/hazard_lights_report.hpp>
 #include <autoware_vehicle_msgs/msg/steering_report.hpp>
 #include <autoware_vehicle_msgs/msg/turn_indicators_report.hpp>
+
+#include <tuple>
 
 namespace autoware::component_interface_specs::vehicle
 {
@@ -63,6 +66,18 @@ struct HazardLightStatus
   static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
 };
+
+static constexpr Version version{0, 1, 0};
+
+using Specs = std::tuple<SteeringStatus, GearStatus, TurnIndicatorStatus, HazardLightStatus>;
+
+/// ADL hook: lets consumers resolve this domain's version from any spec type
+/// defined in this namespace (used by spec_version<Spec>()).
+template <class Spec>
+constexpr Version resolve_domain_version(const Spec &) noexcept
+{
+  return version;
+}
 
 }  // namespace autoware::component_interface_specs::vehicle
 

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/vehicle.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/vehicle.hpp
@@ -26,8 +26,6 @@
 #include <autoware_vehicle_msgs/msg/steering_report.hpp>
 #include <autoware_vehicle_msgs/msg/turn_indicators_report.hpp>
 
-#include <tuple>
-
 namespace autoware::component_interface_specs::vehicle
 {
 
@@ -67,17 +65,8 @@ struct HazardLightStatus
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
 };
 
-static constexpr Version version{0, 1, 0};
-
-using Specs = std::tuple<SteeringStatus, GearStatus, TurnIndicatorStatus, HazardLightStatus>;
-
-/// ADL hook: lets consumers resolve this domain's version from any spec type
-/// defined in this namespace (used by spec_version<Spec>()).
-template <class Spec>
-constexpr Version resolve_domain_version(const Spec &) noexcept
-{
-  return version;
-}
+AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(
+  0, 1, 0, SteeringStatus, GearStatus, TurnIndicatorStatus, HazardLightStatus)
 
 }  // namespace autoware::component_interface_specs::vehicle
 

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/vehicle.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/vehicle.hpp
@@ -19,12 +19,13 @@
 
 #include <autoware/component_interface_specs/utils.hpp>
 #include <autoware/component_interface_specs/version.hpp>
-#include <rclcpp/qos.hpp>
 
 #include <autoware_vehicle_msgs/msg/gear_report.hpp>
 #include <autoware_vehicle_msgs/msg/hazard_lights_report.hpp>
 #include <autoware_vehicle_msgs/msg/steering_report.hpp>
 #include <autoware_vehicle_msgs/msg/turn_indicators_report.hpp>
+
+#include <rmw/qos_profiles.h>
 
 namespace autoware::component_interface_specs::vehicle
 {

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/version.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/version.hpp
@@ -1,0 +1,80 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__COMPONENT_INTERFACE_SPECS__VERSION_HPP_
+#define AUTOWARE__COMPONENT_INTERFACE_SPECS__VERSION_HPP_
+
+#include <cstdint>
+
+namespace autoware::component_interface_specs
+{
+
+/// Per-domain semantic version. 0.x is unstable while the standard is stabilizing.
+struct Version
+{
+  std::uint16_t major;
+  std::uint16_t minor;
+  std::uint16_t patch;
+};
+
+constexpr bool operator==(const Version & a, const Version & b)
+{
+  return a.major == b.major && a.minor == b.minor && a.patch == b.patch;
+}
+
+constexpr bool operator!=(const Version & a, const Version & b)
+{
+  return !(a == b);
+}
+
+/// Inclusive MAJOR acceptance window declared by a required (consumer) side.
+struct accept_major
+{
+  std::uint16_t lo;
+  std::uint16_t hi;
+};
+
+/// The reference encoding of the MAJOR compatibility axis: a provided interface
+/// satisfies a required MAJOR iff equal. This is the definition consumers compile
+/// against; it is not itself the deploy-time gate. The gate lives in
+/// autoware_component_interface_admission, a no-dependency leaf package that cannot
+/// include this header and therefore restates the same relation. Change one and the
+/// other must follow.
+constexpr bool is_compatible(const Version & provided, std::uint16_t required_major)
+{
+  return provided.major == required_major;
+}
+
+/// The same reference encoding against a migration window [lo, hi].
+constexpr bool is_compatible(const Version & provided, const accept_major & range)
+{
+  return range.lo <= provided.major && provided.major <= range.hi;
+}
+
+/// Owner of every spec defined in this package (the OSS standard partition).
+static constexpr char owner[] = "autowarefoundation";
+
+/// Resolve a spec type's domain version via ADL into the spec's own namespace.
+/// Each domain header declares a `resolve_domain_version(const Spec &)` overload
+/// that returns that namespace's `version`. A compile error if a spec's domain
+/// forgot to declare one is exactly the version-consistency discipline we want.
+template <class Spec>
+constexpr Version spec_version()
+{
+  return resolve_domain_version(Spec{});
+}
+
+}  // namespace autoware::component_interface_specs
+
+#endif  // AUTOWARE__COMPONENT_INTERFACE_SPECS__VERSION_HPP_

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/version.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/version.hpp
@@ -16,6 +16,7 @@
 #define AUTOWARE__COMPONENT_INTERFACE_SPECS__VERSION_HPP_
 
 #include <cstdint>
+#include <tuple>
 
 namespace autoware::component_interface_specs
 {
@@ -76,5 +77,32 @@ constexpr Version spec_version()
 }
 
 }  // namespace autoware::component_interface_specs
+
+/// Declares the three things every domain namespace owes the versioning contract: its
+/// `version`, the `Specs` tuple registering the interfaces it owns, and the ADL hook
+/// `spec_version<Spec>()` resolves through. Emitting them from one macro keeps them from
+/// drifting apart -- a domain cannot bump its version but forget to register a new spec,
+/// or register a spec whose version nothing can resolve.
+///
+/// Invoke once per domain header, inside the domain namespace, after the spec structs:
+///
+///     namespace autoware::component_interface_specs::control
+///     {
+///     struct ControlCommand { ... };
+///     AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(0, 1, 0, ControlCommand)
+///     }
+///
+/// A domain may still add a `resolve_domain_version(const Spec &) = delete;` overload
+/// afterwards to exclude an individual spec from version resolution.
+#define AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(MAJOR, MINOR, PATCH, ...)              \
+  static constexpr ::autoware::component_interface_specs::Version version{MAJOR, MINOR, PATCH}; \
+  using Specs = ::std::tuple<__VA_ARGS__>;                                                      \
+                                                                                                \
+  template <class Spec>                                                                         \
+  constexpr ::autoware::component_interface_specs::Version resolve_domain_version(              \
+    const Spec &) noexcept                                                                      \
+  {                                                                                             \
+    return version;                                                                             \
+  }
 
 #endif  // AUTOWARE__COMPONENT_INTERFACE_SPECS__VERSION_HPP_

--- a/common/autoware_component_interface_specs/interface_manifest.json
+++ b/common/autoware_component_interface_specs/interface_manifest.json
@@ -1,0 +1,159 @@
+{
+  "owner": "autowarefoundation",
+  "interfaces": [
+    {
+      "domain": "control",
+      "interface": "/control/command/control_cmd",
+      "type": "autoware_control_msgs/msg/Control",
+      "kind": "topic",
+      "version": "0.1.0"
+    },
+    {
+      "domain": "localization",
+      "interface": "/localization/initialize",
+      "type": "autoware_localization_msgs/srv/InitializeLocalization",
+      "kind": "service",
+      "version": "0.1.0"
+    },
+    {
+      "domain": "localization",
+      "interface": "/localization/initialization_state",
+      "type": "autoware_adapi_v1_msgs/msg/LocalizationInitializationState",
+      "kind": "topic",
+      "version": "0.1.0"
+    },
+    {
+      "domain": "localization",
+      "interface": "/localization/kinematic_state",
+      "type": "nav_msgs/msg/Odometry",
+      "kind": "topic",
+      "version": "0.1.0"
+    },
+    {
+      "domain": "localization",
+      "interface": "/localization/acceleration",
+      "type": "geometry_msgs/msg/AccelWithCovarianceStamped",
+      "kind": "topic",
+      "version": "0.1.0"
+    },
+    {
+      "domain": "map",
+      "interface": "/map/map_projector_info",
+      "type": "autoware_map_msgs/msg/MapProjectorInfo",
+      "kind": "topic",
+      "version": "0.1.0"
+    },
+    {
+      "domain": "map",
+      "interface": "/map/point_cloud_map",
+      "type": "sensor_msgs/msg/PointCloud2",
+      "kind": "topic",
+      "version": "0.1.0"
+    },
+    {
+      "domain": "map",
+      "interface": "/map/vector_map",
+      "type": "autoware_map_msgs/msg/LaneletMapBin",
+      "kind": "topic",
+      "version": "0.1.0"
+    },
+    {
+      "domain": "perception",
+      "interface": "/perception/object_recognition/objects",
+      "type": "autoware_perception_msgs/msg/PredictedObjects",
+      "kind": "topic",
+      "version": "0.1.0"
+    },
+    {
+      "domain": "planning",
+      "interface": "/planning/set_lanelet_route",
+      "type": "autoware_planning_msgs/srv/SetLaneletRoute",
+      "kind": "service",
+      "version": "0.1.0"
+    },
+    {
+      "domain": "planning",
+      "interface": "/planning/set_waypoint_route",
+      "type": "autoware_planning_msgs/srv/SetWaypointRoute",
+      "kind": "service",
+      "version": "0.1.0"
+    },
+    {
+      "domain": "planning",
+      "interface": "/planning/clear_route",
+      "type": "autoware_planning_msgs/srv/ClearRoute",
+      "kind": "service",
+      "version": "0.1.0"
+    },
+    {
+      "domain": "planning",
+      "interface": "/planning/route_state",
+      "type": "autoware_planning_msgs/msg/RouteState",
+      "kind": "topic",
+      "version": "0.1.0"
+    },
+    {
+      "domain": "planning",
+      "interface": "/planning/route",
+      "type": "autoware_planning_msgs/msg/LaneletRoute",
+      "kind": "topic",
+      "version": "0.1.0"
+    },
+    {
+      "domain": "planning",
+      "interface": "/planning/trajectory",
+      "type": "autoware_planning_msgs/msg/Trajectory",
+      "kind": "topic",
+      "version": "0.1.0"
+    },
+    {
+      "domain": "system",
+      "interface": "/system/operation_mode/change_autoware_control",
+      "type": "autoware_system_msgs/srv/ChangeAutowareControl",
+      "kind": "service",
+      "version": "0.1.0"
+    },
+    {
+      "domain": "system",
+      "interface": "/system/operation_mode/change_operation_mode",
+      "type": "autoware_system_msgs/srv/ChangeOperationMode",
+      "kind": "service",
+      "version": "0.1.0"
+    },
+    {
+      "domain": "system",
+      "interface": "/system/operation_mode/state",
+      "type": "autoware_adapi_v1_msgs/msg/OperationModeState",
+      "kind": "topic",
+      "version": "0.1.0"
+    },
+    {
+      "domain": "vehicle",
+      "interface": "/vehicle/status/steering_status",
+      "type": "autoware_vehicle_msgs/msg/SteeringReport",
+      "kind": "topic",
+      "version": "0.1.0"
+    },
+    {
+      "domain": "vehicle",
+      "interface": "/vehicle/status/gear_status",
+      "type": "autoware_vehicle_msgs/msg/GearReport",
+      "kind": "topic",
+      "version": "0.1.0"
+    },
+    {
+      "domain": "vehicle",
+      "interface": "/vehicle/status/turn_indicators_status",
+      "type": "autoware_vehicle_msgs/msg/TurnIndicatorsReport",
+      "kind": "topic",
+      "version": "0.1.0"
+    },
+    {
+      "domain": "vehicle",
+      "interface": "/vehicle/status/hazard_lights_status",
+      "type": "autoware_vehicle_msgs/msg/HazardLightsReport",
+      "kind": "topic",
+      "version": "0.1.0"
+    }
+  ]
+}

--- a/common/autoware_component_interface_specs/interface_manifest.json
+++ b/common/autoware_component_interface_specs/interface_manifest.json
@@ -6,154 +6,286 @@
       "interface": "/control/command/control_cmd",
       "type": "autoware_control_msgs/msg/Control",
       "kind": "topic",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
     },
     {
       "domain": "localization",
       "interface": "/localization/initialize",
       "type": "autoware_localization_msgs/srv/InitializeLocalization",
       "kind": "service",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 10,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
     },
     {
       "domain": "localization",
       "interface": "/localization/initialization_state",
       "type": "autoware_adapi_v1_msgs/msg/LocalizationInitializationState",
       "kind": "topic",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "transient_local"
+      }
     },
     {
       "domain": "localization",
       "interface": "/localization/kinematic_state",
       "type": "nav_msgs/msg/Odometry",
       "kind": "topic",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
     },
     {
       "domain": "localization",
       "interface": "/localization/acceleration",
       "type": "geometry_msgs/msg/AccelWithCovarianceStamped",
       "kind": "topic",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
     },
     {
       "domain": "map",
       "interface": "/map/map_projector_info",
       "type": "autoware_map_msgs/msg/MapProjectorInfo",
       "kind": "topic",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "transient_local"
+      }
     },
     {
       "domain": "map",
       "interface": "/map/point_cloud_map",
       "type": "sensor_msgs/msg/PointCloud2",
       "kind": "topic",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "transient_local"
+      }
     },
     {
       "domain": "map",
       "interface": "/map/vector_map",
       "type": "autoware_map_msgs/msg/LaneletMapBin",
       "kind": "topic",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "transient_local"
+      }
     },
     {
       "domain": "perception",
       "interface": "/perception/object_recognition/objects",
       "type": "autoware_perception_msgs/msg/PredictedObjects",
       "kind": "topic",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
     },
     {
       "domain": "planning",
       "interface": "/planning/set_lanelet_route",
       "type": "autoware_planning_msgs/srv/SetLaneletRoute",
       "kind": "service",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 10,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
     },
     {
       "domain": "planning",
       "interface": "/planning/set_waypoint_route",
       "type": "autoware_planning_msgs/srv/SetWaypointRoute",
       "kind": "service",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 10,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
     },
     {
       "domain": "planning",
       "interface": "/planning/clear_route",
       "type": "autoware_planning_msgs/srv/ClearRoute",
       "kind": "service",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 10,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
     },
     {
       "domain": "planning",
       "interface": "/planning/route_state",
       "type": "autoware_planning_msgs/msg/RouteState",
       "kind": "topic",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "transient_local"
+      }
     },
     {
       "domain": "planning",
       "interface": "/planning/route",
       "type": "autoware_planning_msgs/msg/LaneletRoute",
       "kind": "topic",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "transient_local"
+      }
     },
     {
       "domain": "planning",
       "interface": "/planning/trajectory",
       "type": "autoware_planning_msgs/msg/Trajectory",
       "kind": "topic",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
     },
     {
       "domain": "system",
       "interface": "/system/operation_mode/change_autoware_control",
       "type": "autoware_system_msgs/srv/ChangeAutowareControl",
       "kind": "service",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 10,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
     },
     {
       "domain": "system",
       "interface": "/system/operation_mode/change_operation_mode",
       "type": "autoware_system_msgs/srv/ChangeOperationMode",
       "kind": "service",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 10,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
     },
     {
       "domain": "system",
       "interface": "/system/operation_mode/state",
       "type": "autoware_adapi_v1_msgs/msg/OperationModeState",
       "kind": "topic",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "transient_local"
+      }
     },
     {
       "domain": "vehicle",
       "interface": "/vehicle/status/steering_status",
       "type": "autoware_vehicle_msgs/msg/SteeringReport",
       "kind": "topic",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
     },
     {
       "domain": "vehicle",
       "interface": "/vehicle/status/gear_status",
       "type": "autoware_vehicle_msgs/msg/GearReport",
       "kind": "topic",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
     },
     {
       "domain": "vehicle",
       "interface": "/vehicle/status/turn_indicators_status",
       "type": "autoware_vehicle_msgs/msg/TurnIndicatorsReport",
       "kind": "topic",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
     },
     {
       "domain": "vehicle",
       "interface": "/vehicle/status/hazard_lights_status",
       "type": "autoware_vehicle_msgs/msg/HazardLightsReport",
       "kind": "topic",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
     }
   ]
 }

--- a/common/autoware_component_interface_specs/package.xml
+++ b/common/autoware_component_interface_specs/package.xml
@@ -20,8 +20,8 @@
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_system_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
+  <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
-  <depend>rcl</depend>
   <depend>rclcpp</depend>
   <depend>rosidl_runtime_cpp</depend>
   <depend>sensor_msgs</depend>

--- a/common/autoware_component_interface_specs/src/generate_interface_manifest.cpp
+++ b/common/autoware_component_interface_specs/src/generate_interface_manifest.cpp
@@ -1,0 +1,131 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Deterministic, hand-emitted JSON walker over the per-domain `Specs` tuples.
+// The emitted layout is byte-identical to the committed `interface_manifest.json`
+// (and to what Prettier produces for it), so a rebuild plus diff is the freshness
+// check consumed by later CI work.
+
+#include "autoware/component_interface_specs/concepts.hpp"
+#include "autoware/component_interface_specs/control.hpp"
+#include "autoware/component_interface_specs/localization.hpp"
+#include "autoware/component_interface_specs/map.hpp"
+#include "autoware/component_interface_specs/perception.hpp"
+#include "autoware/component_interface_specs/planning.hpp"
+#include "autoware/component_interface_specs/system.hpp"
+#include "autoware/component_interface_specs/vehicle.hpp"
+
+#include <rosidl_runtime_cpp/traits.hpp>
+
+#include <cstddef>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace cis = autoware::component_interface_specs;
+
+namespace
+{
+
+template <class T>
+concept HasMessage = requires { typename T::Message; };
+
+struct Entry
+{
+  std::string domain;
+  std::string interface;
+  std::string type;
+  std::string kind;  // "topic" | "service"
+  cis::Version version;
+};
+
+template <class Spec>
+Entry make_entry(const std::string & domain, cis::Version version)
+{
+  Entry e;
+  e.domain = domain;
+  e.interface = Spec::name;
+  e.version = version;
+  if constexpr (HasMessage<Spec>) {
+    e.kind = "topic";
+    e.type = rosidl_generator_traits::name<typename Spec::Message>();
+  } else {
+    e.kind = "service";
+    e.type = rosidl_generator_traits::name<typename Spec::Service>();
+  }
+  return e;
+}
+
+template <class Tuple, class F, std::size_t... Is>
+void for_each_type(F && f, std::index_sequence<Is...>)
+{
+  (f(std::type_identity<std::tuple_element_t<Is, Tuple>>{}), ...);
+}
+
+template <class Specs>
+void collect(const std::string & domain, cis::Version version, std::vector<Entry> * out)
+{
+  for_each_type<Specs>(
+    [&](auto tag) {
+      using Spec = typename decltype(tag)::type;
+      out->push_back(make_entry<Spec>(domain, version));
+    },
+    std::make_index_sequence<std::tuple_size_v<Specs>>{});
+}
+
+std::string ver_str(cis::Version v)
+{
+  return std::to_string(v.major) + "." + std::to_string(v.minor) + "." + std::to_string(v.patch);
+}
+
+}  // namespace
+
+int main(int argc, char ** argv)
+{
+  if (argc < 2) {
+    std::cerr << "usage: generate_interface_manifest <out.json>\n";
+    return 1;
+  }
+
+  std::vector<Entry> entries;
+  collect<cis::control::Specs>("control", cis::control::version, &entries);
+  collect<cis::localization::Specs>("localization", cis::localization::version, &entries);
+  collect<cis::map::Specs>("map", cis::map::version, &entries);
+  collect<cis::perception::Specs>("perception", cis::perception::version, &entries);
+  collect<cis::planning::Specs>("planning", cis::planning::version, &entries);
+  collect<cis::system::Specs>("system", cis::system::version, &entries);
+  collect<cis::vehicle::Specs>("vehicle", cis::vehicle::version, &entries);
+
+  std::ofstream os(argv[1]);
+  os << "{\n";
+  os << "  \"owner\": \"" << cis::owner << "\",\n";
+  os << "  \"interfaces\": [\n";
+  for (std::size_t i = 0; i < entries.size(); ++i) {
+    const auto & e = entries[i];
+    os << "    {\n";
+    os << "      \"domain\": \"" << e.domain << "\",\n";
+    os << "      \"interface\": \"" << e.interface << "\",\n";
+    os << "      \"type\": \"" << e.type << "\",\n";
+    os << "      \"kind\": \"" << e.kind << "\",\n";
+    os << "      \"version\": \"" << ver_str(e.version) << "\"\n";
+    os << "    }" << (i + 1 < entries.size() ? "," : "") << "\n";
+  }
+  os << "  ]\n";
+  os << "}\n";
+  return 0;
+}

--- a/common/autoware_component_interface_specs/src/generate_interface_manifest.cpp
+++ b/common/autoware_component_interface_specs/src/generate_interface_manifest.cpp
@@ -24,13 +24,18 @@
 #include "autoware/component_interface_specs/perception.hpp"
 #include "autoware/component_interface_specs/planning.hpp"
 #include "autoware/component_interface_specs/system.hpp"
+#include "autoware/component_interface_specs/utils.hpp"
 #include "autoware/component_interface_specs/vehicle.hpp"
 
 #include <rosidl_runtime_cpp/traits.hpp>
 
+#include <rmw/qos_profiles.h>
+
 #include <cstddef>
 #include <fstream>
 #include <iostream>
+#include <sstream>
+#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -45,6 +50,17 @@ namespace
 template <class T>
 concept HasMessage = requires { typename T::Message; };
 
+/// The QoS an endpoint of this interface is created with: what `get_qos<Spec>()` returns
+/// for a topic spec, and what `get_service_qos()` returns for a service spec. Reliability
+/// and durability are the two axes ROS 2 checks for endpoint compatibility, so they are
+/// what an admission gate reads back out of the manifest.
+struct Qos
+{
+  std::size_t depth;
+  rmw_qos_reliability_policy_t reliability;
+  rmw_qos_durability_policy_t durability;
+};
+
 struct Entry
 {
   std::string domain;
@@ -52,6 +68,7 @@ struct Entry
   std::string type;
   std::string kind;  // "topic" | "service"
   cis::Version version;
+  Qos qos;
 };
 
 template <class Spec>
@@ -64,11 +81,40 @@ Entry make_entry(const std::string & domain, cis::Version version)
   if constexpr (HasMessage<Spec>) {
     e.kind = "topic";
     e.type = rosidl_generator_traits::name<typename Spec::Message>();
+    e.qos = Qos{Spec::depth, Spec::reliability, Spec::durability};
   } else {
     e.kind = "service";
     e.type = rosidl_generator_traits::name<typename Spec::Service>();
+    e.qos =
+      Qos{cis::service_qos::depth, cis::service_qos::reliability, cis::service_qos::durability};
   }
   return e;
+}
+
+/// Unmapped policies throw rather than emit a placeholder: a spec that reaches for a policy
+/// the manifest cannot name must be an explicit decision, not a silently degraded entry.
+const char * to_string(rmw_qos_reliability_policy_t policy)
+{
+  switch (policy) {
+    case RMW_QOS_POLICY_RELIABILITY_RELIABLE:
+      return "reliable";
+    case RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT:
+      return "best_effort";
+    default:
+      throw std::invalid_argument("spec declares a reliability policy the manifest cannot name");
+  }
+}
+
+const char * to_string(rmw_qos_durability_policy_t policy)
+{
+  switch (policy) {
+    case RMW_QOS_POLICY_DURABILITY_VOLATILE:
+      return "volatile";
+    case RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL:
+      return "transient_local";
+    default:
+      throw std::invalid_argument("spec declares a durability policy the manifest cannot name");
+  }
 }
 
 template <class Tuple, class F, std::size_t... Is>
@@ -111,21 +157,43 @@ int main(int argc, char ** argv)
   collect<cis::system::Specs>("system", cis::system::version, &entries);
   collect<cis::vehicle::Specs>("vehicle", cis::vehicle::version, &entries);
 
-  std::ofstream os(argv[1]);
-  os << "{\n";
-  os << "  \"owner\": \"" << cis::owner << "\",\n";
-  os << "  \"interfaces\": [\n";
-  for (std::size_t i = 0; i < entries.size(); ++i) {
-    const auto & e = entries[i];
-    os << "    {\n";
-    os << "      \"domain\": \"" << e.domain << "\",\n";
-    os << "      \"interface\": \"" << e.interface << "\",\n";
-    os << "      \"type\": \"" << e.type << "\",\n";
-    os << "      \"kind\": \"" << e.kind << "\",\n";
-    os << "      \"version\": \"" << ver_str(e.version) << "\"\n";
-    os << "    }" << (i + 1 < entries.size() ? "," : "") << "\n";
+  // Rendered whole before the output file is opened, so a spec the emitter cannot name
+  // leaves the committed manifest untouched instead of truncated.
+  std::ostringstream os;
+  try {
+    os << "{\n";
+    os << "  \"owner\": \"" << cis::owner << "\",\n";
+    os << "  \"interfaces\": [\n";
+    for (std::size_t i = 0; i < entries.size(); ++i) {
+      const auto & e = entries[i];
+      os << "    {\n";
+      os << "      \"domain\": \"" << e.domain << "\",\n";
+      os << "      \"interface\": \"" << e.interface << "\",\n";
+      os << "      \"type\": \"" << e.type << "\",\n";
+      os << "      \"kind\": \"" << e.kind << "\",\n";
+      os << "      \"version\": \"" << ver_str(e.version) << "\",\n";
+      os << "      \"qos\": {\n";
+      // Both get_qos<Spec>() and get_service_qos() build an rclcpp::QoS from a depth alone,
+      // which is KEEP_LAST. No spec can currently ask for KEEP_ALL.
+      os << "        \"history\": \"keep_last\",\n";
+      os << "        \"depth\": " << e.qos.depth << ",\n";
+      os << "        \"reliability\": \"" << to_string(e.qos.reliability) << "\",\n";
+      os << "        \"durability\": \"" << to_string(e.qos.durability) << "\"\n";
+      os << "      }\n";
+      os << "    }" << (i + 1 < entries.size() ? "," : "") << "\n";
+    }
+    os << "  ]\n";
+    os << "}\n";
+  } catch (const std::exception & error) {
+    std::cerr << "generate_interface_manifest: " << error.what() << "\n";
+    return 1;
   }
-  os << "  ]\n";
-  os << "}\n";
+
+  std::ofstream out(argv[1]);
+  if (!out) {
+    std::cerr << "generate_interface_manifest: cannot write " << argv[1] << "\n";
+    return 1;
+  }
+  out << os.str();
   return 0;
 }

--- a/common/autoware_component_interface_specs/test/test_concepts.cpp
+++ b/common/autoware_component_interface_specs/test/test_concepts.cpp
@@ -1,0 +1,36 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/component_interface_specs/concepts.hpp"
+#include "autoware/component_interface_specs/localization.hpp"
+#include "autoware/component_interface_specs/planning.hpp"
+#include "gtest/gtest.h"
+
+namespace cis = autoware::component_interface_specs;
+
+// A topic spec satisfies InterfaceSpec, a service spec satisfies ServiceSpec.
+static_assert(cis::InterfaceSpec<cis::localization::KinematicState>);
+static_assert(cis::ServiceSpec<cis::localization::Initialize>);
+static_assert(!cis::InterfaceSpec<cis::localization::Initialize>);    // no Message/QoS
+static_assert(!cis::ServiceSpec<cis::localization::KinematicState>);  // no Service
+
+// Every member of each domain's Specs tuple is a well-formed spec.
+static_assert(cis::all_specs_valid<cis::localization::Specs>());
+static_assert(cis::all_specs_valid<cis::planning::Specs>());
+
+TEST(concepts, registered_tuples_are_valid)
+{
+  EXPECT_TRUE(cis::all_specs_valid<cis::localization::Specs>());
+  EXPECT_TRUE(cis::all_specs_valid<cis::planning::Specs>());
+}

--- a/common/autoware_component_interface_specs/test/test_concepts.cpp
+++ b/common/autoware_component_interface_specs/test/test_concepts.cpp
@@ -17,6 +17,13 @@
 #include "autoware/component_interface_specs/planning.hpp"
 #include "gtest/gtest.h"
 
+// concepts.hpp is an empty header below C++20. Without this, dropping the target's
+// `target_compile_features(... cxx_std_20)` would not fail here as a missing standard but as a
+// wall of "no member named InterfaceSpec" further down.
+#if !AUTOWARE_COMPONENT_INTERFACE_SPECS_HAS_CONCEPTS
+#error "this target must be compiled as C++20; see target_compile_features() in CMakeLists.txt"
+#endif
+
 namespace cis = autoware::component_interface_specs;
 
 // A topic spec satisfies InterfaceSpec, a service spec satisfies ServiceSpec.

--- a/common/autoware_component_interface_specs/test/test_cxx17_compat.cpp
+++ b/common/autoware_component_interface_specs/test/test_cxx17_compat.cpp
@@ -1,0 +1,68 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The domain headers are the surface every consumer compiles against, and every consumer gets
+// the C++17 that autoware_package() sets. Only this package's own producer-side targets opt up
+// to C++20. This target is pinned to C++17 so that a C++20 construct leaking into a domain
+// header, or into version.hpp or utils.hpp, fails here rather than in a downstream package --
+// on Humble / gcc-11 as much as on Jazzy.
+
+#include "autoware/component_interface_specs/concepts.hpp"
+#include "autoware/component_interface_specs/control.hpp"
+#include "autoware/component_interface_specs/localization.hpp"
+#include "autoware/component_interface_specs/map.hpp"
+#include "autoware/component_interface_specs/perception.hpp"
+#include "autoware/component_interface_specs/planning.hpp"
+#include "autoware/component_interface_specs/system.hpp"
+#include "autoware/component_interface_specs/utils.hpp"
+#include "autoware/component_interface_specs/vehicle.hpp"
+#include "autoware/component_interface_specs/version.hpp"
+#include "gtest/gtest.h"
+
+// Including concepts.hpp from a C++17 translation unit has to stay safe: it must expand to
+// nothing rather than leak C++20 syntax into the parse.
+#if AUTOWARE_COMPONENT_INTERFACE_SPECS_HAS_CONCEPTS
+#error "this target must be compiled as C++17; see set_target_properties() in CMakeLists.txt"
+#endif
+
+namespace cis = autoware::component_interface_specs;
+
+// Every domain resolves its version through the ADL hook the domain macro emits, with no
+// C++20 machinery involved.
+TEST(cxx17_compat, every_domain_resolves_its_version)
+{
+  constexpr cis::Version v0_1_0{0, 1, 0};
+
+  static_assert(cis::spec_version<cis::control::ControlCommand>() == v0_1_0);
+  static_assert(cis::spec_version<cis::localization::Initialize>() == v0_1_0);
+  static_assert(cis::spec_version<cis::map::VectorMap>() == v0_1_0);
+  static_assert(cis::spec_version<cis::perception::ObjectRecognition>() == v0_1_0);
+  static_assert(cis::spec_version<cis::planning::Trajectory>() == v0_1_0);
+  static_assert(cis::spec_version<cis::system::OperationModeState>() == v0_1_0);
+  static_assert(cis::spec_version<cis::vehicle::GearStatus>() == v0_1_0);
+
+  EXPECT_EQ(cis::spec_version<cis::control::ControlCommand>(), v0_1_0);
+  EXPECT_EQ(std::tuple_size_v<cis::planning::Specs>, 6u);
+}
+
+TEST(cxx17_compat, qos_helpers_are_available)
+{
+  const auto topic = cis::get_qos<cis::vehicle::GearStatus>();
+  EXPECT_EQ(topic.depth(), cis::vehicle::GearStatus::depth);
+  EXPECT_EQ(topic.reliability(), rclcpp::ReliabilityPolicy::Reliable);
+
+  const auto service = cis::get_service_qos();
+  EXPECT_EQ(service.depth(), cis::service_qos::depth);
+  EXPECT_EQ(service.reliability(), rclcpp::ReliabilityPolicy::Reliable);
+}

--- a/common/autoware_component_interface_specs/test/test_manifest.cpp
+++ b/common/autoware_component_interface_specs/test/test_manifest.cpp
@@ -19,22 +19,62 @@
 #include <sstream>
 #include <string>
 
+namespace
+{
+
+std::string read_file(const std::string & path)
+{
+  std::ifstream is(path);
+  EXPECT_TRUE(is.good()) << "cannot read " << path;
+  std::stringstream ss;
+  ss << is.rdbuf();
+  return ss.str();
+}
+
 // GENERATE_TOOL is passed by CMake as the path to the built generator.
-TEST(manifest, generates_known_boundaries)
+std::string regenerate()
 {
   const char * tmpdir = std::getenv("TEST_TMPDIR");
   const std::string out = std::string(tmpdir ? tmpdir : "/tmp") + "/manifest_under_test.json";
   const std::string cmd = std::string(GENERATE_TOOL) + " " + out;
-  ASSERT_EQ(std::system(cmd.c_str()), 0);
+  EXPECT_EQ(std::system(cmd.c_str()), 0);
+  return read_file(out);
+}
 
-  std::ifstream is(out);
-  std::stringstream ss;
-  ss << is.rdbuf();
-  const std::string json = ss.str();
+}  // namespace
+
+TEST(manifest, generates_known_boundaries)
+{
+  const std::string json = regenerate();
 
   EXPECT_NE(json.find("\"owner\": \"autowarefoundation\""), std::string::npos);
   EXPECT_NE(json.find("/localization/kinematic_state"), std::string::npos);
   EXPECT_NE(json.find("nav_msgs/msg/Odometry"), std::string::npos);
   EXPECT_NE(json.find("/planning/set_lanelet_route"), std::string::npos);
   EXPECT_NE(json.find("\"version\": \"0.1.0\""), std::string::npos);
+}
+
+// QoS is half of a topic's contract: a RELIABLE subscription never hears a BEST_EFFORT
+// publisher, and a TRANSIENT_LOCAL one never gets the latched message a VOLATILE publisher
+// dropped. A deploy-time gate reading this manifest cannot check that unless the manifest
+// records it -- for services, which all share one profile, as well as for topics.
+TEST(manifest, records_the_qos_of_topics_and_services)
+{
+  const std::string json = regenerate();
+
+  EXPECT_NE(json.find(R"("history": "keep_last")"), std::string::npos);
+  EXPECT_NE(json.find(R"("reliability": "reliable")"), std::string::npos);
+  EXPECT_NE(json.find(R"("durability": "volatile")"), std::string::npos);
+  EXPECT_NE(json.find(R"("durability": "transient_local")"), std::string::npos);
+  EXPECT_NE(json.find(R"("depth": 1)"), std::string::npos);
+  EXPECT_NE(json.find(R"("depth": 10)"), std::string::npos);  // the shared service profile
+}
+
+// The committed manifest is what consumers and the deploy-time admission gate read; the
+// generator is only how it is produced. Anything that changes a spec, a QoS policy or a
+// domain version has to land the regenerated file in the same commit.
+TEST(manifest, committed_file_is_up_to_date)
+{
+  EXPECT_EQ(regenerate(), read_file(COMMITTED_MANIFEST))
+    << "interface_manifest.json is stale -- regenerate it, see README.md";
 }

--- a/common/autoware_component_interface_specs/test/test_manifest.cpp
+++ b/common/autoware_component_interface_specs/test/test_manifest.cpp
@@ -1,0 +1,40 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+// GENERATE_TOOL is passed by CMake as the path to the built generator.
+TEST(manifest, generates_known_boundaries)
+{
+  const char * tmpdir = std::getenv("TEST_TMPDIR");
+  const std::string out = std::string(tmpdir ? tmpdir : "/tmp") + "/manifest_under_test.json";
+  const std::string cmd = std::string(GENERATE_TOOL) + " " + out;
+  ASSERT_EQ(std::system(cmd.c_str()), 0);
+
+  std::ifstream is(out);
+  std::stringstream ss;
+  ss << is.rdbuf();
+  const std::string json = ss.str();
+
+  EXPECT_NE(json.find("\"owner\": \"autowarefoundation\""), std::string::npos);
+  EXPECT_NE(json.find("/localization/kinematic_state"), std::string::npos);
+  EXPECT_NE(json.find("nav_msgs/msg/Odometry"), std::string::npos);
+  EXPECT_NE(json.find("/planning/set_lanelet_route"), std::string::npos);
+  EXPECT_NE(json.find("\"version\": \"0.1.0\""), std::string::npos);
+}

--- a/common/autoware_component_interface_specs/test/test_service_qos.cpp
+++ b/common/autoware_component_interface_specs/test/test_service_qos.cpp
@@ -1,0 +1,42 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/component_interface_specs/utils.hpp"
+#include "gtest/gtest.h"
+
+#include <rmw/qos_profiles.h>
+
+namespace cis = autoware::component_interface_specs;
+
+// Service specs carry no QoS members: every service in this package runs on ROS 2's default
+// service profile, which no call site overrides. `service_qos` restates that profile so the
+// manifest can record it. Pin the two together here -- if a ROS release ever changes the
+// default, this fails loudly instead of letting the manifest describe a profile the services
+// no longer run on.
+TEST(service_qos, mirrors_the_rmw_service_default)
+{
+  EXPECT_EQ(rmw_qos_profile_services_default.history, RMW_QOS_POLICY_HISTORY_KEEP_LAST);
+  EXPECT_EQ(cis::service_qos::depth, rmw_qos_profile_services_default.depth);
+  EXPECT_EQ(cis::service_qos::reliability, rmw_qos_profile_services_default.reliability);
+  EXPECT_EQ(cis::service_qos::durability, rmw_qos_profile_services_default.durability);
+}
+
+TEST(service_qos, get_service_qos_returns_the_declared_policies)
+{
+  const auto qos = cis::get_service_qos();
+  EXPECT_EQ(qos.depth(), cis::service_qos::depth);
+  EXPECT_EQ(qos.history(), rclcpp::HistoryPolicy::KeepLast);
+  EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
+  EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);
+}

--- a/common/autoware_component_interface_specs/test/test_version.cpp
+++ b/common/autoware_component_interface_specs/test/test_version.cpp
@@ -1,0 +1,57 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/component_interface_specs/version.hpp"
+#include "gtest/gtest.h"
+
+namespace cis = autoware::component_interface_specs;
+
+TEST(version, value_and_equality)
+{
+  constexpr cis::Version v{0, 1, 0};
+  EXPECT_EQ(v.major, 0u);
+  EXPECT_EQ(v.minor, 1u);
+  EXPECT_EQ(v.patch, 0u);
+  EXPECT_EQ(v, (cis::Version{0, 1, 0}));
+  EXPECT_NE(v, (cis::Version{1, 0, 0}));
+}
+
+TEST(version, owner_is_autowarefoundation)
+{
+  EXPECT_STREQ(cis::owner, "autowarefoundation");
+}
+
+TEST(version, is_compatible_checks_major_only)
+{
+  // 0.x is unstable, but admission is gated on MAJOR per the shared contract.
+  static_assert(cis::is_compatible(cis::Version{0, 1, 0}, 0));
+  static_assert(cis::is_compatible(cis::Version{0, 7, 3}, 0));
+  static_assert(!cis::is_compatible(cis::Version{1, 0, 0}, 0));
+  EXPECT_TRUE(cis::is_compatible(cis::Version{2, 4, 1}, 2));
+  EXPECT_FALSE(cis::is_compatible(cis::Version{2, 4, 1}, 3));
+}
+
+TEST(version, accept_major_range)
+{
+  constexpr cis::accept_major range{0, 1};  // migration window: accept MAJOR 0 or 1
+  EXPECT_TRUE(cis::is_compatible(cis::Version{0, 9, 0}, range));
+  EXPECT_TRUE(cis::is_compatible(cis::Version{1, 0, 0}, range));
+  EXPECT_FALSE(cis::is_compatible(cis::Version{2, 0, 0}, range));
+
+  // A window with a non-zero lo exercises the below-lo side of the check.
+  constexpr cis::accept_major shifted{1, 2};                         // accept MAJOR 1 or 2
+  EXPECT_FALSE(cis::is_compatible(cis::Version{0, 9, 0}, shifted));  // below lo
+  EXPECT_TRUE(cis::is_compatible(cis::Version{2, 0, 0}, shifted));   // at hi
+  EXPECT_FALSE(cis::is_compatible(cis::Version{3, 0, 0}, shifted));  // above hi
+}


### PR DESCRIPTION
## Description

Adds a versioning foundation to `autoware_component_interface_specs` additively and behavior-neutrally: value types, compile-time validation concepts, a per-domain `Specs` registry, and a committed machine-readable manifest recording each interface's type, version and QoS. No interface semantics change and no new spec structs are introduced.

- `version.hpp` (new): a `Version` value type with `operator==`/`operator!=`, an inclusive `accept_major` MAJOR window, two `is_compatible` overloads (MAJOR-only and a `[lo, hi]` migration range), the `owner` constant, and an ADL `spec_version<Spec>()` resolver. It also defines `AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(MAJOR, MINOR, PATCH, ...)`, which emits a domain's `version`, its `Specs` tuple and its `resolve_domain_version` hook from a single call, so a domain cannot bump its version but forget to register a spec, or register a spec whose version nothing can resolve. It is C++17-clean, so existing C++17 consumers of the domain headers keep compiling untouched.
- `concepts.hpp` (new): `InterfaceSpec` / `ServiceSpec` / `AnySpec` concepts and `all_specs_valid<Tuple>()`, guarded so the C++20 concept syntax never leaks into C++17 translation units. Below C++20 the header is an empty but _detectable_ no-op — `AUTOWARE_COMPONENT_INTERFACE_SPECS_HAS_CONCEPTS` tells a consumer whether the concepts are available, instead of the declarations silently vanishing.
- The 7 domain headers (`control`, `localization`, `map`, `perception`, `planning`, `system`, `vehicle`) each declare their version and registry with one `AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN` call over the structs that already exist.
- `utils.hpp`: adds `service_qos` and `get_service_qos()`. ROS 2 gives services a QoS profile too — `rmw_qos_profile_services_default` (`KEEP_LAST(10)`, `RELIABLE`, `VOLATILE`), which every `create_service` / `create_client` call takes unmodified — so it is declared once at package level rather than repeated on each `ServiceSpec`, and asserted against the RMW default in a test.
- `src/generate_interface_manifest.cpp` (new): a producer-side C++20 tool that walks the `Specs` tuples and hand-emits `interface_manifest.json` deterministically (no new runtime dependency), in the layout Prettier produces so the committed manifest is stable across regenerations. It renders the whole document before opening the output file, and rejects a QoS policy it cannot name rather than degrading an entry or truncating the committed file.
- `interface_manifest.json` (new): the committed manifest, byte-identical to the generator output. Each entry carries `domain`, `interface`, `type`, `kind`, `version` and a `qos` object (`history`, `depth`, `reliability`, `durability`). `reliability` and `durability` are the two axes ROS 2 evaluates before a publisher and a subscription may communicate at all, so a deploy-time admission gate needs them alongside the type and the version.
- `CMakeLists.txt`: the C++20 generator is gated behind `if(BUILD_TESTING)`, alongside the C++20 gtest target that consumes its `$<TARGET_FILE>` via `GENERATE_TOOL`. `target_compile_features(... cxx_std_20)` raises those two targets above the `CMAKE_CXX_STANDARD 17` that `autoware_package()` sets, leaving every other target — and every C++17 consumer of the domain headers — on C++17. A third gtest target is pinned to `CXX_STANDARD 17` and compiles all seven domain headers there, so a C++20 construct leaking into the consumer surface fails in this package rather than in a downstream one.
- `README.md`: documents the domain macro, the shared service QoS profile, the C++ standard contract, the manifest schema, and the manual regeneration command; the build never writes into the source tree.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

## How was this PR tested?

Built and tested from clean in the Autoware Jazzy devel container (`colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release`, then `colcon test`): 6 test suites, 75 tests, 0 failures (copyright / cppcheck / lint_cmake / xmllint linters also green).

- The three targets take exactly the standards intended under `autoware_package()`'s C++17 default: `-std=c++17` for the consumer-surface gtest, `-std=c++20` for `generate_interface_manifest` and for the C++20 gtest.
- `generate_interface_manifest` regenerates a manifest byte-identical to the committed `interface_manifest.json`, and `pre-commit run prettier` is a no-op on that file.
- `test_manifest.cpp` diffs the generator's output against the committed manifest; `test_service_qos.cpp` asserts `service_qos` still equals `rmw_qos_profile_services_default` on the building distro; `test_version.cpp` covers both out-of-range sides of the `accept_major` migration window. Both new gates were checked to fail when they should, by staling the committed manifest and by perturbing `service_qos::depth`.
- clang-tidy is clean under `.clang-tidy-ci` (`bugprone-*` with `WarningsAsErrors: "*"`). The macro checks were confirmed to actually reach `version.hpp`, rather than being filtered out, by planting a deliberately bad macro there and watching them fire.
- The Humble / gcc-11 (Ubuntu 22.04) compile of the `BUILD_TESTING`-gated C++20 targets is covered by the `build-and-test-diff-humble` CI gate, which passes.

### youtalk fork CI — build-and-test all green

This change was staged on the youtalk fork before submission; the full gate is green (the two universe `-above` bonus jobs are excluded — jazzy-`above` has a pre-existing headless-Qt universe-test failure unrelated to this package):

- `build-and-test-diff-jazzy / build-and-test-diff`: https://github.com/youtalk/autoware_core/actions/runs/29054976649/job/86244315965
- `build-and-test-diff-jazzy-agnocast / build-and-test-diff`: https://github.com/youtalk/autoware_core/actions/runs/29054976649/job/86244315877
- `build-and-test-diff-humble / build-and-test-diff`: https://github.com/youtalk/autoware_core/actions/runs/29054976649/job/86244315980
- `build-and-test-diff-jazzy / clang-tidy-diff`: https://github.com/youtalk/autoware_core/actions/runs/29054976649/job/86245698280
- `build-and-test-diff-humble / clang-tidy-diff`: https://github.com/youtalk/autoware_core/actions/runs/29054976649/job/86245540315
- `cppcheck-differential`: https://github.com/youtalk/autoware_core/actions/runs/29054976438/job/86244266856
- `spell-check-differential`: https://github.com/youtalk/autoware_core/actions/runs/29054976434/job/86244266687

## Notes for reviewers

Both C++20 targets are `BUILD_TESTING`-gated, so a producer-side C++20 compile failure could never break the header-only package for its C++17 consumers.

This is the foundation for the interface-versioning work tracked in autowarefoundation/autoware#7210. Follow-up PRs register the remaining domains and add the advisory CI lint; they build on the manifest schema and the declaration macro introduced here.

## Interface changes

None. The manifest records the QoS the interfaces already ran on; no spec's message type, topic name, or QoS policy changes.

## Effects on system behavior

None.
