### PR TITLE
refactor(pointcloud_map_loader): move first segment to avoid a full-cloud copy

### DIFF
--- a/map/autoware_map_loader/src/pointcloud_map_loader/pointcloud_map_loader.cpp
+++ b/map/autoware_map_loader/src/pointcloud_map_loader/pointcloud_map_loader.cpp
@@ -24,6 +24,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::map_loader
@@ -86,7 +87,7 @@ sensor_msgs::msg::PointCloud2 load_pointcloud_map(
     }
 
     if (whole_pcd.width == 0) {
-      whole_pcd = partial_pcd;
+      whole_pcd = std::move(partial_pcd);
     } else {
       whole_pcd.width += partial_pcd.width;
       whole_pcd.row_step += partial_pcd.row_step;


### PR DESCRIPTION
## Description

`load_pointcloud_map()` assembled the first PCD segment with `whole_pcd = partial_pcd`, which copies the entire cloud. `partial_pcd` is a loop-local that is re-created on the next iteration, so it can be moved instead of copied. For single-file maps this removes a full-map copy; for multi-file maps it removes the first-segment copy. Pure refactor, no behavior change.

## Related links

None.

## How was this PR tested?

`colcon build` with `ENABLE_AGNOCAST=0`. The `pointcloud_map_loader` module unit tests (`test_pointcloud_map_loader`, `test_partial_map_loader`, `test_differential_map_loader`, `test_selected_map_loader`) pass.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
