### PR TITLE
feat(autoware_interface_spec_lint): add WARN-only interface spec CI lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -119,3 +119,13 @@ repos:
     hooks:
       - id: hadolint
         exclude: .svg$
+
+  - repo: local
+    hooks:
+      - id: interface-spec-lint
+        name: interface-spec-lint (WARN)
+        entry: python3 common/autoware_interface_spec_lint/scripts/run_lint.py --warn-only
+        language: system
+        files: ^.*/autoware_component_interface_specs/include/.*\.hpp$
+        pass_filenames: false
+        verbose: true

--- a/common/autoware_interface_spec_lint/README.md
+++ b/common/autoware_interface_spec_lint/README.md
@@ -6,14 +6,23 @@ In milestone M0 every check is advisory: the tool prints findings but always exi
 
 ## Checks
 
-| Check                    | Input                      | Flags (WARN)                                                                                                                                                                              |
-| ------------------------ | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `interface_spec_concept` | domain headers             | a struct with a `name[]` that is neither a valid topic (`Message` + `depth` + `reliability` + `durability`) nor a valid service (`Service`)                                               |
-| `spec_registered`        | domain headers             | a spec struct not listed in its namespace's `using Specs = std::tuple<...>`                                                                                                               |
-| `version_consistency`    | headers + manifest         | a domain not declaring exactly one `version{...}`, a MAJOR that is not `0` (the standard is unstable at `0.x` in this wave), or a manifest version that disagrees with the header version |
-| `manifest_fresh`         | generator + committed JSON | the rebuilt generator output differs from the committed `interface_manifest.json`                                                                                                         |
+| Check                    | Input                      | Flags (WARN)                                                                                                                                                                                        |
+| ------------------------ | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `interface_spec_concept` | domain headers             | a struct with a `name[]` that is neither a valid topic (`Message` + `depth` + `reliability` + `durability`) nor a valid service (`Service`)                                                         |
+| `spec_registered`        | domain headers             | a spec struct not listed in its namespace's `using Specs = std::tuple<...>`                                                                                                                         |
+| `version_consistency`    | headers + manifest         | a domain not declaring exactly one `version{...}`, a MAJOR that is not `0` (the standard is unstable at `0.x` in this wave), or a manifest version that disagrees with the header version           |
+| `qos_consistency`        | headers + manifest         | a registered spec whose `history` / `depth` / `reliability` / `durability` disagrees with its manifest `qos` block, is missing from the manifest, or names a QoS policy the manifest cannot express |
+| `manifest_fresh`         | generator + committed JSON | the rebuilt generator output differs from the committed `interface_manifest.json`                                                                                                                   |
 
-`interface_spec_concept`, `spec_registered` and `version_consistency` are pure-Python static analyses over the domain headers and are wired into pre-commit. `manifest_fresh` is a colcon test because it needs the built M0.1 generator binary.
+`interface_spec_concept`, `spec_registered`, `version_consistency` and `qos_consistency` are pure-Python static analyses over the domain headers and are wired into pre-commit. `manifest_fresh` is a colcon test because it needs the built M0.1 generator binary.
+
+A domain declares its `version` and its `Specs` tuple either literally or through `AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(MAJOR, MINOR, PATCH, ...)`, which expands to both. The header parser understands each form, including the multi-line invocation clang-format produces.
+
+### `qos_consistency` vs `manifest_fresh`
+
+Both catch QoS drift between the domain headers and the committed manifest, but `manifest_fresh` needs the built generator binary and skips without it — which is the ordinary pre-commit path. `qos_consistency` reads only the headers and the committed JSON, so `reliability` and `durability` stay verified there too. Those are the two axes ROS 2 evaluates before it will let a publisher and a subscription talk at all: a `RELIABLE` subscription never hears a `BEST_EFFORT` publisher, and a `TRANSIENT_LOCAL` one never receives the latched message a `VOLATILE` publisher dropped.
+
+Topic specs carry their own QoS. Service specs carry none, so `qos_consistency` derives theirs from the single `service_qos` profile in `utils.hpp` rather than restating the values — a second copy would be one more place for the specs and the wire to drift apart.
 
 ## Suppression contract
 

