### PR TITLE
ci: add lint-autoware-system-design-format and bump system_designer

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -26,6 +26,7 @@
     - source: .github/workflows/update-codeowners-from-packages.yaml
       pre-commands: |
         sd "          auto-merge-method: squash\n" "          auto-merge-method: squash\n          global-codeowners: \"@autowarefoundation/autoware-core-global-codeowners\"\n" {source}
+    - source: .github/workflows/lint-autoware-system-design-format.yaml
     - source: .clang-format
     - source: .clang-tidy
     - source: .markdown-link-check.json

--- a/.github/workflows/lint-autoware-system-design-format.yaml
+++ b/.github/workflows/lint-autoware-system-design-format.yaml
@@ -1,0 +1,30 @@
+name: Lint Autoware System Design Format
+
+on:
+  pull_request:
+    paths:
+      - "**/*.node.yaml"
+      - "**/*.module.yaml"
+      - "**/*.system.yaml"
+      - "**/*.parameter_set.yaml"
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.node.yaml"
+      - "**/*.module.yaml"
+      - "**/*.system.yaml"
+      - "**/*.parameter_set.yaml"
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Lint system design format files
+        uses: autowarefoundation/autoware_system_designer@v0.4.1
+        with:
+          design_files_path: .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -109,7 +109,7 @@ repos:
         additional_dependencies: [prettier@2.7.1, "@prettier/plugin-xml@2.2.0"]
 
   - repo: https://github.com/autowarefoundation/autoware_system_designer
-    rev: v0.3.1
+    rev: v0.4.1
     hooks:
       - id: lint-system-design-format
         args: [--format=github-actions]


### PR DESCRIPTION
## Description

Opt autoware_core into the Autoware system design format lint workflow ahead of node description files landing here.

- Add `.github/workflows/lint-autoware-system-design-format.yaml` (matches the [sync-file-templates](https://github.com/autowarefoundation/sync-file-templates) source added in autowarefoundation/sync-file-templates#91) and register it in `.github/sync-files.yaml` so it stays managed by `sync-files`.
- Bump `autoware_system_designer` in `.pre-commit-config.yaml` from `v0.3.1` to `v0.4.1` to match the workflow and the current template.

The workflow only triggers on `*.node.yaml`, `*.module.yaml`, `*.system.yaml`, and `*.parameter_set.yaml`, so it stays dormant until such design files are added to the repository.

## Related links

**Parent Issue:**

- autowarefoundation/sync-file-templates#91

## How was this PR tested?

CI-configuration change only. Verified the mapping entry matches the sync-file-templates source.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
