### PR TITLE
feat(autoware_component_interface_specs): register and version the localization boundary specs

### DIFF
--- a/common/autoware_component_interface_specs/test/spec_test_utils.hpp
+++ b/common/autoware_component_interface_specs/test/spec_test_utils.hpp
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 
 namespace autoware::component_interface_specs::test_utils
 {
@@ -32,6 +33,21 @@ template <typename T, typename Tuple>
 struct has_type;
 template <typename T, typename... Us>
 struct has_type<T, std::tuple<Us...>> : std::disjunction<std::is_same<T, Us>...>
+{
+};
+
+/// Mirror of universe's HasDomainVersion: a void_t/expression-SFINAE probe over the
+/// ADL-resolved resolve_domain_version(const Spec &). Downstream consumers use exactly
+/// this shape to decide whether a spec participates in versioned interface
+/// registration, so a domain can type-enforce that a deliberately unversioned spec
+/// fails version resolution, rather than merely being absent from the Specs tuple.
+template <class, class = void>
+struct has_domain_version : std::false_type
+{
+};
+template <class S>
+struct has_domain_version<
+  S, std::void_t<decltype(resolve_domain_version(std::declval<const S &>()))>> : std::true_type
 {
 };
 

--- a/common/autoware_component_interface_specs/test/spec_test_utils.hpp
+++ b/common/autoware_component_interface_specs/test/spec_test_utils.hpp
@@ -1,0 +1,60 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SPEC_TEST_UTILS_HPP_
+#define SPEC_TEST_UTILS_HPP_
+
+#include "autoware/component_interface_specs/concepts.hpp"
+#include "gtest/gtest.h"
+
+#include <rclcpp/qos.hpp>
+
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+
+namespace autoware::component_interface_specs::test_utils
+{
+
+/// True when T is one of the alternatives of the std::tuple Tuple.
+template <typename T, typename Tuple>
+struct has_type;
+template <typename T, typename... Us>
+struct has_type<T, std::tuple<Us...>> : std::disjunction<std::is_same<T, Us>...>
+{
+};
+
+/// Pin a topic spec's declared QoS members and the rclcpp::QoS that get_qos<Spec>()
+/// derives from them. Every expected value is supplied by the caller as a literal, so the
+/// assertions are never checked against the spec's own fields.
+template <class Spec>
+void expect_topic_qos(
+  const char * expected_name, std::size_t expected_depth,
+  rmw_qos_reliability_policy_t expected_reliability,
+  rmw_qos_durability_policy_t expected_durability)
+{
+  EXPECT_STREQ(Spec::name, expected_name);
+  EXPECT_EQ(Spec::depth, expected_depth);
+  EXPECT_EQ(Spec::reliability, expected_reliability);
+  EXPECT_EQ(Spec::durability, expected_durability);
+
+  const auto qos = get_qos<Spec>();
+  EXPECT_EQ(qos.depth(), expected_depth);
+  EXPECT_EQ(qos.reliability(), static_cast<rclcpp::ReliabilityPolicy>(expected_reliability));
+  EXPECT_EQ(qos.durability(), static_cast<rclcpp::DurabilityPolicy>(expected_durability));
+}
+
+}  // namespace autoware::component_interface_specs::test_utils
+
+#endif  // SPEC_TEST_UTILS_HPP_

--- a/common/autoware_component_interface_specs/test/test_localization.cpp
+++ b/common/autoware_component_interface_specs/test/test_localization.cpp
@@ -23,14 +23,6 @@
 namespace specs = autoware::component_interface_specs;
 namespace tu = autoware::component_interface_specs::test_utils;
 
-TEST(localization, version)
-{
-  static_assert(specs::localization::version.major == 0);
-  static_assert(specs::localization::version.minor == 1);
-  static_assert(specs::localization::version.patch == 0);
-  EXPECT_EQ(specs::localization::version.major, 0);
-}
-
 TEST(localization, concept_and_registration)
 {
   using specs::localization::Acceleration;

--- a/common/autoware_component_interface_specs/test/test_localization.cpp
+++ b/common/autoware_component_interface_specs/test/test_localization.cpp
@@ -14,7 +14,6 @@
 
 #include "autoware/component_interface_specs/concepts.hpp"
 #include "autoware/component_interface_specs/localization.hpp"
-#include "autoware/component_interface_specs/version.hpp"
 #include "gtest/gtest.h"
 #include "spec_test_utils.hpp"
 
@@ -47,41 +46,23 @@ TEST(localization, concept_and_registration)
 TEST(localization, interface)
 {
   {
-    using autoware::component_interface_specs::localization::KinematicState;
-    size_t depth = 1;
-    EXPECT_EQ(KinematicState::depth, depth);
-    EXPECT_EQ(KinematicState::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(KinematicState::durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
-
-    const auto qos = autoware::component_interface_specs::get_qos<KinematicState>();
-    EXPECT_EQ(qos.depth(), depth);
-    EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
-    EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);
+    using specs::localization::KinematicState;
+    tu::expect_topic_qos<KinematicState>(
+      "/localization/kinematic_state", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+      RMW_QOS_POLICY_DURABILITY_VOLATILE);
   }
 
   {
-    using autoware::component_interface_specs::localization::Acceleration;
-    size_t depth = 1;
-    EXPECT_EQ(Acceleration::depth, depth);
-    EXPECT_EQ(Acceleration::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(Acceleration::durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
-
-    const auto qos = autoware::component_interface_specs::get_qos<Acceleration>();
-    EXPECT_EQ(qos.depth(), depth);
-    EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
-    EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);
+    using specs::localization::Acceleration;
+    tu::expect_topic_qos<Acceleration>(
+      "/localization/acceleration", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+      RMW_QOS_POLICY_DURABILITY_VOLATILE);
   }
 
   {
-    using autoware::component_interface_specs::localization::InitializationState;
-    size_t depth = 1;
-    EXPECT_EQ(InitializationState::depth, depth);
-    EXPECT_EQ(InitializationState::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(InitializationState::durability, RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
-
-    const auto qos = autoware::component_interface_specs::get_qos<InitializationState>();
-    EXPECT_EQ(qos.depth(), depth);
-    EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
-    EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::TransientLocal);
+    using specs::localization::InitializationState;
+    tu::expect_topic_qos<InitializationState>(
+      "/localization/initialization_state", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+      RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
   }
 }

--- a/common/autoware_component_interface_specs/test/test_localization.cpp
+++ b/common/autoware_component_interface_specs/test/test_localization.cpp
@@ -12,8 +12,45 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/component_interface_specs/concepts.hpp"
 #include "autoware/component_interface_specs/localization.hpp"
+#include "autoware/component_interface_specs/version.hpp"
 #include "gtest/gtest.h"
+#include "spec_test_utils.hpp"
+
+#include <tuple>
+
+namespace specs = autoware::component_interface_specs;
+namespace tu = autoware::component_interface_specs::test_utils;
+
+TEST(localization, version)
+{
+  static_assert(specs::localization::version.major == 0);
+  static_assert(specs::localization::version.minor == 1);
+  static_assert(specs::localization::version.patch == 0);
+  EXPECT_EQ(specs::localization::version.major, 0);
+}
+
+TEST(localization, concept_and_registration)
+{
+  using specs::localization::Acceleration;
+  using specs::localization::InitializationState;
+  using specs::localization::Initialize;
+  using specs::localization::KinematicState;
+  using specs::localization::Specs;
+
+  static_assert(specs::InterfaceSpec<KinematicState>);
+  static_assert(specs::InterfaceSpec<Acceleration>);
+  static_assert(specs::InterfaceSpec<InitializationState>);
+  static_assert(specs::ServiceSpec<Initialize>);
+
+  static_assert(tu::has_type<KinematicState, Specs>::value);
+  static_assert(tu::has_type<Acceleration, Specs>::value);
+  static_assert(tu::has_type<InitializationState, Specs>::value);
+  static_assert(tu::has_type<Initialize, Specs>::value);
+  static_assert(std::tuple_size_v<Specs> == 4);
+  SUCCEED();
+}
 
 TEST(localization, interface)
 {


### PR DESCRIPTION
## Description

Register and version the localization inter-component boundary specs in `autoware_component_interface_specs` at v0.1.0, on the per-domain versioning foundation from #1259: this branch adds no new specs — it locks down the existing four-entry `localization::Specs` registration (`KinematicState`, `Acceleration`, `InitializationState`, `Initialize`) with explicit version and concept/registration tests.

Localization's boundary is the ego state the rest of the stack reads plus the control surface for bringing it up: `/localization/kinematic_state` and `/localization/acceleration` are the fused result other domains consume, and the `Initialize` service together with the transient-local `InitializationState` topic are how another component requests initialization and observes whether it took. Deliberately absent is the estimator chain that produces that result — the pose-estimator pose-with-covariance outputs, the fusion-filter intermediates, and the estimate-health topics. Those are not a fixed thing to version: which estimator runs is a launch-time choice (`pose_source` selects among NDT, YabLoc, AR-tag, LiDAR-marker and Eagleye, and can combine several), so the intermediate topics vary by deployment while `/localization/kinematic_state` does not. That is also why this branch adds no new spec: the four already in the header are the whole boundary, and this PR pins them with tests.

Each spec records the message/service type, topic/service name, and QoS the boundary is published/consumed with today; `interface_manifest.json` is regenerated by the in-package generator.

**Stack note:** this PR is based on #1307, which adds the shared test helper its tests include, so its diff shows that helper until #1307 merges and only this domain's own change afterwards. The eight domain PRs in this series (perception, planning, control, localization, map, sensing, vehicle, system) are independent of one another and can be reviewed and merged in any order: they touch disjoint domain headers and test files, and their generated `interface_manifest.json` entries occupy disjoint regions of the same sorted array.

The table below is the localization domain's complete registered spec set after this PR — every entry of `localization::Specs`, so a reader can see the whole domain contract at a glance. This PR registers no new spec, so every row reads "already registered"; the table is the full set the added tests now pin down.

| Spec | Topic or service | Type | Status |
| --- | --- | --- | --- |
| `Initialize` | `/localization/initialize` | `autoware_localization_msgs/srv/InitializeLocalization` (service) | already registered |
| `InitializationState` | `/localization/initialization_state` | `autoware_adapi_v1_msgs/msg/LocalizationInitializationState` (topic) | already registered |
| `KinematicState` | `/localization/kinematic_state` | `nav_msgs/msg/Odometry` (topic) | already registered |
| `Acceleration` | `/localization/acceleration` | `geometry_msgs/msg/AccelWithCovarianceStamped` (topic) | already registered |

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

## How was this PR tested?

Built and tested in the `autoware:universe-devel-jazzy` devel container (`colcon build && colcon test`, 0 failures) at this branch tip.

## Notes for reviewers

Only `test/test_localization.cpp` changes in this PR's own commit; `localization.hpp` already carried `version{0, 1, 0}`, the `Specs` tuple, and the version-resolution hook, so this PR adds no new production code. This PR is core-only; the matching re-export of these specs in the universe package is tracked as separate follow-up work.

## Interface changes

None. No publisher, subscriber, or service is created or modified — all four localization specs already existed; this PR only adds test coverage that pins the existing registration down.

## Effects on system behavior

None. Header-only data (already present) plus tests; no node, launch, or QoS-on-the-wire change.
