### PR TITLE
fix(autoware_ekf_localizer): link fmt target

### DIFF
--- a/localization/autoware_ekf_localizer/CMakeLists.txt
+++ b/localization/autoware_ekf_localizer/CMakeLists.txt
@@ -36,7 +36,7 @@ autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   ROS2_EXECUTOR SingleThreadedExecutor
 )
 
-target_link_libraries(${PROJECT_NAME} Eigen3::Eigen)
+target_link_libraries(${PROJECT_NAME} Eigen3::Eigen fmt::fmt)
 
 function(add_testcase filepath)
   get_filename_component(filename ${filepath} NAME)


### PR DESCRIPTION
## Description

This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-autoware-ekf-localizer.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: `autoware_ekf_localizer` already declares `fmt` in `package.xml`, and linking `fmt::fmt` explicitly makes the CMake target closure complete for toolchains and package managers that do not rely on transitive link information.

## Related links

**Parent Issue:**

- https://github.com/RoboStack/robostack.github.io/issues/16

## How was this PR tested?

Not run locally for this upstreaming batch; relying on upstream CI.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
