### PR TITLE
docs(autoware_agnocast_wrapper): fix statements that no longer match the implementation

### DIFF
--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -2,7 +2,7 @@
 
 The purpose of this package is to integrate Agnocast, a zero-copy middleware, into each topic in Autoware with minimal side effects. Agnocast is a library designed to work alongside ROS 2, enabling true zero-copy publish/subscribe communication for all ROS 2 message types, including unsized message types.
 
-- Agnocast Repository: <https://github.com/tier4/agnocast>
+- Agnocast Repository: <https://github.com/autowarefoundation/agnocast>
 - Discussion on Agnocast Integration into Autoware: <https://github.com/orgs/autowarefoundation/discussions/5835>
 - [Review Guide for Agnocast Wrapper PRs](docs/review_guide.md)
 
@@ -18,30 +18,32 @@ Use this when you want the **entire node** to transparently switch between `rclc
 
 `agnocast_wrapper::Node` does **not** publicly derive from `rclcpp::Node`. It exposes a curated subset
 of the `rclcpp::Node` surface and forwards each member to the underlying implementation (`rclcpp::Node`
-or `agnocast::Node`). This subset is **identical in both builds** (`ENABLE_AGNOCAST=0` and `=1`), so a
-node written against it compiles unchanged either way. If you need an API that is not listed below,
-reach the underlying node via `get_rclcpp_node()` (always available) or extend the wrapper.
+or `agnocast::Node`). The **member names and argument lists are identical in both builds**
+(`ENABLE_AGNOCAST=0` and `=1`), so a node written against it compiles unchanged either way, provided the
+handle, options and message types are spelled with the `AUTOWARE_*` macros (the underlying types differ
+per build). If you need an API that is not listed below, extend the wrapper, or reach the underlying node
+via `get_rclcpp_node()` — declared in both builds, but it throws when the node is in Agnocast mode (see
+the [build-modes table](#build-modes-agnocast-disabled-vs-agnocast-enabled)).
 
 #### Supported API surface
 
 The following members / free functions are provided. Unless noted, signatures mirror their
 `rclcpp::Node` counterparts.
 
-| Category           | Members                                                                                                                                                                                                                                                                                                                                                                                                               |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Construction       | `Node(name, options)`, `Node(name, namespace, options)`, virtual destructor, `SharedPtr`                                                                                                                                                                                                                                                                                                                              |
-| Basic info         | `get_name()`, `get_namespace()`, `get_fully_qualified_name()`, `get_logger()`                                                                                                                                                                                                                                                                                                                                         |
-| Time               | `get_clock()`, `now()`                                                                                                                                                                                                                                                                                                                                                                                                |
-| Node interfaces    | `get_node_base_interface()`, `get_node_topics_interface()`, `get_node_parameters_interface()` (partial — only these three)                                                                                                                                                                                                                                                                                            |
-| Callback groups    | `create_callback_group()`                                                                                                                                                                                                                                                                                                                                                                                             |
-| Parameters         | `declare_parameter()` (typed + `ParameterValue`/`ParameterType` overloads), `has_parameter()`, `undeclare_parameter()`, `get_parameter()` / `get_parameters()` (typed + prefix overloads), `set_parameter()` / `set_parameters()` / `set_parameters_atomically()`, `describe_parameter(s)()`, `get_parameter_types()`, `list_parameters()`, `add_on_set_parameters_callback()`, `remove_on_set_parameters_callback()` |
-| Publisher          | `create_publisher<MessageT>()` (`QoS` and depth overloads)                                                                                                                                                                                                                                                                                                                                                            |
-| Subscription       | `create_subscription<MessageT>()` (`QoS` and depth overloads)                                                                                                                                                                                                                                                                                                                                                         |
-| Polling subscriber | `create_polling_subscriber<MessageT>()` (`QoS` and depth overloads)                                                                                                                                                                                                                                                                                                                                                   |
-| Client             | `create_client<ServiceT>()` — takes `rclcpp::QoS` (the wrapper normalizes the Humble vs. Jazzy QoS-argument difference)                                                                                                                                                                                                                                                                                               |
-| Service            | `create_service<ServiceT>()` — `message_ptr` callback form and an rclcpp-style `shared_ptr` callback form                                                                                                                                                                                                                                                                                                             |
-| Timer              | `create_wall_timer()`; free `create_timer(node, clock, period, cb, group)` and free `set_period(timer, period)` (see [Timer notes](#timer-notes))                                                                                                                                                                                                                                                                     |
-| Underlying node    | `get_rclcpp_node()`; `get_agnocast_node()` (agnocast-enabled build only — not declared in an agnocast-disabled build, so calling it there is a compile error); free `to_rclcpp_node(node)`                                                                                                                                                                                                                            |
+| Category        | Members                                                                                                                                                                                                                                                                                                                                                                                                               |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Construction    | `Node(name, options)`, `Node(name, namespace, options)`, virtual destructor, `SharedPtr`                                                                                                                                                                                                                                                                                                                              |
+| Basic info      | `get_name()`, `get_namespace()`, `get_fully_qualified_name()`, `get_logger()`                                                                                                                                                                                                                                                                                                                                         |
+| Time            | `get_clock()`, `now()`                                                                                                                                                                                                                                                                                                                                                                                                |
+| Node interfaces | `get_node_base_interface()`, `get_node_topics_interface()`, `get_node_parameters_interface()` (partial — only these three)                                                                                                                                                                                                                                                                                            |
+| Callback groups | `create_callback_group()`                                                                                                                                                                                                                                                                                                                                                                                             |
+| Parameters      | `declare_parameter()` (typed + `ParameterValue`/`ParameterType` overloads), `has_parameter()`, `undeclare_parameter()`, `get_parameter()` / `get_parameters()` (typed + prefix overloads), `set_parameter()` / `set_parameters()` / `set_parameters_atomically()`, `describe_parameter(s)()`, `get_parameter_types()`, `list_parameters()`, `add_on_set_parameters_callback()`, `remove_on_set_parameters_callback()` |
+| Publisher       | `create_publisher<MessageT>()` (`QoS` and depth overloads)                                                                                                                                                                                                                                                                                                                                                            |
+| Subscription    | `create_subscription<MessageT>()` (`QoS` and depth overloads)                                                                                                                                                                                                                                                                                                                                                         |
+| Client          | `create_client<ServiceT>()` — takes `rclcpp::QoS` (the wrapper normalizes the Humble vs. Jazzy QoS-argument difference)                                                                                                                                                                                                                                                                                               |
+| Service         | `create_service<ServiceT>()` — `message_ptr` callback form and an rclcpp-style `shared_ptr` callback form                                                                                                                                                                                                                                                                                                             |
+| Timer           | `create_wall_timer()`; free `create_timer(node, clock, period, cb, group)` and free `set_period(timer, period)` (see [Timer notes](#timer-notes))                                                                                                                                                                                                                                                                     |
+| Underlying node | `get_rclcpp_node()`; `get_agnocast_node()` (agnocast-enabled build only — not declared in an agnocast-disabled build, so calling it there is a compile error); free `to_rclcpp_node(node)`                                                                                                                                                                                                                            |
 
 > `OnSetParametersCallbackType` is aliased in this namespace and resolves to the correct rclcpp type
 > for both Humble (rclcpp 16.x) and Jazzy (rclcpp 28+).
@@ -114,7 +116,12 @@ To use the Node wrapper in your package, add the following to your `CMakeLists.t
 ```cmake
 find_package(autoware_agnocast_wrapper REQUIRED)
 ament_target_dependencies(my_node_component autoware_agnocast_wrapper)
+autoware_agnocast_wrapper_setup(my_node_component)
 ```
