### PR TITLE
feat(autoware_component_interface_specs): register and version the control boundary specs

### DIFF
--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/control.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/control.hpp
@@ -19,9 +19,11 @@
 #include <autoware/component_interface_specs/version.hpp>
 
 #include <autoware_control_msgs/msg/control.hpp>
+#include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <autoware_vehicle_msgs/msg/gear_command.hpp>
 #include <autoware_vehicle_msgs/msg/hazard_lights_command.hpp>
 #include <autoware_vehicle_msgs/msg/turn_indicators_command.hpp>
+#include <autoware_vehicle_msgs/srv/control_mode_command.hpp>
 
 #include <rmw/qos_profiles.h>
 
@@ -64,8 +66,24 @@ struct HazardLightsCommand
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
 };
 
+struct PredictedTrajectory  // new - control->planning predicted-path feedback
+{
+  using Message = autoware_planning_msgs::msg::Trajectory;
+  static constexpr char name[] = "/control/trajectory_follower/lateral/predicted_trajectory";
+  static constexpr size_t depth = 1;
+  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+};
+
+struct ControlModeRequest  // new - control/system->vehicle control-mode request
+{
+  using Service = autoware_vehicle_msgs::srv::ControlModeCommand;
+  static constexpr char name[] = "/control/control_mode_request";
+};
+
 AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(
-  0, 1, 0, ControlCommand, GearCommand, TurnIndicatorsCommand, HazardLightsCommand)
+  0, 1, 0, ControlCommand, GearCommand, TurnIndicatorsCommand, HazardLightsCommand,
+  PredictedTrajectory, ControlModeRequest)
 
 }  // namespace autoware::component_interface_specs::control
 

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/control.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/control.hpp
@@ -19,6 +19,9 @@
 #include <autoware/component_interface_specs/version.hpp>
 
 #include <autoware_control_msgs/msg/control.hpp>
+#include <autoware_vehicle_msgs/msg/gear_command.hpp>
+#include <autoware_vehicle_msgs/msg/hazard_lights_command.hpp>
+#include <autoware_vehicle_msgs/msg/turn_indicators_command.hpp>
 
 #include <rmw/qos_profiles.h>
 
@@ -34,7 +37,35 @@ struct ControlCommand
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
 };
 
-AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(0, 1, 0, ControlCommand)
+struct GearCommand
+{
+  using Message = autoware_vehicle_msgs::msg::GearCommand;
+  static constexpr char name[] = "/control/command/gear_cmd";
+  static constexpr size_t depth = 1;
+  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+};
+
+struct TurnIndicatorsCommand
+{
+  using Message = autoware_vehicle_msgs::msg::TurnIndicatorsCommand;
+  static constexpr char name[] = "/control/command/turn_indicators_cmd";
+  static constexpr size_t depth = 1;
+  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+};
+
+struct HazardLightsCommand
+{
+  using Message = autoware_vehicle_msgs::msg::HazardLightsCommand;
+  static constexpr char name[] = "/control/command/hazard_lights_cmd";
+  static constexpr size_t depth = 1;
+  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+};
+
+AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(
+  0, 1, 0, ControlCommand, GearCommand, TurnIndicatorsCommand, HazardLightsCommand)
 
 }  // namespace autoware::component_interface_specs::control
 

