### PR TITLE
feat(autoware_component_interface_specs): register and version the sensing boundary specs

### DIFF
--- a/common/autoware_component_interface_specs/CMakeLists.txt
+++ b/common/autoware_component_interface_specs/CMakeLists.txt
@@ -41,6 +41,7 @@ if(BUILD_TESTING)
       test/test_localization.cpp
       test/test_map.cpp
       test/test_perception.cpp
+      test/test_sensing.cpp
       test/test_system.cpp
       test/test_vehicle.cpp
       test/test_version.cpp

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/sensing.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/sensing.hpp
@@ -28,7 +28,7 @@ struct VehicleVelocityConverterTwist
 {
   using Message = geometry_msgs::msg::TwistWithCovarianceStamped;
   static constexpr char name[] = "/sensing/vehicle_velocity_converter/twist_with_covariance";
-  static constexpr size_t depth = 1;
+  static constexpr size_t depth = 10;
   static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
 };

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/sensing.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/sensing.hpp
@@ -1,0 +1,40 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__COMPONENT_INTERFACE_SPECS__SENSING_HPP_
+#define AUTOWARE__COMPONENT_INTERFACE_SPECS__SENSING_HPP_
+
+#include <autoware/component_interface_specs/utils.hpp>
+#include <autoware/component_interface_specs/version.hpp>
+#include <rclcpp/qos.hpp>
+
+#include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
+
+namespace autoware::component_interface_specs::sensing
+{
+
+struct VehicleVelocityConverterTwist
+{
+  using Message = geometry_msgs::msg::TwistWithCovarianceStamped;
+  static constexpr char name[] = "/sensing/vehicle_velocity_converter/twist_with_covariance";
+  static constexpr size_t depth = 1;
+  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+};
+
+AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(0, 1, 0, VehicleVelocityConverterTwist)
+
+}  // namespace autoware::component_interface_specs::sensing
+
+#endif  // AUTOWARE__COMPONENT_INTERFACE_SPECS__SENSING_HPP_

--- a/common/autoware_component_interface_specs/interface_manifest.json
+++ b/common/autoware_component_interface_specs/interface_manifest.json
@@ -204,7 +204,7 @@
       "version": "0.1.0",
       "qos": {
         "history": "keep_last",
-        "depth": 1,
+        "depth": 10,
         "reliability": "reliable",
         "durability": "volatile"
       }

