### PR TITLE
fix(autoware_interpolation): include string in utilities

### DIFF
--- a/common/autoware_interpolation/include/autoware/interpolation/interpolation_utils.hpp
+++ b/common/autoware_interpolation/include/autoware/interpolation/interpolation_utils.hpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <array>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace autoware::interpolation


### PR DESCRIPTION
## Description

This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-autoware-interpolation.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: `interpolation_utils.hpp` uses `std::string` in its public interface, so including `<string>` directly avoids relying on transitive standard-library includes.

## Related links

**Parent Issue:**

- https://github.com/RoboStack/robostack.github.io/issues/16

## How was this PR tested?

Not run locally for this upstreaming batch; relying on upstream CI.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
