### PR TITLE
fix(autoware_test_utils): link to yaml-cpp target

### DIFF
--- a/testing/autoware_test_utils/CMakeLists.txt
+++ b/testing/autoware_test_utils/CMakeLists.txt
@@ -11,8 +11,15 @@ ament_auto_add_library(autoware_test_utils SHARED
   src/mock_data_parser.cpp
 )
 target_link_libraries(autoware_test_utils
-  yaml-cpp
+  yaml-cpp::yaml-cpp
 )
+
+if(NOT MSVC)
+  target_compile_options(autoware_test_utils
+    PUBLIC
+      -Wno-deprecated-declarations
+  )
+endif()
 
 ament_auto_add_executable(topic_snapshot_saver src/topic_snapshot_saver.cpp)
 


### PR DESCRIPTION
## Description

This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-autoware-test-utils.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: using `yaml-cpp::yaml-cpp` makes the dependency explicit for CMake-based package managers, and suppressing deprecated declaration warnings outside MSVC keeps current dependency warnings from breaking strict builds.

## Related links

**Parent Issue:**

- https://github.com/RoboStack/robostack.github.io/issues/16

## How was this PR tested?

Not run locally for this upstreaming batch; relying on upstream CI.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
