### PR TITLE
feat(autoware_component_interface_specs): register and version the perception boundary specs

### DIFF
--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/perception.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/perception.hpp
@@ -18,8 +18,8 @@
 #include <autoware/component_interface_specs/utils.hpp>
 #include <autoware/component_interface_specs/version.hpp>
 
-#include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 
 #include <rmw/qos_profiles.h>
@@ -45,17 +45,17 @@ struct TrafficSignals  // new spec (safety dependency; canonical = producer name
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
 };
 
-struct DetectedObjects  // new spec - sanctioned pre-tracking detection boundary
+struct TrackedObjects  // new spec (tracking-stage output read by a planning-side consumer)
 {
-  using Message = autoware_perception_msgs::msg::DetectedObjects;
-  static constexpr char name[] = "/perception/object_recognition/detection/objects";
+  using Message = autoware_perception_msgs::msg::TrackedObjects;
+  static constexpr char name[] = "/perception/object_recognition/tracking/objects";
   static constexpr size_t depth = 1;
   static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
 };
 
 AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(
-  0, 1, 0, ObjectRecognition, TrafficSignals, DetectedObjects)
+  0, 1, 0, ObjectRecognition, TrafficSignals, TrackedObjects)
 
 }  // namespace autoware::component_interface_specs::perception
 

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/perception.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/perception.hpp
@@ -18,7 +18,9 @@
 #include <autoware/component_interface_specs/utils.hpp>
 #include <autoware/component_interface_specs/version.hpp>
 
+#include <autoware_perception_msgs/msg/detected_objects.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 
 #include <rmw/qos_profiles.h>
 
@@ -34,7 +36,26 @@ struct ObjectRecognition
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
 };
 
-AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(0, 1, 0, ObjectRecognition)
+struct TrafficSignals  // new spec (safety dependency; canonical = producer name)
+{
+  using Message = autoware_perception_msgs::msg::TrafficLightGroupArray;
+  static constexpr char name[] = "/perception/traffic_light_recognition/traffic_signals";
+  static constexpr size_t depth = 1;
+  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+};
+
+struct DetectedObjects  // new spec - sanctioned pre-tracking detection boundary
+{
+  using Message = autoware_perception_msgs::msg::DetectedObjects;
+  static constexpr char name[] = "/perception/object_recognition/detection/objects";
+  static constexpr size_t depth = 1;
+  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+};
+
+AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(
+  0, 1, 0, ObjectRecognition, TrafficSignals, DetectedObjects)
 
 }  // namespace autoware::component_interface_specs::perception
 