--- a/common/autoware_interface_spec_lint/README.md
+++ b/common/autoware_interface_spec_lint/README.md
@@ -41,10 +41,10 @@ struct PointCloudMap {
 
 ```bash
 # Lint the core specs include dir (defaults resolve relative to the repo root).
-ament_interface_spec_lint --warn-only
+ament_autoware_interface_spec_lint --warn-only
 
 # Lint an explicit directory and diff against a manifest.
-ament_interface_spec_lint --warn-only \
+ament_autoware_interface_spec_lint --warn-only \
   --spec-dir common/autoware_component_interface_specs/include/autoware/component_interface_specs \
   --manifest common/autoware_component_interface_specs/interface_manifest.json
 ```
@@ -55,7 +55,7 @@ ament_interface_spec_lint --warn-only \
 
 ```bash
 export INTERFACE_MANIFEST_GENERATOR=$PWD/build/autoware_component_interface_specs/generate_interface_manifest
-ament_interface_spec_lint --warn-only \
+ament_autoware_interface_spec_lint --warn-only \
   --manifest common/autoware_component_interface_specs/interface_manifest.json \
   --generator "$INTERFACE_MANIFEST_GENERATOR"
 ```

--- a/common/autoware_interface_spec_lint/README.md
+++ b/common/autoware_interface_spec_lint/README.md
@@ -2,7 +2,7 @@
 
 WARN-only static and manifest checks for the Autoware component interface specifications defined in `autoware_component_interface_specs`. This package gives fast, pre-build, human-readable warnings that complement the compile-time `all_specs_valid<>` static assertions: it catches "defined-but-unregistered" specs and manifest drift that the compiler alone does not.
 
-In milestone M0 every check is advisory: the tool prints findings but always exits 0 with `--warn-only`, and the pre-commit hook never fails the commit. The warn-to-error ratchet is a later milestone (M2).
+In this initial version every check is advisory: the tool prints findings but always exits 0 with `--warn-only`, and the pre-commit hook never fails the commit. Flipping the warnings into hard errors (the warn-to-error ratchet) is left to a follow-up change.
 
 ## Checks
 
@@ -10,11 +10,11 @@ In milestone M0 every check is advisory: the tool prints findings but always exi
 | ------------------------ | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `interface_spec_concept` | domain headers             | a struct with a `name[]` that is neither a valid topic (`Message` + `depth` + `reliability` + `durability`) nor a valid service (`Service`)                                                         |
 | `spec_registered`        | domain headers             | a spec struct not listed in its namespace's `using Specs = std::tuple<...>`                                                                                                                         |
-| `version_consistency`    | headers + manifest         | a domain not declaring exactly one `version{...}`, a MAJOR that is not `0` (the standard is unstable at `0.x` in this wave), or a manifest version that disagrees with the header version           |
+| `version_consistency`    | headers + manifest         | a domain not declaring exactly one `version{...}`, a MAJOR that is not `0` (the standard is unstable while at `0.x`), or a manifest version that disagrees with the header version                  |
 | `qos_consistency`        | headers + manifest         | a registered spec whose `history` / `depth` / `reliability` / `durability` disagrees with its manifest `qos` block, is missing from the manifest, or names a QoS policy the manifest cannot express |
 | `manifest_fresh`         | generator + committed JSON | the rebuilt generator output differs from the committed `interface_manifest.json`                                                                                                                   |
 
-`interface_spec_concept`, `spec_registered`, `version_consistency` and `qos_consistency` are pure-Python static analyses over the domain headers and are wired into pre-commit. `manifest_fresh` is a colcon test because it needs the built M0.1 generator binary.
+`interface_spec_concept`, `spec_registered`, `version_consistency` and `qos_consistency` are pure-Python static analyses over the domain headers and are wired into pre-commit. `manifest_fresh` is a colcon test because it needs the built manifest generator binary.
 
 A domain declares its `version` and its `Specs` tuple either literally or through `AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(MAJOR, MINOR, PATCH, ...)`, which expands to both. The header parser understands each form, including the multi-line invocation clang-format produces.
 
@@ -53,7 +53,7 @@ ament_autoware_interface_spec_lint --warn-only \
 
 ### `manifest_fresh`
 
-`manifest_fresh` needs the M0.1 generator binary. Point at it with `--generator <path>` or the `INTERFACE_MANIFEST_GENERATOR` environment variable. When neither is available the check skips gracefully with a warning and records nothing, so it never blocks a build in M0.
+`manifest_fresh` needs the manifest generator binary. Point at it with `--generator <path>` or the `INTERFACE_MANIFEST_GENERATOR` environment variable. When neither is available the check skips gracefully with a warning and records nothing, so it never blocks a build.
 
 ```bash
 export INTERFACE_MANIFEST_GENERATOR=$PWD/build/autoware_component_interface_specs/generate_interface_manifest
@@ -62,6 +62,6 @@ ament_autoware_interface_spec_lint --warn-only \
   --generator "$INTERFACE_MANIFEST_GENERATOR"
 ```
 
-## Milestone status
+## Status
 
-M0 is advisory only. `manifest_fresh` records drift but returns success; the pre-commit hook prints warnings and exits 0. M2 flips both the static checks and `manifest_fresh` to hard failures.
+The checks are advisory only. `manifest_fresh` records drift but returns success; the pre-commit hook prints warnings and exits 0. A follow-up change flips both the static checks and `manifest_fresh` to hard failures.

--- a/common/autoware_interface_spec_lint/README.md
+++ b/common/autoware_interface_spec_lint/README.md
@@ -1,0 +1,56 @@
+# autoware_interface_spec_lint
+
+WARN-only static and manifest checks for the Autoware component interface specifications defined in `autoware_component_interface_specs`. This package gives fast, pre-build, human-readable warnings that complement the compile-time `all_specs_valid<>` static assertions: it catches "defined-but-unregistered" specs and manifest drift that the compiler alone does not.
+
+In milestone M0 every check is advisory: the tool prints findings but always exits 0 with `--warn-only`, and the pre-commit hook never fails the commit. The warn-to-error ratchet is a later milestone (M2).
+
+## Checks
+
+| Check                    | Input                      | Flags (WARN)                                                                                                                                                                              |
+| ------------------------ | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `interface_spec_concept` | domain headers             | a struct with a `name[]` that is neither a valid topic (`Message` + `depth` + `reliability` + `durability`) nor a valid service (`Service`)                                               |
+| `spec_registered`        | domain headers             | a spec struct not listed in its namespace's `using Specs = std::tuple<...>`                                                                                                               |
+| `version_consistency`    | headers + manifest         | a domain not declaring exactly one `version{...}`, a MAJOR that is not `0` (the standard is unstable at `0.x` in this wave), or a manifest version that disagrees with the header version |
+| `manifest_fresh`         | generator + committed JSON | the rebuilt generator output differs from the committed `interface_manifest.json`                                                                                                         |
+
+`interface_spec_concept`, `spec_registered` and `version_consistency` are pure-Python static analyses over the domain headers and are wired into pre-commit. `manifest_fresh` is a colcon test because it needs the built M0.1 generator binary.
+
+## Suppression contract
+
+A spec struct is exempt from `spec_registered` when the marker `// interface-spec-lint: not-versioned` appears on the struct's own declaration line or on the line directly above it. Use it for a topic that is deliberately not part of the versioned interface set. The marker string is a fixed contract that other packages depend on, so do not change its text.
+
+```cpp
+// interface-spec-lint: not-versioned
+struct PointCloudMap {
+  using Message = sensor_msgs::msg::PointCloud2;
+  static constexpr char name[] = "/map/point_cloud_map";
+  // ...
+};
+```
+
+## Usage
+
+```bash
+# Lint the core specs include dir (defaults resolve relative to the repo root).
+ament_interface_spec_lint --warn-only
+
+# Lint an explicit directory and diff against a manifest.
+ament_interface_spec_lint --warn-only \
+  --spec-dir common/autoware_component_interface_specs/include/autoware/component_interface_specs \
+  --manifest common/autoware_component_interface_specs/interface_manifest.json
+```
+
+### `manifest_fresh`
+
+`manifest_fresh` needs the M0.1 generator binary. Point at it with `--generator <path>` or the `INTERFACE_MANIFEST_GENERATOR` environment variable. When neither is available the check skips gracefully with a warning and records nothing, so it never blocks a build in M0.
+
+```bash
+export INTERFACE_MANIFEST_GENERATOR=$PWD/build/autoware_component_interface_specs/generate_interface_manifest
+ament_interface_spec_lint --warn-only \
+  --manifest common/autoware_component_interface_specs/interface_manifest.json \
+  --generator "$INTERFACE_MANIFEST_GENERATOR"
+```
+
+## Milestone status
+
+M0 is advisory only. `manifest_fresh` records drift but returns success; the pre-commit hook prints warnings and exits 0. M2 flips both the static checks and `manifest_fresh` to hard failures.

--- a/common/autoware_interface_spec_lint/README.md
+++ b/common/autoware_interface_spec_lint/README.md
@@ -30,12 +30,14 @@ A spec struct is exempt from `spec_registered` when the marker `// interface-spe
 
 ```cpp
 // interface-spec-lint: not-versioned
-struct PointCloudMap {
-  using Message = sensor_msgs::msg::PointCloud2;
-  static constexpr char name[] = "/map/point_cloud_map";
+struct PlanningDebugMarkers {
+  using Message = visualization_msgs::msg::MarkerArray;
+  static constexpr char name[] = "/planning/debug/markers";
   // ...
 };
 ```
+
+The struct above is illustrative: a debug/visualization topic is the kind of interface that is deliberately outside the versioned set. It is not a real spec in this package -- the committed domain headers do not use the marker, since every struct they declare is registered.
 
 ## Usage
 

--- a/common/autoware_interface_spec_lint/autoware_interface_spec_lint/__init__.py
+++ b/common/autoware_interface_spec_lint/autoware_interface_spec_lint/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""WARN-only lint for the Autoware component interface specs."""

--- a/common/autoware_interface_spec_lint/autoware_interface_spec_lint/checks.py
+++ b/common/autoware_interface_spec_lint/autoware_interface_spec_lint/checks.py
@@ -14,8 +14,9 @@
 
 """Static and manifest checks for the Autoware component interface specs.
 
-All checks are WARN-only in milestone M0: they report human-readable findings
-but never fail the build. The warn->error ratchet is a later milestone (M2).
+All checks are advisory (WARN-only) in this initial version: they report
+human-readable findings but never fail the build. Flipping the warnings into
+hard errors (the warn->error ratchet) is left to a follow-up change.
 """
 
 from __future__ import annotations
@@ -35,7 +36,7 @@ import tempfile
 # declaration is exempt from the spec_registered check.
 SUPPRESS_MARKER = "// interface-spec-lint: not-versioned"
 
-# Environment variable that points at the built M0.1 manifest generator binary.
+# Environment variable that points at the built manifest generator binary.
 GENERATOR_ENV = "INTERFACE_MANIFEST_GENERATOR"
 
 # Headers that are not per-domain spec files and carry no domain version / Specs.
@@ -82,7 +83,7 @@ _HISTORY = "keep_last"
 class Finding:
     """A single WARN-level diagnostic anchored at a file and line."""
 
-    level: str  # "WARN" (M0); "ERROR" later.
+    level: str  # "WARN" for now; "ERROR" later.
     file: str
     line: int
     message: str
@@ -256,7 +257,7 @@ def interface_spec_concept(spec_dir: Path, _manifest=None) -> list:
     """WARN for a struct with a `name[]` that is neither a valid topic nor service.
 
     A valid topic has Message + depth + reliability + durability; a valid service
-    has Service. This mirrors the compile-time AnySpec concept from M0.1.
+    has Service. This mirrors the compile-time AnySpec concept in autoware_component_interface_specs.
     """
     findings: list = []
     for path in _domain_headers(spec_dir):
@@ -304,7 +305,7 @@ def version_consistency(spec_dir: Path, manifest=None) -> list:
     """WARN on version-declaration problems in the domain headers.
 
     Flags a domain that does not declare exactly one `version{...}`, a domain
-    whose MAJOR is not 0 (the standard is unstable at 0.x in this wave), and a
+    whose MAJOR is not 0 (the standard is unstable while at 0.x), and a
     manifest version that disagrees with the header version for that domain.
     """
     findings: list = []
@@ -333,7 +334,7 @@ def version_consistency(spec_dir: Path, manifest=None) -> list:
                     str(path),
                     anchor,
                     f"domain '{domain}' version '{header_version}' is not 0.x; the "
-                    f"interface standard is unstable (0.x) in this wave",
+                    f"interface standard is unstable (0.x)",
                 )
             )
         for manifest_version in sorted(manifest_versions.get(domain, set())):
@@ -507,22 +508,22 @@ def resolve_generator(generator=None):
 
 
 def manifest_fresh(manifest=None, generator=None) -> list:
-    """Rebuild the manifest with the M0.1 generator and diff the committed copy.
+    """Rebuild the manifest with the specs generator and diff the committed copy.
 
-    In M0 this only RECORDS drift: it returns a WARN finding when the committed
+    For now this only RECORDS drift: it returns a WARN finding when the committed
     manifest is stale but never raises. It skips gracefully (returns []) when the
-    generator or committed manifest is unavailable. M2 flips drift to a hard
+    generator or committed manifest is unavailable. A follow-up change flips drift to a hard
     failure.
     """
     gen = resolve_generator(generator)
     if gen is None:
         _warn(
             "manifest_fresh: generator unavailable "
-            f"(pass --generator or set {GENERATOR_ENV}); skipping in M0"
+            f"(pass --generator or set {GENERATOR_ENV}); skipping"
         )
         return []
     if manifest is None or not Path(manifest).is_file():
-        _warn("manifest_fresh: committed manifest not found; skipping in M0")
+        _warn("manifest_fresh: committed manifest not found; skipping")
         return []
     with tempfile.TemporaryDirectory() as tmp:
         out = Path(tmp) / "manifest_under_test.json"
@@ -533,7 +534,7 @@ def manifest_fresh(manifest=None, generator=None) -> list:
             check=False,
         )
         if proc.returncode != 0 or not out.is_file():
-            _warn(f"manifest_fresh: generator failed (rc={proc.returncode}); skipping in M0")
+            _warn(f"manifest_fresh: generator failed (rc={proc.returncode}); skipping")
             return []
         generated = out.read_text()
     committed = Path(manifest).read_text()
@@ -544,7 +545,7 @@ def manifest_fresh(manifest=None, generator=None) -> list:
                 str(manifest),
                 1,
                 "committed interface_manifest.json is stale: it differs from the "
-                "generator output; regenerate it (M0 records only, M2 fails the build)",
+                "generator output; regenerate it (advisory for now; a follow-up fails the build)",
             )
         ]
     return []

--- a/common/autoware_interface_spec_lint/autoware_interface_spec_lint/checks.py
+++ b/common/autoware_interface_spec_lint/autoware_interface_spec_lint/checks.py
@@ -41,10 +41,41 @@ GENERATOR_ENV = "INTERFACE_MANIFEST_GENERATOR"
 # Headers that are not per-domain spec files and carry no domain version / Specs.
 _SKIP_HEADERS = {"utils.hpp", "version.hpp", "concepts.hpp"}
 
+# The header declaring the one QoS profile every service spec runs on.
+_UTILS_HEADER = "utils.hpp"
+
 _STRUCT_RE = re.compile(r"\bstruct\s+([A-Z]\w*)\s*\{(.*?)\}\s*;", re.DOTALL)
 _SPECS_RE = re.compile(r"using\s+Specs\s*=\s*std::tuple<([^>]*)>\s*;")
 _VERSION_RE = re.compile(r"constexpr\s+Version\s+version\s*\{([^}]*)\}\s*;")
 _NAME_RE = re.compile(r"\bname\s*\[\s*\]")
+
+# A domain may declare its version and its `Specs` tuple either literally or through
+# AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(MAJOR, MINOR, PATCH, ...), which
+# expands to both. clang-format wraps the invocation across lines, hence `[^)]*`.
+_DEFINE_DOMAIN_RE = re.compile(r"\bAUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN\s*\(([^)]*)\)")
+
+_NAME_VALUE_RE = re.compile(r'\bname\s*\[\s*\]\s*=\s*"([^"]*)"')
+_DEPTH_VALUE_RE = re.compile(r"\bdepth\s*=\s*(\d+)\s*;")
+_RELIABILITY_VALUE_RE = re.compile(r"\breliability\s*=\s*(\w+)\s*;")
+_DURABILITY_VALUE_RE = re.compile(r"\bdurability\s*=\s*(\w+)\s*;")
+_SERVICE_QOS_RE = re.compile(r"namespace\s+service_qos\s*\{([^}]*)\}")
+
+# The RMW policy enumerators the manifest can name, and the spelling the generator's
+# `to_string` emits for each. A policy outside these maps is rejected rather than
+# guessed at, mirroring the generator: a spec that reaches for a policy the manifest
+# cannot name must be an explicit decision, not a silently degraded entry.
+_RELIABILITY_NAMES = {
+    "RMW_QOS_POLICY_RELIABILITY_RELIABLE": "reliable",
+    "RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT": "best_effort",
+}
+_DURABILITY_NAMES = {
+    "RMW_QOS_POLICY_DURABILITY_VOLATILE": "volatile",
+    "RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL": "transient_local",
+}
+
+# Both get_qos<Spec>() and get_service_qos() build an rclcpp::QoS from a depth alone,
+# which is KEEP_LAST; no spec can currently ask for KEEP_ALL.
+_HISTORY = "keep_last"
 
 
 @dataclass
@@ -128,6 +159,10 @@ def _is_suppressed(lines: list, struct_line: int) -> bool:
     return any(SUPPRESS_MARKER in line for line in candidates)
 
 
+def _group(match, default=None):
+    return match.group(1) if match else default
+
+
 def parse_header(path: Path) -> Header:
     """Extract structs, the Specs tuple members and version literals of a header."""
     text = path.read_text()
@@ -146,16 +181,32 @@ def parse_header(path: Path) -> Header:
             "has_reliability": "reliability" in body,
             "has_durability": "durability" in body,
             "suppressed": _is_suppressed(lines, struct_line),
+            # Values, not just presence: qos_consistency compares them to the manifest.
+            "interface": _group(_NAME_VALUE_RE.search(body)),
+            "depth": _group(_DEPTH_VALUE_RE.search(body)),
+            "reliability": _group(_RELIABILITY_VALUE_RE.search(body)),
+            "durability": _group(_DURABILITY_VALUE_RE.search(body)),
         }
     specs_members: list = []
+    versions = []
+    version_lines = []
     sm = _SPECS_RE.search(scan)
     if sm:
         specs_members = [s.strip() for s in sm.group(1).split(",") if s.strip()]
-    versions = []
-    version_lines = []
     for vm in _VERSION_RE.finditer(scan):
         versions.append(vm.group(1).strip())
         version_lines.append(_line_of(scan, vm.start()))
+    # The macro form expands to both a `version{...}` and a `using Specs = ...`, so a
+    # domain that uses it declares exactly what the literal form above declares. Parsing
+    # only the literal form would make every macro-using domain look version-less and
+    # its every spec look unregistered.
+    for dm in _DEFINE_DOMAIN_RE.finditer(scan):
+        args = [a.strip() for a in dm.group(1).split(",") if a.strip()]
+        if len(args) < 3:
+            continue  # malformed; version_consistency reports the missing version
+        versions.append(", ".join(args[:3]))
+        version_lines.append(_line_of(scan, dm.start()))
+        specs_members.extend(args[3:])
     return Header(
         path=path,
         structs=structs,
@@ -294,6 +345,149 @@ def version_consistency(spec_dir: Path, manifest=None) -> list:
                         anchor,
                         f"domain '{domain}' manifest version '{manifest_version}' does "
                         f"not match header version '{header_version}'",
+                    )
+                )
+    return findings
+
+
+def _manifest_entries_by_key(manifest):
+    """Index the committed manifest by (domain, interface), or None if unreadable."""
+    path = Path(manifest)
+    if not path.is_file():
+        return None
+    data = json.loads(path.read_text())
+    entries = {}
+    for entry in data.get("interfaces", []):
+        domain, interface = entry.get("domain"), entry.get("interface")
+        if domain is not None and interface is not None:
+            entries[(domain, interface)] = entry
+    return entries
+
+
+def _parse_service_qos(spec_dir: Path):
+    """Read the one QoS profile every service spec shares out of ``utils.hpp``.
+
+    Derived rather than restated here: a copy of `depth`/`reliability`/`durability` in
+    the linter would be one more place for the specs and the wire to drift apart, which
+    is the drift this package exists to catch.
+    """
+    utils = Path(spec_dir) / _UTILS_HEADER
+    if not utils.is_file():
+        return None
+    body = _group(_SERVICE_QOS_RE.search(_blank_comments(utils.read_text())))
+    if body is None:
+        return None
+    qos = {
+        "depth": _group(_DEPTH_VALUE_RE.search(body)),
+        "reliability": _group(_RELIABILITY_VALUE_RE.search(body)),
+        "durability": _group(_DURABILITY_VALUE_RE.search(body)),
+    }
+    return None if any(v is None for v in qos.values()) else qos
+
+
+def _expected_qos(depth, reliability, durability):
+    """Render a spec's QoS the way the generator's `to_string` does, or say why not."""
+    if depth is None:
+        return None, "declares no 'depth'"
+    if reliability not in _RELIABILITY_NAMES:
+        return None, f"declares a reliability policy the manifest cannot name: '{reliability}'"
+    if durability not in _DURABILITY_NAMES:
+        return None, f"declares a durability policy the manifest cannot name: '{durability}'"
+    return {
+        "history": _HISTORY,
+        "depth": int(depth),
+        "reliability": _RELIABILITY_NAMES[reliability],
+        "durability": _DURABILITY_NAMES[durability],
+    }, None
+
+
+def qos_consistency(spec_dir: Path, manifest=None) -> list:
+    """WARN when a registered spec's QoS disagrees with the manifest's `qos` block.
+
+    `manifest_fresh` catches this too, but only where the generator binary is built; on
+    the pre-commit path it skips. This check reads nothing but the headers and the
+    committed JSON, so reliability and durability -- the two axes ROS 2 evaluates before
+    it lets a publisher and a subscription talk at all -- stay verified there too.
+
+    Topic specs carry their own QoS; service specs share the `service_qos` profile from
+    `utils.hpp`. A spec absent from its namespace's `Specs` tuple is `spec_registered`'s
+    finding, not this check's, so it is skipped rather than reported twice.
+    """
+    findings: list = []
+    if manifest is None:
+        return findings
+    entries = _manifest_entries_by_key(manifest)
+    if entries is None:
+        _warn(f"qos_consistency: manifest not found at {manifest}; skipping the cross-check")
+        return findings
+    service_qos = _parse_service_qos(spec_dir)
+    warned_no_service_qos = False
+
+    for path in _domain_headers(spec_dir):
+        header = parse_header(path)
+        domain = path.stem
+        registered = set(header.specs_members)
+        for name, info in header.structs.items():
+            if not info["has_name"] or name not in registered or not info["interface"]:
+                continue
+            if info["has_message"]:
+                expected, error = _expected_qos(
+                    info["depth"], info["reliability"], info["durability"]
+                )
+            elif info["has_service"]:
+                if service_qos is None:
+                    if not warned_no_service_qos:
+                        _warn(
+                            "qos_consistency: no 'service_qos' profile found in "
+                            f"{_UTILS_HEADER}; skipping the service QoS cross-check"
+                        )
+                        warned_no_service_qos = True
+                    continue
+                expected, error = _expected_qos(**service_qos)
+            else:
+                continue  # neither topic nor service: interface_spec_concept's finding
+            if error is not None:
+                findings.append(Finding("WARN", str(path), info["line"], f"spec '{name}' {error}"))
+                continue
+
+            entry = entries.get((domain, info["interface"]))
+            if entry is None:
+                findings.append(
+                    Finding(
+                        "WARN",
+                        str(path),
+                        info["line"],
+                        f"spec '{name}' is registered in 'Specs' but the manifest has no "
+                        f"'{domain}' entry for '{info['interface']}'; regenerate it",
+                    )
+                )
+                continue
+            actual = entry.get("qos")
+            if actual is None:
+                findings.append(
+                    Finding(
+                        "WARN",
+                        str(path),
+                        info["line"],
+                        f"spec '{name}' manifest entry records no 'qos' block; regenerate it",
+                    )
+                )
+                continue
+            # "specs", not "header": a service spec's QoS comes from the shared
+            # `service_qos` profile in utils.hpp rather than from its own struct.
+            keys = sorted(set(expected) | set(actual))
+            drifted = [
+                f"{k}: specs={expected.get(k)!r}, manifest={actual.get(k)!r}"
+                for k in keys
+                if expected.get(k) != actual.get(k)
+            ]
+            if drifted:
+                findings.append(
+                    Finding(
+                        "WARN",
+                        str(path),
+                        info["line"],
+                        f"spec '{name}' QoS disagrees with the manifest " f"({'; '.join(drifted)})",
                     )
                 )
     return findings

--- a/common/autoware_interface_spec_lint/autoware_interface_spec_lint/checks.py
+++ b/common/autoware_interface_spec_lint/autoware_interface_spec_lint/checks.py
@@ -1,0 +1,356 @@
+# Copyright 2026 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Static and manifest checks for the Autoware component interface specs.
+
+All checks are WARN-only in milestone M0: they report human-readable findings
+but never fail the build. The warn->error ratchet is a later milestone (M2).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+
+# Suppression marker (fixed string; other PRs depend on the exact text). A spec
+# struct carrying this marker on its own line or on the line directly above its
+# declaration is exempt from the spec_registered check.
+SUPPRESS_MARKER = "// interface-spec-lint: not-versioned"
+
+# Environment variable that points at the built M0.1 manifest generator binary.
+GENERATOR_ENV = "INTERFACE_MANIFEST_GENERATOR"
+
+# Headers that are not per-domain spec files and carry no domain version / Specs.
+_SKIP_HEADERS = {"utils.hpp", "version.hpp", "concepts.hpp"}
+
+_STRUCT_RE = re.compile(r"\bstruct\s+([A-Z]\w*)\s*\{(.*?)\}\s*;", re.DOTALL)
+_SPECS_RE = re.compile(r"using\s+Specs\s*=\s*std::tuple<([^>]*)>\s*;")
+_VERSION_RE = re.compile(r"constexpr\s+Version\s+version\s*\{([^}]*)\}\s*;")
+_NAME_RE = re.compile(r"\bname\s*\[\s*\]")
+
+
+@dataclass
+class Finding:
+    """A single WARN-level diagnostic anchored at a file and line."""
+
+    level: str  # "WARN" (M0); "ERROR" later.
+    file: str
+    line: int
+    message: str
+
+
+@dataclass
+class Header:
+    """Parsed view of one domain header used by every static check."""
+
+    path: Path
+    structs: dict = field(default_factory=dict)  # name -> info dict
+    specs_members: list = field(default_factory=list)  # names in `using Specs`
+    versions: list = field(default_factory=list)  # each `version{a,b,c}` body text
+    version_lines: list = field(default_factory=list)  # 1-indexed lines of each version
+
+
+def _line_of(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _blank_comments(text: str) -> str:
+    """Overwrite C/C++ comments with spaces, keeping every offset and newline.
+
+    The scanners below anchor findings by byte offset and `_is_suppressed` reads the
+    raw lines, so the blanked copy must stay the same length and keep its line breaks.
+    Without this a declaration such as `struct Foo  // note` followed by `{` on the
+    next line never matches `_STRUCT_RE`, and the struct becomes invisible to the
+    static gates.
+    """
+    out = list(text)
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        if c in ('"', "'"):  # skip a string/char literal; `//` inside it is not a comment
+            i += 1
+            while i < n:
+                if text[i] == "\\":
+                    i += 2
+                    continue
+                if text[i] == c:
+                    i += 1
+                    break
+                i += 1
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "/":
+            while i < n and text[i] != "\n":
+                out[i] = " "
+                i += 1
+            continue
+        if c == "/" and i + 1 < n and text[i + 1] == "*":
+            out[i] = out[i + 1] = " "
+            i += 2
+            while i < n and not (text[i] == "*" and i + 1 < n and text[i + 1] == "/"):
+                if text[i] != "\n":
+                    out[i] = " "
+                i += 1
+            if i < n:
+                out[i] = " "
+                if i + 1 < n:
+                    out[i + 1] = " "
+                i += 2
+            continue
+        i += 1
+    return "".join(out)
+
+
+def _is_suppressed(lines: list, struct_line: int) -> bool:
+    idx = struct_line - 1  # 0-indexed own line
+    candidates = []
+    if 0 <= idx < len(lines):
+        candidates.append(lines[idx])
+    if 0 <= idx - 1 < len(lines):
+        candidates.append(lines[idx - 1])
+    return any(SUPPRESS_MARKER in line for line in candidates)
+
+
+def parse_header(path: Path) -> Header:
+    """Extract structs, the Specs tuple members and version literals of a header."""
+    text = path.read_text()
+    lines = text.splitlines()  # raw: the suppression marker is itself a comment
+    scan = _blank_comments(text)  # same offsets, comments neutralised
+    structs: dict = {}
+    for m in _STRUCT_RE.finditer(scan):
+        name, body = m.group(1), m.group(2)
+        struct_line = _line_of(scan, m.start())
+        structs[name] = {
+            "line": struct_line,
+            "has_name": ("name[]" in body) or (_NAME_RE.search(body) is not None),
+            "has_message": "using Message" in body,
+            "has_service": "using Service" in body,
+            "has_depth": "depth" in body,
+            "has_reliability": "reliability" in body,
+            "has_durability": "durability" in body,
+            "suppressed": _is_suppressed(lines, struct_line),
+        }
+    specs_members: list = []
+    sm = _SPECS_RE.search(scan)
+    if sm:
+        specs_members = [s.strip() for s in sm.group(1).split(",") if s.strip()]
+    versions = []
+    version_lines = []
+    for vm in _VERSION_RE.finditer(scan):
+        versions.append(vm.group(1).strip())
+        version_lines.append(_line_of(scan, vm.start()))
+    return Header(
+        path=path,
+        structs=structs,
+        specs_members=specs_members,
+        versions=versions,
+        version_lines=version_lines,
+    )
+
+
+def _domain_headers(spec_dir: Path) -> list:
+    return sorted(p for p in Path(spec_dir).glob("*.hpp") if p.name not in _SKIP_HEADERS)
+
+
+def _version_str(raw: str) -> str:
+    return ".".join(part.strip() for part in raw.split(",") if part.strip())
+
+
+def spec_registered(spec_dir: Path, _manifest=None) -> list:
+    """WARN for each spec struct missing from its namespace's `using Specs` tuple.
+
+    A struct carrying the SUPPRESS_MARKER on or directly above its declaration is
+    treated as intentionally not-versioned and skipped.
+    """
+    findings: list = []
+    for path in _domain_headers(spec_dir):
+        h = parse_header(path)
+        registered = set(h.specs_members)
+        for name, info in h.structs.items():
+            if not info["has_name"]:
+                continue
+            if info["suppressed"]:
+                continue
+            if name not in registered:
+                findings.append(
+                    Finding(
+                        "WARN",
+                        str(path),
+                        info["line"],
+                        f"spec struct '{name}' is not registered in its namespace's "
+                        f"'using Specs = std::tuple<...>'",
+                    )
+                )
+    return findings
+
+
+def interface_spec_concept(spec_dir: Path, _manifest=None) -> list:
+    """WARN for a struct with a `name[]` that is neither a valid topic nor service.
+
+    A valid topic has Message + depth + reliability + durability; a valid service
+    has Service. This mirrors the compile-time AnySpec concept from M0.1.
+    """
+    findings: list = []
+    for path in _domain_headers(spec_dir):
+        h = parse_header(path)
+        for name, info in h.structs.items():
+            if not info["has_name"]:
+                continue
+            is_topic = (
+                info["has_message"]
+                and info["has_depth"]
+                and info["has_reliability"]
+                and info["has_durability"]
+            )
+            is_service = info["has_service"]
+            if not (is_topic or is_service):
+                findings.append(
+                    Finding(
+                        "WARN",
+                        str(path),
+                        info["line"],
+                        f"spec struct '{name}' satisfies neither the topic concept "
+                        f"(Message + depth + reliability + durability) nor the "
+                        f"service concept (Service)",
+                    )
+                )
+    return findings
+
+
+def _manifest_versions_by_domain(manifest) -> dict:
+    path = Path(manifest)
+    if not path.is_file():
+        _warn(f"version_consistency: manifest not found at {path}; skipping the cross-check")
+        return {}
+    data = json.loads(path.read_text())
+    result: dict = {}
+    for entry in data.get("interfaces", []):
+        domain = entry.get("domain")
+        version = entry.get("version")
+        if domain is not None and version is not None:
+            result.setdefault(domain, set()).add(version)
+    return result
+
+
+def version_consistency(spec_dir: Path, manifest=None) -> list:
+    """WARN on version-declaration problems in the domain headers.
+
+    Flags a domain that does not declare exactly one `version{...}`, a domain
+    whose MAJOR is not 0 (the standard is unstable at 0.x in this wave), and a
+    manifest version that disagrees with the header version for that domain.
+    """
+    findings: list = []
+    manifest_versions = _manifest_versions_by_domain(manifest) if manifest else {}
+    for path in _domain_headers(spec_dir):
+        h = parse_header(path)
+        domain = path.stem
+        anchor = h.version_lines[0] if h.version_lines else 1
+        if len(h.versions) != 1:
+            findings.append(
+                Finding(
+                    "WARN",
+                    str(path),
+                    anchor,
+                    f"domain '{domain}' must declare exactly one "
+                    f"'static constexpr Version version{{...}}' (found {len(h.versions)})",
+                )
+            )
+            continue
+        header_version = _version_str(h.versions[0])
+        major = header_version.split(".")[0] if header_version else ""
+        if major != "0":
+            findings.append(
+                Finding(
+                    "WARN",
+                    str(path),
+                    anchor,
+                    f"domain '{domain}' version '{header_version}' is not 0.x; the "
+                    f"interface standard is unstable (0.x) in this wave",
+                )
+            )
+        for manifest_version in sorted(manifest_versions.get(domain, set())):
+            if manifest_version != header_version:
+                findings.append(
+                    Finding(
+                        "WARN",
+                        str(path),
+                        anchor,
+                        f"domain '{domain}' manifest version '{manifest_version}' does "
+                        f"not match header version '{header_version}'",
+                    )
+                )
+    return findings
+
+
+def _warn(message: str) -> None:
+    print(f"WARN {message}", file=sys.stderr)
+
+
+def resolve_generator(generator=None):
+    """Return a usable generator path from the argument or GENERATOR_ENV, else None."""
+    candidate = generator or os.environ.get(GENERATOR_ENV)
+    if not candidate:
+        return None
+    path = Path(candidate)
+    return path if path.is_file() else None
+
+
+def manifest_fresh(manifest=None, generator=None) -> list:
+    """Rebuild the manifest with the M0.1 generator and diff the committed copy.
+
+    In M0 this only RECORDS drift: it returns a WARN finding when the committed
+    manifest is stale but never raises. It skips gracefully (returns []) when the
+    generator or committed manifest is unavailable. M2 flips drift to a hard
+    failure.
+    """
+    gen = resolve_generator(generator)
+    if gen is None:
+        _warn(
+            "manifest_fresh: generator unavailable "
+            f"(pass --generator or set {GENERATOR_ENV}); skipping in M0"
+        )
+        return []
+    if manifest is None or not Path(manifest).is_file():
+        _warn("manifest_fresh: committed manifest not found; skipping in M0")
+        return []
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "manifest_under_test.json"
+        proc = subprocess.run(
+            [str(gen), str(out)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0 or not out.is_file():
+            _warn(f"manifest_fresh: generator failed (rc={proc.returncode}); skipping in M0")
+            return []
+        generated = out.read_text()
+    committed = Path(manifest).read_text()
+    if generated != committed:
+        return [
+            Finding(
+                "WARN",
+                str(manifest),
+                1,
+                "committed interface_manifest.json is stale: it differs from the "
+                "generator output; regenerate it (M0 records only, M2 fails the build)",
+            )
+        ]
+    return []

--- a/common/autoware_interface_spec_lint/autoware_interface_spec_lint/main.py
+++ b/common/autoware_interface_spec_lint/autoware_interface_spec_lint/main.py
@@ -62,12 +62,12 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--generator",
         default=None,
-        help="Path to the M0.1 manifest generator binary; enables the manifest_fresh check.",
+        help="Path to the manifest generator binary; enables the manifest_fresh check.",
     )
     parser.add_argument(
         "--warn-only",
         action="store_true",
-        help="Always exit 0 (M0 behavior). Without it, findings cause a non-zero exit.",
+        help="Always exit 0 (advisory behavior). Without it, findings cause a non-zero exit.",
     )
     return parser
 
@@ -88,8 +88,7 @@ def run(spec_dirs, manifest, generator, warn_only) -> int:
     for finding in findings:
         print(f"{finding.level} {finding.file}:{finding.line} {finding.message}")
     print(
-        f"interface-spec-lint: {len(findings)} warning(s) "
-        f"[WARN-only, M0 does not fail the build]"
+        f"interface-spec-lint: {len(findings)} warning(s) " f"[WARN-only; does not fail the build]"
     )
 
     if warn_only:

--- a/common/autoware_interface_spec_lint/autoware_interface_spec_lint/main.py
+++ b/common/autoware_interface_spec_lint/autoware_interface_spec_lint/main.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Console entry point for the interface spec lint (``ament_interface_spec_lint``)."""
+"""Console entry point for the interface spec lint (``ament_autoware_interface_spec_lint``)."""
 
 from __future__ import annotations
 
@@ -39,7 +39,7 @@ DEFAULT_MANIFEST = "common/autoware_component_interface_specs/interface_manifest
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        prog="ament_interface_spec_lint",
+        prog="ament_autoware_interface_spec_lint",
         description=(
             "WARN-only lint for the Autoware component interface specs "
             "(interface_spec_concept, spec_registered, version_consistency, "

--- a/common/autoware_interface_spec_lint/autoware_interface_spec_lint/main.py
+++ b/common/autoware_interface_spec_lint/autoware_interface_spec_lint/main.py
@@ -1,0 +1,111 @@
+# Copyright 2026 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Console entry point for the interface spec lint (``ament_interface_spec_lint``)."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+from autoware_interface_spec_lint.checks import interface_spec_concept
+from autoware_interface_spec_lint.checks import manifest_fresh
+from autoware_interface_spec_lint.checks import spec_registered
+from autoware_interface_spec_lint.checks import version_consistency
+
+# The three fast, pure-Python static checks wired into pre-commit.
+STATIC_CHECKS = (interface_spec_concept, spec_registered, version_consistency)
+
+# Default core specs include dir and committed manifest, relative to the repo root
+# (the working directory pre-commit runs the hook from).
+DEFAULT_SPEC_DIRS = (
+    "common/autoware_component_interface_specs/include/autoware/component_interface_specs",
+)
+DEFAULT_MANIFEST = "common/autoware_component_interface_specs/interface_manifest.json"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="ament_interface_spec_lint",
+        description=(
+            "WARN-only lint for the Autoware component interface specs "
+            "(interface_spec_concept, spec_registered, version_consistency, manifest_fresh)."
+        ),
+    )
+    parser.add_argument(
+        "--spec-dir",
+        action="append",
+        default=None,
+        help="Directory of domain headers to lint (repeatable). "
+        "Defaults to the core component_interface_specs include dir.",
+    )
+    parser.add_argument(
+        "--manifest",
+        default=None,
+        help="Committed interface_manifest.json used by version_consistency / manifest_fresh.",
+    )
+    parser.add_argument(
+        "--generator",
+        default=None,
+        help="Path to the M0.1 manifest generator binary; enables the manifest_fresh check.",
+    )
+    parser.add_argument(
+        "--warn-only",
+        action="store_true",
+        help="Always exit 0 (M0 behavior). Without it, findings cause a non-zero exit.",
+    )
+    return parser
+
+
+def run(spec_dirs, manifest, generator, warn_only) -> int:
+    """Run the checks over the given spec dirs, print findings, return an exit code."""
+    findings = []
+    for spec_dir in spec_dirs:
+        path = Path(spec_dir)
+        if not path.is_dir():
+            print(f"WARN spec dir not found: {spec_dir}", file=sys.stderr)
+            continue
+        for check in STATIC_CHECKS:
+            findings.extend(check(path, manifest))
+    if generator is not None:
+        findings.extend(manifest_fresh(manifest, generator))
+
+    for finding in findings:
+        print(f"{finding.level} {finding.file}:{finding.line} {finding.message}")
+    print(
+        f"interface-spec-lint: {len(findings)} warning(s) "
+        f"[WARN-only, M0 does not fail the build]"
+    )
+
+    if warn_only:
+        return 0
+    return 1 if findings else 0
+
+
+def main(argv=None) -> int:
+    """Parse arguments and run the interface spec lint."""
+    args = _build_parser().parse_args(argv)
+    spec_dirs = args.spec_dir or [d for d in DEFAULT_SPEC_DIRS if Path(d).is_dir()]
+    if args.manifest is not None:
+        manifest = args.manifest
+    elif Path(DEFAULT_MANIFEST).is_file():
+        manifest = DEFAULT_MANIFEST
+    else:
+        manifest = None
+    return run(spec_dirs, manifest, args.generator, args.warn_only)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/common/autoware_interface_spec_lint/autoware_interface_spec_lint/main.py
+++ b/common/autoware_interface_spec_lint/autoware_interface_spec_lint/main.py
@@ -22,11 +22,12 @@ import sys
 
 from autoware_interface_spec_lint.checks import interface_spec_concept
 from autoware_interface_spec_lint.checks import manifest_fresh
+from autoware_interface_spec_lint.checks import qos_consistency
 from autoware_interface_spec_lint.checks import spec_registered
 from autoware_interface_spec_lint.checks import version_consistency
 
-# The three fast, pure-Python static checks wired into pre-commit.
-STATIC_CHECKS = (interface_spec_concept, spec_registered, version_consistency)
+# The fast, pure-Python static checks wired into pre-commit.
+STATIC_CHECKS = (interface_spec_concept, spec_registered, version_consistency, qos_consistency)
 
 # Default core specs include dir and committed manifest, relative to the repo root
 # (the working directory pre-commit runs the hook from).
@@ -41,7 +42,8 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="ament_interface_spec_lint",
         description=(
             "WARN-only lint for the Autoware component interface specs "
-            "(interface_spec_concept, spec_registered, version_consistency, manifest_fresh)."
+            "(interface_spec_concept, spec_registered, version_consistency, "
+            "qos_consistency, manifest_fresh)."
         ),
     )
     parser.add_argument(
@@ -54,7 +56,8 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--manifest",
         default=None,
-        help="Committed interface_manifest.json used by version_consistency / manifest_fresh.",
+        help="Committed interface_manifest.json used by version_consistency, "
+        "qos_consistency and manifest_fresh.",
     )
     parser.add_argument(
         "--generator",

--- a/common/autoware_interface_spec_lint/package.xml
+++ b/common/autoware_interface_spec_lint/package.xml
@@ -8,8 +8,8 @@
   <license>Apache License 2.0</license>
 
   <!-- autoware_component_interface_specs is a test dependency because its
-       BUILD_TESTING-gated generator binary backs the manifest_fresh test; see
-       test/conftest.py for how the test locates it. -->
+       BUILD_TESTING-gated generator binary backs the manifest_fresh test; the
+       pytest setup under test/ locates that binary via the ament index. -->
   <test_depend>ament_copyright</test_depend>
   <test_depend>autoware_component_interface_specs</test_depend>
   <test_depend>python3-pytest</test_depend>

--- a/common/autoware_interface_spec_lint/package.xml
+++ b/common/autoware_interface_spec_lint/package.xml
@@ -4,7 +4,7 @@
   <name>autoware_interface_spec_lint</name>
   <version>1.9.0</version>
   <description>WARN-only lint for the Autoware component interface specs</description>
-  <maintainer email="yutaka.kondo@youtalk.jp">Yutaka Kondo</maintainer>
+  <maintainer email="yutaka.kondo@tier4.jp">Yutaka Kondo</maintainer>
   <license>Apache License 2.0</license>
 
   <test_depend>ament_copyright</test_depend>

--- a/common/autoware_interface_spec_lint/package.xml
+++ b/common/autoware_interface_spec_lint/package.xml
@@ -7,7 +7,11 @@
   <maintainer email="yutaka.kondo@tier4.jp">Yutaka Kondo</maintainer>
   <license>Apache License 2.0</license>
 
+  <!-- autoware_component_interface_specs is a test dependency because its
+       BUILD_TESTING-gated generator binary backs the manifest_fresh test; see
+       test/conftest.py for how the test locates it. -->
   <test_depend>ament_copyright</test_depend>
+  <test_depend>autoware_component_interface_specs</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/common/autoware_interface_spec_lint/package.xml
+++ b/common/autoware_interface_spec_lint/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_interface_spec_lint</name>
+  <version>1.9.0</version>
+  <description>WARN-only lint for the Autoware component interface specs</description>
+  <maintainer email="yutaka.kondo@youtalk.jp">Yutaka Kondo</maintainer>
+  <license>Apache License 2.0</license>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/common/autoware_interface_spec_lint/scripts/run_lint.py
+++ b/common/autoware_interface_spec_lint/scripts/run_lint.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Repo-local launcher for the pre-commit hook.
+
+Runs the interface spec lint without requiring the package to be installed, so
+the pre-commit hook works from a plain checkout (no colcon build, no pip). It
+adds the package root to ``sys.path`` and delegates to the console entry's
+``main``; the working directory (the repo root) is where the default spec dir
+and manifest are resolved from.
+"""
+
+import os
+import sys
+
+_PKG_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _PKG_ROOT not in sys.path:
+    sys.path.insert(0, _PKG_ROOT)
+
+from autoware_interface_spec_lint.main import main  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/common/autoware_interface_spec_lint/setup.cfg
+++ b/common/autoware_interface_spec_lint/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/autoware_interface_spec_lint
+[install]
+install_scripts=$base/lib/autoware_interface_spec_lint

--- a/common/autoware_interface_spec_lint/setup.py
+++ b/common/autoware_interface_spec_lint/setup.py
@@ -27,13 +27,13 @@ setup(
     install_requires=["setuptools"],
     zip_safe=True,
     maintainer="Yutaka Kondo",
-    maintainer_email="yutaka.kondo@youtalk.jp",
+    maintainer_email="yutaka.kondo@tier4.jp",
     description="WARN-only lint for the Autoware component interface specs",
     license="Apache License 2.0",
     tests_require=["pytest"],
     entry_points={
         "console_scripts": [
-            "ament_interface_spec_lint = autoware_interface_spec_lint.main:main",
+            "ament_autoware_interface_spec_lint = autoware_interface_spec_lint.main:main",
         ],
     },
 )

--- a/common/autoware_interface_spec_lint/setup.py
+++ b/common/autoware_interface_spec_lint/setup.py
@@ -1,0 +1,39 @@
+# Copyright 2026 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from setuptools import setup
+
+package_name = "autoware_interface_spec_lint"
+
+setup(
+    name=package_name,
+    version="1.9.0",
+    packages=[package_name],
+    data_files=[
+        ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
+        ("share/" + package_name, ["package.xml"]),
+    ],
+    install_requires=["setuptools"],
+    zip_safe=True,
+    maintainer="Yutaka Kondo",
+    maintainer_email="yutaka.kondo@youtalk.jp",
+    description="WARN-only lint for the Autoware component interface specs",
+    license="Apache License 2.0",
+    tests_require=["pytest"],
+    entry_points={
+        "console_scripts": [
+            "ament_interface_spec_lint = autoware_interface_spec_lint.main:main",
+        ],
+    },
+)

--- a/common/autoware_interface_spec_lint/test/conftest.py
+++ b/common/autoware_interface_spec_lint/test/conftest.py
@@ -1,0 +1,58 @@
+# Copyright 2026 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Make the real manifest generator discoverable to the manifest_fresh test in CI.
+
+`manifest_fresh` needs the built ``generate_interface_manifest`` binary and otherwise
+skips. Locally a developer exports ``INTERFACE_MANIFEST_GENERATOR``; in CI nothing does,
+so the freshness test used to skip on the runner even though the same drift is already a
+hard failure in the specs package's own C++ test. This locates the binary through the
+ament index -- the specs package installs it under ``<prefix>/lib/<pkg>/`` -- and exports
+the variable before the tests run, so the colcon test exercises the real generator too.
+
+The ``autoware_component_interface_specs`` test dependency in package.xml is what makes
+that install present in this package's colcon build+test. A pre-set variable always wins,
+so a developer can still point the test at a hand-built binary.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from autoware_interface_spec_lint.checks import GENERATOR_ENV
+
+_GENERATOR_PACKAGE = "autoware_component_interface_specs"
+_GENERATOR_NAME = "generate_interface_manifest"
+
+
+def _discover_generator() -> Path | None:
+    try:
+        from ament_index_python.packages import get_package_prefix
+    except ImportError:
+        return None  # ament not on the path (e.g. a bare `pytest` run); leave it to skip.
+    try:
+        prefix = Path(get_package_prefix(_GENERATOR_PACKAGE))
+    except Exception:
+        return None  # specs package not installed in this workspace.
+    candidate = prefix / "lib" / _GENERATOR_PACKAGE / _GENERATOR_NAME
+    return candidate if candidate.is_file() else None
+
+
+def pytest_configure(config):
+    if os.environ.get(GENERATOR_ENV):
+        return  # An explicit path (local dev) always wins over discovery.
+    generator = _discover_generator()
+    if generator is not None:
+        os.environ[GENERATOR_ENV] = str(generator)

--- a/common/autoware_interface_spec_lint/test/test_committed_specs.py
+++ b/common/autoware_interface_spec_lint/test/test_committed_specs.py
@@ -1,0 +1,60 @@
+# Copyright 2026 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The checks run clean against the real committed specs, not just against fixtures.
+
+Every other test in this package feeds the parser a hand-written fixture, so the suite
+stayed green when `autoware_component_interface_specs` moved its per-domain `version` and
+`Specs` declarations into AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN: the fixtures
+still used the old literal syntax, while the real headers emitted 29 false positives and
+`version_consistency` stopped cross-checking the manifest entirely. A check that reads the
+committed sources is the only one that notices when the sources move out from under it.
+"""
+
+from pathlib import Path
+
+from autoware_interface_spec_lint.checks import parse_header
+from autoware_interface_spec_lint.main import STATIC_CHECKS
+import pytest
+
+_SPECS_PKG = Path(__file__).resolve().parents[2] / "autoware_component_interface_specs"
+_SPEC_DIR = _SPECS_PKG / "include" / "autoware" / "component_interface_specs"
+_MANIFEST = _SPECS_PKG / "interface_manifest.json"
+
+requires_committed_specs = pytest.mark.skipif(
+    not _SPEC_DIR.is_dir() or not _MANIFEST.is_file(),
+    reason="autoware_component_interface_specs sources not present in this workspace",
+)
+
+
+@requires_committed_specs
+@pytest.mark.parametrize("check", STATIC_CHECKS, ids=lambda c: c.__name__)
+def test_static_check_is_clean_on_the_committed_specs(check):
+    findings = check(_SPEC_DIR, _MANIFEST)
+    assert findings == [], "\n".join(f"{f.file}:{f.line} {f.message}" for f in findings)
+
+
+@requires_committed_specs
+def test_every_committed_domain_declares_a_version_and_registers_its_specs():
+    # Anchors the parser to the syntax the headers actually use. Were the macro to stop
+    # being understood, every domain here would report zero versions and zero members --
+    # which is precisely how the check above silently lost its cross-check once before.
+    domains = [p for p in _SPEC_DIR.glob("*.hpp") if p.name not in {"utils.hpp", "version.hpp"}]
+    assert domains, "no domain headers found"
+    for path in domains:
+        if path.name == "concepts.hpp":
+            continue
+        header = parse_header(path)
+        assert len(header.versions) == 1, f"{path.name} declares {len(header.versions)} versions"
+        assert header.specs_members, f"{path.name} registers no specs"

--- a/common/autoware_interface_spec_lint/test/test_committed_specs.py
+++ b/common/autoware_interface_spec_lint/test/test_committed_specs.py
@@ -24,6 +24,7 @@ committed sources is the only one that notices when the sources move out from un
 
 from pathlib import Path
 
+from autoware_interface_spec_lint.checks import _domain_headers
 from autoware_interface_spec_lint.checks import parse_header
 from autoware_interface_spec_lint.main import STATIC_CHECKS
 import pytest
@@ -50,11 +51,10 @@ def test_every_committed_domain_declares_a_version_and_registers_its_specs():
     # Anchors the parser to the syntax the headers actually use. Were the macro to stop
     # being understood, every domain here would report zero versions and zero members --
     # which is precisely how the check above silently lost its cross-check once before.
-    domains = [p for p in _SPEC_DIR.glob("*.hpp") if p.name not in {"utils.hpp", "version.hpp"}]
+    # Uses the checks' own header set so the two cannot drift apart.
+    domains = _domain_headers(_SPEC_DIR)
     assert domains, "no domain headers found"
     for path in domains:
-        if path.name == "concepts.hpp":
-            continue
         header = parse_header(path)
         assert len(header.versions) == 1, f"{path.name} declares {len(header.versions)} versions"
         assert header.specs_members, f"{path.name} registers no specs"

--- a/common/autoware_interface_spec_lint/test/test_copyright.py
+++ b/common/autoware_interface_spec_lint/test/test_copyright.py
@@ -1,0 +1,23 @@
+# Copyright 2026 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_copyright.main import main
+import pytest
+
+
+@pytest.mark.copyright
+@pytest.mark.linter
+def test_copyright():
+    rc = main(argv=[".", "test"])
+    assert rc == 0, "Found errors"

--- a/common/autoware_interface_spec_lint/test/test_interface_spec_concept.py
+++ b/common/autoware_interface_spec_lint/test/test_interface_spec_concept.py
@@ -1,0 +1,89 @@
+# Copyright 2026 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+import textwrap
+
+from autoware_interface_spec_lint.checks import interface_spec_concept
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    d = tmp_path / "component_interface_specs"
+    d.mkdir(parents=True)
+    f = d / "localization.hpp"
+    f.write_text(textwrap.dedent(body))
+    return d
+
+
+def test_valid_topic_and_service_pass(tmp_path):
+    spec_dir = _write(
+        tmp_path,
+        """
+        namespace autoware::component_interface_specs::localization {
+        struct KinematicState {
+          using Message = nav_msgs::msg::Odometry;
+          static constexpr char name[] = "/localization/kinematic_state";
+          static constexpr size_t depth = 1;
+          static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+          static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+        };
+        struct Initialize {
+          using Service = autoware_localization_msgs::srv::InitializeLocalization;
+          static constexpr char name[] = "/localization/initialize";
+        };
+        }
+        """,
+    )
+    assert interface_spec_concept(spec_dir, None) == []
+
+
+def test_incomplete_topic_warns(tmp_path):
+    spec_dir = _write(
+        tmp_path,
+        """
+        namespace autoware::component_interface_specs::localization {
+        struct KinematicState {
+          using Message = nav_msgs::msg::Odometry;
+          static constexpr char name[] = "/localization/kinematic_state";
+          static constexpr size_t depth = 1;
+        };
+        }
+        """,
+    )
+    findings = interface_spec_concept(spec_dir, None)
+    assert len(findings) == 1
+    assert "KinematicState" in findings[0].message
+    assert findings[0].level == "WARN"
+
+
+def test_nonconforming_struct_with_trailing_comment_warns(tmp_path):
+    # Same trailing-comment declaration form: the struct must still be scanned,
+    # so its missing `durability` is reported.
+    spec_dir = _write(
+        tmp_path,
+        """
+        namespace autoware::component_interface_specs::localization {
+        struct KinematicState  // canonical producer name
+        {
+          using Message = nav_msgs::msg::Odometry;
+          static constexpr char name[] = "/localization/kinematic_state";
+          static constexpr size_t depth = 1;
+          static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+        };
+        }
+        """,
+    )
+    findings = interface_spec_concept(spec_dir, None)
+    assert len(findings) == 1
+    assert "KinematicState" in findings[0].message

--- a/common/autoware_interface_spec_lint/test/test_manifest_fresh.py
+++ b/common/autoware_interface_spec_lint/test/test_manifest_fresh.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# cspell:ignore delenv
+
 import os
 from pathlib import Path
 import stat

--- a/common/autoware_interface_spec_lint/test/test_manifest_fresh.py
+++ b/common/autoware_interface_spec_lint/test/test_manifest_fresh.py
@@ -1,0 +1,76 @@
+# Copyright 2026 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from pathlib import Path
+import stat
+
+from autoware_interface_spec_lint.checks import GENERATOR_ENV
+from autoware_interface_spec_lint.checks import manifest_fresh
+import pytest
+
+
+def _make_stub_generator(tmp_path: Path, out_content: str) -> Path:
+    gen = tmp_path / "generate_stub"
+    gen.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "with open(sys.argv[1], 'w') as f:\n"
+        f"    f.write({out_content!r})\n"
+    )
+    gen.chmod(gen.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return gen
+
+
+def test_skips_when_generator_unavailable(tmp_path):
+    manifest = tmp_path / "interface_manifest.json"
+    manifest.write_text('{"owner": "x", "interfaces": []}\n')
+    # No generator provided and env not set -> record-only skip (M0), never raises.
+    assert manifest_fresh(manifest, generator=None) == []
+
+
+def test_fresh_manifest_has_no_findings(tmp_path):
+    content = '{"owner": "autowarefoundation", "interfaces": []}\n'
+    manifest = tmp_path / "interface_manifest.json"
+    manifest.write_text(content)
+    gen = _make_stub_generator(tmp_path, content)
+    assert manifest_fresh(manifest, generator=gen) == []
+
+
+def test_drift_is_recorded_as_warning(tmp_path):
+    manifest = tmp_path / "interface_manifest.json"
+    manifest.write_text('{"owner": "autowarefoundation", "interfaces": []}\n')
+    gen = _make_stub_generator(tmp_path, '{"owner": "autowarefoundation", "interfaces": [1]}\n')
+    findings = manifest_fresh(manifest, generator=gen)
+    # M0 is record-only: drift is detected and reported as WARN, but this test
+    # never fails on drift itself. M2 flips this to a hard failure.
+    assert len(findings) == 1
+    assert findings[0].level == "WARN"
+    assert "stale" in findings[0].message
+
+
+def test_real_generator_against_committed_manifest():
+    gen = os.environ.get(GENERATOR_ENV)
+    if not gen or not Path(gen).is_file():
+        pytest.skip(f"{GENERATOR_ENV} not set (generator not built in this workspace)")
+    committed = (
+        Path(__file__).resolve().parents[2]
+        / "autoware_component_interface_specs"
+        / "interface_manifest.json"
+    )
+    if not committed.is_file():
+        pytest.skip("committed interface_manifest.json not found in this workspace")
+    findings = manifest_fresh(committed, generator=gen)
+    # Record-only in M0: only assert the finding shape, never fail on drift.
+    assert all(f.level == "WARN" for f in findings)

--- a/common/autoware_interface_spec_lint/test/test_manifest_fresh.py
+++ b/common/autoware_interface_spec_lint/test/test_manifest_fresh.py
@@ -43,7 +43,7 @@ def test_skips_when_generator_unavailable(tmp_path, monkeypatch):
     monkeypatch.delenv(GENERATOR_ENV, raising=False)
     manifest = tmp_path / "interface_manifest.json"
     manifest.write_text('{"owner": "x", "interfaces": []}\n')
-    # No generator provided and env not set -> record-only skip (M0), never raises.
+    # No generator provided and env not set -> record-only skip, never raises.
     assert manifest_fresh(manifest, generator=None) == []
 
 
@@ -68,8 +68,8 @@ def test_drift_is_recorded_as_warning(tmp_path):
     manifest.write_text('{"owner": "autowarefoundation", "interfaces": []}\n')
     gen = _make_stub_generator(tmp_path, '{"owner": "autowarefoundation", "interfaces": [1]}\n')
     findings = manifest_fresh(manifest, generator=gen)
-    # M0 is record-only: drift is detected and reported as WARN, but this test
-    # never fails on drift itself. M2 flips this to a hard failure.
+    # This is record-only: drift is detected and reported as WARN, but this test
+    # never fails on drift itself. A follow-up flips this to a hard failure.
     assert len(findings) == 1
     assert findings[0].level == "WARN"
     assert "stale" in findings[0].message
@@ -87,7 +87,7 @@ def test_committed_manifest_is_up_to_date():
     if not committed.is_file():
         pytest.skip("committed interface_manifest.json not found in this workspace")
     findings = manifest_fresh(committed, generator=gen)
-    # WARN-only governs the *hook*: a contributor's commit is never blocked in M0. The
+    # WARN-only governs the *hook*: a contributor's commit is never blocked. The
     # committed manifest matching the generator is a separate thing -- a repo invariant --
     # so a spec, QoS or version change that does not land the regenerated manifest in the
     # same commit fails here rather than reaching consumers.

--- a/common/autoware_interface_spec_lint/test/test_manifest_fresh.py
+++ b/common/autoware_interface_spec_lint/test/test_manifest_fresh.py
@@ -33,10 +33,23 @@ def _make_stub_generator(tmp_path: Path, out_content: str) -> Path:
     return gen
 
 
-def test_skips_when_generator_unavailable(tmp_path):
+def test_skips_when_generator_unavailable(tmp_path, monkeypatch):
+    # `resolve_generator` falls back to GENERATOR_ENV when no generator is passed, so the
+    # variable has to be cleared for this test to be about an unavailable generator at
+    # all. Left set -- as it is wherever the generator is actually built -- this ran the
+    # real generator against the stub manifest below and reported drift.
+    monkeypatch.delenv(GENERATOR_ENV, raising=False)
     manifest = tmp_path / "interface_manifest.json"
     manifest.write_text('{"owner": "x", "interfaces": []}\n')
     # No generator provided and env not set -> record-only skip (M0), never raises.
+    assert manifest_fresh(manifest, generator=None) == []
+
+
+def test_env_var_supplies_the_generator(tmp_path, monkeypatch):
+    content = '{"owner": "autowarefoundation", "interfaces": []}\n'
+    manifest = tmp_path / "interface_manifest.json"
+    manifest.write_text(content)
+    monkeypatch.setenv(GENERATOR_ENV, str(_make_stub_generator(tmp_path, content)))
     assert manifest_fresh(manifest, generator=None) == []
 
 
@@ -60,7 +73,7 @@ def test_drift_is_recorded_as_warning(tmp_path):
     assert "stale" in findings[0].message
 
 
-def test_real_generator_against_committed_manifest():
+def test_committed_manifest_is_up_to_date():
     gen = os.environ.get(GENERATOR_ENV)
     if not gen or not Path(gen).is_file():
         pytest.skip(f"{GENERATOR_ENV} not set (generator not built in this workspace)")
@@ -72,5 +85,12 @@ def test_real_generator_against_committed_manifest():
     if not committed.is_file():
         pytest.skip("committed interface_manifest.json not found in this workspace")
     findings = manifest_fresh(committed, generator=gen)
-    # Record-only in M0: only assert the finding shape, never fail on drift.
-    assert all(f.level == "WARN" for f in findings)
+    # WARN-only governs the *hook*: a contributor's commit is never blocked in M0. The
+    # committed manifest matching the generator is a separate thing -- a repo invariant --
+    # so a spec, QoS or version change that does not land the regenerated manifest in the
+    # same commit fails here rather than reaching consumers.
+    #
+    # The assertion this replaces was `all(f.level == "WARN" for f in findings)`, which
+    # holds on an empty list and holds again on a list of drift findings, so it passed
+    # whether or not the manifest was stale and verified nothing.
+    assert findings == [], findings[0].message if findings else ""

--- a/common/autoware_interface_spec_lint/test/test_qos_consistency.py
+++ b/common/autoware_interface_spec_lint/test/test_qos_consistency.py
@@ -1,0 +1,189 @@
+# Copyright 2026 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path
+import textwrap
+
+from autoware_interface_spec_lint.checks import qos_consistency
+
+# The real headers declare their domain through the macro, so the fixtures do too.
+_HEADER = """
+namespace autoware::component_interface_specs::localization {
+struct KinematicState {
+  using Message = nav_msgs::msg::Odometry;
+  static constexpr char name[] = "/localization/kinematic_state";
+  static constexpr size_t depth = 1;
+  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  static constexpr auto durability = %s;
+};
+struct Initialize {
+  using Service = autoware_localization_msgs::srv::InitializeLocalization;
+  static constexpr char name[] = "/localization/initialize";
+};
+AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(0, 1, 0, KinematicState, Initialize)
+}
+"""
+
+# The shared service profile qos_consistency derives instead of restating.
+_UTILS = """
+namespace autoware::component_interface_specs {
+namespace service_qos {
+static constexpr std::size_t depth = 10;
+static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+}
+}
+"""
+
+_TOPIC_QOS = {
+    "history": "keep_last",
+    "depth": 1,
+    "reliability": "reliable",
+    "durability": "volatile",
+}
+_SERVICE_QOS = {
+    "history": "keep_last",
+    "depth": 10,
+    "reliability": "reliable",
+    "durability": "volatile",
+}
+
+
+def _spec_dir(tmp_path: Path, durability="RMW_QOS_POLICY_DURABILITY_VOLATILE") -> Path:
+    d = tmp_path / "component_interface_specs"
+    d.mkdir(parents=True)
+    (d / "localization.hpp").write_text(textwrap.dedent(_HEADER % durability))
+    (d / "utils.hpp").write_text(textwrap.dedent(_UTILS))
+    return d
+
+
+def _manifest(tmp_path: Path, topic_qos=None, service_qos=None, drop_qos=False) -> Path:
+    topic = {
+        "domain": "localization",
+        "interface": "/localization/kinematic_state",
+        "type": "nav_msgs/msg/Odometry",
+        "kind": "topic",
+        "version": "0.1.0",
+        "qos": dict(topic_qos or _TOPIC_QOS),
+    }
+    service = {
+        "domain": "localization",
+        "interface": "/localization/initialize",
+        "type": "autoware_localization_msgs/srv/InitializeLocalization",
+        "kind": "service",
+        "version": "0.1.0",
+        "qos": dict(service_qos or _SERVICE_QOS),
+    }
+    if drop_qos:
+        topic.pop("qos")
+    path = tmp_path / "interface_manifest.json"
+    path.write_text(json.dumps({"owner": "autowarefoundation", "interfaces": [topic, service]}))
+    return path
+
+
+def test_matching_qos_passes(tmp_path):
+    assert qos_consistency(_spec_dir(tmp_path), _manifest(tmp_path)) == []
+
+
+def test_no_manifest_is_a_graceful_skip(tmp_path):
+    spec_dir = _spec_dir(tmp_path)
+    assert qos_consistency(spec_dir, None) == []
+    assert qos_consistency(spec_dir, str(tmp_path / "no" / "such.json")) == []
+
+
+def test_durability_drift_warns(tmp_path):
+    # The axis a manifest-only gate would miss: a TRANSIENT_LOCAL subscription never
+    # receives the latched message a VOLATILE publisher dropped.
+    manifest = _manifest(tmp_path, topic_qos={**_TOPIC_QOS, "durability": "transient_local"})
+    findings = qos_consistency(_spec_dir(tmp_path), manifest)
+    assert len(findings) == 1
+    assert findings[0].level == "WARN"
+    assert "durability: specs='volatile', manifest='transient_local'" in findings[0].message
+
+
+def test_reliability_drift_warns(tmp_path):
+    manifest = _manifest(tmp_path, topic_qos={**_TOPIC_QOS, "reliability": "best_effort"})
+    findings = qos_consistency(_spec_dir(tmp_path), manifest)
+    assert len(findings) == 1
+    assert "reliability: specs='reliable', manifest='best_effort'" in findings[0].message
+
+
+def test_depth_drift_warns(tmp_path):
+    manifest = _manifest(tmp_path, topic_qos={**_TOPIC_QOS, "depth": 5})
+    findings = qos_consistency(_spec_dir(tmp_path), manifest)
+    assert len(findings) == 1
+    assert "depth: specs=1, manifest=5" in findings[0].message
+
+
+def test_header_side_drift_warns(tmp_path):
+    # The manifest is untouched; the header moved. Same finding, opposite direction.
+    spec_dir = _spec_dir(tmp_path, durability="RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL")
+    findings = qos_consistency(spec_dir, _manifest(tmp_path))
+    assert len(findings) == 1
+    assert "durability: specs='transient_local', manifest='volatile'" in findings[0].message
+
+
+def test_service_qos_drift_warns(tmp_path):
+    # Services carry no QoS of their own; theirs comes from utils.hpp's shared profile.
+    manifest = _manifest(tmp_path, service_qos={**_SERVICE_QOS, "depth": 1})
+    findings = qos_consistency(_spec_dir(tmp_path), manifest)
+    assert len(findings) == 1
+    assert "'Initialize'" in findings[0].message
+    assert "depth: specs=10, manifest=1" in findings[0].message
+
+
+def test_missing_qos_block_warns(tmp_path):
+    findings = qos_consistency(_spec_dir(tmp_path), _manifest(tmp_path, drop_qos=True))
+    assert len(findings) == 1
+    assert "records no 'qos' block" in findings[0].message
+
+
+def test_unnameable_policy_warns_instead_of_guessing(tmp_path):
+    # Mirrors the generator, which throws rather than emitting a placeholder entry.
+    spec_dir = _spec_dir(tmp_path, durability="RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT")
+    findings = qos_consistency(spec_dir, _manifest(tmp_path))
+    assert len(findings) == 1
+    assert "durability policy the manifest cannot name" in findings[0].message
+
+
+def test_spec_missing_from_manifest_warns(tmp_path):
+    path = tmp_path / "interface_manifest.json"
+    path.write_text(json.dumps({"owner": "autowarefoundation", "interfaces": []}))
+    findings = qos_consistency(_spec_dir(tmp_path), path)
+    assert len(findings) == 2
+    assert all("the manifest has no" in f.message for f in findings)
+
+
+def test_unregistered_spec_is_not_reported_twice(tmp_path):
+    # A spec absent from `Specs` is spec_registered's finding. qos_consistency stays quiet
+    # so one root cause does not produce two warnings.
+    d = tmp_path / "component_interface_specs"
+    d.mkdir(parents=True)
+    (d / "localization.hpp").write_text(textwrap.dedent("""
+            namespace autoware::component_interface_specs::localization {
+            struct KinematicState {
+              using Message = nav_msgs::msg::Odometry;
+              static constexpr char name[] = "/localization/kinematic_state";
+              static constexpr size_t depth = 1;
+              static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+              static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+            };
+            AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(0, 1, 0)
+            }
+            """))
+    (d / "utils.hpp").write_text(textwrap.dedent(_UTILS))
+    path = tmp_path / "interface_manifest.json"
+    path.write_text(json.dumps({"owner": "autowarefoundation", "interfaces": []}))
+    assert qos_consistency(d, path) == []

--- a/common/autoware_interface_spec_lint/test/test_spec_registered.py
+++ b/common/autoware_interface_spec_lint/test/test_spec_registered.py
@@ -138,6 +138,50 @@ def test_unregistered_struct_with_trailing_comment_warns(tmp_path):
     assert "Acceleration" in findings[0].message
 
 
+def test_macro_registration_is_understood(tmp_path):
+    # The real headers register their specs through
+    # AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN, which expands to the
+    # `using Specs = std::tuple<...>` the literal fixtures above spell out. Parsing only
+    # the literal form once made every macro-registered spec look unregistered.
+    spec_dir = _write(
+        tmp_path,
+        """
+        namespace autoware::component_interface_specs::localization {
+        struct KinematicState {
+          using Message = nav_msgs::msg::Odometry;
+          static constexpr char name[] = "/localization/kinematic_state";
+        };
+        AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(0, 1, 0, KinematicState)
+        }
+        """,
+    )
+    assert spec_registered(spec_dir, None) == []
+
+
+def test_macro_registration_still_catches_an_unregistered_spec(tmp_path):
+    # clang-format wraps a long invocation across lines; the scanner must see through it.
+    spec_dir = _write(
+        tmp_path,
+        """
+        namespace autoware::component_interface_specs::localization {
+        struct KinematicState {
+          using Message = nav_msgs::msg::Odometry;
+          static constexpr char name[] = "/localization/kinematic_state";
+        };
+        struct Acceleration {
+          using Message = geometry_msgs::msg::AccelWithCovarianceStamped;
+          static constexpr char name[] = "/localization/acceleration";
+        };
+        AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(
+          0, 1, 0, KinematicState)
+        }
+        """,
+    )
+    findings = spec_registered(spec_dir, None)
+    assert len(findings) == 1
+    assert "Acceleration" in findings[0].message
+
+
 def test_suppression_marker_survives_trailing_comment_form(tmp_path):
     spec_dir = _write(
         tmp_path,

--- a/common/autoware_interface_spec_lint/test/test_spec_registered.py
+++ b/common/autoware_interface_spec_lint/test/test_spec_registered.py
@@ -1,0 +1,160 @@
+# Copyright 2026 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+import textwrap
+
+from autoware_interface_spec_lint.checks import spec_registered
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    d = tmp_path / "component_interface_specs"
+    d.mkdir(parents=True)
+    f = d / "localization.hpp"
+    f.write_text(textwrap.dedent(body))
+    return d
+
+
+def test_registered_struct_passes(tmp_path):
+    spec_dir = _write(
+        tmp_path,
+        """
+        namespace autoware::component_interface_specs::localization {
+        struct KinematicState {
+          using Message = nav_msgs::msg::Odometry;
+          static constexpr char name[] = "/localization/kinematic_state";
+          static constexpr size_t depth = 1;
+        };
+        static constexpr Version version{0, 1, 0};
+        using Specs = std::tuple<KinematicState>;
+        }
+        """,
+    )
+    assert spec_registered(spec_dir, None) == []
+
+
+def test_unregistered_struct_warns(tmp_path):
+    spec_dir = _write(
+        tmp_path,
+        """
+        namespace autoware::component_interface_specs::localization {
+        struct KinematicState {
+          using Message = nav_msgs::msg::Odometry;
+          static constexpr char name[] = "/localization/kinematic_state";
+        };
+        struct Acceleration {
+          using Message = geometry_msgs::msg::AccelWithCovarianceStamped;
+          static constexpr char name[] = "/localization/acceleration";
+        };
+        static constexpr Version version{0, 1, 0};
+        using Specs = std::tuple<KinematicState>;  // Acceleration missing
+        }
+        """,
+    )
+    findings = spec_registered(spec_dir, None)
+    assert len(findings) == 1
+    assert "Acceleration" in findings[0].message
+    assert findings[0].level == "WARN"
+
+
+def test_suppression_marker_on_line_above_exempts(tmp_path):
+    spec_dir = _write(
+        tmp_path,
+        """
+        namespace autoware::component_interface_specs::localization {
+        struct KinematicState {
+          using Message = nav_msgs::msg::Odometry;
+          static constexpr char name[] = "/localization/kinematic_state";
+        };
+        // interface-spec-lint: not-versioned
+        struct Acceleration {
+          using Message = geometry_msgs::msg::AccelWithCovarianceStamped;
+          static constexpr char name[] = "/localization/acceleration";
+        };
+        static constexpr Version version{0, 1, 0};
+        using Specs = std::tuple<KinematicState>;
+        }
+        """,
+    )
+    # Acceleration is unregistered but marked not-versioned, so it is exempt.
+    assert spec_registered(spec_dir, None) == []
+
+
+def test_suppression_marker_on_same_line_exempts(tmp_path):
+    spec_dir = _write(
+        tmp_path,
+        """
+        namespace autoware::component_interface_specs::localization {
+        struct KinematicState {
+          using Message = nav_msgs::msg::Odometry;
+          static constexpr char name[] = "/localization/kinematic_state";
+        };
+        struct Acceleration {  // interface-spec-lint: not-versioned
+          using Message = geometry_msgs::msg::AccelWithCovarianceStamped;
+          static constexpr char name[] = "/localization/acceleration";
+        };
+        static constexpr Version version{0, 1, 0};
+        using Specs = std::tuple<KinematicState>;
+        }
+        """,
+    )
+    assert spec_registered(spec_dir, None) == []
+
+
+def test_unregistered_struct_with_trailing_comment_warns(tmp_path):
+    # The real domain headers declare specs as `struct Foo  // note` with the brace
+    # on the next line. The struct scanner must see through the trailing comment.
+    spec_dir = _write(
+        tmp_path,
+        """
+        namespace autoware::component_interface_specs::localization {
+        struct KinematicState {
+          using Message = nav_msgs::msg::Odometry;
+          static constexpr char name[] = "/localization/kinematic_state";
+        };
+        struct Acceleration  // new spec (safety dependency)
+        {
+          using Message = geometry_msgs::msg::AccelWithCovarianceStamped;
+          static constexpr char name[] = "/localization/acceleration";
+        };
+        static constexpr Version version{0, 1, 0};
+        using Specs = std::tuple<KinematicState>;
+        }
+        """,
+    )
+    findings = spec_registered(spec_dir, None)
+    assert len(findings) == 1
+    assert "Acceleration" in findings[0].message
+
+
+def test_suppression_marker_survives_trailing_comment_form(tmp_path):
+    spec_dir = _write(
+        tmp_path,
+        """
+        namespace autoware::component_interface_specs::localization {
+        struct KinematicState {
+          using Message = nav_msgs::msg::Odometry;
+          static constexpr char name[] = "/localization/kinematic_state";
+        };
+        struct Acceleration  // interface-spec-lint: not-versioned
+        {
+          using Message = geometry_msgs::msg::AccelWithCovarianceStamped;
+          static constexpr char name[] = "/localization/acceleration";
+        };
+        static constexpr Version version{0, 1, 0};
+        using Specs = std::tuple<KinematicState>;
+        }
+        """,
+    )
+    assert spec_registered(spec_dir, None) == []

--- a/common/autoware_interface_spec_lint/test/test_version_consistency.py
+++ b/common/autoware_interface_spec_lint/test/test_version_consistency.py
@@ -1,0 +1,91 @@
+# Copyright 2026 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path
+import textwrap
+
+from autoware_interface_spec_lint.checks import version_consistency
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    d = tmp_path / "component_interface_specs"
+    d.mkdir(parents=True)
+    f = d / "localization.hpp"
+    f.write_text(textwrap.dedent(body))
+    return d
+
+
+_ONE_STRUCT = """
+namespace autoware::component_interface_specs::localization {
+struct KinematicState {
+  using Message = nav_msgs::msg::Odometry;
+  static constexpr char name[] = "/localization/kinematic_state";
+};
+%s
+using Specs = std::tuple<KinematicState>;
+}
+"""
+
+
+def test_single_zero_x_version_passes(tmp_path):
+    spec_dir = _write(tmp_path, _ONE_STRUCT % "static constexpr Version version{0, 1, 0};")
+    assert version_consistency(spec_dir, None) == []
+
+
+def test_missing_version_warns(tmp_path):
+    spec_dir = _write(tmp_path, _ONE_STRUCT % "")
+    findings = version_consistency(spec_dir, None)
+    assert len(findings) == 1
+    assert "exactly one" in findings[0].message
+    assert findings[0].level == "WARN"
+
+
+def test_non_zero_major_warns(tmp_path):
+    spec_dir = _write(tmp_path, _ONE_STRUCT % "static constexpr Version version{1, 0, 0};")
+    findings = version_consistency(spec_dir, None)
+    assert len(findings) == 1
+    assert "not 0.x" in findings[0].message
+
+
+def test_manifest_version_mismatch_warns(tmp_path):
+    spec_dir = _write(tmp_path, _ONE_STRUCT % "static constexpr Version version{0, 1, 0};")
+    manifest = tmp_path / "interface_manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "owner": "autowarefoundation",
+                "interfaces": [
+                    {
+                        "domain": "localization",
+                        "interface": "/localization/kinematic_state",
+                        "type": "nav_msgs/msg/Odometry",
+                        "kind": "topic",
+                        "version": "0.2.0",
+                    }
+                ],
+            }
+        )
+    )
+    findings = version_consistency(spec_dir, manifest)
+    assert len(findings) == 1
+    assert "manifest version '0.2.0'" in findings[0].message
+    assert "header version '0.1.0'" in findings[0].message
+
+
+def test_unreadable_manifest_path_warns_and_skips(tmp_path):
+    # Every other manifest-backed gate warns and skips when the manifest cannot be
+    # read; version_consistency must not raise FileNotFoundError at the user.
+    spec_dir = _write(tmp_path, _ONE_STRUCT % "static constexpr Version version{0, 1, 0};")
+    assert version_consistency(spec_dir, str(tmp_path / "no" / "such.json")) == []