+
+`autoware_agnocast_wrapper_setup()` is required: it defines `USE_AGNOCAST_ENABLED` on the target, which
+`ament_target_dependencies()` does not propagate. Apply it to every target that includes a wrapper header;
+`autoware_agnocast_wrapper_register_node()` does it for the targets it handles.
 
 #### Registering a Node with `autoware_agnocast_wrapper_register_node`
 
@@ -446,17 +453,6 @@ private:
   autoware::agnocast_wrapper::polling::PollingSubscriber<nav_msgs::msg::Odometry>::SharedPtr sub_;
 };
 ```
-
-### When to use this vs the existing member API
-
-This package currently exposes two polling APIs:
-
-| API                                                                               | Returns                                 | Form          |
-| --------------------------------------------------------------------------------- | --------------------------------------- | ------------- |
-| `Node::create_polling_subscriber` / `AUTOWARE_POLLING_SUBSCRIBER_PTR` (top-level) | `message_ptr`                           | `Node` member |
-| `polling::create_polling_subscriber` (this section)                               | plain `std::shared_ptr<const MessageT>` | free function |
-
-Prefer `polling::` for new code: it returns a plain `std::shared_ptr` (no `message_ptr`), is node-independent, and confines the `autoware_utils_rclcpp` dependency to a single header. The top-level member API is kept for backward compatibility with already-merged consumers and is planned to be removed once they are migrated to `polling::`.
 
 ## How to Enable/Disable Agnocast on Build
 

--- a/common/autoware_agnocast_wrapper/docs/review_guide.md
+++ b/common/autoware_agnocast_wrapper/docs/review_guide.md
@@ -405,22 +405,20 @@ All macros below are defined in [`autoware_agnocast_wrapper.hpp`](https://github
 
 ### Publisher/Subscriber Types
 
-| Macro                                   | ENABLE_AGNOCAST=1 (Agnocast)         | ENABLE_AGNOCAST=0 (ROS 2)                        |
-| --------------------------------------- | ------------------------------------ | ------------------------------------------------ |
-| `AUTOWARE_PUBLISHER_PTR(MsgT)`          | `Publisher<MsgT>::SharedPtr`         | `rclcpp::Publisher<MsgT>::SharedPtr`             |
-| `AUTOWARE_SUBSCRIPTION_PTR(MsgT)`       | `Subscription<MsgT>::SharedPtr`      | `rclcpp::Subscription<MsgT>::SharedPtr`          |
-| `AUTOWARE_POLLING_SUBSCRIBER_PTR(MsgT)` | `PollingSubscriber<MsgT>::SharedPtr` | `InterProcessPollingSubscriber<MsgT>::SharedPtr` |
+| Macro                             | ENABLE_AGNOCAST=1 (Agnocast)    | ENABLE_AGNOCAST=0 (ROS 2)               |
+| --------------------------------- | ------------------------------- | --------------------------------------- |
+| `AUTOWARE_PUBLISHER_PTR(MsgT)`    | `Publisher<MsgT>::SharedPtr`    | `rclcpp::Publisher<MsgT>::SharedPtr`    |
+| `AUTOWARE_SUBSCRIPTION_PTR(MsgT)` | `Subscription<MsgT>::SharedPtr` | `rclcpp::Subscription<MsgT>::SharedPtr` |
 
 &nbsp;
 
 ### Publisher/Subscriber Creation
 
-| Macro                                                                   | ENABLE_AGNOCAST=1 (Agnocast)                                         | ENABLE_AGNOCAST=0 (ROS 2)                                                   |
-| ----------------------------------------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| `AUTOWARE_CREATE_SUBSCRIPTION(msg_type, topic, qos, callback, options)` | `agnocast_wrapper::create_subscription<msg_type>(...)`               | `this->create_subscription<msg_type>(...)`                                  |
-| `AUTOWARE_CREATE_PUBLISHER2(msg_type, topic, qos)`                      | `agnocast_wrapper::create_publisher<msg_type>(...)`                  | `this->create_publisher<msg_type>(...)`                                     |
-| `AUTOWARE_CREATE_PUBLISHER3(msg_type, topic, qos, options)`             | `agnocast_wrapper::create_publisher<msg_type>(...)`                  | `this->create_publisher<msg_type>(...)`                                     |
-| `AUTOWARE_CREATE_POLLING_SUBSCRIBER(msg_type, policy, topic, qos)`      | `agnocast_wrapper::create_polling_subscriber<msg_type, policy>(...)` | `InterProcessPollingSubscriber<msg_type, policy>::create_subscription(...)` |
+| Macro                                                                   | ENABLE_AGNOCAST=1 (Agnocast)                           | ENABLE_AGNOCAST=0 (ROS 2)                  |
+| ----------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------ |
+| `AUTOWARE_CREATE_SUBSCRIPTION(msg_type, topic, qos, callback, options)` | `agnocast_wrapper::create_subscription<msg_type>(...)` | `this->create_subscription<msg_type>(...)` |
+| `AUTOWARE_CREATE_PUBLISHER2(msg_type, topic, qos)`                      | `agnocast_wrapper::create_publisher<msg_type>(...)`    | `this->create_publisher<msg_type>(...)`    |
+| `AUTOWARE_CREATE_PUBLISHER3(msg_type, topic, qos, options)`             | `agnocast_wrapper::create_publisher<msg_type>(...)`    | `this->create_publisher<msg_type>(...)`    |
 
 &nbsp;
 
@@ -525,14 +523,30 @@ private:
 
 ### Method 2 Behavior with ENABLE_AGNOCAST=0
 
-When built with `ENABLE_AGNOCAST=0` (or unset), [`node.hpp`](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp) defines `autoware::agnocast_wrapper::Node` as a simple typedef for `rclcpp::Node`:
+When built with `ENABLE_AGNOCAST=0` (or unset), [`node.hpp`](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp) defines `autoware::agnocast_wrapper::Node` as a **real class that owns an internal `rclcpp::Node` and forwards a curated set of members to it**. It is not a typedef for `rclcpp::Node`, and it does not derive from `rclcpp::Node` in either build:
 
 ```cpp
