### PR TITLE
feat(autoware_component_interface_specs): register and version the system boundary specs

### DIFF
--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/system.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/system.hpp
@@ -20,7 +20,6 @@
 
 #include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
-#include <autoware_system_msgs/msg/hazard_status_stamped.hpp>
 #include <autoware_system_msgs/srv/change_autoware_control.hpp>
 #include <autoware_system_msgs/srv/change_operation_mode.hpp>
 
@@ -59,17 +58,8 @@ struct MrmState  // promoted universe -> core (the fail-safe state belongs in th
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
 };
 
-struct HazardStatus  // new - diagnostics-driven emergency trigger
-{
-  using Message = autoware_system_msgs::msg::HazardStatusStamped;
-  static constexpr char name[] = "/system/emergency/hazard_status";
-  static constexpr size_t depth = 1;
-  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
-  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-};
-
 AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(
-  0, 1, 0, OperationModeState, ChangeOperationMode, ChangeAutowareControl, MrmState, HazardStatus)
+  0, 1, 0, OperationModeState, ChangeOperationMode, ChangeAutowareControl, MrmState)
 
 }  // namespace autoware::component_interface_specs::system
 

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/system.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/system.hpp
@@ -15,10 +15,12 @@
 #ifndef AUTOWARE__COMPONENT_INTERFACE_SPECS__SYSTEM_HPP_
 #define AUTOWARE__COMPONENT_INTERFACE_SPECS__SYSTEM_HPP_
 
+#include <autoware/component_interface_specs/utils.hpp>
 #include <autoware/component_interface_specs/version.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
+#include <autoware_system_msgs/msg/hazard_status_stamped.hpp>
 #include <autoware_system_msgs/srv/change_autoware_control.hpp>
 #include <autoware_system_msgs/srv/change_operation_mode.hpp>
 
@@ -48,8 +50,26 @@ struct OperationModeState
   static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
 };
 
+struct MrmState  // promoted universe -> core (the fail-safe state belongs in the standard subset)
+{
+  using Message = autoware_adapi_v1_msgs::msg::MrmState;
+  static constexpr char name[] = "/system/fail_safe/mrm_state";
+  static constexpr size_t depth = 1;
+  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+};
+
+struct HazardStatus  // new - diagnostics-driven emergency trigger
+{
+  using Message = autoware_system_msgs::msg::HazardStatusStamped;
+  static constexpr char name[] = "/system/emergency/hazard_status";
+  static constexpr size_t depth = 1;
+  static constexpr auto reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  static constexpr auto durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+};
+
 AUTOWARE_COMPONENT_INTERFACE_SPECS_DEFINE_DOMAIN(
-  0, 1, 0, ChangeAutowareControl, ChangeOperationMode, OperationModeState)
+  0, 1, 0, OperationModeState, ChangeOperationMode, ChangeAutowareControl, MrmState, HazardStatus)
 
 }  // namespace autoware::component_interface_specs::system
 

