### PR TITLE
refactor(autoware_agnocast_wrapper): remove old polling subscriber API

### DIFF
--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include "autoware_utils_rclcpp/polling_subscriber.hpp"
-
 #include <rclcpp/exceptions/exceptions.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -64,8 +62,6 @@
   typename autoware::agnocast_wrapper::Subscription<MessageT>::SharedPtr
 #define AUTOWARE_PUBLISHER_PTR(MessageT) \
   typename autoware::agnocast_wrapper::Publisher<MessageT>::SharedPtr
-#define AUTOWARE_POLLING_SUBSCRIBER_PTR(...) \
-  typename autoware::agnocast_wrapper::PollingSubscriber<__VA_ARGS__>::SharedPtr
 #define AUTOWARE_CLIENT_PTR(ServiceT) \
   typename autoware::agnocast_wrapper::Client<ServiceT>::SharedPtr
 #define AUTOWARE_SERVICE_PTR(ServiceT) \
@@ -93,11 +89,6 @@
   autoware::agnocast_wrapper::create_publisher<message_type>(node, arg1, arg2)
 #define AUTOWARE_CREATE_PUBLISHER3_ON_NODE(message_type, node, arg1, arg2, arg3) \
   autoware::agnocast_wrapper::create_publisher<message_type>(node, arg1, arg2, arg3)
-
-#define AUTOWARE_CREATE_POLLING_SUBSCRIBER(message_type, policy, topic, qos) \
-  autoware::agnocast_wrapper::create_polling_subscriber<message_type, policy>(this, topic, qos)
-#define AUTOWARE_CREATE_POLLING_SUBSCRIBER_ON_NODE(message_type, policy, node, topic, qos) \
-  autoware::agnocast_wrapper::create_polling_subscriber<message_type, policy>(node, topic, qos)
 
 #define AUTOWARE_CREATE_CLIENT1(service_type, service_name) \
   autoware::agnocast_wrapper::create_client<service_type>(this, service_name)
@@ -558,140 +549,6 @@ typename Subscription<MessageT>::SharedPtr create_subscription(
     return std::make_shared<ROS2Subscription<MessageT>>(
       node, topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)),
       std::forward<Func>(callback), options);
-  }
-}
-
-// Reuse the polling policy tag types (Latest / Newest / All) from autoware_utils_rclcpp so that
-// node code can specify the policy by type, exactly as with the original
-// InterProcessPollingSubscriber.
-namespace polling_policy = autoware_utils_rclcpp::polling_policy;
-
-// Default value for take_data(allow_same_message): Latest re-delivers the cached message (true),
-// Newest only delivers a message that is new since the last take (false).
-template <typename MessageT, template <typename> class PollingPolicy>
-inline constexpr bool polling_default_allow_same_message_v =
-  !std::is_same_v<PollingPolicy<MessageT>, polling_policy::Newest<MessageT>>;
-
-// The wrapper's PollingSubscriber interface returns a single message from take_data(), so the
-// All policy (which yields a std::vector in InterProcessPollingSubscriber, and has no equivalent
-// in agnocast's native polling subscriber) cannot be represented. Reject it at compile time.
-template <typename MessageT, template <typename> class PollingPolicy>
-inline constexpr bool polling_policy_supported_v =
-  !std::is_same_v<PollingPolicy<MessageT>, polling_policy::All<MessageT>>;
-
-template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
-class PollingSubscriber
-{
-public:
-  static_assert(
-    polling_policy_supported_v<MessageT, PollingPolicy>,
-    "polling_policy::All is not supported by autoware::agnocast_wrapper::create_polling_subscriber "
-    "(take_data() returns a single message, not a vector). Use polling_policy::Latest or "
-    "polling_policy::Newest.");
-
-  using SharedPtr = std::shared_ptr<PollingSubscriber<MessageT, PollingPolicy>>;
-
-  static constexpr bool default_allow_same_message =
-    polling_default_allow_same_message_v<MessageT, PollingPolicy>;
-
-  virtual ~PollingSubscriber() = default;
-
-  virtual AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)
-    takeData(bool allow_same_message = default_allow_same_message) = 0;
-  virtual AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)
-    take_data(bool allow_same_message = default_allow_same_message) = 0;
-};
-
-template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
-class AgnocastPollingSubscriber : public PollingSubscriber<MessageT, PollingPolicy>
-{
-  typename agnocast::TakeSubscription<MessageT>::SharedPtr subscriber_;
-
-  static constexpr bool default_allow_same_message =
-    polling_default_allow_same_message_v<MessageT, PollingPolicy>;
-
-public:
-  template <typename NodeT>
-  explicit AgnocastPollingSubscriber(
-    NodeT * node, const std::string & topic_name, const rclcpp::QoS & qos)
-  : subscriber_(std::make_shared<agnocast::TakeSubscription<MessageT>>(node, topic_name, qos))
-  {
-  }
-
-  AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)
-  takeData(bool allow_same_message = default_allow_same_message) override
-  {
-    auto data = subscriber_->take(allow_same_message);
-    return AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)(std::move(data));
-  }
-
-  AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)
-  take_data(bool allow_same_message = default_allow_same_message) override
-  {
-    auto data = subscriber_->take(allow_same_message);
-    return AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)(std::move(data));
-  }
-};
-
-template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
-class ROS2PollingSubscriber : public PollingSubscriber<MessageT, PollingPolicy>
-{
-  typename autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT, PollingPolicy>::SharedPtr
-    subscriber_;
-
-  static constexpr bool default_allow_same_message =
-    polling_default_allow_same_message_v<MessageT, PollingPolicy>;
-
-  AUTOWARE_MESSAGE_SHARED_PTR(const MessageT) take_data_impl(bool allow_same_message)
-  {
-    (void)allow_same_message;
-    return AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)(std::move(subscriber_->take_data()));
-  }
-
-public:
-  explicit ROS2PollingSubscriber(
-    rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos)
-  : subscriber_(
-      autoware_utils_rclcpp::InterProcessPollingSubscriber<
-        MessageT, PollingPolicy>::create_subscription(node, topic_name, qos))
-  {
-  }
-
-  AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)
-  takeData(bool allow_same_message = default_allow_same_message) override
-  {
-    return take_data_impl(allow_same_message);
-  }
-
-  AUTOWARE_MESSAGE_SHARED_PTR(const MessageT)
-  take_data(bool allow_same_message = default_allow_same_message) override
-  {
-    return take_data_impl(allow_same_message);
-  }
-};
-
-template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
-typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_subscriber(
-  rclcpp::Node * node, const std::string & topic_name, const size_t qos_history_depth)
-{
-  if (use_agnocast()) {
-    return std::make_shared<AgnocastPollingSubscriber<MessageT, PollingPolicy>>(
-      node, topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)));
-  } else {
-    return std::make_shared<ROS2PollingSubscriber<MessageT, PollingPolicy>>(
-      node, topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)));
-  }
-}
-
-template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
-typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_subscriber(
-  rclcpp::Node * node, const std::string & topic_name, const rclcpp::QoS & qos = rclcpp::QoS{1})
-{
-  if (use_agnocast()) {
-    return std::make_shared<AgnocastPollingSubscriber<MessageT, PollingPolicy>>(
-      node, topic_name, qos);
-  } else {
-    return std::make_shared<ROS2PollingSubscriber<MessageT, PollingPolicy>>(node, topic_name, qos);
   }
 }
 