--- a/common/autoware_component_interface_specs/interface_manifest.json
+++ b/common/autoware_component_interface_specs/interface_manifest.json
@@ -133,8 +133,8 @@
     },
     {
       "domain": "perception",
-      "interface": "/perception/object_recognition/detection/objects",
-      "type": "autoware_perception_msgs/msg/DetectedObjects",
+      "interface": "/perception/object_recognition/tracking/objects",
+      "type": "autoware_perception_msgs/msg/TrackedObjects",
       "kind": "topic",
       "version": "0.1.0",
       "qos": {

--- a/common/autoware_component_interface_specs/interface_manifest.json
+++ b/common/autoware_component_interface_specs/interface_manifest.json
@@ -119,6 +119,32 @@
       }
     },
     {
+      "domain": "perception",
+      "interface": "/perception/traffic_light_recognition/traffic_signals",
+      "type": "autoware_perception_msgs/msg/TrafficLightGroupArray",
+      "kind": "topic",
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
+    },
+    {
+      "domain": "perception",
+      "interface": "/perception/object_recognition/detection/objects",
+      "type": "autoware_perception_msgs/msg/DetectedObjects",
+      "kind": "topic",
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
+    },
+    {
       "domain": "planning",
       "interface": "/planning/set_lanelet_route",
       "type": "autoware_planning_msgs/srv/SetLaneletRoute",

--- a/common/autoware_component_interface_specs/test/spec_test_utils.hpp
+++ b/common/autoware_component_interface_specs/test/spec_test_utils.hpp
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 
 namespace autoware::component_interface_specs::test_utils
 {
@@ -32,6 +33,21 @@ template <typename T, typename Tuple>
 struct has_type;
 template <typename T, typename... Us>
 struct has_type<T, std::tuple<Us...>> : std::disjunction<std::is_same<T, Us>...>
+{
+};
+
+/// Mirror of universe's HasDomainVersion: a void_t/expression-SFINAE probe over the
+/// ADL-resolved resolve_domain_version(const Spec &). Downstream consumers use exactly
+/// this shape to decide whether a spec participates in versioned interface
+/// registration, so a domain can type-enforce that a deliberately unversioned spec
+/// fails version resolution, rather than merely being absent from the Specs tuple.
+template <class, class = void>
+struct has_domain_version : std::false_type
+{
+};
+template <class S>
+struct has_domain_version<
+  S, std::void_t<decltype(resolve_domain_version(std::declval<const S &>()))>> : std::true_type
 {
 };
 

--- a/common/autoware_component_interface_specs/test/spec_test_utils.hpp
+++ b/common/autoware_component_interface_specs/test/spec_test_utils.hpp
@@ -1,0 +1,60 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SPEC_TEST_UTILS_HPP_
+#define SPEC_TEST_UTILS_HPP_
+
+#include "autoware/component_interface_specs/concepts.hpp"
+#include "gtest/gtest.h"
+
+#include <rclcpp/qos.hpp>
+
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+
+namespace autoware::component_interface_specs::test_utils
+{
+
+/// True when T is one of the alternatives of the std::tuple Tuple.
+template <typename T, typename Tuple>
+struct has_type;
+template <typename T, typename... Us>
+struct has_type<T, std::tuple<Us...>> : std::disjunction<std::is_same<T, Us>...>
+{
+};
+
+/// Pin a topic spec's declared QoS members and the rclcpp::QoS that get_qos<Spec>()
+/// derives from them. Every expected value is supplied by the caller as a literal, so the
+/// assertions are never checked against the spec's own fields.
+template <class Spec>
+void expect_topic_qos(
+  const char * expected_name, std::size_t expected_depth,
+  rmw_qos_reliability_policy_t expected_reliability,
+  rmw_qos_durability_policy_t expected_durability)
+{
+  EXPECT_STREQ(Spec::name, expected_name);
+  EXPECT_EQ(Spec::depth, expected_depth);
+  EXPECT_EQ(Spec::reliability, expected_reliability);
+  EXPECT_EQ(Spec::durability, expected_durability);
+
+  const auto qos = get_qos<Spec>();
+  EXPECT_EQ(qos.depth(), expected_depth);
+  EXPECT_EQ(qos.reliability(), static_cast<rclcpp::ReliabilityPolicy>(expected_reliability));
+  EXPECT_EQ(qos.durability(), static_cast<rclcpp::DurabilityPolicy>(expected_durability));
+}
+
+}  // namespace autoware::component_interface_specs::test_utils
+
+#endif  // SPEC_TEST_UTILS_HPP_

--- a/common/autoware_component_interface_specs/test/test_perception.cpp
+++ b/common/autoware_component_interface_specs/test/test_perception.cpp
@@ -14,7 +14,6 @@
 
 #include "autoware/component_interface_specs/concepts.hpp"
 #include "autoware/component_interface_specs/perception.hpp"
-#include "autoware/component_interface_specs/version.hpp"
 #include "gtest/gtest.h"
 #include "spec_test_utils.hpp"
 
@@ -43,16 +42,8 @@ TEST(perception, concept_and_registration)
 
 TEST(perception, interface)
 {
-  {
-    using autoware::component_interface_specs::perception::ObjectRecognition;
-    size_t depth = 1;
-    EXPECT_EQ(ObjectRecognition::depth, depth);
-    EXPECT_EQ(ObjectRecognition::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(ObjectRecognition::durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
-
-    const auto qos = autoware::component_interface_specs::get_qos<ObjectRecognition>();
-    EXPECT_EQ(qos.depth(), depth);
-    EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
-    EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);
-  }
+  using specs::perception::ObjectRecognition;
+  tu::expect_topic_qos<ObjectRecognition>(
+    "/perception/object_recognition/objects", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+    RMW_QOS_POLICY_DURABILITY_VOLATILE);
 }

--- a/common/autoware_component_interface_specs/test/test_perception.cpp
+++ b/common/autoware_component_interface_specs/test/test_perception.cpp
@@ -24,18 +24,18 @@ namespace tu = autoware::component_interface_specs::test_utils;
 
 TEST(perception, concept_and_registration)
 {
-  using specs::perception::DetectedObjects;
   using specs::perception::ObjectRecognition;
   using specs::perception::Specs;
+  using specs::perception::TrackedObjects;
   using specs::perception::TrafficSignals;
 
   static_assert(specs::InterfaceSpec<ObjectRecognition>);
   static_assert(specs::InterfaceSpec<TrafficSignals>);
-  static_assert(specs::InterfaceSpec<DetectedObjects>);
+  static_assert(specs::InterfaceSpec<TrackedObjects>);
 
   static_assert(tu::has_type<ObjectRecognition, Specs>::value);
   static_assert(tu::has_type<TrafficSignals, Specs>::value);
-  static_assert(tu::has_type<DetectedObjects, Specs>::value);
+  static_assert(tu::has_type<TrackedObjects, Specs>::value);
   static_assert(std::tuple_size_v<Specs> == 3);
   SUCCEED();
 }

--- a/common/autoware_component_interface_specs/test/test_perception.cpp
+++ b/common/autoware_component_interface_specs/test/test_perception.cpp
@@ -23,14 +23,6 @@
 namespace specs = autoware::component_interface_specs;
 namespace tu = autoware::component_interface_specs::test_utils;
 
-TEST(perception, version)
-{
-  static_assert(specs::perception::version.major == 0);
-  static_assert(specs::perception::version.minor == 1);
-  static_assert(specs::perception::version.patch == 0);
-  EXPECT_EQ(specs::perception::version.major, 0);
-}
-
 TEST(perception, concept_and_registration)
 {
   using specs::perception::DetectedObjects;
@@ -63,20 +55,4 @@ TEST(perception, interface)
     EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
     EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);
   }
-}
-
-TEST(perception, traffic_signals_qos)
-{
-  using specs::perception::TrafficSignals;
-  tu::expect_topic_qos<TrafficSignals>(
-    "/perception/traffic_light_recognition/traffic_signals", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-    RMW_QOS_POLICY_DURABILITY_VOLATILE);
-}
-
-TEST(perception, detected_objects_qos)
-{
-  using specs::perception::DetectedObjects;
-  tu::expect_topic_qos<DetectedObjects>(
-    "/perception/object_recognition/detection/objects", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-    RMW_QOS_POLICY_DURABILITY_VOLATILE);
 }

--- a/common/autoware_component_interface_specs/test/test_perception.cpp
+++ b/common/autoware_component_interface_specs/test/test_perception.cpp
@@ -12,8 +12,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/component_interface_specs/concepts.hpp"
 #include "autoware/component_interface_specs/perception.hpp"
+#include "autoware/component_interface_specs/version.hpp"
 #include "gtest/gtest.h"
+#include "spec_test_utils.hpp"
+
+#include <tuple>
+
+namespace specs = autoware::component_interface_specs;
+namespace tu = autoware::component_interface_specs::test_utils;
+
+TEST(perception, version)
+{
+  static_assert(specs::perception::version.major == 0);
+  static_assert(specs::perception::version.minor == 1);
+  static_assert(specs::perception::version.patch == 0);
+  EXPECT_EQ(specs::perception::version.major, 0);
+}
+
+TEST(perception, concept_and_registration)
+{
+  using specs::perception::DetectedObjects;
+  using specs::perception::ObjectRecognition;
+  using specs::perception::Specs;
+  using specs::perception::TrafficSignals;
+
+  static_assert(specs::InterfaceSpec<ObjectRecognition>);
+  static_assert(specs::InterfaceSpec<TrafficSignals>);
+  static_assert(specs::InterfaceSpec<DetectedObjects>);
+
+  static_assert(tu::has_type<ObjectRecognition, Specs>::value);
+  static_assert(tu::has_type<TrafficSignals, Specs>::value);
+  static_assert(tu::has_type<DetectedObjects, Specs>::value);
+  static_assert(std::tuple_size_v<Specs> == 3);
+  SUCCEED();
+}
 
 TEST(perception, interface)
 {
@@ -29,4 +63,20 @@ TEST(perception, interface)
     EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
     EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);
   }
