### PR TITLE
docs(autoware_component_interface_utils): add README lost in the move to core

### DIFF
--- a/common/autoware_component_interface_utils/README.md
+++ b/common/autoware_component_interface_utils/README.md
@@ -1,0 +1,131 @@
+# autoware_component_interface_utils
+
+## Features
+
+This is a utility package that provides the following features:
+
+- Instantiation of the wrapper class
+- Opt-in service introspection for service and client
+- Service exception for response
+- Relays for topic and service
+
+## Design
+
+This package provides the wrappers for the interface classes of rclcpp.
+The wrappers limit the usage of the original class to enforce the processing recommended by the component interface.
+Do not inherit the class of rclcpp, and forward or wrap the member function that is allowed to be used.
+
+## Instantiation of the wrapper class
+
+The wrapper class requires interface information in this format.
+
+```cpp
+struct SampleService
+{
+  using Service = sample_msgs::srv::ServiceType;
+  static constexpr char name[] = "/sample/service";
+};
+
+struct SampleMessage
+{
+  using Message = sample_msgs::msg::MessageType;
+  static constexpr char name[] = "/sample/message";
+  static constexpr size_t depth = 1;
+  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+};
+```
+
+Create the wrapper using the above definition as follows.
+
+```cpp
+// header file
+autoware::component_interface_utils::Service<SampleService>::SharedPtr srv_;
+autoware::component_interface_utils::Client<SampleService>::SharedPtr cli_;
+autoware::component_interface_utils::Publisher<SampleMessage>::SharedPtr pub_;
+autoware::component_interface_utils::Subscription<SampleMessage>::SharedPtr sub_;
+
+// source file
+const auto node = autoware::component_interface_utils::NodeAdaptor(this);
+node.init_srv(srv_, callback);
+node.init_cli(cli_);
+node.init_pub(pub_);
+node.init_sub(sub_, callback);
+```
+
+The adaptor also provides returning forms that take the specification as an explicit template argument instead of deducing it from the output variable.
+They create the same wrappers as the `init_*` methods, so the two styles can be mixed.
+These are non-const member functions, so the adaptor must not be declared `const` when they are used.
+
+```cpp
+// source file
+auto node = autoware::component_interface_utils::NodeAdaptor(this);
+srv_ = node.create_service<SampleService>(callback);
+cli_ = node.create_client<SampleService>();
+pub_ = node.create_publisher<SampleMessage>();
+sub_ = node.create_subscription<SampleMessage>(callback);
+```
+
+## Opt-in service introspection for service and client
+
+This package does not trace service calls by itself.
+What it provides is a single node-scoped switch that turns on the standard [ROS 2 service introspection](https://docs.ros.org/en/jazzy/Tutorials/Demos/Service-Introspection.html) for every wrapper of that node, so the wrappers do not have to be configured one by one.
+Each node that creates wrappers through `NodeAdaptor` declares the following parameter, and its value is applied to all the `Service` and `Client` wrappers that the adaptor creates.
+
+| Name                                        | Type     | Default | Description                                                                       |
+| ------------------------------------------- | -------- | ------- | --------------------------------------------------------------------------------- |
+| `component_interface.service_introspection` | `string` | `off`   | Introspection mode of the service wrappers. One of `off`, `metadata`, `contents`. |
+
+Introspection is disabled by default, so nothing is recorded unless the parameter is set.
+When the mode is not `off`, each wrapper exposes the service event topic `<service name>/_service_event`, which is `/sample/service/_service_event` for the specification above.
+The `metadata` mode records the event types and timestamps, and the `contents` mode also records the request and response contents.
+
+Service introspection requires ROS 2 Iron (rclcpp 21) or later.
+On ROS 2 Humble the parameter is not declared and the wrappers are created without introspection.
+
+The `autoware_universe` version of this package published a `tier4_system_msgs/ServiceLog` message on a single `/service_log` topic for every request, response and error, and that tracer is not part of this package.
+Service introspection is not a drop-in replacement for it: the events are published per service instead of being aggregated on one topic, they use the event types that ROS 2 generates instead of `tier4_system_msgs/ServiceLog`, and they are off unless enabled.
+An unready service and a service timeout are still reported by `Client::call` as the `ServiceUnready` and `ServiceTimeout` exceptions.
+
+## Service exception for response
+
+If the wrapper class is used and the service response has status, throwing `ServiceException` will automatically catch and set it to status.
+This is useful when returning an error from a function called from the service callback.
+
+```cpp
+void service_callback(Request req, Response res)
+{
+   function();
+   res->status.success = true;
+}
+
+void function()
+{
+   throw ServiceException(ERROR_CODE, "message");
+}
+```
+
+If the wrapper class is not used or the service response has no status, manually catch the `ServiceException` as follows.
+
+```cpp
+void service_callback(Request req, Response res)
+{
+   try {
+      function();
+      res->status.success = true;
+   } catch (const ServiceException & error) {
+      res->status = error.status();
+   }
+}
+```
+
+## Relays for topic and service
+
+There are utilities for relaying services and messages of the same type.
+
+```cpp
+const auto node = autoware::component_interface_utils::NodeAdaptor(this);
+service_callback_group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+node.relay_message(pub_, sub_);
+node.relay_service(cli_, srv_, service_callback_group_);  // group is for avoiding deadlocks
+```


### PR DESCRIPTION
## Description

Restores the `autoware_component_interface_utils` README, which was lost when the package was moved from `autoware_universe` to `autoware_core`.

`common/autoware_component_interface_utils/README.md` existed in `autoware_universe` and was removed there by autowarefoundation/autoware_universe#13002, but it was not among the files added by #1262 — so the package currently has no docs page. Reported by @Koichi98 in https://github.com/autowarefoundation/autoware_core/pull/1262#issuecomment-5097987952. The README was not intentionally dropped; it was an oversight in the move.

The file is restored with its content updated for the moved implementation rather than copied verbatim:

- **"Logging for service and client" dropped.** The core version carries no `/service_log` tracer, so the section no longer describes this package: the `autoware_universe` wrappers published a `tier4_system_msgs/ServiceLog` message unconditionally for every request, response and error, and that is gone. The section was also already stale in `autoware_universe` — it claimed the log level was `RCLCPP_INFO`, while `NodeInterface::log` used `RCLCPP_DEBUG_STREAM` — which is a further reason not to port it verbatim.
- **"Opt-in service introspection for service and client" added in its place, deliberately without overstating it.** Service introspection is a standard ROS 2 feature, not something this package implements; what the package provides is a single node-scoped switch — the `component_interface.service_introspection` parameter (`off` / `metadata` / `contents`, default `off`) — that applies it to every `Service` / `Client` wrapper the adaptor creates, so they need not be configured one by one. The section states that introspection is **off by default** (unlike the always-on `/service_log`), documents the resulting `<service name>/_service_event` topic and the ROS 2 Iron (rclcpp 21) requirement — it is unavailable on Humble, where the parameter is not declared — and says explicitly that introspection is **not a drop-in replacement** for `/service_log`: events are per-service rather than aggregated on one topic, use the event types ROS 2 generates rather than `tier4_system_msgs/ServiceLog`, and are off unless enabled.
- **Returning `NodeAdaptor` API documented.** The `create_publisher` / `create_subscription` / `create_service` / `create_client<Spec>()` forms added in #1262 are described alongside the existing `init_*` methods, including the fact that they are non-`const`, so the adaptor cannot be declared `const` when they are used.
- **Service log removal called out explicitly**, since consumers migrating from `autoware_universe` need to know: an unready service and a timeout are still surfaced as the `ServiceUnready` / `ServiceTimeout` exceptions thrown by `Client::call`.

The "Design", "Instantiation of the wrapper class", "Service exception for response" and "Relays for topic and service" sections are unchanged from the `autoware_universe` original, because the corresponding code moved verbatim.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

Context:

- https://github.com/autowarefoundation/autoware_core/pull/1262#issuecomment-5097987952 — the review comment this PR addresses.
- #1262 — the move of the package into `autoware_core`, which this README belongs to.
- autowarefoundation/autoware_universe#13002 — the `autoware_universe` removal that deleted the original file.

## How was this PR tested?

Documentation only; there are no code changes, so there is nothing to build or run. Verification was therefore against the merged sources and the doc toolchain:

- `pre-commit run --files common/autoware_component_interface_utils/README.md` passes — `markdownlint`, `prettier`, and the end-of-file / trailing-whitespace / mixed-line-ending hooks.
- Every factual statement was checked against the code merged in #1262: the parameter name, its `off` / `metadata` / `contents` values and `off` default against `rclcpp/interface.hpp`; the `<service name>/_service_event` topic name against `rclcpp/service_server.hpp`, `rclcpp/service_client.hpp` and the package's gtest cases; the returning `create_*<Spec>()` signatures, their return types and their non-`const`-ness against `rclcpp.hpp`; the `ServiceUnready` / `ServiceTimeout` throw sites against `Client::call`.
- The removed-logging claims were checked against the `autoware_universe` sources at the commit before autowarefoundation/autoware_universe#13002, to confirm what the wrappers actually used to do (`NodeInterface::log` publishing `tier4_system_msgs/ServiceLog` on `/service_log` plus an `RCLCPP_DEBUG_STREAM`) rather than trusting the old README's own description of it.
- The new external link resolves — `https://docs.ros.org/en/jazzy/Tutorials/Demos/Service-Introspection.html` returns HTTP 200.
- The `build-test-tidy-pr` build gate does not exercise this PR by design: `check_if_relevant_files_changed` lists `**/*.md` under `files_ignore`, so a docs-only change skips the build / test / clang-tidy jobs. There is consequently no fork build-and-test run to cite for this change.

## Notes for reviewers

No nav change is needed for the docs site: `mkdocs.yaml` uses the `awesome-pages` and `same-dir` plugins, so a package `README.md` becomes its docs page automatically, the same way the other `common/*` package READMEs do.

## Interface changes

None. The `component_interface.service_introspection` parameter was introduced by #1262 and is already documented in that PR's interface-changes table; this PR only adds the package-level documentation for it.

## Effects on system behavior

None.