@@ -1338,8 +1195,6 @@ inline void set_period(const Timer::SharedPtr & timer, std::chrono::nanoseconds 
 #define AUTOWARE_CLIENT_RESPONSE_PTR(ServiceT) std::shared_ptr<const typename ServiceT::Response>
 #define AUTOWARE_SUBSCRIPTION_PTR(MessageT) typename rclcpp::Subscription<MessageT>::SharedPtr
 #define AUTOWARE_PUBLISHER_PTR(MessageT) typename rclcpp::Publisher<MessageT>::SharedPtr
-#define AUTOWARE_POLLING_SUBSCRIBER_PTR(...) \
-  typename autoware_utils_rclcpp::InterProcessPollingSubscriber<__VA_ARGS__>::SharedPtr
 #define AUTOWARE_CLIENT_PTR(ServiceT) \
   typename autoware::agnocast_wrapper::Client<ServiceT>::SharedPtr
 #define AUTOWARE_SERVICE_PTR(ServiceT) \
@@ -1367,13 +1222,6 @@ inline void set_period(const Timer::SharedPtr & timer, std::chrono::nanoseconds 
   node->create_publisher<message_type>(arg1, arg2)
 #define AUTOWARE_CREATE_PUBLISHER3_ON_NODE(message_type, node, arg1, arg2, arg3) \
   node->create_publisher<message_type>(arg1, arg2, arg3)
-
-#define AUTOWARE_CREATE_POLLING_SUBSCRIBER(message_type, policy, topic, qos)                       \
-  autoware_utils_rclcpp::InterProcessPollingSubscriber<message_type, policy>::create_subscription( \
-    this, topic, qos)
-#define AUTOWARE_CREATE_POLLING_SUBSCRIBER_ON_NODE(message_type, policy, node, topic, qos)         \
-  autoware_utils_rclcpp::InterProcessPollingSubscriber<message_type, policy>::create_subscription( \
-    node, topic, qos)
 
 #define AUTOWARE_CREATE_CLIENT1(service_type, service_name) \
   autoware::agnocast_wrapper::create_client<service_type>(this, service_name)
@@ -1634,10 +1482,6 @@ create_service(
 
 namespace autoware::agnocast_wrapper
 {
-
-// Mirror the Agnocast-build alias so node code can name the polling policy the same way in both
-// builds (e.g. autoware::agnocast_wrapper::polling_policy::Newest).
-namespace polling_policy = autoware_utils_rclcpp::polling_policy;
 
 /// @brief Set the timer period (non-Agnocast build).
 ///

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -246,32 +246,6 @@ public:
       options);
   }
 
-  // ===== Polling Subscriber =====
-  template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
-  typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_subscriber(
-    const std::string & topic_name, const rclcpp::QoS & qos = rclcpp::QoS{1})
-  {
-    return visit_node(
-      [&](auto & n) -> typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr {
-        using NodeT = std::decay_t<decltype(*n)>;
-        if constexpr (std::is_same_v<NodeT, agnocast::Node>) {
-          return std::make_shared<AgnocastPollingSubscriber<MessageT, PollingPolicy>>(
-            n.get(), topic_name, qos);
-        } else {
-          return std::make_shared<ROS2PollingSubscriber<MessageT, PollingPolicy>>(
-            n.get(), topic_name, qos);
-        }
-      });
-  }
-
-  template <typename MessageT, template <typename> class PollingPolicy = polling_policy::Latest>
-  typename PollingSubscriber<MessageT, PollingPolicy>::SharedPtr create_polling_subscriber(
-    const std::string & topic_name, size_t qos_history_depth)
-  {
-    return create_polling_subscriber<MessageT, PollingPolicy>(
-      topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)));
-  }
-
   // ===== Client / Service =====
   template <typename ServiceT>
   AUTOWARE_CLIENT_PTR(ServiceT)