+}
+
+TEST(perception, traffic_signals_qos)
+{
+  using specs::perception::TrafficSignals;
+  tu::expect_topic_qos<TrafficSignals>(
+    "/perception/traffic_light_recognition/traffic_signals", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+    RMW_QOS_POLICY_DURABILITY_VOLATILE);
+}
+
+TEST(perception, detected_objects_qos)
+{
+  using specs::perception::DetectedObjects;
+  tu::expect_topic_qos<DetectedObjects>(
+    "/perception/object_recognition/detection/objects", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+    RMW_QOS_POLICY_DURABILITY_VOLATILE);
 }


### PR DESCRIPTION
## Description

Register and version the perception inter-component boundary specs in `autoware_component_interface_specs` at v0.1.0, on the per-domain versioning foundation from #1259: this branch adds `TrafficSignals` (`autoware_perception_msgs/msg/TrafficLightGroupArray`, `/perception/traffic_light_recognition/traffic_signals`) and `TrackedObjects` (`autoware_perception_msgs/msg/TrackedObjects`, `/perception/object_recognition/tracking/objects`) alongside the existing `ObjectRecognition` spec, registering all three in `perception::Specs`.

The set is minimal in the sense that it is exactly the part of perception another component reads: planning and control drive on the predicted objects and the traffic-signal state, and the tracking-stage object output is read outside perception by `autoware_diffusion_planner`, wired through `tier4_planning_launch/planning.launch.xml` under `planning_setting:=diffusion_planner`. What stays out is the detection-stage output `/perception/object_recognition/detection/objects`: in the standard launch tree its consumers are all inside perception — `autoware_multi_object_tracker`, and `autoware_perception_objects_converter`, whose own output is the already-registered predicted-objects topic — so versioning it would freeze an internal pipeline stage for no external benefit. (`autoware_spheric_collision_detector` under `control/` does carry a subscription defaulting to that topic, but no launch file in the tree includes it, so it is not part of the running system.) The same reasoning keeps out the per-camera traffic-light detection and classification topics that feed the registered signal state, and perception's debug and visualization output. All three specs use the message types perception already publishes — no type was invented, thinned, or split for this registration.