--- a/common/autoware_interface_spec_lint/test/test_version_consistency.py
+++ b/common/autoware_interface_spec_lint/test/test_version_consistency.py
@@ -84,6 +84,58 @@ def test_manifest_version_mismatch_warns(tmp_path):
     assert "header version '0.1.0'" in findings[0].message
 
 
+_MACRO_STRUCT = """
+namespace autoware::component_interface_specs::localization {
+struct KinematicState {
+  using Message = nav_msgs::msg::Odometry;
+  static constexpr char name[] = "/localization/kinematic_state";
+};
+AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(%s, KinematicState)
+}
+"""
+
+
+def test_macro_declared_version_passes(tmp_path):
+    # The macro expands to the same `version{...}` the literal fixtures declare. Reading
+    # only the literal form made every domain look version-less -- and because this check
+    # `continue`s past a domain without exactly one version, it silently stopped
+    # cross-checking the manifest at all.
+    spec_dir = _write(tmp_path, _MACRO_STRUCT % "0, 1, 0")
+    assert version_consistency(spec_dir, None) == []
+
+
+def test_macro_declared_non_zero_major_warns(tmp_path):
+    spec_dir = _write(tmp_path, _MACRO_STRUCT % "1, 0, 0")
+    findings = version_consistency(spec_dir, None)
+    assert len(findings) == 1
+    assert "not 0.x" in findings[0].message
+
+
+def test_macro_declared_version_is_cross_checked_against_the_manifest(tmp_path):
+    spec_dir = _write(tmp_path, _MACRO_STRUCT % "0, 1, 0")
+    manifest = tmp_path / "interface_manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "owner": "autowarefoundation",
+                "interfaces": [
+                    {
+                        "domain": "localization",
+                        "interface": "/localization/kinematic_state",
+                        "type": "nav_msgs/msg/Odometry",
+                        "kind": "topic",
+                        "version": "0.2.0",
+                    }
+                ],
+            }
+        )
+    )
+    findings = version_consistency(spec_dir, manifest)
+    assert len(findings) == 1
+    assert "manifest version '0.2.0'" in findings[0].message
+    assert "header version '0.1.0'" in findings[0].message
+
+
 def test_unreadable_manifest_path_warns_and_skips(tmp_path):
     # Every other manifest-backed gate warns and skips when the manifest cannot be
     # read; version_consistency must not raise FileNotFoundError at the user.


