### PR TITLE
fix(autoware_osqp_interface): use CMake targets

### DIFF
--- a/common/autoware_osqp_interface/CMakeLists.txt
+++ b/common/autoware_osqp_interface/CMakeLists.txt
@@ -34,9 +34,9 @@ target_include_directories(${PROJECT_NAME}
     "${EIGEN3_INCLUDE_DIR}"
 )
 
-ament_target_dependencies(${PROJECT_NAME}
-  Eigen3
-  osqp_vendor
+target_link_libraries(${PROJECT_NAME}
+  Eigen3::Eigen
+  osqp::osqp
 )
 
 # crucial so downstream package builds because autoware_osqp_interface exposes osqp.hpp

--- a/common/autoware_osqp_interface/src/csc_matrix_conv.cpp
+++ b/common/autoware_osqp_interface/src/csc_matrix_conv.cpp
@@ -25,9 +25,9 @@ namespace autoware::osqp_interface
 {
 CSC_Matrix calCSCMatrix(const Eigen::MatrixXd & mat)
 {
-  const size_t elem = static_cast<size_t>(mat.nonZeros());
   const Eigen::Index rows = mat.rows();
   const Eigen::Index cols = mat.cols();
+  const size_t elem = static_cast<size_t>(rows * cols);
 
   std::vector<c_float> vals;
   vals.reserve(elem);
@@ -66,9 +66,9 @@ CSC_Matrix calCSCMatrix(const Eigen::MatrixXd & mat)
 
 CSC_Matrix calCSCMatrixTrapezoidal(const Eigen::MatrixXd & mat)
 {
-  const size_t elem = static_cast<size_t>(mat.nonZeros());
   const Eigen::Index rows = mat.rows();
   const Eigen::Index cols = mat.cols();
+  const size_t elem = static_cast<size_t>(rows * (rows + 1) / 2);
 
   if (rows != cols) {
     throw std::invalid_argument("Matrix must be square (n, n)");


### PR DESCRIPTION
## Description

This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-autoware-osqp-interface.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: linking against `Eigen3::Eigen` and `osqp::osqp` exposes the actual imported targets to CMake, and reserving enough CSC storage avoids under-reserving when dense matrices report fewer non-zero elements than the conversion loops may visit.

## Related links

**Parent Issue:**

- https://github.com/RoboStack/robostack.github.io/issues/16

## How was this PR tested?

Not run locally for this upstreaming batch; relying on upstream CI.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
