### PR TITLE
feat(autoware_component_interface_specs): register and version the map boundary specs

### DIFF
--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/map.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/map.hpp
@@ -20,6 +20,7 @@
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_map_msgs/msg/map_projector_info.hpp>
+#include <autoware_map_msgs/srv/get_differential_point_cloud_map.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <rmw/qos_profiles.h>
@@ -36,6 +37,7 @@ struct MapProjectorInfo
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
 };
 
+// interface-spec-lint: not-versioned (heavy-raw confinement, design section 5)
 struct PointCloudMap
 {
   using Message = sensor_msgs::msg::PointCloud2;
@@ -54,8 +56,17 @@ struct VectorMap
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
 };
 
+struct GetDifferentialPointCloudMap
+{
+  using Service = autoware_map_msgs::srv::GetDifferentialPointCloudMap;
+  static constexpr char name[] = "/map/get_differential_pointcloud_map";
+};
+
+// PointCloudMap is intentionally excluded: heavy-raw confinement (design section 5)
+// keeps the full point cloud map out of the versioned registration surface while
+// the struct itself stays available for existing consumers.
 AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(
-  0, 1, 0, MapProjectorInfo, PointCloudMap, VectorMap)
+  0, 1, 0, VectorMap, MapProjectorInfo, GetDifferentialPointCloudMap)
 
 }  // namespace autoware::component_interface_specs::map
 

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/map.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/map.hpp
@@ -38,7 +38,7 @@ struct MapProjectorInfo
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
 };
 
-// interface-spec-lint: not-versioned (heavy-raw confinement, design section 5)
+// interface-spec-lint: not-versioned (raw point cloud; read by autoware_interface_spec_lint)
 struct PointCloudMap
 {
   using Message = sensor_msgs::msg::PointCloud2;
@@ -69,20 +69,23 @@ struct GetPartialPointCloudMap  // new - companion PCD-map delivery path
   static constexpr char name[] = "/map/get_partial_pointcloud_map";
 };
 
-// PointCloudMap is intentionally excluded: heavy-raw confinement (design section 5)
-// keeps the full point cloud map out of the versioned registration surface while
-// the struct itself stays available for existing consumers.
+// PointCloudMap is intentionally excluded from the versioned registration surface:
+// it carries the full raw point cloud payload rather than a bounded interface
+// message, so it is left out of the Specs tuple while the struct itself stays
+// available for existing consumers.
 AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(
   0, 1, 0, VectorMap, MapProjectorInfo, GetDifferentialPointCloudMap, GetPartialPointCloudMap)
 
-// Type-enforce PointCloudMap's exclusion from the versioned surface (heavy-raw
-// confinement, design section 5). This non-template exact match wins overload
-// resolution over the template above, so version resolution is ill-formed for
-// PointCloudMap: a downstream detection trait (e.g. universe's HasDomainVersion)
-// then sees it as unversioned, and a direct spec_version<PointCloudMap>() is a hard
-// compile error. Without this the exclusion would be a tuple omission only, and a
-// consumer could still register PointCloudMap and emit a manifest record for an
-// interface absent from the authority manifest.
+// Type-enforce PointCloudMap's exclusion from the versioned surface: it carries a
+// raw point cloud payload rather than a bounded interface message, so version
+// resolution for it is made ill-formed outright rather than left as a tuple
+// omission. This non-template exact match wins overload resolution over the
+// template above, so version resolution is ill-formed for PointCloudMap: a
+// downstream detection trait (e.g. universe's HasDomainVersion) then sees it as
+// unversioned, and a direct spec_version<PointCloudMap>() is a hard compile error.
+// Without this the exclusion would be a tuple omission only, and a consumer could
+// still register PointCloudMap and emit a manifest record for an interface absent
+// from the authority manifest.
 constexpr Version resolve_domain_version(const PointCloudMap &) = delete;
 
 }  // namespace autoware::component_interface_specs::map

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/map.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/map.hpp
@@ -68,6 +68,16 @@ struct GetDifferentialPointCloudMap
 AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(
   0, 1, 0, VectorMap, MapProjectorInfo, GetDifferentialPointCloudMap)
 
