### PR TITLE
fix(autoware_agnocast_wrapper): build ROS2 polling with upstream autoware_utils

### DIFF
--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
@@ -63,17 +63,6 @@ public:
     return take_data_impl(polling_default_allow_same_message_v<MessageT, PollingPolicy>);
   }
 
-  /// @brief (Latest only) When allow_same_message is false, returns nullptr if no new message has
-  /// arrived since the last take. Not declared for Newest/All (passing the flag there is a compile
-  /// error), matching autoware_utils_rclcpp.
-  template <
-    template <typename> class P = PollingPolicy,
-    std::enable_if_t<std::is_same_v<P<MessageT>, polling_policy::Latest<MessageT>>, int> = 0>
-  std::shared_ptr<const MessageT> take_data(bool allow_same_message)
-  {
-    return take_data_impl(allow_same_message);
-  }
-
 protected:
   virtual std::shared_ptr<const MessageT> take_data_impl(bool allow_same_message) = 0;
 };
@@ -95,12 +84,8 @@ public:
 
   std::shared_ptr<const MessageT> take_data_impl(bool allow_same_message) override
   {
-    if constexpr (std::is_same_v<PollingPolicy<MessageT>, polling_policy::Latest<MessageT>>) {
-      return subscriber_->take_data(allow_same_message);
-    } else {
-      (void)allow_same_message;
-      return subscriber_->take_data();
-    }
+    (void)allow_same_message;
+    return subscriber_->take_data();
   }
 };
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/polling_subscriber.hpp
@@ -82,6 +82,8 @@ public:
   {
   }
 
+  // allow_same_message is unused: upstream autoware_utils_rclcpp has no take_data(bool);
+  // re-delivery is already governed by the PollingPolicy tag (Latest re-delivers, Newest only new).
   std::shared_ptr<const MessageT> take_data_impl(bool allow_same_message) override
   {
     (void)allow_same_message;


### PR DESCRIPTION
## Description

The new `autoware::agnocast_wrapper::polling::` API (`polling_subscriber.hpp`) exposed a `take_data(bool allow_same_message)` overload and made `ROS2PollingSubscriber` call `autoware_utils_rclcpp::InterProcessPollingSubscriber<T, Latest>::take_data(allow_same_message)`. Upstream `autoware_utils_rclcpp` has no `take_data(bool)` (only the no-argument `take_data()`), so any downstream package instantiating a `Latest` polling subscriber failed to build with `no matching function for call to take_data(bool)`.

This removes the non-upstream dependency: the wrapper's `take_data(bool)` overload is dropped so the public polling API is just `take_data()`, matching `autoware_utils_rclcpp`, and `ROS2PollingSubscriber::take_data_impl` forwards to the no-argument `take_data()`. Re-delivery is governed by the policy tag (`Latest` re-delivers, `Newest` only new), so no behavior changes for existing consumers (all use `take_data()`).

## Related links

None.

## How was this PR tested?

Built a downstream consumer of the new polling API (`autoware_collision_detector`) with `ENABLE_AGNOCAST=0` against upstream `autoware_utils_rclcpp`; it now compiles (previously failed in CI with `take_data(bool)`).

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