@@ -693,34 +667,6 @@ public:
     return node_->create_subscription<MessageT>(
       topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)), std::forward<Func>(callback),
       options);
-  }
-
-  // ===== Polling Subscriber =====
-  template <
-    typename MessageT,
-    template <typename> class PollingPolicy = autoware_utils_rclcpp::polling_policy::Latest>
-  typename autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT, PollingPolicy>::SharedPtr
-  create_polling_subscriber(
-    const std::string & topic_name, const rclcpp::QoS & qos = rclcpp::QoS{1})
-  {
-    static_assert(
-      !std::is_same_v<
-        PollingPolicy<MessageT>, autoware_utils_rclcpp::polling_policy::All<MessageT>>,
-      "polling_policy::All is not supported by "
-      "autoware::agnocast_wrapper::Node::create_polling_subscriber; use polling_policy::Latest or "
-      "polling_policy::Newest (or use InterProcessPollingSubscriber directly for the All policy).");
-    return autoware_utils_rclcpp::InterProcessPollingSubscriber<
-      MessageT, PollingPolicy>::create_subscription(node_.get(), topic_name, qos);
-  }
-
-  template <
-    typename MessageT,
-    template <typename> class PollingPolicy = autoware_utils_rclcpp::polling_policy::Latest>
-  typename autoware_utils_rclcpp::InterProcessPollingSubscriber<MessageT, PollingPolicy>::SharedPtr
-  create_polling_subscriber(const std::string & topic_name, size_t qos_history_depth)
-  {
-    return create_polling_subscriber<MessageT, PollingPolicy>(
-      topic_name, rclcpp::QoS(rclcpp::KeepLast(qos_history_depth)));
   }
 
   // ===== Client =====


### PR DESCRIPTION
## Description

Remove the old polling-subscriber API from `autoware_agnocast_wrapper`, now that its consumers have migrated to the new `autoware::agnocast_wrapper::polling::` free-function API (in `polling_subscriber.hpp`).

Deleted from `autoware_agnocast_wrapper.hpp` (both `ENABLE_AGNOCAST=0` and `=1`): the `AUTOWARE_POLLING_SUBSCRIBER_PTR` / `AUTOWARE_CREATE_POLLING_SUBSCRIBER[_ON_NODE]` macros, the `PollingSubscriber` / `AgnocastPollingSubscriber` / `ROS2PollingSubscriber` classes and their `create_polling_subscriber` free functions, and the `polling_policy` namespace aliases. Deleted from `node.hpp`: the `create_polling_subscriber` member methods.

As a result, `autoware_utils_rclcpp` is now included only by `polling_subscriber.hpp`; code that includes just `node.hpp` / the umbrella header no longer pulls it in. The package-level `autoware_utils_rclcpp` dependency stays because `polling_subscriber.hpp` is a public installed header. Pure refactor, no behavior change.

## Related links

**Parent Issue:**

- None.

## How was this PR tested?

Built `autoware_agnocast_wrapper` with both `ENABLE_AGNOCAST=0` and `=1`, and built a new-API consumer (`autoware_lane_departure_checker`) with `ENABLE_AGNOCAST=0`.

## Notes for reviewers

This PR removes the old API, so it is safe to merge only after all of its consumers in `autoware_universe` have migrated to the new `polling::` API. Those migrations are tracked by the following PRs; this PR becomes mergeable once they are all merged:

- autowarefoundation/autoware_universe#13034 — `autoware_lane_departure_checker` (merged)
- autowarefoundation/autoware_universe#13032 — `autoware_collision_detector`
- autowarefoundation/autoware_universe#13033 — `autoware_control_evaluator`
- autowarefoundation/autoware_universe#13035 — `autoware_planning_evaluator`
- autowarefoundation/autoware_universe#13036 — `autoware_map_based_prediction`

## Interface changes

None.

## Effects on system behavior

None.