+// Type-enforce PointCloudMap's exclusion from the versioned surface (heavy-raw
+// confinement, design section 5). This non-template exact match wins overload
+// resolution over the template above, so version resolution is ill-formed for
+// PointCloudMap: a downstream detection trait (e.g. universe's HasDomainVersion)
+// then sees it as unversioned, and a direct spec_version<PointCloudMap>() is a hard
+// compile error. Without this the exclusion would be a tuple omission only, and a
+// consumer could still register PointCloudMap and emit a manifest record for an
+// interface absent from the authority manifest.
+constexpr Version resolve_domain_version(const PointCloudMap &) = delete;
+
 }  // namespace autoware::component_interface_specs::map
 
 #endif  // AUTOWARE__COMPONENT_INTERFACE_SPECS__MAP_HPP_

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/map.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/map.hpp
@@ -21,6 +21,7 @@
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_map_msgs/msg/map_projector_info.hpp>
 #include <autoware_map_msgs/srv/get_differential_point_cloud_map.hpp>
+#include <autoware_map_msgs/srv/get_partial_point_cloud_map.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 
 #include <rmw/qos_profiles.h>
@@ -62,11 +63,17 @@ struct GetDifferentialPointCloudMap
   static constexpr char name[] = "/map/get_differential_pointcloud_map";
 };
 
+struct GetPartialPointCloudMap  // new - companion PCD-map delivery path
+{
+  using Service = autoware_map_msgs::srv::GetPartialPointCloudMap;
+  static constexpr char name[] = "/map/get_partial_pointcloud_map";
+};
+
 // PointCloudMap is intentionally excluded: heavy-raw confinement (design section 5)
 // keeps the full point cloud map out of the versioned registration surface while
 // the struct itself stays available for existing consumers.
 AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(
-  0, 1, 0, VectorMap, MapProjectorInfo, GetDifferentialPointCloudMap)
+  0, 1, 0, VectorMap, MapProjectorInfo, GetDifferentialPointCloudMap, GetPartialPointCloudMap)
 
 // Type-enforce PointCloudMap's exclusion from the versioned surface (heavy-raw
 // confinement, design section 5). This non-template exact match wins overload