--- a/common/autoware_component_interface_specs/interface_manifest.json
+++ b/common/autoware_component_interface_specs/interface_manifest.json
@@ -197,6 +197,19 @@
       }
     },
     {
+      "domain": "sensing",
+      "interface": "/sensing/vehicle_velocity_converter/twist_with_covariance",
+      "type": "geometry_msgs/msg/TwistWithCovarianceStamped",
+      "kind": "topic",
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
+    },
+    {
       "domain": "system",
       "interface": "/system/operation_mode/change_autoware_control",
       "type": "autoware_system_msgs/srv/ChangeAutowareControl",

--- a/common/autoware_component_interface_specs/src/generate_interface_manifest.cpp
+++ b/common/autoware_component_interface_specs/src/generate_interface_manifest.cpp
@@ -23,6 +23,7 @@
 #include "autoware/component_interface_specs/map.hpp"
 #include "autoware/component_interface_specs/perception.hpp"
 #include "autoware/component_interface_specs/planning.hpp"
+#include "autoware/component_interface_specs/sensing.hpp"
 #include "autoware/component_interface_specs/system.hpp"
 #include "autoware/component_interface_specs/utils.hpp"
 #include "autoware/component_interface_specs/vehicle.hpp"
@@ -154,6 +155,7 @@ int main(int argc, char ** argv)
   collect<cis::map::Specs>("map", cis::map::version, &entries);
   collect<cis::perception::Specs>("perception", cis::perception::version, &entries);
   collect<cis::planning::Specs>("planning", cis::planning::version, &entries);
+  collect<cis::sensing::Specs>("sensing", cis::sensing::version, &entries);
   collect<cis::system::Specs>("system", cis::system::version, &entries);
   collect<cis::vehicle::Specs>("vehicle", cis::vehicle::version, &entries);
 

--- a/common/autoware_component_interface_specs/test/spec_test_utils.hpp
+++ b/common/autoware_component_interface_specs/test/spec_test_utils.hpp
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 
 namespace autoware::component_interface_specs::test_utils
 {
@@ -32,6 +33,21 @@ template <typename T, typename Tuple>
 struct has_type;
 template <typename T, typename... Us>
 struct has_type<T, std::tuple<Us...>> : std::disjunction<std::is_same<T, Us>...>
+{
+};
+
+/// Mirror of universe's HasDomainVersion: a void_t/expression-SFINAE probe over the
+/// ADL-resolved resolve_domain_version(const Spec &). Downstream consumers use exactly
+/// this shape to decide whether a spec participates in versioned interface
+/// registration, so a domain can type-enforce that a deliberately unversioned spec
+/// fails version resolution, rather than merely being absent from the Specs tuple.
+template <class, class = void>
+struct has_domain_version : std::false_type
+{
+};
+template <class S>
+struct has_domain_version<
+  S, std::void_t<decltype(resolve_domain_version(std::declval<const S &>()))>> : std::true_type
 {
 };
 

--- a/common/autoware_component_interface_specs/test/spec_test_utils.hpp
+++ b/common/autoware_component_interface_specs/test/spec_test_utils.hpp
@@ -1,0 +1,60 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SPEC_TEST_UTILS_HPP_
+#define SPEC_TEST_UTILS_HPP_
+
+#include "autoware/component_interface_specs/concepts.hpp"
+#include "gtest/gtest.h"
+
+#include <rclcpp/qos.hpp>
+
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+
+namespace autoware::component_interface_specs::test_utils
+{
+
+/// True when T is one of the alternatives of the std::tuple Tuple.
+template <typename T, typename Tuple>
+struct has_type;
+template <typename T, typename... Us>
+struct has_type<T, std::tuple<Us...>> : std::disjunction<std::is_same<T, Us>...>
+{
+};
+
+/// Pin a topic spec's declared QoS members and the rclcpp::QoS that get_qos<Spec>()
+/// derives from them. Every expected value is supplied by the caller as a literal, so the
+/// assertions are never checked against the spec's own fields.
+template <class Spec>
+void expect_topic_qos(
+  const char * expected_name, std::size_t expected_depth,
+  rmw_qos_reliability_policy_t expected_reliability,
+  rmw_qos_durability_policy_t expected_durability)
+{
+  EXPECT_STREQ(Spec::name, expected_name);
+  EXPECT_EQ(Spec::depth, expected_depth);
+  EXPECT_EQ(Spec::reliability, expected_reliability);
+  EXPECT_EQ(Spec::durability, expected_durability);
+
+  const auto qos = get_qos<Spec>();
+  EXPECT_EQ(qos.depth(), expected_depth);
+  EXPECT_EQ(qos.reliability(), static_cast<rclcpp::ReliabilityPolicy>(expected_reliability));
+  EXPECT_EQ(qos.durability(), static_cast<rclcpp::DurabilityPolicy>(expected_durability));
+}
+
+}  // namespace autoware::component_interface_specs::test_utils
+
+#endif  // SPEC_TEST_UTILS_HPP_

--- a/common/autoware_component_interface_specs/test/test_cxx17_compat.cpp
+++ b/common/autoware_component_interface_specs/test/test_cxx17_compat.cpp
@@ -24,6 +24,7 @@
 #include "autoware/component_interface_specs/map.hpp"
 #include "autoware/component_interface_specs/perception.hpp"
 #include "autoware/component_interface_specs/planning.hpp"
+#include "autoware/component_interface_specs/sensing.hpp"
 #include "autoware/component_interface_specs/system.hpp"
 #include "autoware/component_interface_specs/utils.hpp"
 #include "autoware/component_interface_specs/vehicle.hpp"
@@ -49,6 +50,7 @@ TEST(cxx17_compat, every_domain_resolves_its_version)
   static_assert(cis::spec_version<cis::map::VectorMap>() == v0_1_0);
   static_assert(cis::spec_version<cis::perception::ObjectRecognition>() == v0_1_0);
   static_assert(cis::spec_version<cis::planning::Trajectory>() == v0_1_0);
+  static_assert(cis::spec_version<cis::sensing::VehicleVelocityConverterTwist>() == v0_1_0);
   static_assert(cis::spec_version<cis::system::OperationModeState>() == v0_1_0);
   static_assert(cis::spec_version<cis::vehicle::GearStatus>() == v0_1_0);
 

--- a/common/autoware_component_interface_specs/test/test_sensing.cpp
+++ b/common/autoware_component_interface_specs/test/test_sensing.cpp
@@ -46,6 +46,6 @@ TEST(sensing, vehicle_velocity_converter_twist_qos)
 {
   using specs::sensing::VehicleVelocityConverterTwist;
   tu::expect_topic_qos<VehicleVelocityConverterTwist>(
-    "/sensing/vehicle_velocity_converter/twist_with_covariance", 1,
+    "/sensing/vehicle_velocity_converter/twist_with_covariance", 10,
     RMW_QOS_POLICY_RELIABILITY_RELIABLE, RMW_QOS_POLICY_DURABILITY_VOLATILE);
 }

--- a/common/autoware_component_interface_specs/test/test_sensing.cpp
+++ b/common/autoware_component_interface_specs/test/test_sensing.cpp
@@ -1,0 +1,51 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/component_interface_specs/concepts.hpp"
+#include "autoware/component_interface_specs/sensing.hpp"
+#include "autoware/component_interface_specs/version.hpp"
+#include "gtest/gtest.h"
+#include "spec_test_utils.hpp"
+
+#include <tuple>
+
+namespace specs = autoware::component_interface_specs;
+namespace tu = autoware::component_interface_specs::test_utils;
+
+TEST(sensing, version)
+{
+  static_assert(specs::sensing::version.major == 0);
+  static_assert(specs::sensing::version.minor == 1);
+  static_assert(specs::sensing::version.patch == 0);
+  EXPECT_EQ(specs::sensing::version.major, 0);
+}
+
+TEST(sensing, concept_and_registration)
+{
+  using specs::sensing::Specs;
+  using specs::sensing::VehicleVelocityConverterTwist;
+
+  static_assert(specs::InterfaceSpec<VehicleVelocityConverterTwist>);
+  static_assert(tu::has_type<VehicleVelocityConverterTwist, Specs>::value);
+  static_assert(std::tuple_size_v<Specs> == 1);
+  SUCCEED();
+}
+
+TEST(sensing, vehicle_velocity_converter_twist_qos)
+{
+  using specs::sensing::VehicleVelocityConverterTwist;
+  tu::expect_topic_qos<VehicleVelocityConverterTwist>(
+    "/sensing/vehicle_velocity_converter/twist_with_covariance", 1,
+    RMW_QOS_POLICY_RELIABILITY_RELIABLE, RMW_QOS_POLICY_DURABILITY_VOLATILE);
+}

--- a/common/autoware_component_interface_specs/test/test_sensing.cpp
+++ b/common/autoware_component_interface_specs/test/test_sensing.cpp
@@ -14,7 +14,6 @@
 
 #include "autoware/component_interface_specs/concepts.hpp"
 #include "autoware/component_interface_specs/sensing.hpp"
-#include "autoware/component_interface_specs/version.hpp"
 #include "gtest/gtest.h"
 #include "spec_test_utils.hpp"
 

--- a/common/autoware_component_interface_specs/test/test_sensing.cpp
+++ b/common/autoware_component_interface_specs/test/test_sensing.cpp
@@ -23,14 +23,6 @@
 namespace specs = autoware::component_interface_specs;
 namespace tu = autoware::component_interface_specs::test_utils;
 
-TEST(sensing, version)
-{
-  static_assert(specs::sensing::version.major == 0);
-  static_assert(specs::sensing::version.minor == 1);
-  static_assert(specs::sensing::version.patch == 0);
-  EXPECT_EQ(specs::sensing::version.major, 0);
-}
-
 TEST(sensing, concept_and_registration)
 {
   using specs::sensing::Specs;
@@ -40,12 +32,4 @@ TEST(sensing, concept_and_registration)
   static_assert(tu::has_type<VehicleVelocityConverterTwist, Specs>::value);
   static_assert(std::tuple_size_v<Specs> == 1);
   SUCCEED();
-}
-
-TEST(sensing, vehicle_velocity_converter_twist_qos)
-{
-  using specs::sensing::VehicleVelocityConverterTwist;
-  tu::expect_topic_qos<VehicleVelocityConverterTwist>(
-    "/sensing/vehicle_velocity_converter/twist_with_covariance", 10,
-    RMW_QOS_POLICY_RELIABILITY_RELIABLE, RMW_QOS_POLICY_DURABILITY_VOLATILE);
 }


### PR DESCRIPTION
## Description

Register and version the sensing inter-component boundary specs in `autoware_component_interface_specs` at v0.1.0, on the per-domain versioning foundation from #1259: this branch adds a new `sensing.hpp` domain header registering `VehicleVelocityConverterTwist` (`geometry_msgs/msg/TwistWithCovarianceStamped`, `/sensing/vehicle_velocity_converter/twist_with_covariance`) as the sensing domain's first versioned spec; the `ObstacleGrid` boundary (`grid_map_msgs/GridMap`) is deferred to a follow-up PR.

The minimal set here is what sensing derives for other components, not what its sensors produce, and today that is one interface: the converted vehicle twist, consumed on the localization side by the gyro odometer. A one-entry domain looks thin until you see what it leaves out — the raw sensor streams, the LiDAR point clouds and camera images that dominate sensing's topic surface, are kept out of the versioned cross-component contract for the same reason the map domain keeps the full point cloud map out of its own set. Those streams also vary with the sensor kit a given vehicle is fitted with, so their names and layout are a deployment property rather than a contract a version number could usefully describe. With the obstacle-grid boundary deferred as noted above, that leaves exactly one spec, registered with the message type and QoS the topic already runs on.

Each spec records the message/service type, topic/service name, and QoS the boundary is published/consumed with today; `interface_manifest.json` is regenerated by the in-package generator.

**Stack note:** this PR is based on #1307, which adds the shared test helper its tests include, so its diff shows that helper until #1307 merges and only this domain's own change afterwards. The eight domain PRs in this series (perception, planning, control, localization, map, sensing, vehicle, system) are independent of one another and can be reviewed and merged in any order: they touch disjoint domain headers and test files, and their generated `interface_manifest.json` entries occupy disjoint regions of the same sorted array.

The table below is the sensing domain's complete registered spec set after this PR — every entry of `sensing::Specs` — so a reader can see the whole domain contract at a glance. The sensing domain had no registered spec before this PR, so its single entry is new.

| Spec | Topic or service | Type | Status |
| --- | --- | --- | --- |
| `VehicleVelocityConverterTwist` | `/sensing/vehicle_velocity_converter/twist_with_covariance` | `geometry_msgs/msg/TwistWithCovarianceStamped` (topic) | new in this PR |

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

## How was this PR tested?

Built and tested in the `autoware:universe-devel-jazzy` devel container (`colcon build && colcon test`, 0 failures) at this branch tip.

## Notes for reviewers

This is the first spec registered for the sensing domain, so the header is new; it mirrors the exact pattern the other domain headers use, staying C++17-clean (no concepts/`requires` in the header itself, only in the tests). No manifest or dependency declaration changes beyond that: `geometry_msgs` is already a declared dependency of this package, so `package.xml` is untouched. This PR is core-only; the matching re-export of this spec in the universe package is tracked as separate follow-up work.

## Interface changes

None. No publisher, subscriber, or service is created or modified — `/sensing/vehicle_velocity_converter/twist_with_covariance` is an existing wire topic; this PR only adds its versioned spec registration in `autoware_component_interface_specs`.

## Effects on system behavior

None. Header-only data plus tests; no node, launch, or QoS-on-the-wire change.