### PR DESCRIPTION
> **#1259 has merged.** This branch has been rebased onto `main`, so the diff is now exactly `autoware_interface_spec_lint` + `.pre-commit-config.yaml`. No dependency remains.

## Description

Adds a new `ament_python` lint package `common/autoware_interface_spec_lint` with advisory, pre-build checks over the component interface specs defined in `autoware_component_interface_specs`. Every check is WARN-only: the tool prints human-readable findings but always exits 0 with `--warn-only`, so nothing fails the build yet (flipping the warnings into hard errors is left to a follow-up change). It gives fast, pre-build feedback that complements the compile-time `all_specs_valid<>` static assertions from #1259: it catches "defined-but-unregistered" specs and manifest / QoS drift that the compiler alone does not.

The checks (`autoware_interface_spec_lint/checks.py`) share one small header parser (`parse_header`) and a `Finding` record:

- `interface_spec_concept` flags a struct with a `name[]` that is neither a valid topic (`Message` + `depth` + `reliability` + `durability`) nor a valid service (`Service`);
- `spec_registered` flags a spec struct missing from its namespace's `using Specs = std::tuple<...>`;
- `version_consistency` flags a domain that does not declare exactly one `version{...}`, a MAJOR that is not `0` (the standard is unstable while at 0.x), or a manifest version that disagrees with the header version;
- `qos_consistency` flags a registered spec whose `history` / `depth` / `reliability` / `durability` disagrees with its manifest `qos` block, is missing from the manifest, or names a QoS policy the manifest cannot express. It reads only the headers and the committed JSON, so `reliability` and `durability` — the two axes ROS 2 evaluates before a publisher and a subscription may communicate — stay verified without a build;
- `manifest_fresh` rebuilds the manifest with the generator and diffs its output against the committed `interface_manifest.json`.