--- a/common/autoware_component_interface_specs/interface_manifest.json
+++ b/common/autoware_component_interface_specs/interface_manifest.json
@@ -106,6 +106,19 @@
       }
     },
     {
+      "domain": "map",
+      "interface": "/map/get_partial_pointcloud_map",
+      "type": "autoware_map_msgs/srv/GetPartialPointCloudMap",
+      "kind": "service",
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 10,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
+    },
+    {
       "domain": "perception",
       "interface": "/perception/object_recognition/objects",
       "type": "autoware_perception_msgs/msg/PredictedObjects",

--- a/common/autoware_component_interface_specs/interface_manifest.json
+++ b/common/autoware_component_interface_specs/interface_manifest.json
@@ -68,6 +68,19 @@
     },
     {
       "domain": "map",
+      "interface": "/map/vector_map",
+      "type": "autoware_map_msgs/msg/LaneletMapBin",
+      "kind": "topic",
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "transient_local"
+      }
+    },
+    {
+      "domain": "map",
       "interface": "/map/map_projector_info",
       "type": "autoware_map_msgs/msg/MapProjectorInfo",
       "kind": "topic",
@@ -81,28 +94,15 @@
     },
     {
       "domain": "map",
-      "interface": "/map/point_cloud_map",
-      "type": "sensor_msgs/msg/PointCloud2",
-      "kind": "topic",
+      "interface": "/map/get_differential_pointcloud_map",
+      "type": "autoware_map_msgs/srv/GetDifferentialPointCloudMap",
+      "kind": "service",
       "version": "0.1.0",
       "qos": {
         "history": "keep_last",
-        "depth": 1,
+        "depth": 10,
         "reliability": "reliable",
-        "durability": "transient_local"
-      }
-    },
-    {
-      "domain": "map",
-      "interface": "/map/vector_map",
-      "type": "autoware_map_msgs/msg/LaneletMapBin",
-      "kind": "topic",
-      "version": "0.1.0",
-      "qos": {
-        "history": "keep_last",
-        "depth": 1,
-        "reliability": "reliable",
-        "durability": "transient_local"
+        "durability": "volatile"
       }
     },
     {

--- a/common/autoware_component_interface_specs/test/spec_test_utils.hpp
+++ b/common/autoware_component_interface_specs/test/spec_test_utils.hpp
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 
 namespace autoware::component_interface_specs::test_utils
 {
@@ -32,6 +33,21 @@ template <typename T, typename Tuple>
 struct has_type;
 template <typename T, typename... Us>
 struct has_type<T, std::tuple<Us...>> : std::disjunction<std::is_same<T, Us>...>
+{
+};
+
+/// Mirror of universe's HasDomainVersion: a void_t/expression-SFINAE probe over the
+/// ADL-resolved resolve_domain_version(const Spec &). Downstream consumers use exactly
+/// this shape to decide whether a spec participates in versioned interface
+/// registration, so a domain can type-enforce that a deliberately unversioned spec
+/// fails version resolution, rather than merely being absent from the Specs tuple.
+template <class, class = void>
+struct has_domain_version : std::false_type
+{
+};
+template <class S>
+struct has_domain_version<
+  S, std::void_t<decltype(resolve_domain_version(std::declval<const S &>()))>> : std::true_type
 {
 };
 

--- a/common/autoware_component_interface_specs/test/spec_test_utils.hpp
+++ b/common/autoware_component_interface_specs/test/spec_test_utils.hpp
@@ -1,0 +1,60 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SPEC_TEST_UTILS_HPP_
+#define SPEC_TEST_UTILS_HPP_
+
+#include "autoware/component_interface_specs/concepts.hpp"
+#include "gtest/gtest.h"
+
+#include <rclcpp/qos.hpp>
+
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+
+namespace autoware::component_interface_specs::test_utils
+{
+
+/// True when T is one of the alternatives of the std::tuple Tuple.
+template <typename T, typename Tuple>
+struct has_type;
+template <typename T, typename... Us>
+struct has_type<T, std::tuple<Us...>> : std::disjunction<std::is_same<T, Us>...>
+{
+};
+
+/// Pin a topic spec's declared QoS members and the rclcpp::QoS that get_qos<Spec>()
+/// derives from them. Every expected value is supplied by the caller as a literal, so the
+/// assertions are never checked against the spec's own fields.
+template <class Spec>
+void expect_topic_qos(
+  const char * expected_name, std::size_t expected_depth,
+  rmw_qos_reliability_policy_t expected_reliability,
+  rmw_qos_durability_policy_t expected_durability)
+{
+  EXPECT_STREQ(Spec::name, expected_name);
+  EXPECT_EQ(Spec::depth, expected_depth);
+  EXPECT_EQ(Spec::reliability, expected_reliability);
+  EXPECT_EQ(Spec::durability, expected_durability);
+
+  const auto qos = get_qos<Spec>();
+  EXPECT_EQ(qos.depth(), expected_depth);
+  EXPECT_EQ(qos.reliability(), static_cast<rclcpp::ReliabilityPolicy>(expected_reliability));
+  EXPECT_EQ(qos.durability(), static_cast<rclcpp::DurabilityPolicy>(expected_durability));
+}
+
+}  // namespace autoware::component_interface_specs::test_utils
+
+#endif  // SPEC_TEST_UTILS_HPP_

--- a/common/autoware_component_interface_specs/test/test_map.cpp
+++ b/common/autoware_component_interface_specs/test/test_map.cpp
@@ -66,6 +66,7 @@ TEST(map, version)
 TEST(map, concept_and_registration)
 {
   using specs::map::GetDifferentialPointCloudMap;
+  using specs::map::GetPartialPointCloudMap;
   using specs::map::MapProjectorInfo;
   using specs::map::PointCloudMap;
   using specs::map::Specs;
@@ -74,11 +75,13 @@ TEST(map, concept_and_registration)
   static_assert(specs::InterfaceSpec<MapProjectorInfo>);
   static_assert(specs::InterfaceSpec<VectorMap>);
   static_assert(specs::ServiceSpec<GetDifferentialPointCloudMap>);
+  static_assert(specs::ServiceSpec<GetPartialPointCloudMap>);
 
   static_assert(tu::has_type<MapProjectorInfo, Specs>::value);
   static_assert(tu::has_type<VectorMap, Specs>::value);
   static_assert(tu::has_type<GetDifferentialPointCloudMap, Specs>::value);
-  static_assert(std::tuple_size_v<Specs> == 3);
+  static_assert(tu::has_type<GetPartialPointCloudMap, Specs>::value);
+  static_assert(std::tuple_size_v<Specs> == 4);
 
   // PointCloudMap stays available to existing consumers but is deliberately kept
   // out of the versioned registration surface (heavy-raw confinement, design section 5).
@@ -99,6 +102,12 @@ TEST(map, get_differential_pointcloud_map_name)
 {
   using specs::map::GetDifferentialPointCloudMap;
   EXPECT_STREQ(GetDifferentialPointCloudMap::name, "/map/get_differential_pointcloud_map");
+}
+
+TEST(map, get_partial_pointcloud_map_name)
+{
+  using specs::map::GetPartialPointCloudMap;
+  EXPECT_STREQ(GetPartialPointCloudMap::name, "/map/get_partial_pointcloud_map");
 }
 
 TEST(map, interface)

--- a/common/autoware_component_interface_specs/test/test_map.cpp
+++ b/common/autoware_component_interface_specs/test/test_map.cpp
@@ -19,42 +19,19 @@
 #include "spec_test_utils.hpp"
 
 #include <tuple>
-#include <type_traits>
-#include <utility>
 
 namespace specs = autoware::component_interface_specs;
 namespace tu = autoware::component_interface_specs::test_utils;
-
-// Local mirror of universe's HasDomainVersion: a void_t/expression-SFINAE probe over
-// the ADL-resolved resolve_domain_version(const Spec &). Downstream consumers use
-// exactly this shape to decide whether a spec participates in versioned interface
-// registration, so PointCloudMap's exclusion (it carries a raw point cloud payload
-// rather than a bounded interface message) must be type-enforced here as an
-// ill-formed version resolution, not merely as a tuple omission. Otherwise a
-// consumer registering PointCloudMap would emit a manifest record for an interface
-// absent from the authority manifest.
-namespace
-{
-template <class, class = void>
-struct has_domain_version : std::false_type
-{
-};
-template <class S>
-struct has_domain_version<
-  S, std::void_t<decltype(resolve_domain_version(std::declval<const S &>()))>> : std::true_type
-{
-};
-}  // namespace
 
 // PointCloudMap is intentionally excluded from the versioned surface, so version
 // resolution must be ill-formed for it and the detection trait must report it as
 // unversioned.
 static_assert(
-  !has_domain_version<specs::map::PointCloudMap>::value,
+  !tu::has_domain_version<specs::map::PointCloudMap>::value,
   "PointCloudMap must not resolve a domain version (raw point cloud, excluded from versioning)");
 // Positive control: a genuinely registered spec is still detected as versioned.
 static_assert(
-  has_domain_version<specs::map::VectorMap>::value, "VectorMap must resolve a domain version");
+  tu::has_domain_version<specs::map::VectorMap>::value, "VectorMap must resolve a domain version");
 
 TEST(map, concept_and_registration)
 {
@@ -86,41 +63,23 @@ TEST(map, concept_and_registration)
 TEST(map, interface)
 {
   {
-    using autoware::component_interface_specs::map::MapProjectorInfo;
-    size_t depth = 1;
-    EXPECT_EQ(MapProjectorInfo::depth, depth);
-    EXPECT_EQ(MapProjectorInfo::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(MapProjectorInfo::durability, RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
-
-    const auto qos = autoware::component_interface_specs::get_qos<MapProjectorInfo>();
-    EXPECT_EQ(qos.depth(), depth);
-    EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
-    EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::TransientLocal);
+    using specs::map::MapProjectorInfo;
+    tu::expect_topic_qos<MapProjectorInfo>(
+      "/map/map_projector_info", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+      RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
   }
 
   {
-    using autoware::component_interface_specs::map::PointCloudMap;
-    size_t depth = 1;
-    EXPECT_EQ(PointCloudMap::depth, depth);
-    EXPECT_EQ(PointCloudMap::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(PointCloudMap::durability, RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
-
-    const auto qos = autoware::component_interface_specs::get_qos<PointCloudMap>();
-    EXPECT_EQ(qos.depth(), depth);
-    EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
-    EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::TransientLocal);
+    using specs::map::PointCloudMap;
+    tu::expect_topic_qos<PointCloudMap>(
+      "/map/point_cloud_map", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+      RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
   }
 
   {
-    using autoware::component_interface_specs::map::VectorMap;
-    size_t depth = 1;
-    EXPECT_EQ(VectorMap::depth, depth);
-    EXPECT_EQ(VectorMap::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(VectorMap::durability, RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
-
-    const auto qos = autoware::component_interface_specs::get_qos<VectorMap>();
-    EXPECT_EQ(qos.depth(), depth);
-    EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
-    EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::TransientLocal);
+    using specs::map::VectorMap;
+    tu::expect_topic_qos<VectorMap>(
+      "/map/vector_map", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+      RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
   }
 }

--- a/common/autoware_component_interface_specs/test/test_map.cpp
+++ b/common/autoware_component_interface_specs/test/test_map.cpp
@@ -19,9 +19,41 @@
 #include "spec_test_utils.hpp"
 
 #include <tuple>
+#include <type_traits>
+#include <utility>
 
 namespace specs = autoware::component_interface_specs;
 namespace tu = autoware::component_interface_specs::test_utils;
+
+// Local mirror of universe's HasDomainVersion: a void_t/expression-SFINAE probe over
+// the ADL-resolved resolve_domain_version(const Spec &). Downstream consumers use
+// exactly this shape to decide whether a spec participates in versioned interface
+// registration, so PointCloudMap's heavy-raw confinement (design section 5) must be
+// type-enforced here as an ill-formed version resolution, not merely as a tuple
+// omission. Otherwise a consumer registering PointCloudMap would emit a manifest
+// record for an interface absent from the authority manifest.
+namespace
+{
+template <class, class = void>
+struct has_domain_version : std::false_type
+{
+};
+template <class S>
+struct has_domain_version<
+  S, std::void_t<decltype(resolve_domain_version(std::declval<const S &>()))>> : std::true_type
+{
+};
+}  // namespace
+
+// PointCloudMap is intentionally excluded from the versioned surface, so version
+// resolution must be ill-formed for it and the detection trait must report it as
+// unversioned.
+static_assert(
+  !has_domain_version<specs::map::PointCloudMap>::value,
+  "PointCloudMap must not resolve a domain version (heavy-raw confinement, design section 5)");
+// Positive control: a genuinely registered spec is still detected as versioned.
+static_assert(
+  has_domain_version<specs::map::VectorMap>::value, "VectorMap must resolve a domain version");
 
 TEST(map, version)
 {
@@ -52,6 +84,15 @@ TEST(map, concept_and_registration)
   // out of the versioned registration surface (heavy-raw confinement, design section 5).
   static_assert(!tu::has_type<PointCloudMap, Specs>::value);
   SUCCEED();
+}
+
+TEST(map, point_cloud_map_version_is_type_enforced)
+{
+  // The heavy-raw confinement of PointCloudMap is enforced through the version
+  // resolution hook, not just by omission from the Specs tuple: a downstream
+  // detection trait (universe's HasDomainVersion) must see it as unversioned.
+  EXPECT_FALSE(has_domain_version<specs::map::PointCloudMap>::value);
+  EXPECT_TRUE(has_domain_version<specs::map::VectorMap>::value);
 }
 
 TEST(map, get_differential_pointcloud_map_name)

--- a/common/autoware_component_interface_specs/test/test_map.cpp
+++ b/common/autoware_component_interface_specs/test/test_map.cpp
@@ -12,8 +12,53 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/component_interface_specs/concepts.hpp"
 #include "autoware/component_interface_specs/map.hpp"
+#include "autoware/component_interface_specs/version.hpp"
 #include "gtest/gtest.h"
+#include "spec_test_utils.hpp"
+
+#include <tuple>
+
+namespace specs = autoware::component_interface_specs;
+namespace tu = autoware::component_interface_specs::test_utils;
+
+TEST(map, version)
+{
+  static_assert(specs::map::version.major == 0);
+  static_assert(specs::map::version.minor == 1);
+  static_assert(specs::map::version.patch == 0);
+  EXPECT_EQ(specs::map::version.major, 0);
+}
+
+TEST(map, concept_and_registration)
+{
+  using specs::map::GetDifferentialPointCloudMap;
+  using specs::map::MapProjectorInfo;
+  using specs::map::PointCloudMap;
+  using specs::map::Specs;
+  using specs::map::VectorMap;
+
+  static_assert(specs::InterfaceSpec<MapProjectorInfo>);
+  static_assert(specs::InterfaceSpec<VectorMap>);
+  static_assert(specs::ServiceSpec<GetDifferentialPointCloudMap>);
+
+  static_assert(tu::has_type<MapProjectorInfo, Specs>::value);
+  static_assert(tu::has_type<VectorMap, Specs>::value);
+  static_assert(tu::has_type<GetDifferentialPointCloudMap, Specs>::value);
+  static_assert(std::tuple_size_v<Specs> == 3);
+
+  // PointCloudMap stays available to existing consumers but is deliberately kept
+  // out of the versioned registration surface (heavy-raw confinement, design section 5).
+  static_assert(!tu::has_type<PointCloudMap, Specs>::value);
+  SUCCEED();
+}
+
+TEST(map, get_differential_pointcloud_map_name)
+{
+  using specs::map::GetDifferentialPointCloudMap;
+  EXPECT_STREQ(GetDifferentialPointCloudMap::name, "/map/get_differential_pointcloud_map");
+}
 
 TEST(map, interface)
 {

--- a/common/autoware_component_interface_specs/test/test_map.cpp
+++ b/common/autoware_component_interface_specs/test/test_map.cpp
@@ -28,10 +28,11 @@ namespace tu = autoware::component_interface_specs::test_utils;
 // Local mirror of universe's HasDomainVersion: a void_t/expression-SFINAE probe over
 // the ADL-resolved resolve_domain_version(const Spec &). Downstream consumers use
 // exactly this shape to decide whether a spec participates in versioned interface
-// registration, so PointCloudMap's heavy-raw confinement (design section 5) must be
-// type-enforced here as an ill-formed version resolution, not merely as a tuple
-// omission. Otherwise a consumer registering PointCloudMap would emit a manifest
-// record for an interface absent from the authority manifest.
+// registration, so PointCloudMap's exclusion (it carries a raw point cloud payload
+// rather than a bounded interface message) must be type-enforced here as an
+// ill-formed version resolution, not merely as a tuple omission. Otherwise a
+// consumer registering PointCloudMap would emit a manifest record for an interface
+// absent from the authority manifest.
 namespace
 {
 template <class, class = void>
@@ -50,7 +51,7 @@ struct has_domain_version<
 // unversioned.
 static_assert(
   !has_domain_version<specs::map::PointCloudMap>::value,
-  "PointCloudMap must not resolve a domain version (heavy-raw confinement, design section 5)");
+  "PointCloudMap must not resolve a domain version (raw point cloud, excluded from versioning)");
 // Positive control: a genuinely registered spec is still detected as versioned.
 static_assert(
   has_domain_version<specs::map::VectorMap>::value, "VectorMap must resolve a domain version");
@@ -84,16 +85,17 @@ TEST(map, concept_and_registration)
   static_assert(std::tuple_size_v<Specs> == 4);
 
   // PointCloudMap stays available to existing consumers but is deliberately kept
-  // out of the versioned registration surface (heavy-raw confinement, design section 5).
+  // out of the versioned registration surface because it carries a raw point cloud
+  // payload rather than a bounded interface message.
   static_assert(!tu::has_type<PointCloudMap, Specs>::value);
   SUCCEED();
 }
 
 TEST(map, point_cloud_map_version_is_type_enforced)
 {
-  // The heavy-raw confinement of PointCloudMap is enforced through the version
-  // resolution hook, not just by omission from the Specs tuple: a downstream
-  // detection trait (universe's HasDomainVersion) must see it as unversioned.
+  // PointCloudMap's exclusion is enforced through the version resolution hook, not
+  // just by omission from the Specs tuple: a downstream detection trait (universe's
+  // HasDomainVersion) must see it as unversioned.
   EXPECT_FALSE(has_domain_version<specs::map::PointCloudMap>::value);
   EXPECT_TRUE(has_domain_version<specs::map::VectorMap>::value);
 }

--- a/common/autoware_component_interface_specs/test/test_map.cpp
+++ b/common/autoware_component_interface_specs/test/test_map.cpp
@@ -56,14 +56,6 @@ static_assert(
 static_assert(
   has_domain_version<specs::map::VectorMap>::value, "VectorMap must resolve a domain version");
 
-TEST(map, version)
-{
-  static_assert(specs::map::version.major == 0);
-  static_assert(specs::map::version.minor == 1);
-  static_assert(specs::map::version.patch == 0);
-  EXPECT_EQ(specs::map::version.major, 0);
-}
-
 TEST(map, concept_and_registration)
 {
   using specs::map::GetDifferentialPointCloudMap;
@@ -89,27 +81,6 @@ TEST(map, concept_and_registration)
   // payload rather than a bounded interface message.
   static_assert(!tu::has_type<PointCloudMap, Specs>::value);
   SUCCEED();
-}
-
-TEST(map, point_cloud_map_version_is_type_enforced)
-{
-  // PointCloudMap's exclusion is enforced through the version resolution hook, not
-  // just by omission from the Specs tuple: a downstream detection trait (universe's
-  // HasDomainVersion) must see it as unversioned.
-  EXPECT_FALSE(has_domain_version<specs::map::PointCloudMap>::value);
-  EXPECT_TRUE(has_domain_version<specs::map::VectorMap>::value);
-}
-
-TEST(map, get_differential_pointcloud_map_name)
-{
-  using specs::map::GetDifferentialPointCloudMap;
-  EXPECT_STREQ(GetDifferentialPointCloudMap::name, "/map/get_differential_pointcloud_map");
-}
-
-TEST(map, get_partial_pointcloud_map_name)
-{
-  using specs::map::GetPartialPointCloudMap;
-  EXPECT_STREQ(GetPartialPointCloudMap::name, "/map/get_partial_pointcloud_map");
 }
 
 TEST(map, interface)


### PR DESCRIPTION
## Description

Register and version the map inter-component boundary specs in `autoware_component_interface_specs` at v0.1.0, on the per-domain versioning foundation from #1259: this branch registers the existing `VectorMap` and `MapProjectorInfo` specs plus two new service specs, `GetDifferentialPointCloudMap` (`/map/get_differential_pointcloud_map`) and `GetPartialPointCloudMap` (`/map/get_partial_pointcloud_map`), into `map::Specs`; `PointCloudMap` keeps its struct for existing consumers but is deliberately excluded from the versioned `Specs` tuple, and its version resolution is deleted at compile time so the exclusion cannot be bypassed, to keep the large raw point-cloud payload out of the versioned registration surface.

The map domain's boundary is what a component must know about the world before it can drive, and this set is bounded by one rule rather than by a component split: heavy raw data stays out of the versioned contract where a derived or on-demand form serves the consumer instead. The lanelet map and the projector info are small latched messages every consumer needs in full; map points are needed in regions, so the registered form is the two on-demand services and the full `/map/point_cloud_map` stream is the deliberate omission — the header makes its version resolution ill-formed rather than merely omitting it from the tuple, so the exclusion is enforced by the compiler instead of resting on a convention a downstream package could quietly ignore. Unlike the pipeline domains, map has no internal chain of intermediate topics to leave out, so that raw-payload rule is the whole of what bounds the set. `GetPartialPointCloudMap` and `GetDifferentialPointCloudMap` are what make the omission affordable: they hand a consumer the region it asks for, so leaving the full cloud unversioned costs that consumer nothing.

Each spec records the message/service type, topic/service name, and QoS the boundary is published/consumed with today; `interface_manifest.json` is regenerated by the in-package generator.

**Stack note:** this PR is based on #1307, which adds the shared test helper its tests include, so its diff shows that helper until #1307 merges and only this domain's own change afterwards. The eight domain PRs in this series (perception, planning, control, localization, map, sensing, vehicle, system) are independent of one another and can be reviewed and merged in any order: they touch disjoint domain headers and test files, and their generated `interface_manifest.json` entries occupy disjoint regions of the same sorted array.

The table below is the map domain's complete registered spec set after this PR — every entry of `map::Specs`, not only the ones this PR adds — so a reader can see the whole domain contract at a glance. `PointCloudMap` (`/map/point_cloud_map`) has no row because it is the deliberate exclusion described above: its struct stays in the header for existing consumers, but it is not part of the versioned registration surface and no longer appears in `interface_manifest.json`.

| Spec | Topic or service | Type | Status |
| --- | --- | --- | --- |
| `VectorMap` | `/map/vector_map` | `autoware_map_msgs/msg/LaneletMapBin` (topic) | already registered |
| `MapProjectorInfo` | `/map/map_projector_info` | `autoware_map_msgs/msg/MapProjectorInfo` (topic) | already registered |
| `GetDifferentialPointCloudMap` | `/map/get_differential_pointcloud_map` | `autoware_map_msgs/srv/GetDifferentialPointCloudMap` (service) | new in this PR |
| `GetPartialPointCloudMap` | `/map/get_partial_pointcloud_map` | `autoware_map_msgs/srv/GetPartialPointCloudMap` (service) | new in this PR |

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

## How was this PR tested?

Built and tested in the `autoware:universe-devel-jazzy` devel container (`colcon build && colcon test`, 0 failures) at this branch tip. A regression test asserts `PointCloudMap` is unversioned (a direct `spec_version<PointCloudMap>()` call is a compile error) while `VectorMap` stays versioned.

## Notes for reviewers

`GetPartialPointCloudMap` was added after a review pass over the running system found it consumed cross-domain, as the companion PCD-map delivery path to `GetDifferentialPointCloudMap`: `pose_initializer` (localization) calls it through its embedded map-height fitter. `PointCloudMap`'s struct definition is unchanged; only its inclusion in the `Specs` tuple was removed, so existing consumers of the struct are unaffected. The struct also carries an `// interface-spec-lint: not-versioned` marker: that is a forward reference to the lint package proposed in #1260, which reads the marker to exempt a deliberately unversioned spec from its `spec_registered` check; the marker is an inert comment until #1260 lands. This PR is core-only; the matching re-export of these specs in the universe package is tracked as separate follow-up work.

## Interface changes

None on the wire. No publisher, subscriber, or service is created or modified; all four registered interfaces already exist. The compile-time registration surface does change in both directions: two service specs are added to the `Specs` tuple and `PointCloudMap` is removed from it, so `/map/point_cloud_map` also disappears from the generated `interface_manifest.json`. That is a registration change, not an interface change — the struct, the topic, and its publisher are all untouched.

## Effects on system behavior

None. Header-only data plus tests; no node, launch, or QoS-on-the-wire change.