--- a/common/autoware_component_interface_specs/interface_manifest.json
+++ b/common/autoware_component_interface_specs/interface_manifest.json
@@ -249,19 +249,6 @@
       }
     },
     {
-      "domain": "system",
-      "interface": "/system/emergency/hazard_status",
-      "type": "autoware_system_msgs/msg/HazardStatusStamped",
-      "kind": "topic",
-      "version": "0.1.0",
-      "qos": {
-        "history": "keep_last",
-        "depth": 1,
-        "reliability": "reliable",
-        "durability": "volatile"
-      }
-    },
-    {
       "domain": "vehicle",
       "interface": "/vehicle/status/steering_status",
       "type": "autoware_vehicle_msgs/msg/SteeringReport",

--- a/common/autoware_component_interface_specs/interface_manifest.json
+++ b/common/autoware_component_interface_specs/interface_manifest.json
@@ -198,15 +198,15 @@
     },
     {
       "domain": "system",
-      "interface": "/system/operation_mode/change_autoware_control",
-      "type": "autoware_system_msgs/srv/ChangeAutowareControl",
-      "kind": "service",
+      "interface": "/system/operation_mode/state",
+      "type": "autoware_adapi_v1_msgs/msg/OperationModeState",
+      "kind": "topic",
       "version": "0.1.0",
       "qos": {
         "history": "keep_last",
-        "depth": 10,
+        "depth": 1,
         "reliability": "reliable",
-        "durability": "volatile"
+        "durability": "transient_local"
       }
     },
     {
@@ -224,15 +224,41 @@
     },
     {
       "domain": "system",
-      "interface": "/system/operation_mode/state",
-      "type": "autoware_adapi_v1_msgs/msg/OperationModeState",
+      "interface": "/system/operation_mode/change_autoware_control",
+      "type": "autoware_system_msgs/srv/ChangeAutowareControl",
+      "kind": "service",
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 10,
+        "reliability": "reliable",
+        "durability": "volatile"
+      }
+    },
+    {
+      "domain": "system",
+      "interface": "/system/fail_safe/mrm_state",
+      "type": "autoware_adapi_v1_msgs/msg/MrmState",
       "kind": "topic",
       "version": "0.1.0",
       "qos": {
         "history": "keep_last",
         "depth": 1,
         "reliability": "reliable",
-        "durability": "transient_local"
+        "durability": "volatile"
+      }
+    },
+    {
+      "domain": "system",
+      "interface": "/system/emergency/hazard_status",
+      "type": "autoware_system_msgs/msg/HazardStatusStamped",
+      "kind": "topic",
+      "version": "0.1.0",
+      "qos": {
+        "history": "keep_last",
+        "depth": 1,
+        "reliability": "reliable",
+        "durability": "volatile"
       }
     },
     {

--- a/common/autoware_component_interface_specs/test/spec_test_utils.hpp
+++ b/common/autoware_component_interface_specs/test/spec_test_utils.hpp
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 
 namespace autoware::component_interface_specs::test_utils
 {
@@ -32,6 +33,21 @@ template <typename T, typename Tuple>
 struct has_type;
 template <typename T, typename... Us>
 struct has_type<T, std::tuple<Us...>> : std::disjunction<std::is_same<T, Us>...>
+{
+};
+
+/// Mirror of universe's HasDomainVersion: a void_t/expression-SFINAE probe over the
+/// ADL-resolved resolve_domain_version(const Spec &). Downstream consumers use exactly
+/// this shape to decide whether a spec participates in versioned interface
+/// registration, so a domain can type-enforce that a deliberately unversioned spec
+/// fails version resolution, rather than merely being absent from the Specs tuple.
+template <class, class = void>
+struct has_domain_version : std::false_type
+{
+};
+template <class S>
+struct has_domain_version<
+  S, std::void_t<decltype(resolve_domain_version(std::declval<const S &>()))>> : std::true_type
 {
 };
 

--- a/common/autoware_component_interface_specs/test/spec_test_utils.hpp
+++ b/common/autoware_component_interface_specs/test/spec_test_utils.hpp
@@ -1,0 +1,60 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SPEC_TEST_UTILS_HPP_
+#define SPEC_TEST_UTILS_HPP_
+
+#include "autoware/component_interface_specs/concepts.hpp"
+#include "gtest/gtest.h"
+
+#include <rclcpp/qos.hpp>
+
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+
+namespace autoware::component_interface_specs::test_utils
+{
+
+/// True when T is one of the alternatives of the std::tuple Tuple.
+template <typename T, typename Tuple>
+struct has_type;
+template <typename T, typename... Us>
+struct has_type<T, std::tuple<Us...>> : std::disjunction<std::is_same<T, Us>...>
+{
+};
+
+/// Pin a topic spec's declared QoS members and the rclcpp::QoS that get_qos<Spec>()
+/// derives from them. Every expected value is supplied by the caller as a literal, so the
+/// assertions are never checked against the spec's own fields.
+template <class Spec>
+void expect_topic_qos(
+  const char * expected_name, std::size_t expected_depth,
+  rmw_qos_reliability_policy_t expected_reliability,
+  rmw_qos_durability_policy_t expected_durability)
+{
+  EXPECT_STREQ(Spec::name, expected_name);
+  EXPECT_EQ(Spec::depth, expected_depth);
+  EXPECT_EQ(Spec::reliability, expected_reliability);
+  EXPECT_EQ(Spec::durability, expected_durability);
+
+  const auto qos = get_qos<Spec>();
+  EXPECT_EQ(qos.depth(), expected_depth);
+  EXPECT_EQ(qos.reliability(), static_cast<rclcpp::ReliabilityPolicy>(expected_reliability));
+  EXPECT_EQ(qos.durability(), static_cast<rclcpp::DurabilityPolicy>(expected_durability));
+}
+
+}  // namespace autoware::component_interface_specs::test_utils
+
+#endif  // SPEC_TEST_UTILS_HPP_

--- a/common/autoware_component_interface_specs/test/test_system.cpp
+++ b/common/autoware_component_interface_specs/test/test_system.cpp
@@ -35,14 +35,6 @@ TEST(system, interface)
   }
 }
 