The first four are pure-Python static analyses wired into pre-commit; `manifest_fresh` is a colcon test because it needs the built generator binary.

**Suppression contract:** `spec_registered` treats a struct as intentionally not-versioned and exempts it when the fixed marker `// interface-spec-lint: not-versioned` appears on the struct's own declaration line or the line directly above it. The marker text is a fixed contract that other packages in this effort depend on; at this base no committed header uses it yet. It is implemented in `_is_suppressed` / `parse_header`, unit-tested in `test_spec_registered.py`, and documented in the README.

`manifest_fresh` locates the generator via a `--generator` argument or the `INTERFACE_MANIFEST_GENERATOR` environment variable, regenerates the manifest to a temp file, and diffs it against the committed JSON. It only RECORDS drift (returns a WARN finding, never raises) and skips gracefully (returns `[]` with a stderr warning) when the generator or committed manifest is unavailable.

`main.py` exposes the console entry `ament_autoware_interface_spec_lint` with `--warn-only`, `--spec-dir` (repeatable), `--manifest` and `--generator`; it runs the static checks over each spec dir, prints `WARN file:line message` lines plus a summary count, and returns 0 under `--warn-only`. `scripts/run_lint.py` is a repo-local launcher that adds the package root to `sys.path` and delegates to `main`, so the pre-commit hook works from a plain checkout with no colcon build and no pip install.

