### PR TITLE
ci(build-test-tidy-pr): ignore nested markdown files in the build gate

### DIFF
--- a/.github/workflows/build-test-tidy-pr.yaml
+++ b/.github/workflows/build-test-tidy-pr.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           since_last_remote_commit: true
           files_ignore: |
-            **.md
+            **/*.md
             **/CODEOWNERS
             **/CODEOWNERS-manual
 


### PR DESCRIPTION
## Description

`check_if_relevant_files_changed` is meant to skip the build/test/clang-tidy matrix for docs-only PRs, but its ignore glob `**.md` does not match Markdown files inside directories, so those PRs still run the full matrix. `autowarefoundation/autoware` already uses `**/*.md` in the equivalent gate (`.github/workflows/health-check-pr.yaml`).

## Related links

- #1291 — a docs-only PR that ran the full matrix because of this

## How was this PR tested?

Not yet — this PR changes a workflow file, so the gate correctly treats it as relevant. A subsequent docs-only PR should log `⏭️ No relevant changes detected.` and skip the matrix.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None at runtime. Docs-only PRs will skip `build-and-test-diff-*` and `clang-tidy-diff`; GitHub treats skipped required checks as passing, so they stay mergeable.