-TEST(system, version)
-{
-  static_assert(specs::system::version.major == 0);
-  static_assert(specs::system::version.minor == 1);
-  static_assert(specs::system::version.patch == 0);
-  EXPECT_EQ(specs::system::version.major, 0);
-}
-
 TEST(system, concept_and_registration)
 {
   using specs::system::ChangeAutowareControl;
@@ -63,11 +55,4 @@ TEST(system, concept_and_registration)
   static_assert(std::tuple_size_v<Specs> == 4);
   SUCCEED();
 }
-
-TEST(system, mrm_state_qos)
-{
-  using specs::system::MrmState;
-  tu::expect_topic_qos<MrmState>(
-    "/system/fail_safe/mrm_state", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-    RMW_QOS_POLICY_DURABILITY_VOLATILE);
 }

--- a/common/autoware_component_interface_specs/test/test_system.cpp
+++ b/common/autoware_component_interface_specs/test/test_system.cpp
@@ -47,13 +47,11 @@ TEST(system, concept_and_registration)
 {
   using specs::system::ChangeAutowareControl;
   using specs::system::ChangeOperationMode;
-  using specs::system::HazardStatus;
   using specs::system::MrmState;
   using specs::system::OperationModeState;
   using specs::system::Specs;
 
   static_assert(specs::InterfaceSpec<MrmState>);
-  static_assert(specs::InterfaceSpec<HazardStatus>);
   static_assert(specs::InterfaceSpec<OperationModeState>);
   static_assert(specs::ServiceSpec<ChangeOperationMode>);
   static_assert(specs::ServiceSpec<ChangeAutowareControl>);
@@ -62,8 +60,7 @@ TEST(system, concept_and_registration)
   static_assert(tu::has_type<ChangeOperationMode, Specs>::value);
   static_assert(tu::has_type<ChangeAutowareControl, Specs>::value);
   static_assert(tu::has_type<MrmState, Specs>::value);
-  static_assert(tu::has_type<HazardStatus, Specs>::value);
-  static_assert(std::tuple_size_v<Specs> == 5);
+  static_assert(std::tuple_size_v<Specs> == 4);
   SUCCEED();
 }
 
@@ -72,13 +69,5 @@ TEST(system, mrm_state_qos)
   using specs::system::MrmState;
   tu::expect_topic_qos<MrmState>(
     "/system/fail_safe/mrm_state", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
-    RMW_QOS_POLICY_DURABILITY_VOLATILE);
-}
-
-TEST(system, hazard_status_qos)
-{
-  using specs::system::HazardStatus;
-  tu::expect_topic_qos<HazardStatus>(
-    "/system/emergency/hazard_status", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
     RMW_QOS_POLICY_DURABILITY_VOLATILE);
 }