--- a/common/autoware_component_interface_specs/interface_manifest.json
+++ b/common/autoware_component_interface_specs/interface_manifest.json
@@ -54,6 +54,32 @@
       }
     },
     {
+      "domain": "control",
+      "interface": "/control/trajectory_follower/lateral/predicted_trajectory",
+      "type": "autoware_planning_msgs/msg/Trajectory",
+      "kind": "topic",
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
+    },
+    {
+      "domain": "control",
+      "interface": "/control/control_mode_request",
+      "type": "autoware_vehicle_msgs/srv/ControlModeCommand",
+      "kind": "service",
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 10,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
+    },
+    {
       "domain": "localization",
       "interface": "/localization/initialize",
       "type": "autoware_localization_msgs/srv/InitializeLocalization",

--- a/common/autoware_component_interface_specs/interface_manifest.json
+++ b/common/autoware_component_interface_specs/interface_manifest.json
@@ -15,6 +15,45 @@
       }
     },
     {
+      "domain": "control",
+      "interface": "/control/command/gear_cmd",
+      "type": "autoware_vehicle_msgs/msg/GearCommand",
+      "kind": "topic",
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
+    },
+    {
+      "domain": "control",
+      "interface": "/control/command/turn_indicators_cmd",
+      "type": "autoware_vehicle_msgs/msg/TurnIndicatorsCommand",
+      "kind": "topic",
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
+    },
+    {
+      "domain": "control",
+      "interface": "/control/command/hazard_lights_cmd",
+      "type": "autoware_vehicle_msgs/msg/HazardLightsCommand",
+      "kind": "topic",
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
+    },
+    {
       "domain": "localization",
       "interface": "/localization/initialize",
       "type": "autoware_localization_msgs/srv/InitializeLocalization",

--- a/common/autoware_component_interface_specs/test/spec_test_utils.hpp
+++ b/common/autoware_component_interface_specs/test/spec_test_utils.hpp
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 
 namespace autoware::component_interface_specs::test_utils
 {
@@ -32,6 +33,21 @@ template <typename T, typename Tuple>
 struct has_type;
 template <typename T, typename... Us>
 struct has_type<T, std::tuple<Us...>> : std::disjunction<std::is_same<T, Us>...>
+{
+};
+
+/// Mirror of universe's HasDomainVersion: a void_t/expression-SFINAE probe over the
+/// ADL-resolved resolve_domain_version(const Spec &). Downstream consumers use exactly
+/// this shape to decide whether a spec participates in versioned interface
+/// registration, so a domain can type-enforce that a deliberately unversioned spec
+/// fails version resolution, rather than merely being absent from the Specs tuple.
+template <class, class = void>
+struct has_domain_version : std::false_type
+{
+};
+template <class S>
+struct has_domain_version<
+  S, std::void_t<decltype(resolve_domain_version(std::declval<const S &>()))>> : std::true_type
 {
 };
 

--- a/common/autoware_component_interface_specs/test/spec_test_utils.hpp
+++ b/common/autoware_component_interface_specs/test/spec_test_utils.hpp
@@ -1,0 +1,60 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SPEC_TEST_UTILS_HPP_
+#define SPEC_TEST_UTILS_HPP_
+
+#include "autoware/component_interface_specs/concepts.hpp"
+#include "gtest/gtest.h"
+
+#include <rclcpp/qos.hpp>
+
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+
+namespace autoware::component_interface_specs::test_utils
+{
+
+/// True when T is one of the alternatives of the std::tuple Tuple.
+template <typename T, typename Tuple>
+struct has_type;
+template <typename T, typename... Us>
+struct has_type<T, std::tuple<Us...>> : std::disjunction<std::is_same<T, Us>...>
+{
+};
+
+/// Pin a topic spec's declared QoS members and the rclcpp::QoS that get_qos<Spec>()
+/// derives from them. Every expected value is supplied by the caller as a literal, so the
+/// assertions are never checked against the spec's own fields.
+template <class Spec>
+void expect_topic_qos(
+  const char * expected_name, std::size_t expected_depth,
+  rmw_qos_reliability_policy_t expected_reliability,
+  rmw_qos_durability_policy_t expected_durability)
+{
+  EXPECT_STREQ(Spec::name, expected_name);
+  EXPECT_EQ(Spec::depth, expected_depth);
+  EXPECT_EQ(Spec::reliability, expected_reliability);
+  EXPECT_EQ(Spec::durability, expected_durability);
+
+  const auto qos = get_qos<Spec>();
+  EXPECT_EQ(qos.depth(), expected_depth);
+  EXPECT_EQ(qos.reliability(), static_cast<rclcpp::ReliabilityPolicy>(expected_reliability));
+  EXPECT_EQ(qos.durability(), static_cast<rclcpp::DurabilityPolicy>(expected_durability));
+}
+
+}  // namespace autoware::component_interface_specs::test_utils
+
+#endif  // SPEC_TEST_UTILS_HPP_

--- a/common/autoware_component_interface_specs/test/test_control.cpp
+++ b/common/autoware_component_interface_specs/test/test_control.cpp
@@ -23,14 +23,6 @@
 namespace specs = autoware::component_interface_specs;
 namespace tu = autoware::component_interface_specs::test_utils;
 
-TEST(control, version)
-{
-  static_assert(specs::control::version.major == 0);
-  static_assert(specs::control::version.minor == 1);
-  static_assert(specs::control::version.patch == 0);
-  EXPECT_EQ(specs::control::version.major, 0);
-}
-
 TEST(control, concept_and_registration)
 {
   using specs::control::ControlCommand;
@@ -70,42 +62,4 @@ TEST(control, interface)
   EXPECT_EQ(qos.depth(), depth);
   EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
   EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);
-}
-
-TEST(control, gear_command_qos)
-{
-  using specs::control::GearCommand;
-  tu::expect_topic_qos<GearCommand>(
-    "/control/command/gear_cmd", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-    RMW_QOS_POLICY_DURABILITY_VOLATILE);
-}
-
-TEST(control, turn_indicators_command_qos)
-{
-  using specs::control::TurnIndicatorsCommand;
-  tu::expect_topic_qos<TurnIndicatorsCommand>(
-    "/control/command/turn_indicators_cmd", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-    RMW_QOS_POLICY_DURABILITY_VOLATILE);
-}
-
-TEST(control, hazard_lights_command_qos)
-{
-  using specs::control::HazardLightsCommand;
-  tu::expect_topic_qos<HazardLightsCommand>(
-    "/control/command/hazard_lights_cmd", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-    RMW_QOS_POLICY_DURABILITY_VOLATILE);
-}
-
-TEST(control, predicted_trajectory_qos)
-{
-  using specs::control::PredictedTrajectory;
-  tu::expect_topic_qos<PredictedTrajectory>(
-    "/control/trajectory_follower/lateral/predicted_trajectory", 1,
-    RMW_QOS_POLICY_RELIABILITY_RELIABLE, RMW_QOS_POLICY_DURABILITY_VOLATILE);
-}
-
-TEST(control, control_mode_request_name)
-{
-  using specs::control::ControlModeRequest;
-  EXPECT_STREQ(ControlModeRequest::name, "/control/control_mode_request");
 }

--- a/common/autoware_component_interface_specs/test/test_control.cpp
+++ b/common/autoware_component_interface_specs/test/test_control.cpp
@@ -34,8 +34,10 @@ TEST(control, version)
 TEST(control, concept_and_registration)
 {
   using specs::control::ControlCommand;
+  using specs::control::ControlModeRequest;
   using specs::control::GearCommand;
   using specs::control::HazardLightsCommand;
+  using specs::control::PredictedTrajectory;
   using specs::control::Specs;
   using specs::control::TurnIndicatorsCommand;
 
@@ -43,12 +45,16 @@ TEST(control, concept_and_registration)
   static_assert(specs::InterfaceSpec<GearCommand>);
   static_assert(specs::InterfaceSpec<TurnIndicatorsCommand>);
   static_assert(specs::InterfaceSpec<HazardLightsCommand>);
+  static_assert(specs::InterfaceSpec<PredictedTrajectory>);
+  static_assert(specs::ServiceSpec<ControlModeRequest>);
 
   static_assert(tu::has_type<ControlCommand, Specs>::value);
   static_assert(tu::has_type<GearCommand, Specs>::value);
   static_assert(tu::has_type<TurnIndicatorsCommand, Specs>::value);
   static_assert(tu::has_type<HazardLightsCommand, Specs>::value);
-  static_assert(std::tuple_size_v<Specs> == 4);
+  static_assert(tu::has_type<PredictedTrajectory, Specs>::value);
+  static_assert(tu::has_type<ControlModeRequest, Specs>::value);
+  static_assert(std::tuple_size_v<Specs> == 6);
   SUCCEED();
 }
 
@@ -88,4 +94,18 @@ TEST(control, hazard_lights_command_qos)
   tu::expect_topic_qos<HazardLightsCommand>(
     "/control/command/hazard_lights_cmd", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
     RMW_QOS_POLICY_DURABILITY_VOLATILE);
+}
+
+TEST(control, predicted_trajectory_qos)
+{
+  using specs::control::PredictedTrajectory;
+  tu::expect_topic_qos<PredictedTrajectory>(
+    "/control/trajectory_follower/lateral/predicted_trajectory", 1,
+    RMW_QOS_POLICY_RELIABILITY_RELIABLE, RMW_QOS_POLICY_DURABILITY_VOLATILE);
+}
+
+TEST(control, control_mode_request_name)
+{
+  using specs::control::ControlModeRequest;
+  EXPECT_STREQ(ControlModeRequest::name, "/control/control_mode_request");
 }

