### PR TITLE
fix(autoware_kalman_filter): resolve Eigen include path

### DIFF
--- a/common/autoware_kalman_filter/CMakeLists.txt
+++ b/common/autoware_kalman_filter/CMakeLists.txt
@@ -1,11 +1,12 @@
 cmake_minimum_required(VERSION 3.14)
 project(autoware_kalman_filter)
 
+find_package(eigen3_cmake_module REQUIRED)
+find_package(Eigen3 REQUIRED)
+get_target_property(EIGEN3_INCLUDE_DIR Eigen3::Eigen INTERFACE_INCLUDE_DIRECTORIES)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
-find_package(eigen3_cmake_module REQUIRED)
-find_package(Eigen3 REQUIRED)
 
 include_directories(
   SYSTEM


### PR DESCRIPTION
## Description

This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-autoware-kalman-filter.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: `autoware_kalman_filter` adds Eigen include directories manually, so resolving `Eigen3` and its target include path before `autoware_package` makes the include path deterministic for downstream builds.

## Related links

**Parent Issue:**

- https://github.com/RoboStack/robostack.github.io/issues/16

## How was this PR tested?

Not run locally for this upstreaming batch; relying on upstream CI.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
