### PR TITLE
feat(autoware_agnocast_wrapper): polling bridge `polling:` namespace

### DIFF
--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -451,10 +451,10 @@ private:
 
 This package currently exposes two polling APIs:
 
-| API | Returns | Form |
-| --- | --- | --- |
-| `Node::create_polling_subscriber` / `AUTOWARE_POLLING_SUBSCRIBER_PTR` (top-level) | `message_ptr` | `Node` member |
-| `polling::create_polling_subscriber` (this section) | plain `std::shared_ptr<const MessageT>` | free function |
+| API                                                                               | Returns                                 | Form          |
+| --------------------------------------------------------------------------------- | --------------------------------------- | ------------- |
+| `Node::create_polling_subscriber` / `AUTOWARE_POLLING_SUBSCRIBER_PTR` (top-level) | `message_ptr`                           | `Node` member |
+| `polling::create_polling_subscriber` (this section)                               | plain `std::shared_ptr<const MessageT>` | free function |
 
 Prefer `polling::` for new code: it returns a plain `std::shared_ptr` (no `message_ptr`), is node-independent, and confines the `autoware_utils_rclcpp` dependency to a single header. The top-level member API is kept for backward compatibility with already-merged consumers and is planned to be removed once they are migrated to `polling::`.
 

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -406,6 +406,58 @@ The `add()` / `removeByName()` / `setHardwareID()` / `setHardwareIDf()` / `broad
 
 > **Note:** `DiagnosticTask` subclasses (e.g. `FrequencyStatus`, `TimeStampStatus`, `Heartbeat`) defined in `diagnostic_updater` can be added via `updater_.add(task)` unchanged.
 
+## Polling Subscriber (`polling::` namespace)
+
+`autoware::agnocast_wrapper::polling::create_polling_subscriber<MessageT>(node, topic, qos)` creates a polling (take-based) subscriber whose `take_data()` returns a plain `std::shared_ptr<const MessageT>` in **both** `ENABLE_AGNOCAST` modes. In agnocast mode the message stays in shared memory and is aliased into the returned `shared_ptr` (zero-copy, no payload copy); in rclcpp mode it reuses `autoware_utils_rclcpp::InterProcessPollingSubscriber`.
+
+### `take_data()` contract
+
+- Returns the latest message, or `nullptr` when none is available.
+- Re-delivery is governed by the **policy tag** and is identical across backends:
+  - `polling_policy::Latest` (default): re-delivers the cached message.
+  - `polling_policy::Newest`: returns `nullptr` until a new message arrives.
+- `polling_policy::All` is rejected at compile time (`take_data()` returns a single message, not a vector).
+- The returned `std::shared_ptr` has the same lifetime semantics in both modes.
+
+### Usage example
+
+```cpp
+#include <autoware/agnocast_wrapper/polling_subscriber.hpp>
+
+class MyNode : public autoware::agnocast_wrapper::Node
+{
+public:
+  explicit MyNode(const rclcpp::NodeOptions & options) : Node("my_node", options)
+  {
+    namespace polling = autoware::agnocast_wrapper::polling;
+    sub_ = polling::create_polling_subscriber<nav_msgs::msg::Odometry>(this, "~/input/odometry", 1);
+  }
+
+  void on_timer()
+  {
+    const std::shared_ptr<const nav_msgs::msg::Odometry> msg = sub_->take_data();
+    if (!msg) {
+      return;
+    }
+    // use msg->...
+  }
+
+private:
+  autoware::agnocast_wrapper::polling::PollingSubscriber<nav_msgs::msg::Odometry>::SharedPtr sub_;
+};
+```
+
+### When to use this vs the existing member API
+
+This package currently exposes two polling APIs:
+
+| API | Returns | Form |
+| --- | --- | --- |
+| `Node::create_polling_subscriber` / `AUTOWARE_POLLING_SUBSCRIBER_PTR` (top-level) | `message_ptr` | `Node` member |
+| `polling::create_polling_subscriber` (this section) | plain `std::shared_ptr<const MessageT>` | free function |
+
+Prefer `polling::` for new code: it returns a plain `std::shared_ptr` (no `message_ptr`), is node-independent, and confines the `autoware_utils_rclcpp` dependency to a single header. The top-level member API is kept for backward compatibility with already-merged consumers and is planned to be removed once they are migrated to `polling::`.
+
 ## How to Enable/Disable Agnocast on Build
 
 To build Autoware **with** Agnocast:

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
@@ -1,0 +1,175 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "autoware/agnocast_wrapper/node.hpp"
+
+#include <autoware_utils_rclcpp/polling_subscriber.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#ifdef USE_AGNOCAST_ENABLED
+#include <agnocast/agnocast.hpp>
+#endif
+
+namespace autoware::agnocast_wrapper::polling
+{
+
+// Reuse the polling policy tag types (Latest / Newest / All) from autoware_utils_rclcpp.
+namespace polling_policy = autoware_utils_rclcpp::polling_policy;
+
+// Latest re-delivers the cached message by default; Newest only delivers messages new since the
+// last take.
+template <typename MessageT, template <typename> class PollingPolicy>
+inline constexpr bool polling_default_allow_same_message_v =
+  !std::is_same_v<PollingPolicy<MessageT>, polling_policy::Newest<MessageT>>;
+
+template <typename MessageT, template <typename> class PollingPolicy>
+inline constexpr bool polling_policy_supported_v =
+  !std::is_same_v<PollingPolicy<MessageT>, polling_policy::All<MessageT>>;
+
+/// @brief Backend-agnostic polling subscriber. take_data() returns a plain
+/// std::shared_ptr<const MessageT> regardless of ENABLE_AGNOCAST.
+template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
+class PollingSubscriber
+{
+public:
+  static_assert(
+    polling_policy_supported_v<MessageT, PollingPolicy>,
+    "polling_policy::All is not supported by "
+    "autoware::agnocast_wrapper::polling::create_polling_subscriber "
+    "(take_data() returns a single message, not a vector). Use polling_policy::Latest or "
+    "polling_policy::Newest.");
+
+  using SharedPtr = std::shared_ptr<PollingSubscriber<MessageT, PollingPolicy>>;
+
+  static constexpr bool default_allow_same_message =
+    polling_default_allow_same_message_v<MessageT, PollingPolicy>;
+
+  virtual ~PollingSubscriber() = default;
+
+  virtual std::shared_ptr<const MessageT> take_data(
+    bool allow_same_message = default_allow_same_message) = 0;
+};
+
+/// @brief rclcpp backend: delegates to autoware_utils_rclcpp::InterProcessPollingSubscriber.
+template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
+class ROS2PollingSubscriber : public PollingSubscriber<MessageT, PollingPolicy>
+{
+  typename autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT, PollingPolicy>::SharedPtr
+    subscriber_;
+
+public:
+  explicit ROS2PollingSubscriber(
+    rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos)
+  : subscriber_(
+      autoware_utils_rclcpp::InterProcessPollingSubscriber<
+        MessageT, PollingPolicy>::create_subscription(node, topic_name, qos))
+  {
+  }
+
+  // The default argument for allow_same_message is declared on the base class; virtual overrides
+  // inherit it via the static call type (PollingSubscriber<...>::SharedPtr).
+  std::shared_ptr<const MessageT> take_data(bool allow_same_message) override
+  {
+    (void)allow_same_message;
+    // InterProcessPollingSubscriber::take_data() already returns MessageT::ConstSharedPtr
+    // (a std::shared_ptr<const MessageT>); no copy needed.
+    return subscriber_->take_data();
+  }
+};
+
+#ifdef USE_AGNOCAST_ENABLED
+
+/// @brief agnocast backend: uses agnocast's native take-subscription and aliases the shared-memory
+/// message into a plain std::shared_ptr (zero-copy).
+template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
+class AgnocastPollingSubscriber : public PollingSubscriber<MessageT, PollingPolicy>
+{
+  typename agnocast::TakeSubscription<MessageT>::SharedPtr subscriber_;
+
+public:
+  explicit AgnocastPollingSubscriber(
+    agnocast::Node * node, const std::string & topic_name, const rclcpp::QoS & qos)
+  : subscriber_(std::make_shared<agnocast::TakeSubscription<MessageT>>(node, topic_name, qos))
+  {
+  }
+
+  std::shared_ptr<const MessageT> take_data(bool allow_same_message) override
+  {
+    agnocast::ipc_shared_ptr<const MessageT> data = subscriber_->take(allow_same_message);
+    if (!data) {
+      return nullptr;
+    }
+    // Zero-copy: alias the message that lives in agnocast shared memory instead of copying it out.
+    // `holder` owns the ipc_shared_ptr; the returned std::shared_ptr shares that ownership
+    // (aliasing constructor) while pointing at the shared-memory message. The kernel subscriber
+    // reference is held for exactly the returned shared_ptr's lifetime and released when the last
+    // copy is destroyed, so lifetime/refcount semantics match the rclcpp heap path (valid while
+    // held). NOTE: while any copy is alive it keeps one agnocast shared-memory entry pinned.
+    auto holder = std::make_shared<agnocast::ipc_shared_ptr<const MessageT>>(std::move(data));
+    return std::shared_ptr<const MessageT>(holder, holder->get());
+  }
+};
+
+/// @brief Create a polling subscriber attached to an agnocast_wrapper::Node.
+/// Dispatches at runtime: agnocast backend when use_agnocast() is true, rclcpp backend otherwise.
+/// @note The returned subscriber references the node's underlying backend by raw pointer, so it
+/// must
+///       not outlive @p node (same lifetime contract as the underlying rclcpp/agnocast
+///       subscribers).
+template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
+typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_subscriber(
+  autoware::agnocast_wrapper::Node * node, const std::string & topic_name,
+  const rclcpp::QoS & qos = rclcpp::QoS{1})
+{
+  if (use_agnocast()) {
+    return std::make_shared<AgnocastPollingSubscriber<MessageT, PollingPolicy>>(
+      node->get_agnocast_node().get(), topic_name, qos);
+  }
+  return std::make_shared<ROS2PollingSubscriber<MessageT, PollingPolicy>>(
+    node->get_rclcpp_node().get(), topic_name, qos);
+}
+
+#else  // USE_AGNOCAST_ENABLED
+
+/// @brief Create a polling subscriber attached to an agnocast_wrapper::Node (rclcpp-only build).
+/// @note The returned subscriber references the node's underlying rclcpp node by raw pointer, so it
+///       must not outlive @p node.
+template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
+typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_subscriber(
+  autoware::agnocast_wrapper::Node * node, const std::string & topic_name,
+  const rclcpp::QoS & qos = rclcpp::QoS{1})
+{
+  return std::make_shared<ROS2PollingSubscriber<MessageT, PollingPolicy>>(
+    node->get_rclcpp_node().get(), topic_name, qos);
+}
+
+#endif  // USE_AGNOCAST_ENABLED
+
+/// @brief History-depth overload.
+template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
+typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_subscriber(
+  autoware::agnocast_wrapper::Node * node, const std::string & topic_name, size_t qos_history_depth)
+{
+  return create_polling_subscriber<MessageT, PollingPolicy>(
+    node, topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)));
+}
+
+}  // namespace autoware::agnocast_wrapper::polling

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
@@ -31,11 +31,8 @@
 namespace autoware::agnocast_wrapper::polling
 {
 
-// Reuse the polling policy tag types (Latest / Newest / All) from autoware_utils_rclcpp.
 namespace polling_policy = autoware_utils_rclcpp::polling_policy;
 
-// Latest re-delivers the cached message by default; Newest only delivers messages new since the
-// last take.
 template <typename MessageT, template <typename> class PollingPolicy>
 inline constexpr bool polling_default_allow_same_message_v =
   !std::is_same_v<PollingPolicy<MessageT>, polling_policy::Newest<MessageT>>;
@@ -59,16 +56,28 @@ public:
 
   using SharedPtr = std::shared_ptr<PollingSubscriber<MessageT, PollingPolicy>>;
 
-  static constexpr bool default_allow_same_message =
-    polling_default_allow_same_message_v<MessageT, PollingPolicy>;
-
   virtual ~PollingSubscriber() = default;
 
-  virtual std::shared_ptr<const MessageT> take_data(
-    bool allow_same_message = default_allow_same_message) = 0;
+  std::shared_ptr<const MessageT> take_data()
+  {
+    return take_data_impl(polling_default_allow_same_message_v<MessageT, PollingPolicy>);
+  }
+
+  /// @brief (Latest only) When allow_same_message is false, returns nullptr if no new message has
+  /// arrived since the last take. Not declared for Newest/All (passing the flag there is a compile
+  /// error), matching autoware_utils_rclcpp.
+  template <
+    template <typename> class P = PollingPolicy,
+    std::enable_if_t<std::is_same_v<P<MessageT>, polling_policy::Latest<MessageT>>, int> = 0>
+  std::shared_ptr<const MessageT> take_data(bool allow_same_message)
+  {
+    return take_data_impl(allow_same_message);
+  }
+
+protected:
+  virtual std::shared_ptr<const MessageT> take_data_impl(bool allow_same_message) = 0;
 };
 
-/// @brief rclcpp backend: delegates to autoware_utils_rclcpp::InterProcessPollingSubscriber.
 template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
 class ROS2PollingSubscriber : public PollingSubscriber<MessageT, PollingPolicy>
 {
@@ -84,21 +93,19 @@ public:
   {
   }
 
-  // The default argument for allow_same_message is declared on the base class; virtual overrides
-  // inherit it via the static call type (PollingSubscriber<...>::SharedPtr).
-  std::shared_ptr<const MessageT> take_data(bool allow_same_message) override
+  std::shared_ptr<const MessageT> take_data_impl(bool allow_same_message) override
   {
-    (void)allow_same_message;
-    // InterProcessPollingSubscriber::take_data() already returns MessageT::ConstSharedPtr
-    // (a std::shared_ptr<const MessageT>); no copy needed.
-    return subscriber_->take_data();
+    if constexpr (std::is_same_v<PollingPolicy<MessageT>, polling_policy::Latest<MessageT>>) {
+      return subscriber_->take_data(allow_same_message);
+    } else {
+      (void)allow_same_message;
+      return subscriber_->take_data();
+    }
   }
 };
 
 #ifdef USE_AGNOCAST_ENABLED
 
-/// @brief agnocast backend: uses agnocast's native take-subscription and aliases the shared-memory
-/// message into a plain std::shared_ptr (zero-copy).
 template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
 class AgnocastPollingSubscriber : public PollingSubscriber<MessageT, PollingPolicy>
 {
@@ -111,29 +118,22 @@ public:
   {
   }
 
-  std::shared_ptr<const MessageT> take_data(bool allow_same_message) override
+  std::shared_ptr<const MessageT> take_data_impl(bool allow_same_message) override
   {
     agnocast::ipc_shared_ptr<const MessageT> data = subscriber_->take(allow_same_message);
     if (!data) {
       return nullptr;
     }
-    // Zero-copy: alias the message that lives in agnocast shared memory instead of copying it out.
-    // `holder` owns the ipc_shared_ptr; the returned std::shared_ptr shares that ownership
-    // (aliasing constructor) while pointing at the shared-memory message. The kernel subscriber
-    // reference is held for exactly the returned shared_ptr's lifetime and released when the last
-    // copy is destroyed, so lifetime/refcount semantics match the rclcpp heap path (valid while
-    // held). NOTE: while any copy is alive it keeps one agnocast shared-memory entry pinned.
+    // Zero-copy: alias the shared-memory message into the returned std::shared_ptr. `holder` keeps
+    // the ipc_shared_ptr alive for the returned pointer's lifetime, so lifetime/refcount match the
+    // rclcpp heap path. While any copy is alive it pins one agnocast shared-memory entry.
     auto holder = std::make_shared<agnocast::ipc_shared_ptr<const MessageT>>(std::move(data));
     return std::shared_ptr<const MessageT>(holder, holder->get());
   }
 };
 
-/// @brief Create a polling subscriber attached to an agnocast_wrapper::Node.
-/// Dispatches at runtime: agnocast backend when use_agnocast() is true, rclcpp backend otherwise.
-/// @note The returned subscriber references the node's underlying backend by raw pointer, so it
-/// must
-///       not outlive @p node (same lifetime contract as the underlying rclcpp/agnocast
-///       subscribers).
+/// @note The returned subscriber references the node's backend by raw pointer, so it must not
+/// outlive @p node.
 template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
 typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_subscriber(
   autoware::agnocast_wrapper::Node * node, const std::string & topic_name,
@@ -149,9 +149,8 @@ typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_su
 
 #else  // USE_AGNOCAST_ENABLED
 
-/// @brief Create a polling subscriber attached to an agnocast_wrapper::Node (rclcpp-only build).
-/// @note The returned subscriber references the node's underlying rclcpp node by raw pointer, so it
-///       must not outlive @p node.
+/// @note The returned subscriber references the node's rclcpp node by raw pointer, so it must not
+/// outlive @p node.
 template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
 typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_subscriber(
   autoware::agnocast_wrapper::Node * node, const std::string & topic_name,
@@ -163,7 +162,6 @@ typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_su
 
 #endif  // USE_AGNOCAST_ENABLED
 
-/// @brief History-depth overload.
 template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
 typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_subscriber(
   autoware::agnocast_wrapper::Node * node, const std::string & topic_name, size_t qos_history_depth)


### PR DESCRIPTION
## Description

Adds a polling-subscriber API under `autoware::agnocast_wrapper::polling`. `take_data()` returns a plain `std::shared_ptr<const MessageT>` in both `ENABLE_AGNOCAST` builds (zero-copy in agnocast mode via `shared_ptr` aliasing; rclcpp mode reuses `autoware_utils_rclcpp::InterProcessPollingSubscriber`, no duplication).

### Free function, node-independent

`polling::create_polling_subscriber(node, topic, qos)` takes the node explicitly instead of being a `Node` member. This wrapper is planned to be synced into nebula (which must stay autoware-independent); keeping polling out of `node.hpp` isolates the `autoware_utils_rclcpp` dependency to this single header, so a downstream mirror can simply omit it.

### Backward-compatible (temporary)

The existing top-level polling API (`Node::create_polling_subscriber` / `AUTOWARE_POLLING_SUBSCRIBER_PTR`), used by the already-merged consumers, is kept untouched so nothing breaks. The new API is additive and lives in the nested `polling` namespace to coexist with it. Once those consumers are migrated to `polling::`, the old top-level API will be removed and this coexistence namespace collapsed.

## Related links
Example - How this is used : https://github.com/autowarefoundation/autoware_universe/pull/12951.

**Parent Issue:**

- Link

## How was this PR tested?

Full autoware build with `ENABLE_AGNOCAST=0` and `ENABLE_AGNOCAST=1`.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