Each spec records the message/service type, topic/service name, and QoS the boundary is published/consumed with today; `interface_manifest.json` is regenerated by the in-package generator.

**Stack note:** this PR is based on #1307, which adds the shared test helper its tests include, so its diff shows that helper until #1307 merges and only this domain's own change afterwards. The eight domain PRs in this series (perception, planning, control, localization, map, sensing, vehicle, system) are independent of one another and can be reviewed and merged in any order: they touch disjoint domain headers and test files, and their generated `interface_manifest.json` entries occupy disjoint regions of the same sorted array.

The table below is the perception domain's complete registered spec set after this PR — every entry of `perception::Specs`, not only the ones this PR adds — so a reader can see the whole domain contract at a glance.

| Spec | Topic or service | Type | Status |
| --- | --- | --- | --- |
| `ObjectRecognition` | `/perception/object_recognition/objects` | `autoware_perception_msgs/msg/PredictedObjects` (topic) | already registered |
| `TrafficSignals` | `/perception/traffic_light_recognition/traffic_signals` | `autoware_perception_msgs/msg/TrafficLightGroupArray` (topic) | new in this PR |
| `TrackedObjects` | `/perception/object_recognition/tracking/objects` | `autoware_perception_msgs/msg/TrackedObjects` (topic) | new in this PR |

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

## How was this PR tested?

Built and tested in the `autoware:universe-devel-jazzy` devel container (`colcon build && colcon test`, 0 failures) at this branch tip.

## Notes for reviewers

This PR is core-only; the matching re-export of these specs in the universe package's `autoware_component_interface_specs_universe` shim is tracked as separate follow-up work, not part of this PR.

## Interface changes

None. No publisher, subscriber, or service is created or modified by this PR — `TrafficSignals` and `TrackedObjects` are existing wire topics; this PR only adds their versioned spec registration (a struct plus a `Specs` tuple entry) in `autoware_component_interface_specs`.

## Effects on system behavior

None. Header-only data plus tests; no node, launch, or QoS-on-the-wire change.
