### PR TITLE
feat(autoware_component_interface_specs): register and version the vehicle boundary specs

### DIFF
--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/vehicle.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/vehicle.hpp
@@ -20,6 +20,7 @@
 #include <autoware/component_interface_specs/utils.hpp>
 #include <autoware/component_interface_specs/version.hpp>
 
+#include <autoware_vehicle_msgs/msg/control_mode_report.hpp>
 #include <autoware_vehicle_msgs/msg/gear_report.hpp>
 #include <autoware_vehicle_msgs/msg/hazard_lights_report.hpp>
 #include <autoware_vehicle_msgs/msg/steering_report.hpp>
@@ -76,8 +77,18 @@ struct HazardLightStatus
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
 };
 
+struct ControlModeStatus  // new spec (vehicle->control/system safety-supervision report)
+{
+  using Message = autoware_vehicle_msgs::msg::ControlModeReport;
+  static constexpr char name[] = "/vehicle/status/control_mode";
+  static constexpr size_t depth = 1;
+  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+};
+
 AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(
-  0, 1, 0, VelocityStatus, SteeringStatus, GearStatus, TurnIndicatorStatus, HazardLightStatus)
+  0, 1, 0, VelocityStatus, SteeringStatus, GearStatus, TurnIndicatorStatus, HazardLightStatus,
+  ControlModeStatus)
 
 }  // namespace autoware::component_interface_specs::vehicle
 

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/vehicle.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/vehicle.hpp
@@ -24,11 +24,21 @@
 #include <autoware_vehicle_msgs/msg/hazard_lights_report.hpp>
 #include <autoware_vehicle_msgs/msg/steering_report.hpp>
 #include <autoware_vehicle_msgs/msg/turn_indicators_report.hpp>
+#include <autoware_vehicle_msgs/msg/velocity_report.hpp>
 
 #include <rmw/qos_profiles.h>
 
 namespace autoware::component_interface_specs::vehicle
 {
+
+struct VelocityStatus  // new spec (largest gap; consumed by every domain)
+{
+  using Message = autoware_vehicle_msgs::msg::VelocityReport;
+  static constexpr char name[] = "/vehicle/status/velocity_status";
+  static constexpr size_t depth = 1;
+  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+};
 
 struct SteeringStatus
 {
@@ -67,7 +77,7 @@ struct HazardLightStatus
 };
 
 AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(
-  0, 1, 0, SteeringStatus, GearStatus, TurnIndicatorStatus, HazardLightStatus)
+  0, 1, 0, VelocityStatus, SteeringStatus, GearStatus, TurnIndicatorStatus, HazardLightStatus)
 
 }  // namespace autoware::component_interface_specs::vehicle
 

--- a/common/autoware_component_interface_specs/interface_manifest.json
+++ b/common/autoware_component_interface_specs/interface_manifest.json
@@ -237,6 +237,19 @@
     },
     {
       "domain": "vehicle",
+      "interface": "/vehicle/status/velocity_status",
+      "type": "autoware_vehicle_msgs/msg/VelocityReport",
+      "kind": "topic",
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
+    },
+    {
+      "domain": "vehicle",
       "interface": "/vehicle/status/steering_status",
       "type": "autoware_vehicle_msgs/msg/SteeringReport",
       "kind": "topic",

--- a/common/autoware_component_interface_specs/interface_manifest.json
+++ b/common/autoware_component_interface_specs/interface_manifest.json
@@ -299,6 +299,19 @@
         "reliability": "reliable",
         "durability": "volatile"
       }
+    },
+    {
+      "domain": "vehicle",
+      "interface": "/vehicle/status/control_mode",
+      "type": "autoware_vehicle_msgs/msg/ControlModeReport",
+      "kind": "topic",
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
     }
   ]
 }