-// node.hpp when ENABLE_AGNOCAST=0
-using Node = rclcpp::Node;
+// node.hpp when ENABLE_AGNOCAST=0 (simplified)
+class Node : public std::enable_shared_from_this<Node>
+{
+public:
+  explicit Node(const std::string & node_name, const rclcpp::NodeOptions & options = {});
+  // ... the same curated member set as the ENABLE_AGNOCAST=1 Node ...
+  std::shared_ptr<rclcpp::Node> get_rclcpp_node() const { return node_; }
+
+private:
+  std::shared_ptr<rclcpp::Node> node_;
+};
 ```
 
-Therefore, code using Method 2 compiles and runs without issues as a regular `rclcpp::Node` when built with `ENABLE_AGNOCAST=0`. Backward compatibility is maintained even in environments without Agnocast support.
+This is deliberate: if the `=0` build aliased or derived from `rclcpp::Node`, the full `rclcpp::Node` API would leak into it, and a node could compile under `=0` while using members that do not exist under `=1`.
+
+Two consequences to keep in mind while reviewing:
+
+- The node **cannot be passed where an `rclcpp::Node *` / `rclcpp::Node &` is expected.** Hand it to executors and utilities via `get_node_base_interface()`.
+- Any `rclcpp::Node` member not in the curated surface (see the [README](../README.md#supported-api-surface)) will not compile.
+
+Code using Method 2 still compiles and runs as a plain ROS 2 node when built with `ENABLE_AGNOCAST=0`, so backward compatibility for users without Agnocast is maintained.
 
 &nbsp;
 
@@ -555,9 +569,13 @@ A CMake macro used in place of `rclcpp_components_register_node`. It generates d
 
 **ENABLE_AGNOCAST=1:**
 
-- Generates two targets:
-  1. `<EXECUTABLE>_component`: Standard rclcpp_components executable (for containers)
-  2. `<EXECUTABLE>`: Runtime-switchable standalone executable
+- `<EXECUTABLE>`: a runtime-switchable standalone executable
+- Component registration via `rclcpp_components_register_nodes` (plural), which populates the ament
+  resource index only — the component can still be loaded into a container, but no extra standalone
+  executable is generated for it
+
+> There is no `<EXECUTABLE>_component` target. Launch files should reference `<EXECUTABLE>`, which is the
+> same name in both modes.
 
 &nbsp;
 
@@ -691,10 +709,11 @@ container = ComposableNodeContainer(
 
 ### Parameters
 
-| Parameter                | Default                                       | Description                               |
-| ------------------------ | --------------------------------------------- | ----------------------------------------- |
-| `agnocast_heaphook_path` | `/opt/ros/humble/lib/libagnocast_heaphook.so` | Path to the heaphook library              |
-| `use_multithread`        | `false`                                       | Whether to use a multi-threaded container |
+| Parameter                | Default                                            | Description                                                                                         |
+| ------------------------ | -------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `agnocast_heaphook_path` | `/opt/ros/$ROS_DISTRO/lib/libagnocast_heaphook.so` | Path to the heaphook library. `$ROS_DISTRO` is read from the environment and falls back to `humble` |
+| `use_multithread`        | `false`                                            | Whether to use a multi-threaded container                                                           |
+| `use_agnocast`           | `$(env ENABLE_AGNOCAST 0)`                         | Per-include override (`1`/`0`). Forces one node/container back to the plain rclcpp path             |
 
 &nbsp;
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -576,11 +576,13 @@ public:
   virtual void publish(AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) && message) = 0;
   virtual void publish(AUTOWARE_MESSAGE_SHARED_PTR(MessageT) && message) = 0;
 
-  /// Publish by const reference (internally copies into allocated message).
-  /// This method is discouraged because it performs an implicit copy.
-  /// Prefer ALLOCATE_OUTPUT_MESSAGE_{UNIQUE,SHARED}(publisher) + the corresponding publish()
-  /// overload. May be marked [[deprecated]] in the future once autoware_cmake supports
-  /// suppressing deprecation warnings for test targets.
+  /// Publish by const reference: copies @p data into a freshly allocated message (allocated in
+  /// shared memory on the Agnocast path), then publishes it.
+  ///
+  /// Use this when the caller already holds a message it does not own or must retain — e.g.
+  /// re-publishing a received message, or publishing a member kept as node state. When the outgoing
+  /// message is being constructed anyway, prefer ALLOCATE_OUTPUT_MESSAGE_{UNIQUE,SHARED}(publisher)
+  /// and the corresponding publish() overload instead, which builds in place and copies no payload.
   virtual void publish(const MessageT & data) = 0;
 
   virtual uint32_t get_subscription_count() const = 0;


### PR DESCRIPTION
## Description

Some statements in `README.md` and `docs/review_guide.md` no longer match the implementation. This PR only corrects statements that are wrong; it adds no new documentation (a follow-up PR covers the undocumented behaviors).

| Where | Was documented | Actual implementation |
| :--- | :--- | :--- |
| `review_guide.md` §4 | With `ENABLE_AGNOCAST=0`, `Node` is `using Node = rclcpp::Node;` | A real class owning an internal `rclcpp::Node`, not deriving from it in either build. It cannot be passed where an `rclcpp::Node *` is expected, and only the curated member set is available |
| `review_guide.md` §5 | `ENABLE_AGNOCAST=1` generates `<EXECUTABLE>_component` and `<EXECUTABLE>` | `rclcpp_components_register_nodes` (plural) populates the resource index only; just `<EXECUTABLE>` is generated. There is no `_component` target |
| `README.md` API table, `review_guide.md` §3 | `Node::create_polling_subscriber` member, `AUTOWARE_POLLING_SUBSCRIBER_PTR`, `AUTOWARE_CREATE_POLLING_SUBSCRIBER` | Removed in #1283. Only `polling::create_polling_subscriber` remains, and it requires an `agnocast_wrapper::Node *` |
| `README.md` Node Wrapper CMake | `find_package` + `ament_target_dependencies` | `autoware_agnocast_wrapper_setup()` was missing. It is what defines `USE_AGNOCAST_ENABLED`, and `ament_target_dependencies()` does not propagate the wrapper's `PUBLIC` definitions |
| `review_guide.md` §7 | Heaphook default is `/opt/ros/humble/...` | `/opt/ros/$ROS_DISTRO/...`, falling back to `humble`. The `use_agnocast` argument was also missing from the table |
| `README.md` §1 | The API surface is "identical in both builds"; `get_rclcpp_node()` is "always available" | Member names and argument lists match, but the underlying handle/options types differ per build (hence the `AUTOWARE_*` macros). `get_rclcpp_node()` is declared in both builds but throws in Agnocast mode |
| `autoware_agnocast_wrapper.hpp` | `publish(const MessageT &)` is "discouraged" and "may be marked `[[deprecated]]`" | Fully supported and widely used. Reworded to state when each overload is appropriate rather than discouraging one |

## Related links

**Parent Issue:**

- None.

## How was this PR tested?

Documentation and one doc comment only, so no runtime testing applies. Each corrected statement was verified against the implementation on this branch's base: `node.hpp`, `autoware_agnocast_wrapper.hpp`, `polling_subscriber.hpp`, `agnocast_wrapper_config_extras.cmake`, `autoware_agnocast_wrapper_register_node.cmake` and `agnocast_env.launch.xml`.

`pre-commit` passed for `clang-format`, `cpplint`, `end-of-file-fixer` and `trailing-whitespace`. `prettier` was applied manually, since the pinned `prettier`/`markdownlint` hooks require a newer Node than the local environment provides.

## Notes for reviewers

The only non-markdown change is the `publish(const MessageT &)` doc comment in `autoware_agnocast_wrapper.hpp`. No code changed.

## Interface changes

None.

## Effects on system behavior

None.