`.pre-commit-config.yaml` gains a local `interface-spec-lint` hook (`language: system`, `verbose: true`, `pass_filenames: false`) that runs the static checks at WARN over the core specs headers. (The `additional_dependencies` local-path mechanism does not work for `repo: local` hooks — pre-commit runs `pip install` from its own cache dir, so a repo-relative path cannot resolve — so the hook uses a `language: system` launcher, which needs no network and no install.)

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

**Builds on (already merged):**

- #1259

## How was this PR tested?

- The package's pytest suite passes: `39 passed, 1 skipped` locally. The skip is the committed-manifest freshness test, which needs a built generator in the workspace; the real-generator path is exercised separately. This count excludes `test_copyright.py`, which needs the ROS `ament_copyright` module and runs in the container / CI.
- Acceptance on real data: the static checks over the committed core specs headers and manifest produce **zero** findings — `ament_autoware_interface_spec_lint --warn-only` → `interface-spec-lint: 0 warning(s)`, exit 0.
- `pre-commit run --files <changed files>` is green (black, isort, flake8-ros, prettier, markdownlint, end-of-file / trailing-whitespace).

### youtalk fork CI — build-and-test all green

Staged on the youtalk fork before submission; the full gate is green (the two universe `-above` bonus jobs are excluded):