--- a/common/autoware_component_interface_specs/test/test_control.cpp
+++ b/common/autoware_component_interface_specs/test/test_control.cpp
@@ -12,8 +12,45 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/component_interface_specs/concepts.hpp"
 #include "autoware/component_interface_specs/control.hpp"
+#include "autoware/component_interface_specs/version.hpp"
 #include "gtest/gtest.h"
+#include "spec_test_utils.hpp"
+
+#include <tuple>
+
+namespace specs = autoware::component_interface_specs;
+namespace tu = autoware::component_interface_specs::test_utils;
+
+TEST(control, version)
+{
+  static_assert(specs::control::version.major == 0);
+  static_assert(specs::control::version.minor == 1);
+  static_assert(specs::control::version.patch == 0);
+  EXPECT_EQ(specs::control::version.major, 0);
+}
+
+TEST(control, concept_and_registration)
+{
+  using specs::control::ControlCommand;
+  using specs::control::GearCommand;
+  using specs::control::HazardLightsCommand;
+  using specs::control::Specs;
+  using specs::control::TurnIndicatorsCommand;
+
+  static_assert(specs::InterfaceSpec<ControlCommand>);
+  static_assert(specs::InterfaceSpec<GearCommand>);
+  static_assert(specs::InterfaceSpec<TurnIndicatorsCommand>);
+  static_assert(specs::InterfaceSpec<HazardLightsCommand>);
+
+  static_assert(tu::has_type<ControlCommand, Specs>::value);
+  static_assert(tu::has_type<GearCommand, Specs>::value);
+  static_assert(tu::has_type<TurnIndicatorsCommand, Specs>::value);
+  static_assert(tu::has_type<HazardLightsCommand, Specs>::value);
+  static_assert(std::tuple_size_v<Specs> == 4);
+  SUCCEED();
+}
 
 TEST(control, interface)
 {
@@ -27,4 +64,28 @@ TEST(control, interface)
   EXPECT_EQ(qos.depth(), depth);
   EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
   EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);
