### PR TITLE
fix(autoware_agnocast_wrapper): `declare_paramter` return type to auto

### DIFF
--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -144,15 +144,19 @@ public:
 
   // ===== Parameters (template) =====
   template <typename ParameterT>
-  ParameterT declare_parameter(
+  auto declare_parameter(
     const std::string & name, const ParameterT & default_value,
     const rcl_interfaces::msg::ParameterDescriptor & descriptor =
       rcl_interfaces::msg::ParameterDescriptor{},
     bool ignore_override = false)
   {
-    return declare_parameter(
-             name, rclcpp::ParameterValue(default_value), descriptor, ignore_override)
-      .get<ParameterT>();
+    try {
+      return declare_parameter(
+               name, rclcpp::ParameterValue(default_value), descriptor, ignore_override)
+        .get<ParameterT>();
+    } catch (const rclcpp::ParameterTypeException & ex) {
+      throw rclcpp::exceptions::InvalidParameterTypeException(name, ex.what());
+    }
   }
 
   template <typename ParameterT>
@@ -603,15 +607,19 @@ public:
 
   // ===== Parameters (template) =====
   template <typename ParameterT>
-  ParameterT declare_parameter(
+  auto declare_parameter(
     const std::string & name, const ParameterT & default_value,
     const rcl_interfaces::msg::ParameterDescriptor & descriptor =
       rcl_interfaces::msg::ParameterDescriptor{},
     bool ignore_override = false)
   {
-    return declare_parameter(
-             name, rclcpp::ParameterValue(default_value), descriptor, ignore_override)
-      .get<ParameterT>();
+    try {
+      return declare_parameter(
+               name, rclcpp::ParameterValue(default_value), descriptor, ignore_override)
+        .get<ParameterT>();
+    } catch (const rclcpp::ParameterTypeException & ex) {
+      throw rclcpp::exceptions::InvalidParameterTypeException(name, ex.what());
+    }
   }
 
   template <typename ParameterT>


### PR DESCRIPTION
## Description

`autoware::agnocast_wrapper::Node::declare_parameter` returned `ParameterT`, while `rclcpp::Node` and `agnocast::Node` both return `auto`. This forced callers to specify the
type explicitly, which upstream does not require.

This PR changes the wrapper's return type to `auto`, matching upstream:

```cpp
// Before
node->declare_parameter<std::string>("frame_id", "map");

// After
node->declare_parameter("frame_id", "map");
```

The upstream `try/catch` that converts `rclcpp::ParameterTypeException` into `rclcpp::exceptions::InvalidParameterTypeException` is also brought over, so the error message includes the parameter name — matching `rclcpp::Node` / `agnocast::Node` behavior. This path is only reachable for `dynamic_typing = true` parameters whose override type differs from the default; static-typed parameters are still rejected upstream as before.

Applied to both the `ENABLE_AGNOCAST=1` and `ENABLE_AGNOCAST=0` class definitions.
