### PR TITLE
fix(autoware_agnocast_wrapper): include <rclcpp/version.h> for version guards

### DIFF
--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -20,6 +20,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <rcl/timer.h>
+#include <rclcpp/version.h>
 
 #include <chrono>
 #include <functional>


### PR DESCRIPTION
## Description

`autoware_agnocast_wrapper.hpp` guards the `create_client` / `create_service` QoS overloads with `#if RCLCPP_VERSION_MAJOR >= 28`, but does not include `<rclcpp/version.h>` (only `<rclcpp/rclcpp.hpp>`, which does not define the macro). So `RCLCPP_VERSION_MAJOR` expands to `0` and the deprecated `rmw_qos_profile_t` branch is always taken, even on Jazzy (rclcpp 28.x), emitting `-Wdeprecated-declarations` and failing clang-tidy CI.

Fix: add the missing `#include <rclcpp/version.h>`.

Failing CI (on #1193): https://github.com/autowarefoundation/autoware_core/actions/runs/29901227377/job/88866335219

## Related links

None.

## How was this PR tested?

Confirmed `RCLCPP_VERSION_MAJOR` is undefined after `<rclcpp/rclcpp.hpp>` alone and defined once `<rclcpp/version.h>` is added; built `autoware_agnocast_wrapper` on Humble.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.