--- a/common/autoware_component_interface_specs/test/spec_test_utils.hpp
+++ b/common/autoware_component_interface_specs/test/spec_test_utils.hpp
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 
 namespace autoware::component_interface_specs::test_utils
 {
@@ -32,6 +33,21 @@ template <typename T, typename Tuple>
 struct has_type;
 template <typename T, typename... Us>
 struct has_type<T, std::tuple<Us...>> : std::disjunction<std::is_same<T, Us>...>
+{
+};
+
+/// Mirror of universe's HasDomainVersion: a void_t/expression-SFINAE probe over the
+/// ADL-resolved resolve_domain_version(const Spec &). Downstream consumers use exactly
+/// this shape to decide whether a spec participates in versioned interface
+/// registration, so a domain can type-enforce that a deliberately unversioned spec
+/// fails version resolution, rather than merely being absent from the Specs tuple.
+template <class, class = void>
+struct has_domain_version : std::false_type
+{
+};
+template <class S>
+struct has_domain_version<
+  S, std::void_t<decltype(resolve_domain_version(std::declval<const S &>()))>> : std::true_type
 {
 };
 

--- a/common/autoware_component_interface_specs/test/spec_test_utils.hpp
+++ b/common/autoware_component_interface_specs/test/spec_test_utils.hpp
@@ -1,0 +1,60 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SPEC_TEST_UTILS_HPP_
+#define SPEC_TEST_UTILS_HPP_
+
+#include "autoware/component_interface_specs/concepts.hpp"
+#include "gtest/gtest.h"
+
+#include <rclcpp/qos.hpp>
+
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+
+namespace autoware::component_interface_specs::test_utils
+{
+
+/// True when T is one of the alternatives of the std::tuple Tuple.
+template <typename T, typename Tuple>
+struct has_type;
+template <typename T, typename... Us>
+struct has_type<T, std::tuple<Us...>> : std::disjunction<std::is_same<T, Us>...>
+{
+};
+
+/// Pin a topic spec's declared QoS members and the rclcpp::QoS that get_qos<Spec>()
+/// derives from them. Every expected value is supplied by the caller as a literal, so the
+/// assertions are never checked against the spec's own fields.
+template <class Spec>
+void expect_topic_qos(
+  const char * expected_name, std::size_t expected_depth,
+  rmw_qos_reliability_policy_t expected_reliability,
+  rmw_qos_durability_policy_t expected_durability)
+{
+  EXPECT_STREQ(Spec::name, expected_name);
+  EXPECT_EQ(Spec::depth, expected_depth);
+  EXPECT_EQ(Spec::reliability, expected_reliability);
+  EXPECT_EQ(Spec::durability, expected_durability);
+
+  const auto qos = get_qos<Spec>();
+  EXPECT_EQ(qos.depth(), expected_depth);
+  EXPECT_EQ(qos.reliability(), static_cast<rclcpp::ReliabilityPolicy>(expected_reliability));
+  EXPECT_EQ(qos.durability(), static_cast<rclcpp::DurabilityPolicy>(expected_durability));
+}
+
+}  // namespace autoware::component_interface_specs::test_utils
+
+#endif  // SPEC_TEST_UTILS_HPP_

--- a/common/autoware_component_interface_specs/test/test_vehicle.cpp
+++ b/common/autoware_component_interface_specs/test/test_vehicle.cpp
@@ -12,8 +12,56 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "autoware/component_interface_specs/concepts.hpp"
 #include "autoware/component_interface_specs/vehicle.hpp"
+#include "autoware/component_interface_specs/version.hpp"
 #include "gtest/gtest.h"
+#include "spec_test_utils.hpp"
+
+#include <tuple>
+
+namespace specs = autoware::component_interface_specs;
+namespace tu = autoware::component_interface_specs::test_utils;
+
+TEST(vehicle, version)
+{
+  static_assert(specs::vehicle::version.major == 0);
+  static_assert(specs::vehicle::version.minor == 1);
+  static_assert(specs::vehicle::version.patch == 0);
+  EXPECT_EQ(specs::vehicle::version.major, 0);
+}
+
+TEST(vehicle, concept_and_registration)
+{
+  using specs::vehicle::GearStatus;
+  using specs::vehicle::HazardLightStatus;
+  using specs::vehicle::Specs;
+  using specs::vehicle::SteeringStatus;
+  using specs::vehicle::TurnIndicatorStatus;
+  using specs::vehicle::VelocityStatus;
+
+  static_assert(specs::InterfaceSpec<VelocityStatus>);
+  static_assert(specs::InterfaceSpec<SteeringStatus>);
+  static_assert(specs::InterfaceSpec<GearStatus>);
+  static_assert(specs::InterfaceSpec<TurnIndicatorStatus>);
+  static_assert(specs::InterfaceSpec<HazardLightStatus>);
+
+  static_assert(tu::has_type<VelocityStatus, Specs>::value);
+  static_assert(tu::has_type<SteeringStatus, Specs>::value);
+  static_assert(tu::has_type<GearStatus, Specs>::value);
+  static_assert(tu::has_type<TurnIndicatorStatus, Specs>::value);
+  static_assert(tu::has_type<HazardLightStatus, Specs>::value);
+  static_assert(std::tuple_size_v<Specs> == 5);
+  SUCCEED();
+}
+
+TEST(vehicle, velocity_status_qos)
+{
+  using specs::vehicle::VelocityStatus;
+  tu::expect_topic_qos<VelocityStatus>(
+    "/vehicle/status/velocity_status", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+    RMW_QOS_POLICY_DURABILITY_VOLATILE);
+}
 
 TEST(vehicle, interface)
 {

--- a/common/autoware_component_interface_specs/test/test_vehicle.cpp
+++ b/common/autoware_component_interface_specs/test/test_vehicle.cpp
@@ -23,14 +23,6 @@
 namespace specs = autoware::component_interface_specs;
 namespace tu = autoware::component_interface_specs::test_utils;
 
-TEST(vehicle, version)
-{
-  static_assert(specs::vehicle::version.major == 0);
-  static_assert(specs::vehicle::version.minor == 1);
-  static_assert(specs::vehicle::version.patch == 0);
-  EXPECT_EQ(specs::vehicle::version.major, 0);
-}
-
 TEST(vehicle, concept_and_registration)
 {
   using specs::vehicle::ControlModeStatus;
@@ -56,22 +48,6 @@ TEST(vehicle, concept_and_registration)
   static_assert(tu::has_type<ControlModeStatus, Specs>::value);
   static_assert(std::tuple_size_v<Specs> == 6);
   SUCCEED();
-}
-
-TEST(vehicle, velocity_status_qos)
-{
-  using specs::vehicle::VelocityStatus;
-  tu::expect_topic_qos<VelocityStatus>(
-    "/vehicle/status/velocity_status", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-    RMW_QOS_POLICY_DURABILITY_VOLATILE);
-}
-
-TEST(vehicle, control_mode_status_qos)
-{
-  using specs::vehicle::ControlModeStatus;
-  tu::expect_topic_qos<ControlModeStatus>(
-    "/vehicle/status/control_mode", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-    RMW_QOS_POLICY_DURABILITY_VOLATILE);
 }
 
 TEST(vehicle, interface)

--- a/common/autoware_component_interface_specs/test/test_vehicle.cpp
+++ b/common/autoware_component_interface_specs/test/test_vehicle.cpp
@@ -14,7 +14,6 @@
 
 #include "autoware/component_interface_specs/concepts.hpp"
 #include "autoware/component_interface_specs/vehicle.hpp"
-#include "autoware/component_interface_specs/version.hpp"
 #include "gtest/gtest.h"
 #include "spec_test_utils.hpp"
 
@@ -53,54 +52,30 @@ TEST(vehicle, concept_and_registration)
 TEST(vehicle, interface)
 {
   {
-    using autoware::component_interface_specs::vehicle::SteeringStatus;
-    size_t depth = 1;
-    EXPECT_EQ(SteeringStatus::depth, depth);
-    EXPECT_EQ(SteeringStatus::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(SteeringStatus::durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
-
-    const auto qos = autoware::component_interface_specs::get_qos<SteeringStatus>();
-    EXPECT_EQ(qos.depth(), depth);
-    EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
-    EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);
+    using specs::vehicle::SteeringStatus;
+    tu::expect_topic_qos<SteeringStatus>(
+      "/vehicle/status/steering_status", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+      RMW_QOS_POLICY_DURABILITY_VOLATILE);
   }
 
   {
-    using autoware::component_interface_specs::vehicle::GearStatus;
-    size_t depth = 1;
-    EXPECT_EQ(GearStatus::depth, depth);
-    EXPECT_EQ(GearStatus::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(GearStatus::durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
-
-    const auto qos = autoware::component_interface_specs::get_qos<GearStatus>();
-    EXPECT_EQ(qos.depth(), depth);
-    EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
-    EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);
+    using specs::vehicle::GearStatus;
+    tu::expect_topic_qos<GearStatus>(
+      "/vehicle/status/gear_status", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+      RMW_QOS_POLICY_DURABILITY_VOLATILE);
   }
 
   {
-    using autoware::component_interface_specs::vehicle::TurnIndicatorStatus;
-    size_t depth = 1;
-    EXPECT_EQ(TurnIndicatorStatus::depth, depth);
-    EXPECT_EQ(TurnIndicatorStatus::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(TurnIndicatorStatus::durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
-
-    const auto qos = autoware::component_interface_specs::get_qos<TurnIndicatorStatus>();
-    EXPECT_EQ(qos.depth(), depth);
-    EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
-    EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);
+    using specs::vehicle::TurnIndicatorStatus;
+    tu::expect_topic_qos<TurnIndicatorStatus>(
+      "/vehicle/status/turn_indicators_status", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+      RMW_QOS_POLICY_DURABILITY_VOLATILE);
   }
 
   {
-    using autoware::component_interface_specs::vehicle::HazardLightStatus;
-    size_t depth = 1;
-    EXPECT_EQ(HazardLightStatus::depth, depth);
-    EXPECT_EQ(HazardLightStatus::reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(HazardLightStatus::durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
-
-    const auto qos = autoware::component_interface_specs::get_qos<HazardLightStatus>();
-    EXPECT_EQ(qos.depth(), depth);
-    EXPECT_EQ(qos.reliability(), rclcpp::ReliabilityPolicy::Reliable);
-    EXPECT_EQ(qos.durability(), rclcpp::DurabilityPolicy::Volatile);
+    using specs::vehicle::HazardLightStatus;
+    tu::expect_topic_qos<HazardLightStatus>(
+      "/vehicle/status/hazard_lights_status", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+      RMW_QOS_POLICY_DURABILITY_VOLATILE);
   }
 }

--- a/common/autoware_component_interface_specs/test/test_vehicle.cpp
+++ b/common/autoware_component_interface_specs/test/test_vehicle.cpp
@@ -33,6 +33,7 @@ TEST(vehicle, version)
 
 TEST(vehicle, concept_and_registration)
 {
+  using specs::vehicle::ControlModeStatus;
   using specs::vehicle::GearStatus;
   using specs::vehicle::HazardLightStatus;
   using specs::vehicle::Specs;
@@ -45,13 +46,15 @@ TEST(vehicle, concept_and_registration)
   static_assert(specs::InterfaceSpec<GearStatus>);
   static_assert(specs::InterfaceSpec<TurnIndicatorStatus>);
   static_assert(specs::InterfaceSpec<HazardLightStatus>);
+  static_assert(specs::InterfaceSpec<ControlModeStatus>);
 
   static_assert(tu::has_type<VelocityStatus, Specs>::value);
   static_assert(tu::has_type<SteeringStatus, Specs>::value);
   static_assert(tu::has_type<GearStatus, Specs>::value);
   static_assert(tu::has_type<TurnIndicatorStatus, Specs>::value);
   static_assert(tu::has_type<HazardLightStatus, Specs>::value);
-  static_assert(std::tuple_size_v<Specs> == 5);
+  static_assert(tu::has_type<ControlModeStatus, Specs>::value);
+  static_assert(std::tuple_size_v<Specs> == 6);
   SUCCEED();
 }
 
@@ -60,6 +63,14 @@ TEST(vehicle, velocity_status_qos)
   using specs::vehicle::VelocityStatus;
   tu::expect_topic_qos<VelocityStatus>(
     "/vehicle/status/velocity_status", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+    RMW_QOS_POLICY_DURABILITY_VOLATILE);
+}
+
+TEST(vehicle, control_mode_status_qos)
+{
+  using specs::vehicle::ControlModeStatus;
+  tu::expect_topic_qos<ControlModeStatus>(
+    "/vehicle/status/control_mode", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
     RMW_QOS_POLICY_DURABILITY_VOLATILE);
 }
 


### PR DESCRIPTION
## Description

Register and version the vehicle inter-component boundary specs in `autoware_component_interface_specs` at v0.1.0, on the per-domain versioning foundation from #1259: this branch adds `VelocityStatus` (`autoware_vehicle_msgs/msg/VelocityReport`, `/vehicle/status/velocity_status`) and `ControlModeStatus` (`autoware_vehicle_msgs/msg/ControlModeReport`, `/vehicle/status/control_mode`) alongside the existing `SteeringStatus`, `GearStatus`, `TurnIndicatorStatus`, and `HazardLightStatus`, bringing `vehicle::Specs` to six entries.

The vehicle domain is one half of a two-way boundary, and the half registered here is the reports coming back: the six `/vehicle/status/*` topics are what the vehicle interface tells the autonomy stack about itself, and they are consumed by components outside the vehicle layer. The commands going the other way are not missing — they are registered under the control domain, because a spec belongs to the domain that produces it, so `ControlModeRequest` (control) and `ControlModeStatus` (vehicle) are the two halves of one handshake, deliberately registered on opposite sides. What a reader may expect here and will not find are the other interfaces under `/vehicle/`: the door command/layout/status and the battery-charge report are body functions off the driving control path whose consumer is the AD API layer, and their specs stay in the universe-side package that this PR does not touch. Nothing below the vehicle interface — actuation feedback, CAN-level signals — appears here either; the contract stops at the report topics.

Each spec records the message/service type, topic/service name, and QoS the boundary is published/consumed with today; `interface_manifest.json` is regenerated by the in-package generator.

**Stack note:** this PR is based on #1307, which adds the shared test helper its tests include, so its diff shows that helper until #1307 merges and only this domain's own change afterwards. The eight domain PRs in this series (perception, planning, control, localization, map, sensing, vehicle, system) are independent of one another and can be reviewed and merged in any order: they touch disjoint domain headers and test files, and their generated `interface_manifest.json` entries occupy disjoint regions of the same sorted array.

The table below is the vehicle domain's complete registered spec set after this PR — every entry of `vehicle::Specs`, not only the ones this PR adds — so a reader can see the whole domain contract at a glance.

| Spec | Topic or service | Type | Status |
| --- | --- | --- | --- |
| `VelocityStatus` | `/vehicle/status/velocity_status` | `autoware_vehicle_msgs/msg/VelocityReport` (topic) | new in this PR |
| `SteeringStatus` | `/vehicle/status/steering_status` | `autoware_vehicle_msgs/msg/SteeringReport` (topic) | already registered |
| `GearStatus` | `/vehicle/status/gear_status` | `autoware_vehicle_msgs/msg/GearReport` (topic) | already registered |
| `TurnIndicatorStatus` | `/vehicle/status/turn_indicators_status` | `autoware_vehicle_msgs/msg/TurnIndicatorsReport` (topic) | already registered |
| `HazardLightStatus` | `/vehicle/status/hazard_lights_status` | `autoware_vehicle_msgs/msg/HazardLightsReport` (topic) | already registered |
| `ControlModeStatus` | `/vehicle/status/control_mode` | `autoware_vehicle_msgs/msg/ControlModeReport` (topic) | new in this PR |

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

## How was this PR tested?

Built and tested in the `autoware:universe-devel-jazzy` devel container (`colcon build && colcon test`, 0 failures) at this branch tip.

## Notes for reviewers

`VelocityStatus` fills the largest previously-unregistered gap in the vehicle domain, since vehicle velocity is consumed by nearly every downstream domain. `ControlModeStatus` was added after a review pass over the running system found it consumed cross-domain, as a safety-supervision report read by the operation-mode-transition manager and the lane-departure checker (control) and the MRM handler (system); it parallels the existing steering/gear status reports. This PR is core-only; the matching re-export of these specs in the universe package is tracked as separate follow-up work.

## Interface changes

None. No publisher, subscriber, or service is created or modified — both topics already exist on the wire; this PR only adds their versioned spec registration in `autoware_component_interface_specs`.

## Effects on system behavior

None. Header-only data plus tests; no node, launch, or QoS-on-the-wire change.
