### PR TITLE
fix(autoware_ekf_localizer): do not ignore Kalman update failures

### DIFF
--- a/common/autoware_kalman_filter/include/autoware/kalman_filter/kalman_filter.hpp
+++ b/common/autoware_kalman_filter/include/autoware/kalman_filter/kalman_filter.hpp
@@ -142,7 +142,7 @@ public:
    * @param Q covariance matrix for process model
    * @return bool to check matrix operations are being performed properly
    */
-  bool predict(
+  [[nodiscard]] bool predict(
     const Eigen::MatrixXd & u, const Eigen::MatrixXd & A, const Eigen::MatrixXd & B,
     const Eigen::MatrixXd & Q);
 
@@ -154,7 +154,7 @@ public:
    * @param Q covariance matrix for process model
    * @return bool to check matrix operations are being performed properly
    */
-  bool predict(
+  [[nodiscard]] bool predict(
     const Eigen::MatrixXd & x_next, const Eigen::MatrixXd & A, const Eigen::MatrixXd & Q);
 
   /**
@@ -164,7 +164,7 @@ public:
    * @param A coefficient matrix of x for process model
    * @return bool to check matrix operations are being performed properly
    */
-  bool predict(const Eigen::MatrixXd & x_next, const Eigen::MatrixXd & A);
+  [[nodiscard]] bool predict(const Eigen::MatrixXd & x_next, const Eigen::MatrixXd & A);
 
   /**
    * @brief calculate kalman filter state by prediction model with A, B and Q being class member
@@ -172,7 +172,7 @@ public:
    * @param u input for the model
    * @return bool to check matrix operations are being performed properly
    */
-  bool predict(const Eigen::MatrixXd & u);
+  [[nodiscard]] bool predict(const Eigen::MatrixXd & u);
 
   /**
    * @brief calculate kalman filter state by measurement model with y_pred, C and R matrix. This is
@@ -183,7 +183,7 @@ public:
    * @param R covariance matrix for measurement model
    * @return bool to check matrix operations are being performed properly
    */
-  bool update(
+  [[nodiscard]] bool update(
     const Eigen::MatrixXd & y, const Eigen::MatrixXd & y_pred, const Eigen::MatrixXd & C,
     const Eigen::MatrixXd & R);
 
@@ -195,7 +195,8 @@ public:
    * @param R covariance matrix for measurement model
    * @return bool to check matrix operations are being performed properly
    */
-  bool update(const Eigen::MatrixXd & y, const Eigen::MatrixXd & C, const Eigen::MatrixXd & R);
+  [[nodiscard]] bool update(
+    const Eigen::MatrixXd & y, const Eigen::MatrixXd & C, const Eigen::MatrixXd & R);
 
   /**
    * @brief calculate kalman filter state by measurement model with C and R being class member
@@ -203,7 +204,7 @@ public:
    * @param y measured values
    * @return bool to check matrix operations are being performed properly
    */
-  bool update(const Eigen::MatrixXd & y);
+  [[nodiscard]] bool update(const Eigen::MatrixXd & y);
 
 protected:
   Eigen::MatrixXd x_;  //!< @brief current estimated state

--- a/common/autoware_kalman_filter/include/autoware/kalman_filter/time_delay_kalman_filter.hpp
+++ b/common/autoware_kalman_filter/include/autoware/kalman_filter/time_delay_kalman_filter.hpp
@@ -73,7 +73,7 @@ public:
    * @param Q covariance matrix for process model
    * @return bool to check matrix operations are being performed properly
    */
-  bool predictWithDelay(
+  [[nodiscard]] bool predictWithDelay(
     const Eigen::MatrixXd & x_next, const Eigen::MatrixXd & A, const Eigen::MatrixXd & Q);
 
   /**
@@ -85,7 +85,7 @@ public:
    * @param delay_step measurement delay
    * @return bool to check matrix operations are being performed properly
    */
-  bool updateWithDelay(
+  [[nodiscard]] bool updateWithDelay(
     const Eigen::MatrixXd & y, const Eigen::MatrixXd & C, const Eigen::MatrixXd & R,
     const int delay_step);
 

--- a/localization/autoware_ekf_localizer/src/ekf_module.cpp
+++ b/localization/autoware_ekf_localizer/src/ekf_module.cpp
@@ -232,7 +232,10 @@ void EKFModule::predict_with_delay(const double dt)
   const Vector6d x_next = predict_next_state(x_curr, dt);
   const Matrix6d a = create_state_transition_matrix(x_curr, dt);
   const Matrix6d q = process_noise_covariance(proc_cov_yaw_d, proc_cov_vx_d, proc_cov_wz_d);
-  kalman_filter_.predictWithDelay(x_next, a, q);
+  if (!kalman_filter_.predictWithDelay(x_next, a, q)) {
+    warning_->warn_throttle("Kalman filter prediction failed.", 2000);
+    return;
+  }
   ekf_dt_ = dt;
 }
 
@@ -318,7 +321,10 @@ bool EKFModule::measurement_update_pose(
   const Eigen::Matrix3d r =
     pose_measurement_covariance(pose.pose.covariance, params_.pose_smoothing_steps);
 
-  kalman_filter_.updateWithDelay(y, c, r, static_cast<int>(delay_step));
+  if (!kalman_filter_.updateWithDelay(y, c, r, static_cast<int>(delay_step))) {
+    warning_->warn_throttle("Kalman filter update failed. Ignore the measurement data.", 2000);
+    return false;
+  }
 
   // Update Simple 1D filter with considering change of roll, pitch and height (position z)
   // values due to measurement pose delay
@@ -441,7 +447,10 @@ bool EKFModule::measurement_update_twist(
   const Eigen::Matrix2d r =
     twist_measurement_covariance(twist.twist.covariance, params_.twist_smoothing_steps);
 
-  kalman_filter_.updateWithDelay(y, c, r, static_cast<int>(delay_step));
+  if (!kalman_filter_.updateWithDelay(y, c, r, static_cast<int>(delay_step))) {
+    warning_->warn_throttle("Kalman filter update failed. Ignore the measurement data.", 2000);
+    return false;
+  }
 
   last_angular_velocity_ = tf2::Vector3(
     twist.twist.twist.angular.x, twist.twist.twist.angular.y, twist.twist.twist.angular.z);

--- a/localization/autoware_ekf_localizer/test/test_ekf_module.cpp
+++ b/localization/autoware_ekf_localizer/test/test_ekf_module.cpp
@@ -430,6 +430,39 @@ TEST_F(MeasurementUpdatePose, RejectsOnMahalanobisGate)
   EXPECT_GT(diag.mahalanobis_distance, 0.0);
 }
 
+TEST_F(MeasurementUpdatePose, RejectsOnKalmanUpdateFailure)
+{
+  using COV_IDX = autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+  const rclcpp::Time t_curr(100, 0, RCL_ROS_TIME);
+
+  // A NaN in the measurement covariance passes the delay, NaN/Inf (measurement vector only) and
+  // Mahalanobis (EKF covariance only) gates, but makes the Kalman gain non-finite inside
+  // updateWithDelay, so the update itself fails and must be treated as no update.
+  auto pose = make_pose(1.0, 2.0, 0.0, "map", t_curr);
+  pose.pose.covariance[COV_IDX::X_X] = std::numeric_limits<double>::quiet_NaN();
+
+  const auto pose_before = module_->get_current_pose(t_curr, false);
+  const auto cov_before = module_->get_current_pose_covariance();
+
+  EKFDiagnosticInfo diag;
+  const bool ok = module_->measurement_update_pose(pose, t_curr, diag);
+
+  EXPECT_FALSE(ok);
+  // The failure happens after the gates, so both gates are still marked passed.
+  EXPECT_TRUE(diag.is_passed_delay_gate);
+  EXPECT_TRUE(diag.is_passed_mahalanobis_gate);
+
+  // The rejected measurement must leave the state and covariance untouched.
+  const auto pose_after = module_->get_current_pose(t_curr, false);
+  EXPECT_DOUBLE_EQ(pose_after.pose.position.x, pose_before.pose.position.x);
+  EXPECT_DOUBLE_EQ(pose_after.pose.position.y, pose_before.pose.position.y);
+  EXPECT_DOUBLE_EQ(pose_after.pose.position.z, pose_before.pose.position.z);
+  const auto cov_after = module_->get_current_pose_covariance();
+  EXPECT_DOUBLE_EQ(cov_after[COV_IDX::X_X], cov_before[COV_IDX::X_X]);
+  EXPECT_DOUBLE_EQ(cov_after[COV_IDX::Y_Y], cov_before[COV_IDX::Y_Y]);
+  EXPECT_DOUBLE_EQ(cov_after[COV_IDX::YAW_YAW], cov_before[COV_IDX::YAW_YAW]);
+}
+
 // ---------------------------------------------------------------------------
 // measurement_update_twist: success and safety-critical rejection branches
 // ---------------------------------------------------------------------------
@@ -544,6 +577,37 @@ TEST_F(MeasurementUpdateTwist, RejectsOnMahalanobisGate)
   EXPECT_TRUE(diag.is_passed_delay_gate);
   EXPECT_FALSE(diag.is_passed_mahalanobis_gate);
   EXPECT_GT(diag.mahalanobis_distance, 0.0);
+}
+
+TEST_F(MeasurementUpdateTwist, RejectsOnKalmanUpdateFailure)
+{
+  using COV_IDX = autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+  const rclcpp::Time t_curr(100, 0, RCL_ROS_TIME);
+
+  // A NaN in the measurement covariance passes the delay, NaN/Inf (measurement vector only) and
+  // Mahalanobis (EKF covariance only) gates, but makes the Kalman gain non-finite inside
+  // updateWithDelay, so the update itself fails and must be treated as no update.
+  auto twist = make_twist(3.0, 1.0, "base_link", t_curr);
+  twist.twist.covariance[COV_IDX::X_X] = std::numeric_limits<double>::quiet_NaN();
+
+  const auto twist_before = module_->get_current_twist(t_curr);
+  const auto cov_before = module_->get_current_twist_covariance();
+
+  EKFDiagnosticInfo diag;
+  const bool ok = module_->measurement_update_twist(twist, t_curr, diag);
+
+  EXPECT_FALSE(ok);
+  // The failure happens after the gates, so both gates are still marked passed.
+  EXPECT_TRUE(diag.is_passed_delay_gate);
+  EXPECT_TRUE(diag.is_passed_mahalanobis_gate);
+
+  // The rejected measurement must leave the state and covariance untouched.
+  const auto twist_after = module_->get_current_twist(t_curr);
+  EXPECT_DOUBLE_EQ(twist_after.twist.linear.x, twist_before.twist.linear.x);
+  EXPECT_DOUBLE_EQ(twist_after.twist.angular.z, twist_before.twist.angular.z);
+  const auto cov_after = module_->get_current_twist_covariance();
+  EXPECT_DOUBLE_EQ(cov_after[COV_IDX::X_X], cov_before[COV_IDX::X_X]);
+  EXPECT_DOUBLE_EQ(cov_after[COV_IDX::YAW_YAW], cov_before[COV_IDX::YAW_YAW]);
 }
 
 }  // namespace autoware::ekf_localizer


### PR DESCRIPTION
## Description

EKFModule discarded the bool returned by
TimeDelayKalmanFilter::updateWithDelay in both measurement_update_pose and measurement_update_twist. When the update failed internally (e.g. a non-positive-definite innovation covariance rejected by the LLT decomposition, or a non-finite Kalman gain), the measurement was still reported as successfully fused: the state silently stopped being corrected while the no_update_count diagnostics kept reporting healthy updates, hiding the stall from monitoring.

Treat an updateWithDelay failure the same way as the existing delay-gate / NaN / Mahalanobis-gate rejections: warn and return false, so the caller's no_update_count diagnostics reflect the missed update. Handle the previously discarded predictWithDelay return in predict_with_delay the same way, and mark the bool-returning predict*/update* methods of KalmanFilter and TimeDelayKalmanFilter as [[nodiscard]] so future callers cannot silently drop a failure.

Add unit tests covering the reachable failure path for both pose and twist: a NaN in the measurement covariance passes the delay, NaN/Inf (measurement vector only) and Mahalanobis (EKF covariance only) gates but fails inside updateWithDelay; the update must return false and leave the state and covariance untouched.

## Related links

**Parent Issue:**

- None

## How was this PR tested?

- `colcon build --packages-select autoware_kalman_filter autoware_ekf_localizer --cmake-args -DCMAKE_BUILD_TYPE=Release` — builds cleanly with zero warnings (in particular, zero `[[nodiscard]]`/unused-result warnings, confirming no remaining call site discards a filter result).
- `colcon test --packages-select autoware_kalman_filter autoware_ekf_localizer`:
  - `autoware_kalman_filter`: 42 tests, 0 failures.
  - `autoware_ekf_localizer`: 160 tests, 0 failures, including the two new failure-path tests
    `MeasurementUpdatePose.RejectsOnKalmanUpdateFailure` and
    `MeasurementUpdateTwist.RejectsOnKalmanUpdateFailure` (assert `false` is returned, both
    gate diagnostic flags stay `true`, and state/covariance are unchanged), plus the launch test.
- Caller audit: `autoware_ekf_localizer` is the only in-tree consumer of `autoware_kalman_filter`;
  the three fixed call sites were the only ones ignoring a return value.

## Notes for reviewers

- `predictWithDelay` currently always returns `true`, so the new early-return in
  `predict_with_delay` is presently unreachable; it is required once the method is
  `[[nodiscard]]` and guards against future failure modes.
- The `[[nodiscard]]` annotations will surface any out-of-tree caller that discards a
  filter result as a compile-time warning. This is intentional.

## Interface changes

None. (`[[nodiscard]]` on existing `bool`-returning methods is source-compatible; no topic or parameter changes.)

## Effects on system behavior

When an internal Kalman update failure occurs, the affected measurement is now counted as
not fused, so the pose/twist `no_update_count` diagnostics can raise WARN/ERROR instead of
silently reporting healthy updates, and a throttled warning is logged. Behavior on the
normal (successful-update) path is unchanged.