+}
+
+TEST(control, gear_command_qos)
+{
+  using specs::control::GearCommand;
+  tu::expect_topic_qos<GearCommand>(
+    "/control/command/gear_cmd", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+    RMW_QOS_POLICY_DURABILITY_VOLATILE);
+}
+
+TEST(control, turn_indicators_command_qos)
+{
+  using specs::control::TurnIndicatorsCommand;
+  tu::expect_topic_qos<TurnIndicatorsCommand>(
+    "/control/command/turn_indicators_cmd", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+    RMW_QOS_POLICY_DURABILITY_VOLATILE);
+}
+
+TEST(control, hazard_lights_command_qos)
+{
+  using specs::control::HazardLightsCommand;
+  tu::expect_topic_qos<HazardLightsCommand>(
+    "/control/command/hazard_lights_cmd", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+    RMW_QOS_POLICY_DURABILITY_VOLATILE);
 }

--- a/common/autoware_component_interface_specs/test/test_control.cpp
+++ b/common/autoware_component_interface_specs/test/test_control.cpp
@@ -14,7 +14,6 @@
 
 #include "autoware/component_interface_specs/concepts.hpp"
 #include "autoware/component_interface_specs/control.hpp"
-#include "autoware/component_interface_specs/version.hpp"
 #include "gtest/gtest.h"
 #include "spec_test_utils.hpp"
 