--- a/common/autoware_component_interface_specs/test/test_system.cpp
+++ b/common/autoware_component_interface_specs/test/test_system.cpp
@@ -14,7 +14,6 @@
 
 #include "autoware/component_interface_specs/concepts.hpp"
 #include "autoware/component_interface_specs/system.hpp"
-#include "autoware/component_interface_specs/version.hpp"
 #include "gtest/gtest.h"
 #include "spec_test_utils.hpp"
 
@@ -54,5 +53,4 @@ TEST(system, concept_and_registration)
   static_assert(tu::has_type<MrmState, Specs>::value);
   static_assert(std::tuple_size_v<Specs> == 4);
   SUCCEED();
-}
 }

--- a/common/autoware_component_interface_specs/test/test_system.cpp
+++ b/common/autoware_component_interface_specs/test/test_system.cpp
@@ -12,9 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <autoware/component_interface_specs/system.hpp>
+#include "autoware/component_interface_specs/concepts.hpp"
+#include "autoware/component_interface_specs/system.hpp"
+#include "autoware/component_interface_specs/version.hpp"
+#include "gtest/gtest.h"
+#include "spec_test_utils.hpp"
 
-#include <gtest/gtest.h>
+#include <tuple>
+
+namespace specs = autoware::component_interface_specs;
+namespace tu = autoware::component_interface_specs::test_utils;
 
 TEST(system, interface)
 {
@@ -26,4 +33,52 @@ TEST(system, interface)
     EXPECT_EQ(state.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
     EXPECT_EQ(state.durability, RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
   }
+}
+
+TEST(system, version)
+{
+  static_assert(specs::system::version.major == 0);
+  static_assert(specs::system::version.minor == 1);
+  static_assert(specs::system::version.patch == 0);
+  EXPECT_EQ(specs::system::version.major, 0);
+}
+
+TEST(system, concept_and_registration)
+{
+  using specs::system::ChangeAutowareControl;
+  using specs::system::ChangeOperationMode;
+  using specs::system::HazardStatus;
+  using specs::system::MrmState;
+  using specs::system::OperationModeState;
+  using specs::system::Specs;
+
+  static_assert(specs::InterfaceSpec<MrmState>);
+  static_assert(specs::InterfaceSpec<HazardStatus>);
+  static_assert(specs::InterfaceSpec<OperationModeState>);
+  static_assert(specs::ServiceSpec<ChangeOperationMode>);
+  static_assert(specs::ServiceSpec<ChangeAutowareControl>);
+
+  static_assert(tu::has_type<OperationModeState, Specs>::value);
+  static_assert(tu::has_type<ChangeOperationMode, Specs>::value);
+  static_assert(tu::has_type<ChangeAutowareControl, Specs>::value);
+  static_assert(tu::has_type<MrmState, Specs>::value);
+  static_assert(tu::has_type<HazardStatus, Specs>::value);
+  static_assert(std::tuple_size_v<Specs> == 5);
+  SUCCEED();
+}
+
+TEST(system, mrm_state_qos)
+{
+  using specs::system::MrmState;
+  tu::expect_topic_qos<MrmState>(
+    "/system/fail_safe/mrm_state", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+    RMW_QOS_POLICY_DURABILITY_VOLATILE);
+}
+
+TEST(system, hazard_status_qos)
+{
+  using specs::system::HazardStatus;
+  tu::expect_topic_qos<HazardStatus>(
+    "/system/emergency/hazard_status", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+    RMW_QOS_POLICY_DURABILITY_VOLATILE);
 }

--- a/common/autoware_component_interface_specs/test/test_system.cpp
+++ b/common/autoware_component_interface_specs/test/test_system.cpp
@@ -25,12 +25,10 @@ namespace tu = autoware::component_interface_specs::test_utils;
 TEST(system, interface)
 {
   {
-    using autoware::component_interface_specs::system::OperationModeState;
-    OperationModeState state;
-    size_t depth = 1;
-    EXPECT_EQ(state.depth, depth);
-    EXPECT_EQ(state.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(state.durability, RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
+    using specs::system::OperationModeState;
+    tu::expect_topic_qos<OperationModeState>(
+      "/system/operation_mode/state", 1, RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+      RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
   }
 }
 


### PR DESCRIPTION
## Description

Register and version the system inter-component boundary specs in `autoware_component_interface_specs` at v0.1.0, on the per-domain versioning foundation from #1259: this branch promotes `MrmState` (`autoware_adapi_v1_msgs/msg/MrmState`, `/system/fail_safe/mrm_state`) from the universe package into core, byte-for-byte identical to the struct it retires there, alongside the existing `OperationModeState`, `ChangeOperationMode`, and `ChangeAutowareControl`, bringing `system::Specs` to four entries and making core the single version authority for `MrmState`.

The system domain owns two questions every other component has to agree on: who is currently driving, and whether the vehicle is still able to drive. The four registered specs are exactly that — the operation-mode state plus the two services that change it, which together form the mode-arbitration handshake, and the fail-safe `MrmState`, promoted here so core is its single definition and version authority. The set is bounded from below as well as above: a `HazardStatus` spec (`/system/emergency/hazard_status`) was added on this branch and then removed, because a consumer sweep found no consumer of any kind for it outside vendor-specific adapter layers — an interface with no cross-component consumer in this codebase is not part of this codebase's contract. The large diagnostics surface the system component publishes is likewise unregistered: it is a monitoring stream rather than a component-to-component handoff, and the fail-safe outcome other components act on is already carried by `MrmState`.

Each spec records the message/service type, topic/service name, and QoS the boundary is published/consumed with today; `interface_manifest.json` is regenerated by the in-package generator.

**Stack note:** this PR is based on #1307, which adds the shared test helper its tests include, so its diff shows that helper until #1307 merges and only this domain's own change afterwards. The eight domain PRs in this series (perception, planning, control, localization, map, sensing, vehicle, system) are independent of one another and can be reviewed and merged in any order: they touch disjoint domain headers and test files, and their generated `interface_manifest.json` entries occupy disjoint regions of the same sorted array.

The table below is the system domain's complete registered spec set after this PR — every entry of `system::Specs`, not only the one this PR adds — so a reader can see the whole domain contract at a glance.

| Spec | Topic or service | Type | Status |
| --- | --- | --- | --- |
| `OperationModeState` | `/system/operation_mode/state` | `autoware_adapi_v1_msgs/msg/OperationModeState` (topic) | already registered |
| `ChangeOperationMode` | `/system/operation_mode/change_operation_mode` | `autoware_system_msgs/srv/ChangeOperationMode` (service) | already registered |
| `ChangeAutowareControl` | `/system/operation_mode/change_autoware_control` | `autoware_system_msgs/srv/ChangeAutowareControl` (service) | already registered |
| `MrmState` | `/system/fail_safe/mrm_state` | `autoware_adapi_v1_msgs/msg/MrmState` (topic) | new in this PR |

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

## How was this PR tested?

Built and tested in the `autoware:universe-devel-jazzy` devel container (`colcon build && colcon test`, 0 failures) at this branch tip.

## Notes for reviewers

A `HazardStatus` spec (`/system/emergency/hazard_status`) was added and then removed on this branch: a review pass over the running system found zero consumers of it outside vendor-specific adapter layers, so it does not belong in this shared registration and was dropped before this PR was opened; `system::Specs` therefore stays at four entries. Existing universe consumers of the universe-side `MrmState` struct keep compiling once the universe package's re-export of the core symbol lands separately; this PR does not touch the universe package. This PR is core-only; the matching universe-side change is tracked as separate follow-up work.

## Interface changes

None. No publisher, subscriber, or service is created or modified — `/system/fail_safe/mrm_state` is an existing wire topic; this PR only adds its versioned spec registration (now authoritative in core) in `autoware_component_interface_specs`.

## Effects on system behavior

None. Header-only data plus tests; no node, launch, or QoS-on-the-wire change.