- `build-and-test-diff-jazzy / build-and-test-diff`: https://github.com/youtalk/autoware_core/actions/runs/29130381627/job/86484516180
- `build-and-test-diff-jazzy-agnocast / build-and-test-diff`: https://github.com/youtalk/autoware_core/actions/runs/29130381627/job/86484516172
- `build-and-test-diff-humble / build-and-test-diff`: https://github.com/youtalk/autoware_core/actions/runs/29130381627/job/86484516212
- `build-and-test-diff-jazzy / clang-tidy-diff`: https://github.com/youtalk/autoware_core/actions/runs/29130381627/job/86484923339
- `build-and-test-diff-humble / clang-tidy-diff`: https://github.com/youtalk/autoware_core/actions/runs/29130381627/job/86484908257
- `cppcheck-differential`: https://github.com/youtalk/autoware_core/actions/runs/29130381391/job/86484463548
- `spell-check-differential`: https://github.com/youtalk/autoware_core/actions/runs/29130381438/job/86484463844

## Notes for reviewers

Advisory tooling only — no runtime or ROS interface symbol is produced. `manifest_fresh` is a colcon test rather than a pre-commit hook because it needs the built generator; it is record-only. `test_copyright.py` runs `ament_copyright` over the package (all new files carry the 2026 Apache header). clang-tidy / cspell are CI-only and are green on the fork run linked above.

Rebased onto `main` after #1259 merged; the branch now carries only the eight `autoware_interface_spec_lint` commits. Re-verified against the merged specs package on `main` (which gained the RHEL-8 GCC 8.5 CMake gate and the `rmw/qos_profiles.h` include change during review): `ament_autoware_interface_spec_lint --warn-only` still reports `0 warning(s)`, and the pytest suite is still `39 passed, 1 skipped`.

## Interface changes

None.

## Effects on system behavior

None.