@@ -52,14 +51,8 @@ TEST(control, concept_and_registration)
 
 TEST(control, interface)
 {
-  using autoware::component_interface_specs::control::ControlCommand;
-  size_t depth = 1;
-  EXPECT_EQ(ControlCommand::depth, depth);
-  EXPECT_EQ(ControlCommand::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-  EXPECT_EQ(ControlCommand::durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
-
-  const auto qos = autoware::component_interface_specs::get_qos<ControlCommand>();
-  EXPECT_EQ(qos.depth(), depth);
-  EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
-  EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);
+  using specs::control::ControlCommand;
+  tu::expect_topic_qos<ControlCommand>(
+    "/control/command/control_cmd", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+    RMW_QOS_POLICY_DURABILITY_VOLATILE);
 }


### PR DESCRIPTION
## Description

Register and version the control inter-component boundary specs in `autoware_component_interface_specs` at v0.1.0, on the per-domain versioning foundation from #1259: this branch adds `GearCommand` (`/control/command/gear_cmd`), `TurnIndicatorsCommand` (`/control/command/turn_indicators_cmd`), `HazardLightsCommand` (`/control/command/hazard_lights_cmd`), `PredictedTrajectory` (`/control/trajectory_follower/lateral/predicted_trajectory`), and `ControlModeRequest` (`/control/control_mode_request`) alongside the existing `ControlCommand`, bringing `control::Specs` to six entries.

The minimal set here is what leaves control for another process: the four `/control/command/*` topics and `ControlModeRequest` are the handoff to the vehicle interface, which is built and deployed separately from the autonomy stack, and the one non-command topic, `PredictedTrajectory`, is registered for that same reason and no other, because a planning module subscribes to it. What a reader may expect and will not find is the rest of that namespace: `/control/trajectory_follower/control_cmd`, the follower's actual output, is unregistered because the command gate that consumes it lives inside control, as do the gate's other inputs. So one topic under `/control/trajectory_follower/` is registered and its sibling is not — the criterion is who reads a topic, not where it sits in the topic tree. Registering the follower's internal chain would freeze control's decomposition without giving any other component a contract it can use.

Each spec records the message/service type, topic/service name, and QoS the boundary is published/consumed with today; `interface_manifest.json` is regenerated by the in-package generator.

**Stack note:** this PR is based on #1307, which adds the shared test helper its tests include, so its diff shows that helper until #1307 merges and only this domain's own change afterwards. The eight domain PRs in this series (perception, planning, control, localization, map, sensing, vehicle, system) are independent of one another and can be reviewed and merged in any order: they touch disjoint domain headers and test files, and their generated `interface_manifest.json` entries occupy disjoint regions of the same sorted array.

The table below is the control domain's complete registered spec set after this PR — every entry of `control::Specs`, not only the ones this PR adds — so a reader can see the whole domain contract at a glance.

| Spec | Topic or service | Type | Status |
| --- | --- | --- | --- |
| `ControlCommand` | `/control/command/control_cmd` | `autoware_control_msgs/msg/Control` (topic) | already registered |
| `GearCommand` | `/control/command/gear_cmd` | `autoware_vehicle_msgs/msg/GearCommand` (topic) | new in this PR |
| `TurnIndicatorsCommand` | `/control/command/turn_indicators_cmd` | `autoware_vehicle_msgs/msg/TurnIndicatorsCommand` (topic) | new in this PR |
| `HazardLightsCommand` | `/control/command/hazard_lights_cmd` | `autoware_vehicle_msgs/msg/HazardLightsCommand` (topic) | new in this PR |
| `PredictedTrajectory` | `/control/trajectory_follower/lateral/predicted_trajectory` | `autoware_planning_msgs/msg/Trajectory` (topic) | new in this PR |
| `ControlModeRequest` | `/control/control_mode_request` | `autoware_vehicle_msgs/srv/ControlModeCommand` (service) | new in this PR |

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

## How was this PR tested?

Built and tested in the `autoware:universe-devel-jazzy` devel container (`colcon build && colcon test`, 0 failures) at this branch tip.

## Notes for reviewers

`PredictedTrajectory` and `ControlModeRequest` were added after a review pass over the running system confirmed both as real cross-domain boundaries: the predicted trajectory is consumed by planning's boundary-departure-prevention logic, and the control-mode request is called by the operation-mode-transition manager and the command-mode switcher against the vehicle-interface server. This PR is core-only; the matching re-export of these specs in the universe package is tracked as separate follow-up work.

## Interface changes

None. No publisher, subscriber, or service is created or modified — all five topics/services already exist on the wire; this PR only adds their versioned spec registration in `autoware_component_interface_specs`.

## Effects on system behavior

None. Header-only data plus tests; no node, launch, or QoS-on-the-wire change.
