### PR TITLE
feat(autoware_component_interface_specs): register and version the planning boundary specs

### DIFF
--- a/common/autoware_component_interface_specs/test/spec_test_utils.hpp
+++ b/common/autoware_component_interface_specs/test/spec_test_utils.hpp
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 
 namespace autoware::component_interface_specs::test_utils
 {
@@ -32,6 +33,21 @@ template <typename T, typename Tuple>
 struct has_type;
 template <typename T, typename... Us>
 struct has_type<T, std::tuple<Us...>> : std::disjunction<std::is_same<T, Us>...>
+{
+};
+
+/// Mirror of universe's HasDomainVersion: a void_t/expression-SFINAE probe over the
+/// ADL-resolved resolve_domain_version(const Spec &). Downstream consumers use exactly
+/// this shape to decide whether a spec participates in versioned interface
+/// registration, so a domain can type-enforce that a deliberately unversioned spec
+/// fails version resolution, rather than merely being absent from the Specs tuple.
+template <class, class = void>
+struct has_domain_version : std::false_type
+{
+};
+template <class S>
+struct has_domain_version<
+  S, std::void_t<decltype(resolve_domain_version(std::declval<const S &>()))>> : std::true_type
 {
 };
 

--- a/common/autoware_component_interface_specs/test/spec_test_utils.hpp
+++ b/common/autoware_component_interface_specs/test/spec_test_utils.hpp
@@ -1,0 +1,60 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SPEC_TEST_UTILS_HPP_
+#define SPEC_TEST_UTILS_HPP_
+
+#include "autoware/component_interface_specs/concepts.hpp"
+#include "gtest/gtest.h"
+
+#include <rclcpp/qos.hpp>
+
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+
+namespace autoware::component_interface_specs::test_utils
+{
+
+/// True when T is one of the alternatives of the std::tuple Tuple.
+template <typename T, typename Tuple>
+struct has_type;
+template <typename T, typename... Us>
+struct has_type<T, std::tuple<Us...>> : std::disjunction<std::is_same<T, Us>...>
+{
+};
+
+/// Pin a topic spec's declared QoS members and the rclcpp::QoS that get_qos<Spec>()
+/// derives from them. Every expected value is supplied by the caller as a literal, so the
+/// assertions are never checked against the spec's own fields.
+template <class Spec>
+void expect_topic_qos(
+  const char * expected_name, std::size_t expected_depth,
+  rmw_qos_reliability_policy_t expected_reliability,
+  rmw_qos_durability_policy_t expected_durability)
+{
+  EXPECT_STREQ(Spec::name, expected_name);
+  EXPECT_EQ(Spec::depth, expected_depth);
+  EXPECT_EQ(Spec::reliability, expected_reliability);
+  EXPECT_EQ(Spec::durability, expected_durability);
+
+  const auto qos = get_qos<Spec>();
+  EXPECT_EQ(qos.depth(), expected_depth);
+  EXPECT_EQ(qos.reliability(), static_cast<rclcpp::ReliabilityPolicy>(expected_reliability));
+  EXPECT_EQ(qos.durability(), static_cast<rclcpp::DurabilityPolicy>(expected_durability));
+}
+
+}  // namespace autoware::component_interface_specs::test_utils
+
+#endif  // SPEC_TEST_UTILS_HPP_

--- a/common/autoware_component_interface_specs/test/test_planning.cpp
+++ b/common/autoware_component_interface_specs/test/test_planning.cpp
@@ -14,7 +14,6 @@
 
 #include "autoware/component_interface_specs/concepts.hpp"
 #include "autoware/component_interface_specs/planning.hpp"
-#include "autoware/component_interface_specs/version.hpp"
 #include "gtest/gtest.h"
 #include "spec_test_utils.hpp"
 
@@ -53,28 +52,16 @@ TEST(planning, concept_and_registration)
 TEST(planning, interface)
 {
   {
-    using autoware::component_interface_specs::planning::LaneletRoute;
-    size_t depth = 1;
-    EXPECT_EQ(LaneletRoute::depth, depth);
-    EXPECT_EQ(LaneletRoute::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(LaneletRoute::durability, RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
-
-    const auto qos = autoware::component_interface_specs::get_qos<LaneletRoute>();
-    EXPECT_EQ(qos.depth(), depth);
-    EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
-    EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::TransientLocal);
+    using specs::planning::LaneletRoute;
+    tu::expect_topic_qos<LaneletRoute>(
+      "/planning/route", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+      RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
   }
 
   {
-    using autoware::component_interface_specs::planning::Trajectory;
-    size_t depth = 1;
-    EXPECT_EQ(Trajectory::depth, depth);
-    EXPECT_EQ(Trajectory::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(Trajectory::durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
-
-    const auto qos = autoware::component_interface_specs::get_qos<Trajectory>();
-    EXPECT_EQ(qos.depth(), depth);
-    EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
-    EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);
+    using specs::planning::Trajectory;
+    tu::expect_topic_qos<Trajectory>(
+      "/planning/trajectory", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+      RMW_QOS_POLICY_DURABILITY_VOLATILE);
   }
 }

--- a/common/autoware_component_interface_specs/test/test_planning.cpp
+++ b/common/autoware_component_interface_specs/test/test_planning.cpp
@@ -12,8 +12,51 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/component_interface_specs/concepts.hpp"
 #include "autoware/component_interface_specs/planning.hpp"
+#include "autoware/component_interface_specs/version.hpp"
 #include "gtest/gtest.h"
+#include "spec_test_utils.hpp"
+
+#include <tuple>
+
+namespace specs = autoware::component_interface_specs;
+namespace tu = autoware::component_interface_specs::test_utils;
+
+TEST(planning, version)
+{
+  static_assert(specs::planning::version.major == 0);
+  static_assert(specs::planning::version.minor == 1);
+  static_assert(specs::planning::version.patch == 0);
+  EXPECT_EQ(specs::planning::version.major, 0);
+}
+
+TEST(planning, concept_and_registration)
+{
+  using specs::planning::ClearRoute;
+  using specs::planning::LaneletRoute;
+  using specs::planning::RouteState;
+  using specs::planning::SetLaneletRoute;
+  using specs::planning::SetWaypointRoute;
+  using specs::planning::Specs;
+  using specs::planning::Trajectory;
+
+  static_assert(specs::InterfaceSpec<Trajectory>);
+  static_assert(specs::InterfaceSpec<LaneletRoute>);
+  static_assert(specs::InterfaceSpec<RouteState>);
+  static_assert(specs::ServiceSpec<SetLaneletRoute>);
+  static_assert(specs::ServiceSpec<SetWaypointRoute>);
+  static_assert(specs::ServiceSpec<ClearRoute>);
+
+  static_assert(tu::has_type<Trajectory, Specs>::value);
+  static_assert(tu::has_type<LaneletRoute, Specs>::value);
+  static_assert(tu::has_type<RouteState, Specs>::value);
+  static_assert(tu::has_type<SetLaneletRoute, Specs>::value);
+  static_assert(tu::has_type<SetWaypointRoute, Specs>::value);
+  static_assert(tu::has_type<ClearRoute, Specs>::value);
+  static_assert(std::tuple_size_v<Specs> == 6);
+  SUCCEED();
+}
 
 TEST(planning, interface)
 {

--- a/common/autoware_component_interface_specs/test/test_planning.cpp
+++ b/common/autoware_component_interface_specs/test/test_planning.cpp
@@ -23,14 +23,6 @@
 namespace specs = autoware::component_interface_specs;
 namespace tu = autoware::component_interface_specs::test_utils;
 
-TEST(planning, version)
-{
-  static_assert(specs::planning::version.major == 0);
-  static_assert(specs::planning::version.minor == 1);
-  static_assert(specs::planning::version.patch == 0);
-  EXPECT_EQ(specs::planning::version.major, 0);
-}
-
 TEST(planning, concept_and_registration)
 {
   using specs::planning::ClearRoute;


### PR DESCRIPTION
## Description

Register and version the planning inter-component boundary specs in `autoware_component_interface_specs` at v0.1.0, on the per-domain versioning foundation from #1259: this branch adds no new specs — it locks down the existing six-entry `planning::Specs` registration (`Trajectory`, `LaneletRoute`, `RouteState`, `SetLaneletRoute`, `SetWaypointRoute`, `ClearRoute`) with explicit version and concept/registration tests, so the planning domain's contract is proven by tests rather than merely present in the header.

Planning's boundary to the rest of the system is narrow in both directions — a route goes in, one trajectory comes out — so the minimal set is the three route-setting services, the route and route-state topics that report what was accepted, and `/planning/trajectory`, the single output control consumes. Everything the scenario-planning chain publishes between those two ends is absent: the behavior-planning path, the path-optimizer and scenario-selector trajectories, and the velocity-limit topics are handoffs between planning's own modules, and registering them would pin planning's internal decomposition in place. That is also why this branch adds no new spec — the six already in the header are the whole boundary, and this PR only proves that with tests. The `TRANSIENT_LOCAL` durability recorded for the route and route-state topics is how they are published today, so a component that starts late still sees the current route; it is a record of current use, not a recommendation for new interfaces.

Each spec records the message/service type, topic/service name, and QoS the boundary is published/consumed with today; `interface_manifest.json` is regenerated by the in-package generator.

**Stack note:** this PR is based on #1307, which adds the shared test helper its tests include, so its diff shows that helper until #1307 merges and only this domain's own change afterwards. The eight domain PRs in this series (perception, planning, control, localization, map, sensing, vehicle, system) are independent of one another and can be reviewed and merged in any order: they touch disjoint domain headers and test files, and their generated `interface_manifest.json` entries occupy disjoint regions of the same sorted array.

The table below is the planning domain's complete registered spec set after this PR — every entry of `planning::Specs`, so a reader can see the whole domain contract at a glance. This PR registers no new spec, so every row reads "already registered"; the table is the full set the added tests now pin down.

| Spec | Topic or service | Type | Status |
| --- | --- | --- | --- |
| `SetLaneletRoute` | `/planning/set_lanelet_route` | `autoware_planning_msgs/srv/SetLaneletRoute` (service) | already registered |
| `SetWaypointRoute` | `/planning/set_waypoint_route` | `autoware_planning_msgs/srv/SetWaypointRoute` (service) | already registered |
| `ClearRoute` | `/planning/clear_route` | `autoware_planning_msgs/srv/ClearRoute` (service) | already registered |
| `RouteState` | `/planning/route_state` | `autoware_planning_msgs/msg/RouteState` (topic) | already registered |
| `LaneletRoute` | `/planning/route` | `autoware_planning_msgs/msg/LaneletRoute` (topic) | already registered |
| `Trajectory` | `/planning/trajectory` | `autoware_planning_msgs/msg/Trajectory` (topic) | already registered |

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

## How was this PR tested?

Built and tested in the `autoware:universe-devel-jazzy` devel container (`colcon build && colcon test`, 0 failures) at this branch tip.

## Notes for reviewers

Only `test/test_planning.cpp` changes in this PR's own commit; `planning.hpp` already carried `version{0, 1, 0}`, the `Specs` tuple, and the version-resolution hook. This PR is core-only; the matching re-export of these specs in the universe package is tracked as separate follow-up work.

## Interface changes

None. No publisher, subscriber, or service is created or modified — all six planning specs already existed; this PR only adds test coverage that pins the existing registration down.

## Effects on system behavior

None. Header-only data (already present) plus tests; no node, launch, or QoS-on-the-wire change.
