### PR TITLE
docs(autoware_agnocast_wrapper): document undocumented behaviors and APIs

### DIFF
--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -2,7 +2,7 @@
 
 The purpose of this package is to integrate Agnocast, a zero-copy middleware, into each topic in Autoware with minimal side effects. Agnocast is a library designed to work alongside ROS 2, enabling true zero-copy publish/subscribe communication for all ROS 2 message types, including unsized message types.
 
-- Agnocast Repository: <https://github.com/tier4/agnocast>
+- Agnocast Repository: <https://github.com/autowarefoundation/agnocast>
 - Discussion on Agnocast Integration into Autoware: <https://github.com/orgs/autowarefoundation/discussions/5835>
 - [Review Guide for Agnocast Wrapper PRs](docs/review_guide.md)
 
@@ -18,30 +18,32 @@ Use this when you want the **entire node** to transparently switch between `rclc
 
 `agnocast_wrapper::Node` does **not** publicly derive from `rclcpp::Node`. It exposes a curated subset
 of the `rclcpp::Node` surface and forwards each member to the underlying implementation (`rclcpp::Node`
-or `agnocast::Node`). This subset is **identical in both builds** (`ENABLE_AGNOCAST=0` and `=1`), so a
-node written against it compiles unchanged either way. If you need an API that is not listed below,
-reach the underlying node via `get_rclcpp_node()` (always available) or extend the wrapper.
+or `agnocast::Node`). The **member names and argument lists are identical in both builds**
+(`ENABLE_AGNOCAST=0` and `=1`), so a node written against it compiles unchanged either way, provided the
+handle, options and message types are spelled with the `AUTOWARE_*` macros (the underlying types differ
+per build). If you need an API that is not listed below, extend the wrapper, or reach the underlying node
+via `get_rclcpp_node()` — declared in both builds, but it throws when the node is in Agnocast mode (see
+the [build-modes table](#build-modes-agnocast-disabled-vs-agnocast-enabled)).
 
 #### Supported API surface
 
 The following members / free functions are provided. Unless noted, signatures mirror their
 `rclcpp::Node` counterparts.
 
-| Category           | Members                                                                                                                                                                                                                                                                                                                                                                                                               |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Construction       | `Node(name, options)`, `Node(name, namespace, options)`, virtual destructor, `SharedPtr`                                                                                                                                                                                                                                                                                                                              |
-| Basic info         | `get_name()`, `get_namespace()`, `get_fully_qualified_name()`, `get_logger()`                                                                                                                                                                                                                                                                                                                                         |
-| Time               | `get_clock()`, `now()`                                                                                                                                                                                                                                                                                                                                                                                                |
-| Node interfaces    | `get_node_base_interface()`, `get_node_topics_interface()`, `get_node_parameters_interface()` (partial — only these three)                                                                                                                                                                                                                                                                                            |
-| Callback groups    | `create_callback_group()`                                                                                                                                                                                                                                                                                                                                                                                             |
-| Parameters         | `declare_parameter()` (typed + `ParameterValue`/`ParameterType` overloads), `has_parameter()`, `undeclare_parameter()`, `get_parameter()` / `get_parameters()` (typed + prefix overloads), `set_parameter()` / `set_parameters()` / `set_parameters_atomically()`, `describe_parameter(s)()`, `get_parameter_types()`, `list_parameters()`, `add_on_set_parameters_callback()`, `remove_on_set_parameters_callback()` |
-| Publisher          | `create_publisher<MessageT>()` (`QoS` and depth overloads)                                                                                                                                                                                                                                                                                                                                                            |
-| Subscription       | `create_subscription<MessageT>()` (`QoS` and depth overloads)                                                                                                                                                                                                                                                                                                                                                         |
-| Polling subscriber | `create_polling_subscriber<MessageT>()` (`QoS` and depth overloads)                                                                                                                                                                                                                                                                                                                                                   |
-| Client             | `create_client<ServiceT>()` — takes `rclcpp::QoS` (the wrapper normalizes the Humble vs. Jazzy QoS-argument difference)                                                                                                                                                                                                                                                                                               |
-| Service            | `create_service<ServiceT>()` — `message_ptr` callback form and an rclcpp-style `shared_ptr` callback form                                                                                                                                                                                                                                                                                                             |
-| Timer              | `create_wall_timer()`; free `create_timer(node, clock, period, cb, group)` and free `set_period(timer, period)` (see [Timer notes](#timer-notes))                                                                                                                                                                                                                                                                     |
-| Underlying node    | `get_rclcpp_node()`; `get_agnocast_node()` (agnocast-enabled build only — not declared in an agnocast-disabled build, so calling it there is a compile error); free `to_rclcpp_node(node)`                                                                                                                                                                                                                            |
+| Category        | Members                                                                                                                                                                                                                                                                                                                                                                                                               |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Construction    | `Node(name, options)`, `Node(name, namespace, options)`, virtual destructor, `SharedPtr`                                                                                                                                                                                                                                                                                                                              |
+| Basic info      | `get_name()`, `get_namespace()`, `get_fully_qualified_name()`, `get_logger()`                                                                                                                                                                                                                                                                                                                                         |
+| Time            | `get_clock()`, `now()`                                                                                                                                                                                                                                                                                                                                                                                                |
+| Node interfaces | `get_node_base_interface()`, `get_node_topics_interface()`, `get_node_parameters_interface()` (partial — only these three)                                                                                                                                                                                                                                                                                            |
+| Callback groups | `create_callback_group()`                                                                                                                                                                                                                                                                                                                                                                                             |
+| Parameters      | `declare_parameter()` (typed + `ParameterValue`/`ParameterType` overloads), `has_parameter()`, `undeclare_parameter()`, `get_parameter()` / `get_parameters()` (typed + prefix overloads), `set_parameter()` / `set_parameters()` / `set_parameters_atomically()`, `describe_parameter(s)()`, `get_parameter_types()`, `list_parameters()`, `add_on_set_parameters_callback()`, `remove_on_set_parameters_callback()` |
+| Publisher       | `create_publisher<MessageT>()` (`QoS` and depth overloads)                                                                                                                                                                                                                                                                                                                                                            |
+| Subscription    | `create_subscription<MessageT>()` (`QoS` and depth overloads)                                                                                                                                                                                                                                                                                                                                                         |
+| Client          | `create_client<ServiceT>()` — takes `rclcpp::QoS` (the wrapper normalizes the Humble vs. Jazzy QoS-argument difference)                                                                                                                                                                                                                                                                                               |
+| Service         | `create_service<ServiceT>()` — `message_ptr` callback form and an rclcpp-style `shared_ptr` callback form                                                                                                                                                                                                                                                                                                             |
+| Timer           | `create_wall_timer()`; free `create_timer(node, clock, period, cb, group)` and free `set_period(timer, period)` (see [Timer notes](#timer-notes))                                                                                                                                                                                                                                                                     |
+| Underlying node | `get_rclcpp_node()`; `get_agnocast_node()` (agnocast-enabled build only — not declared in an agnocast-disabled build, so calling it there is a compile error); free `to_rclcpp_node(node)`                                                                                                                                                                                                                            |
 
 > `OnSetParametersCallbackType` is aliased in this namespace and resolves to the correct rclcpp type
 > for both Humble (rclcpp 16.x) and Jazzy (rclcpp 28+).
@@ -114,7 +116,12 @@ To use the Node wrapper in your package, add the following to your `CMakeLists.t
 ```cmake
 find_package(autoware_agnocast_wrapper REQUIRED)
 ament_target_dependencies(my_node_component autoware_agnocast_wrapper)
+autoware_agnocast_wrapper_setup(my_node_component)
 ```
+
+`autoware_agnocast_wrapper_setup()` is required: it defines `USE_AGNOCAST_ENABLED` on the target, which
+`ament_target_dependencies()` does not propagate. Apply it to every target that includes a wrapper header;
+`autoware_agnocast_wrapper_register_node()` does it for the targets it handles.
 
 #### Registering a Node with `autoware_agnocast_wrapper_register_node`
 
@@ -446,17 +453,6 @@ private:
   autoware::agnocast_wrapper::polling::PollingSubscriber<nav_msgs::msg::Odometry>::SharedPtr sub_;
 };
 ```
-
-### When to use this vs the existing member API
-
-This package currently exposes two polling APIs:
-
-| API                                                                               | Returns                                 | Form          |
-| --------------------------------------------------------------------------------- | --------------------------------------- | ------------- |
-| `Node::create_polling_subscriber` / `AUTOWARE_POLLING_SUBSCRIBER_PTR` (top-level) | `message_ptr`                           | `Node` member |
-| `polling::create_polling_subscriber` (this section)                               | plain `std::shared_ptr<const MessageT>` | free function |
-
-Prefer `polling::` for new code: it returns a plain `std::shared_ptr` (no `message_ptr`), is node-independent, and confines the `autoware_utils_rclcpp` dependency to a single header. The top-level member API is kept for backward compatibility with already-merged consumers and is planned to be removed once they are migrated to `polling::`.
 
 ## How to Enable/Disable Agnocast on Build
 

--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -3,6 +3,7 @@
 The purpose of this package is to integrate Agnocast, a zero-copy middleware, into each topic in Autoware with minimal side effects. Agnocast is a library designed to work alongside ROS 2, enabling true zero-copy publish/subscribe communication for all ROS 2 message types, including unsized message types.
 
 - Agnocast Repository: <https://github.com/autowarefoundation/agnocast>
+- Agnocast Documentation: <https://autowarefoundation.github.io/agnocast_doc/main/>
 - Discussion on Agnocast Integration into Autoware: <https://github.com/orgs/autowarefoundation/discussions/5835>
 - [Review Guide for Agnocast Wrapper PRs](docs/review_guide.md)
 
@@ -19,11 +20,11 @@ Use this when you want the **entire node** to transparently switch between `rclc
 `agnocast_wrapper::Node` does **not** publicly derive from `rclcpp::Node`. It exposes a curated subset
 of the `rclcpp::Node` surface and forwards each member to the underlying implementation (`rclcpp::Node`
 or `agnocast::Node`). The **member names and argument lists are identical in both builds**
-(`ENABLE_AGNOCAST=0` and `=1`), so a node written against it compiles unchanged either way, provided the
-handle, options and message types are spelled with the `AUTOWARE_*` macros (the underlying types differ
-per build). If you need an API that is not listed below, extend the wrapper, or reach the underlying node
-via `get_rclcpp_node()` — declared in both builds, but it throws when the node is in Agnocast mode (see
-the [build-modes table](#build-modes-agnocast-disabled-vs-agnocast-enabled)).
+(`ENABLE_AGNOCAST=0` and `=1`), so a node written against it compiles unchanged either way — provided
+you spell the handle, options and message types with the `AUTOWARE_*` macros (see
+[Type spellings](#type-spellings)). If you need an API that is not listed below, extend the wrapper, or
+reach the underlying node via `get_rclcpp_node()` (declared in both builds, but it throws when the node
+is in Agnocast mode — see the [build-modes table](#build-modes-agnocast-disabled-vs-agnocast-enabled)).
 
 #### Supported API surface
 
@@ -32,21 +33,45 @@ The following members / free functions are provided. Unless noted, signatures mi
 
 | Category        | Members                                                                                                                                                                                                                                                                                                                                                                                                               |
 | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Construction    | `Node(name, options)`, `Node(name, namespace, options)`, virtual destructor, `SharedPtr`                                                                                                                                                                                                                                                                                                                              |
+| Construction    | `Node(name, options)`, `Node(name, namespace, options)`, virtual destructor, `SharedPtr`. Non-copyable and non-movable (copying would alias one backend behind two wrappers). Derives from `std::enable_shared_from_this<Node>`, so `shared_from_this()` is available when the node is owned by a `shared_ptr`                                                                                                        |
 | Basic info      | `get_name()`, `get_namespace()`, `get_fully_qualified_name()`, `get_logger()`                                                                                                                                                                                                                                                                                                                                         |
 | Time            | `get_clock()`, `now()`                                                                                                                                                                                                                                                                                                                                                                                                |
 | Node interfaces | `get_node_base_interface()`, `get_node_topics_interface()`, `get_node_parameters_interface()` (partial — only these three)                                                                                                                                                                                                                                                                                            |
 | Callback groups | `create_callback_group()`                                                                                                                                                                                                                                                                                                                                                                                             |
 | Parameters      | `declare_parameter()` (typed + `ParameterValue`/`ParameterType` overloads), `has_parameter()`, `undeclare_parameter()`, `get_parameter()` / `get_parameters()` (typed + prefix overloads), `set_parameter()` / `set_parameters()` / `set_parameters_atomically()`, `describe_parameter(s)()`, `get_parameter_types()`, `list_parameters()`, `add_on_set_parameters_callback()`, `remove_on_set_parameters_callback()` |
-| Publisher       | `create_publisher<MessageT>()` (`QoS` and depth overloads)                                                                                                                                                                                                                                                                                                                                                            |
+| Publisher       | `create_publisher<MessageT>()` (`QoS` and depth overloads) — see [Publisher API](#publisher-api)                                                                                                                                                                                                                                                                                                                      |
 | Subscription    | `create_subscription<MessageT>()` (`QoS` and depth overloads)                                                                                                                                                                                                                                                                                                                                                         |
 | Client          | `create_client<ServiceT>()` — takes `rclcpp::QoS` (the wrapper normalizes the Humble vs. Jazzy QoS-argument difference)                                                                                                                                                                                                                                                                                               |
 | Service         | `create_service<ServiceT>()` — `message_ptr` callback form and an rclcpp-style `shared_ptr` callback form                                                                                                                                                                                                                                                                                                             |
 | Timer           | `create_wall_timer()`; free `create_timer(node, clock, period, cb, group)` and free `set_period(timer, period)` (see [Timer notes](#timer-notes))                                                                                                                                                                                                                                                                     |
 | Underlying node | `get_rclcpp_node()`; `get_agnocast_node()` (agnocast-enabled build only — not declared in an agnocast-disabled build, so calling it there is a compile error); free `to_rclcpp_node(node)`                                                                                                                                                                                                                            |
+| Context         | free `ok()` — mode-agnostic replacement for `rclcpp::ok()` (see [Context notes](#context-notes))                                                                                                                                                                                                                                                                                                                      |
 
 > `OnSetParametersCallbackType` is aliased in this namespace and resolves to the correct rclcpp type
 > for both Humble (rclcpp 16.x) and Jazzy (rclcpp 28+).
+
+Polling subscribers are **not** a `Node` member. Use the free function
+`polling::create_polling_subscriber<MessageT>(node, topic, qos)` — see
+[Polling Subscriber](#polling-subscriber-polling-namespace).
+
+#### Type spellings
+
+The member _names_ and argument lists above are the same in both builds, but the handle, options and
+message types they use are not the same C++ types. Always spell them with the `AUTOWARE_*` macros so the
+same source compiles in both builds:
+
+| What                             | Spell it as                            | `ENABLE_AGNOCAST=0`                  | `ENABLE_AGNOCAST=1`                            |
+| -------------------------------- | -------------------------------------- | ------------------------------------ | ---------------------------------------------- |
+| `create_publisher` result        | `AUTOWARE_PUBLISHER_PTR(M)`            | `rclcpp::Publisher<M>::SharedPtr`    | `agnocast_wrapper::Publisher<M>::SharedPtr`    |
+| `create_subscription` result     | `AUTOWARE_SUBSCRIPTION_PTR(M)`         | `rclcpp::Subscription<M>::SharedPtr` | `agnocast_wrapper::Subscription<M>::SharedPtr` |
+| `create_wall_timer` result       | `AUTOWARE_TIMER_PTR`                   | `rclcpp::TimerBase::SharedPtr`       | `agnocast_wrapper::Timer::SharedPtr`           |
+| `create_publisher` options arg   | `AUTOWARE_PUBLISHER_OPTIONS`           | `rclcpp::PublisherOptions`           | `agnocast::PublisherOptions`                   |
+| `create_subscription` options    | `AUTOWARE_SUBSCRIPTION_OPTIONS`        | `rclcpp::SubscriptionOptions`        | `agnocast::SubscriptionOptions`                |
+| Owning subscription callback arg | `AUTOWARE_MESSAGE_CONST_SHARED_PTR(M)` | `std::shared_ptr<const M>`           | `message_ptr<const M, Shared>`                 |
+
+`AUTOWARE_CLIENT_PTR(S)` / `AUTOWARE_SERVICE_PTR(S)` and the `AUTOWARE_CLIENT_*FUTURE*` macros resolve to
+the wrapper's own `Client<S>` / `Service<S>` types in **both** builds, so client and service code needs no
+per-build spelling. See [Key Macros](docs/review_guide.md#3-key-macros) for the full macro list.
 
 #### Build modes: agnocast-disabled vs agnocast-enabled
 
@@ -110,6 +135,27 @@ timer_ = autoware::agnocast_wrapper::create_timer(
 ```cpp
 autoware::agnocast_wrapper::set_period(timer_, std::chrono::milliseconds(200));
 ```
+
+#### Context notes
+
+Use `autoware::agnocast_wrapper::ok()` instead of `rclcpp::ok()`. An AgnocastOnly executable never calls
+`rclcpp::init()`, so `rclcpp::ok()` reports `false` there even while the process is healthy; `ok()` checks
+both contexts.
+
+#### Publisher API
+
+A wrapper publisher exposes three `publish()` overloads, all supported in both builds:
+
+| Call                                                                   | Behavior                                                       |
+| ---------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub)` → `pub->publish(std::move(msg))` | Zero-copy: the message is built in place in shared memory.     |
+| `ALLOCATE_OUTPUT_MESSAGE_SHARED(pub)` → `pub->publish(std::move(msg))` | Same, for the shared-ownership form.                           |
+| `pub->publish(msg)` (`const MessageT &`)                               | Copies `msg` into a freshly allocated message, then publishes. |
+
+Prefer the allocate-then-move form when you are constructing the outgoing message anyway; the
+`const MessageT &` overload suits a message you already hold and must keep.
+
+#### CMake setup
 
 To use the Node wrapper in your package, add the following to your `CMakeLists.txt`:
 
@@ -270,6 +316,7 @@ This package provides wrapper types for `message_filters` (`Subscriber`, `Synchr
 - Only `ApproximateTime` and `ExactTime` synchronization policies are supported.
 - 2 to 8 message types per `Synchronizer`. Upstream `message_filters` supports up to 9, but the registration path this wrapper uses caps it at 8.
 - `connectInput()` is not supported; pass `Subscriber` references at construction time.
+- `Subscriber::subscribe()` (and the topic-taking constructor) takes an `autoware::agnocast_wrapper::Node *`, so this wrapper requires a Method 2 node. There is no overload for a plain `rclcpp::Node`.
 
 ### Usage example
 
@@ -325,6 +372,8 @@ void onSynchronized(
 This package provides wrapper types for tf2 (`TransformListener`, `TransformBroadcaster`, `StaticTransformBroadcaster`, `Buffer`) in the `autoware::agnocast_wrapper` namespace. The listener and broadcasters transparently switch between their `tf2_ros` and `agnocast` implementations at runtime, depending on whether the given node is running in Agnocast mode.
 
 The node-taking constructors require a Method 2 node (`autoware::agnocast_wrapper::Node`). This is needed because an AgnocastOnly executor does not spin a plain `tf2_ros::TransformListener` (a ROS 2 subscription); routing `/tf` through Agnocast keeps tf callbacks firing.
+
+All four wrapper types are non-copyable and non-movable (the backend is chosen at construction and bound by reference), so hold them by value or in a `unique_ptr`.
 
 `Buffer` aliases to `agnocast::Buffer` in Agnocast-enabled builds and `tf2_ros::Buffer` otherwise. The agnocast variant intentionally omits APIs that would silently break under an AgnocastOnly executor (currently `waitForTransform` / `setCreateTimerInterface` and the `/tf2_frames` debug service), so misuse is caught at compile time.
 
@@ -509,6 +558,13 @@ In such cases, rebuild both A and B with Agnocast **disabled** to ensure consist
 ## How to Enable Agnocast at Runtime
 
 When Agnocast is enabled at build time, the heaphook shared library must be preloaded at runtime via `LD_PRELOAD`, and component containers must be replaced with their Agnocast equivalents. This package provides `agnocast_env.launch.xml` (and its Python equivalent `agnocast_env.launch.py`) which handles both of these concerns based on the `ENABLE_AGNOCAST` environment variable.
+
+### Discovery agent
+
+Including `agnocast_env.launch.xml` / `.py` also launches the `agnocast_discovery_agent` node
+automatically, once per launch tree and only when `ENABLE_AGNOCAST=1`. It publishes the local Agnocast
+state on `/_agnocast_discovery`, which the `ros2 topic list_agnocast` / `info_agnocast` / `hz_agnocast`
+commands rely on.
 
 ### Provided Variables
 

--- a/common/autoware_agnocast_wrapper/docs/review_guide.md
+++ b/common/autoware_agnocast_wrapper/docs/review_guide.md
@@ -33,6 +33,7 @@ This document serves as a guide for reviewing PRs that apply [autoware_agnocast_
 - What is autoware_agnocast_wrapper?
 - Behavior Changes via ENABLE_AGNOCAST Environment Variable
 - Key Macros
+  - Polling Subscribers (`polling::` free functions)
 - Two Integration Methods: Free Functions vs `agnocast_wrapper::Node`
 - component_container and `autoware_agnocast_wrapper_register_node`
 - Executor Types and Selection
@@ -152,7 +153,9 @@ Once identified, proceed to the corresponding review procedure below.
 
 - [ ] Message allocation (if publisher exists): `std::make_unique<M>()` → `ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_)`
 
-- [ ] Options type: `rclcpp::SubscriptionOptions` → `AUTOWARE_SUBSCRIPTION_OPTIONS`
+- [ ] Options type: `rclcpp::SubscriptionOptions` → `AUTOWARE_SUBSCRIPTION_OPTIONS` (and `rclcpp::PublisherOptions` → `AUTOWARE_PUBLISHER_OPTIONS`)
+
+- [ ] Polling subscribers are left as plain `autoware_utils_rclcpp::InterProcessPollingSubscriber`. `polling::create_polling_subscriber` currently takes an `autoware::agnocast_wrapper::Node *`, so it cannot be called from a Method 1 node (see Part 2 Section 3.1)
 
 &nbsp;
 
@@ -307,6 +310,8 @@ Node-wide migration to `agnocast_wrapper::Node` (see Part 2 Section 4 Method 2).
 
 - [ ] Message allocation (if publisher exists): `std::make_unique<M>()` → `ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_)`
 
+- [ ] Polling subscribers use the `polling::` free-function API (see Part 2 Section 3.1)
+
 - [ ] If the node also uses message_filters, timers, tf2, or diagnostic_updater, they have been migrated to the corresponding `autoware::agnocast_wrapper::*` wrappers (see the [README](../README.md) for usage and current limitations)
 
 - [ ] If the original CMakeLists.txt used `rclcpp_components_register_node()`, it has been replaced with `autoware_agnocast_wrapper_register_node()` (see Part 2 Section 5)
@@ -409,6 +414,32 @@ All macros below are defined in [`autoware_agnocast_wrapper.hpp`](https://github
 | --------------------------------- | ------------------------------- | --------------------------------------- |
 | `AUTOWARE_PUBLISHER_PTR(MsgT)`    | `Publisher<MsgT>::SharedPtr`    | `rclcpp::Publisher<MsgT>::SharedPtr`    |
 | `AUTOWARE_SUBSCRIPTION_PTR(MsgT)` | `Subscription<MsgT>::SharedPtr` | `rclcpp::Subscription<MsgT>::SharedPtr` |
+| `AUTOWARE_TIMER_PTR`              | `Timer::SharedPtr`              | `rclcpp::TimerBase::SharedPtr`          |
+
+&nbsp;
+
+### Client / Service Types
+
+These resolve to the wrapper's **own** types in both builds (the wrapper unifies the Client/Service
+surface), so client and service code needs no per-build spelling:
+
+| Macro                                                | Both builds                              |
+| ---------------------------------------------------- | ---------------------------------------- |
+| `AUTOWARE_CLIENT_PTR(SrvT)`                          | `Client<SrvT>::SharedPtr`                |
+| `AUTOWARE_SERVICE_PTR(SrvT)`                         | `Service<SrvT>::SharedPtr`               |
+| `AUTOWARE_CLIENT_FUTURE(SrvT)`                       | `Client<SrvT>::Future`                   |
+| `AUTOWARE_CLIENT_SHARED_FUTURE(SrvT)`                | `Client<SrvT>::SharedFuture`             |
+| `AUTOWARE_CLIENT_FUTURE_AND_REQUEST_ID(SrvT)`        | `Client<SrvT>::FutureAndRequestId`       |
+| `AUTOWARE_CLIENT_SHARED_FUTURE_AND_REQUEST_ID(SrvT)` | `Client<SrvT>::SharedFutureAndRequestId` |
+
+Request/response pointer types **do** differ per build:
+
+| Macro                                | ENABLE_AGNOCAST=1                | ENABLE_AGNOCAST=0                       |
+| ------------------------------------ | -------------------------------- | --------------------------------------- |
+| `AUTOWARE_SERVER_REQUEST_PTR(SrvT)`  | `message_ptr<const Request, …>`  | `std::shared_ptr<const SrvT::Request>`  |
+| `AUTOWARE_SERVER_RESPONSE_PTR(SrvT)` | `message_ptr<Response, …>`       | `std::shared_ptr<SrvT::Response>`       |
+| `AUTOWARE_CLIENT_REQUEST_PTR(SrvT)`  | `message_ptr<Request, …>`        | `std::shared_ptr<SrvT::Request>`        |
+| `AUTOWARE_CLIENT_RESPONSE_PTR(SrvT)` | `message_ptr<const Response, …>` | `std::shared_ptr<const SrvT::Response>` |
 
 &nbsp;
 
@@ -419,6 +450,43 @@ All macros below are defined in [`autoware_agnocast_wrapper.hpp`](https://github
 | `AUTOWARE_CREATE_SUBSCRIPTION(msg_type, topic, qos, callback, options)` | `agnocast_wrapper::create_subscription<msg_type>(...)` | `this->create_subscription<msg_type>(...)` |
 | `AUTOWARE_CREATE_PUBLISHER2(msg_type, topic, qos)`                      | `agnocast_wrapper::create_publisher<msg_type>(...)`    | `this->create_publisher<msg_type>(...)`    |
 | `AUTOWARE_CREATE_PUBLISHER3(msg_type, topic, qos, options)`             | `agnocast_wrapper::create_publisher<msg_type>(...)`    | `this->create_publisher<msg_type>(...)`    |
+
+The macros above implicitly use `this` as the node. Each has an `_ON_NODE` variant that takes the node
+explicitly as the first argument after the message type — use these when the publisher/subscriber is
+created outside the node class (helper classes, free functions, member objects that only hold a node
+pointer):
+
+- `AUTOWARE_CREATE_SUBSCRIPTION_ON_NODE(msg_type, node, topic, qos, callback, options)`
+- `AUTOWARE_CREATE_PUBLISHER2_ON_NODE(msg_type, node, topic, qos)` / `AUTOWARE_CREATE_PUBLISHER3_ON_NODE(msg_type, node, topic, qos, options)`
+
+Clients and services follow the same pattern, with the numeric suffix selecting the arity:
+
+- `AUTOWARE_CREATE_CLIENT1/2/3(service_type, service_name[, qos[, group]])` (+ `_ON_NODE` variants)
+- `AUTOWARE_CREATE_SERVICE2/3/4(service_type, service_name, callback[, qos[, group]])` (+ `_ON_NODE` variants)
+
+&nbsp;
+
+### 3.1 Polling Subscribers (`polling::` free functions)
+
+Polling subscribers are **not** created via a macro or a `Node` member. Use the free function:
+
+```cpp
+#include <autoware/agnocast_wrapper/polling_subscriber.hpp>
+
+namespace polling = autoware::agnocast_wrapper::polling;
+
+polling::PollingSubscriber<nav_msgs::msg::Odometry>::SharedPtr sub_ =
+  polling::create_polling_subscriber<nav_msgs::msg::Odometry>(this, "~/input/odometry", 1);
+
+// take_data() returns a plain std::shared_ptr<const MessageT> in BOTH builds.
+const std::shared_ptr<const nav_msgs::msg::Odometry> msg = sub_->take_data();
+```
+
+Review points:
+
+- [ ] The receiving variable is `std::shared_ptr<const MessageT>`, not a `message_ptr` or `AUTOWARE_MESSAGE_CONST_SHARED_PTR`.
+- [ ] The **policy tag** is preserved from the original code. `polling_policy::Latest` (the default) re-delivers the cached message every call; `polling_policy::Newest` returns `nullptr` until a new message arrives.
+- [ ] `polling_policy::All` is rejected at compile time — `take_data()` returns a single message, not a vector.
 
 &nbsp;
 
@@ -523,11 +591,11 @@ private:
 
 ### Method 2 Behavior with ENABLE_AGNOCAST=0
 
-When built with `ENABLE_AGNOCAST=0` (or unset), [`node.hpp`](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp) defines `autoware::agnocast_wrapper::Node` as a **real class that owns an internal `rclcpp::Node` and forwards a curated set of members to it**. It is not a typedef for `rclcpp::Node`, and it does not derive from `rclcpp::Node` in either build:
+When built with `ENABLE_AGNOCAST=0` (or unset), [`node.hpp`](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp) defines `autoware::agnocast_wrapper::Node` as a **real class that owns an internal `rclcpp::Node` and forwards a curated set of members to it**. It is _not_ a typedef for `rclcpp::Node`, and it does not derive from `rclcpp::Node` in either build:
 
 ```cpp
 // node.hpp when ENABLE_AGNOCAST=0 (simplified)
-class Node : public std::enable_shared_from_this<Node>
+class Node
 {
 public:
   explicit Node(const std::string & node_name, const rclcpp::NodeOptions & options = {});
@@ -569,13 +637,18 @@ A CMake macro used in place of `rclcpp_components_register_node`. It generates d
 
 **ENABLE_AGNOCAST=1:**
 
-- `<EXECUTABLE>`: a runtime-switchable standalone executable
-- Component registration via `rclcpp_components_register_nodes` (plural), which populates the ament
-  resource index only — the component can still be loaded into a container, but no extra standalone
-  executable is generated for it
+- `<EXECUTABLE>`: a runtime-switchable standalone executable, generated from the package's
+  `node_main_switchable.cpp.in` template
+- Component registration: `rclcpp_components_register_nodes` (plural) is called, which populates the
+  ament resource index **only** — so the component can still be loaded into a container, but no extra
+  standalone executable is generated for it
 
-> There is no `<EXECUTABLE>_component` target. Launch files should reference `<EXECUTABLE>`, which is the
-> same name in both modes.
+> There is no `<EXECUTABLE>_component` target. Launch files should always reference `<EXECUTABLE>`, which
+> is the same name in both modes.
+
+Note that the macro applies `autoware_agnocast_wrapper_setup()` to **both** the component library and the
+generated executable. Both need `USE_AGNOCAST_ENABLED` defined for ABI consistency, and
+`ament_target_dependencies()` does not propagate the wrapper's `PUBLIC` compile definitions.
 
 &nbsp;
 
@@ -709,11 +782,11 @@ container = ComposableNodeContainer(
 
 ### Parameters
 
-| Parameter                | Default                                            | Description                                                                                         |
-| ------------------------ | -------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `agnocast_heaphook_path` | `/opt/ros/$ROS_DISTRO/lib/libagnocast_heaphook.so` | Path to the heaphook library. `$ROS_DISTRO` is read from the environment and falls back to `humble` |
-| `use_multithread`        | `false`                                            | Whether to use a multi-threaded container                                                           |
-| `use_agnocast`           | `$(env ENABLE_AGNOCAST 0)`                         | Per-include override (`1`/`0`). Forces one node/container back to the plain rclcpp path             |
+| Parameter                | Default                                            | Description                                                                                                 |
+| ------------------------ | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `agnocast_heaphook_path` | `/opt/ros/$ROS_DISTRO/lib/libagnocast_heaphook.so` | Path to the heaphook library. `$ROS_DISTRO` is read from the environment and falls back to `humble`         |
+| `use_multithread`        | `false`                                            | Whether to use a multi-threaded container                                                                   |
+| `use_agnocast`           | `$(env ENABLE_AGNOCAST 0)`                         | Per-include override (`1`/`0`). Usually left unset; forces one node/container back to the plain rclcpp path |
 
 &nbsp;
 

--- a/common/autoware_agnocast_wrapper/docs/review_guide.md
+++ b/common/autoware_agnocast_wrapper/docs/review_guide.md
@@ -155,8 +155,6 @@ Once identified, proceed to the corresponding review procedure below.
 
 - [ ] Options type: `rclcpp::SubscriptionOptions` → `AUTOWARE_SUBSCRIPTION_OPTIONS` (and `rclcpp::PublisherOptions` → `AUTOWARE_PUBLISHER_OPTIONS`)
 
-- [ ] Polling subscribers are left as plain `autoware_utils_rclcpp::InterProcessPollingSubscriber`. `polling::create_polling_subscriber` currently takes an `autoware::agnocast_wrapper::Node *`, so it cannot be called from a Method 1 node (see Part 2 Section 3.1)
-
 &nbsp;
 
 #### Step 2: Verification (see Part 2 Section 2, Part 2 Section 8)

--- a/common/autoware_agnocast_wrapper/docs/review_guide.md
+++ b/common/autoware_agnocast_wrapper/docs/review_guide.md
@@ -405,22 +405,20 @@ All macros below are defined in [`autoware_agnocast_wrapper.hpp`](https://github
 
 ### Publisher/Subscriber Types
 
-| Macro                                   | ENABLE_AGNOCAST=1 (Agnocast)         | ENABLE_AGNOCAST=0 (ROS 2)                        |
-| --------------------------------------- | ------------------------------------ | ------------------------------------------------ |
-| `AUTOWARE_PUBLISHER_PTR(MsgT)`          | `Publisher<MsgT>::SharedPtr`         | `rclcpp::Publisher<MsgT>::SharedPtr`             |
-| `AUTOWARE_SUBSCRIPTION_PTR(MsgT)`       | `Subscription<MsgT>::SharedPtr`      | `rclcpp::Subscription<MsgT>::SharedPtr`          |
-| `AUTOWARE_POLLING_SUBSCRIBER_PTR(MsgT)` | `PollingSubscriber<MsgT>::SharedPtr` | `InterProcessPollingSubscriber<MsgT>::SharedPtr` |
+| Macro                             | ENABLE_AGNOCAST=1 (Agnocast)    | ENABLE_AGNOCAST=0 (ROS 2)               |
+| --------------------------------- | ------------------------------- | --------------------------------------- |
+| `AUTOWARE_PUBLISHER_PTR(MsgT)`    | `Publisher<MsgT>::SharedPtr`    | `rclcpp::Publisher<MsgT>::SharedPtr`    |
+| `AUTOWARE_SUBSCRIPTION_PTR(MsgT)` | `Subscription<MsgT>::SharedPtr` | `rclcpp::Subscription<MsgT>::SharedPtr` |
 
 &nbsp;
 
 ### Publisher/Subscriber Creation
 
-| Macro                                                                   | ENABLE_AGNOCAST=1 (Agnocast)                                         | ENABLE_AGNOCAST=0 (ROS 2)                                                   |
-| ----------------------------------------------------------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| `AUTOWARE_CREATE_SUBSCRIPTION(msg_type, topic, qos, callback, options)` | `agnocast_wrapper::create_subscription<msg_type>(...)`               | `this->create_subscription<msg_type>(...)`                                  |
-| `AUTOWARE_CREATE_PUBLISHER2(msg_type, topic, qos)`                      | `agnocast_wrapper::create_publisher<msg_type>(...)`                  | `this->create_publisher<msg_type>(...)`                                     |
-| `AUTOWARE_CREATE_PUBLISHER3(msg_type, topic, qos, options)`             | `agnocast_wrapper::create_publisher<msg_type>(...)`                  | `this->create_publisher<msg_type>(...)`                                     |
-| `AUTOWARE_CREATE_POLLING_SUBSCRIBER(msg_type, policy, topic, qos)`      | `agnocast_wrapper::create_polling_subscriber<msg_type, policy>(...)` | `InterProcessPollingSubscriber<msg_type, policy>::create_subscription(...)` |
+| Macro                                                                   | ENABLE_AGNOCAST=1 (Agnocast)                           | ENABLE_AGNOCAST=0 (ROS 2)                  |
+| ----------------------------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------ |
+| `AUTOWARE_CREATE_SUBSCRIPTION(msg_type, topic, qos, callback, options)` | `agnocast_wrapper::create_subscription<msg_type>(...)` | `this->create_subscription<msg_type>(...)` |
+| `AUTOWARE_CREATE_PUBLISHER2(msg_type, topic, qos)`                      | `agnocast_wrapper::create_publisher<msg_type>(...)`    | `this->create_publisher<msg_type>(...)`    |
+| `AUTOWARE_CREATE_PUBLISHER3(msg_type, topic, qos, options)`             | `agnocast_wrapper::create_publisher<msg_type>(...)`    | `this->create_publisher<msg_type>(...)`    |
 
 &nbsp;
 
@@ -525,14 +523,30 @@ private:
 
 ### Method 2 Behavior with ENABLE_AGNOCAST=0
 
-When built with `ENABLE_AGNOCAST=0` (or unset), [`node.hpp`](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp) defines `autoware::agnocast_wrapper::Node` as a simple typedef for `rclcpp::Node`:
+When built with `ENABLE_AGNOCAST=0` (or unset), [`node.hpp`](https://github.com/autowarefoundation/autoware_core/blob/main/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp) defines `autoware::agnocast_wrapper::Node` as a **real class that owns an internal `rclcpp::Node` and forwards a curated set of members to it**. It is not a typedef for `rclcpp::Node`, and it does not derive from `rclcpp::Node` in either build:
 
 ```cpp
-// node.hpp when ENABLE_AGNOCAST=0
-using Node = rclcpp::Node;
+// node.hpp when ENABLE_AGNOCAST=0 (simplified)
+class Node : public std::enable_shared_from_this<Node>
+{
+public:
+  explicit Node(const std::string & node_name, const rclcpp::NodeOptions & options = {});
+  // ... the same curated member set as the ENABLE_AGNOCAST=1 Node ...
+  std::shared_ptr<rclcpp::Node> get_rclcpp_node() const { return node_; }
+
+private:
+  std::shared_ptr<rclcpp::Node> node_;
+};
 ```
 
-Therefore, code using Method 2 compiles and runs without issues as a regular `rclcpp::Node` when built with `ENABLE_AGNOCAST=0`. Backward compatibility is maintained even in environments without Agnocast support.
+This is deliberate: if the `=0` build aliased or derived from `rclcpp::Node`, the full `rclcpp::Node` API would leak into it, and a node could compile under `=0` while using members that do not exist under `=1`.
+
+Two consequences to keep in mind while reviewing:
+
+- The node **cannot be passed where an `rclcpp::Node *` / `rclcpp::Node &` is expected.** Hand it to executors and utilities via `get_node_base_interface()`.
+- Any `rclcpp::Node` member not in the curated surface (see the [README](../README.md#supported-api-surface)) will not compile.
+
+Code using Method 2 still compiles and runs as a plain ROS 2 node when built with `ENABLE_AGNOCAST=0`, so backward compatibility for users without Agnocast is maintained.
 
 &nbsp;
 
@@ -555,9 +569,13 @@ A CMake macro used in place of `rclcpp_components_register_node`. It generates d
 
 **ENABLE_AGNOCAST=1:**
 
-- Generates two targets:
-  1. `<EXECUTABLE>_component`: Standard rclcpp_components executable (for containers)
-  2. `<EXECUTABLE>`: Runtime-switchable standalone executable
+- `<EXECUTABLE>`: a runtime-switchable standalone executable
+- Component registration via `rclcpp_components_register_nodes` (plural), which populates the ament
+  resource index only — the component can still be loaded into a container, but no extra standalone
+  executable is generated for it
+
+> There is no `<EXECUTABLE>_component` target. Launch files should reference `<EXECUTABLE>`, which is the
+> same name in both modes.
 
 &nbsp;
 
@@ -691,10 +709,11 @@ container = ComposableNodeContainer(
 
 ### Parameters
 
-| Parameter                | Default                                       | Description                               |
-| ------------------------ | --------------------------------------------- | ----------------------------------------- |
-| `agnocast_heaphook_path` | `/opt/ros/humble/lib/libagnocast_heaphook.so` | Path to the heaphook library              |
-| `use_multithread`        | `false`                                       | Whether to use a multi-threaded container |
+| Parameter                | Default                                            | Description                                                                                         |
+| ------------------------ | -------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `agnocast_heaphook_path` | `/opt/ros/$ROS_DISTRO/lib/libagnocast_heaphook.so` | Path to the heaphook library. `$ROS_DISTRO` is read from the environment and falls back to `humble` |
+| `use_multithread`        | `false`                                            | Whether to use a multi-threaded container                                                           |
+| `use_agnocast`           | `$(env ENABLE_AGNOCAST 0)`                         | Per-include override (`1`/`0`). Forces one node/container back to the plain rclcpp path             |
 
 &nbsp;
 

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -576,11 +576,13 @@ public:
   virtual void publish(AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) && message) = 0;
   virtual void publish(AUTOWARE_MESSAGE_SHARED_PTR(MessageT) && message) = 0;
 
-  /// Publish by const reference (internally copies into allocated message).
-  /// This method is discouraged because it performs an implicit copy.
-  /// Prefer ALLOCATE_OUTPUT_MESSAGE_{UNIQUE,SHARED}(publisher) + the corresponding publish()
-  /// overload. May be marked [[deprecated]] in the future once autoware_cmake supports
-  /// suppressing deprecation warnings for test targets.
+  /// Publish by const reference: copies @p data into a freshly allocated message (allocated in
+  /// shared memory on the Agnocast path), then publishes it.
+  ///
+  /// Use this when the caller already holds a message it does not own or must retain — e.g.
+  /// re-publishing a received message, or publishing a member kept as node state. When the outgoing
+  /// message is being constructed anyway, prefer ALLOCATE_OUTPUT_MESSAGE_{UNIQUE,SHARED}(publisher)
+  /// and the corresponding publish() overload instead, which builds in place and copies no payload.
   virtual void publish(const MessageT & data) = 0;
 
   virtual uint32_t get_subscription_count() const = 0;

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp
@@ -53,6 +53,8 @@ namespace autoware::agnocast_wrapper
 /// @brief Node wrapper class that can switch between rclcpp::Node and agnocast::Node at runtime
 /// based on the ENABLE_AGNOCAST environment variable.
 ///
+/// Derives from std::enable_shared_from_this so shared_from_this() works, as on rclcpp::Node.
+///
 /// @invariant The backend variant (rclcpp::Node or agnocast::Node) is chosen at construction
 ///            based on use_agnocast() and never mutates for the lifetime of the Node.
 /// @invariant `use_agnocast() == true`  iff `get_agnocast_node()` returns a valid
@@ -443,6 +445,8 @@ namespace autoware::agnocast_wrapper
 /// from rclcpp::Node. This keeps the public surface identical to the Agnocast-build Node, so code
 /// compiles under both ENABLE_AGNOCAST=0 and =1. Deriving from rclcpp::Node would instead leak its
 /// full API into the =0 build, allowing =0-only code that breaks under =1.
+///
+/// Derives from std::enable_shared_from_this so shared_from_this() works, as on rclcpp::Node.
 class Node : public std::enable_shared_from_this<Node>
 {
 public:


### PR DESCRIPTION
## Description

Documents behaviors and APIs of `autoware_agnocast_wrapper` that were not covered by `README.md` / `docs/review_guide.md`. 

**README.md**

- **Publisher API**: the three `publish()` overloads and the two `ALLOCATE_OUTPUT_MESSAGE_*` helpers were not described anywhere. Adds a table and states when the zero-copy path versus the `const MessageT &` path is appropriate, plus the shared-memory allocation window.
- **Type spellings**: member names match across builds, but the handle/options/message types do not, so the `AUTOWARE_*` macros are required. Adds a mapping table, and notes that client/service handles are the wrapper's own types in both builds.
- **`ok()`** (added in #1232): a mode-agnostic replacement for `rclcpp::ok()`, needed because an AgnocastOnly executable never calls `rclcpp::init()`.
- **`enable_shared_from_this`** (added in #1294): recorded in the API surface table.
- **Discovery agent**: including `agnocast_env.launch.{xml,py}` also spawns `agnocast_discovery_agent`, once per launch tree, when `ENABLE_AGNOCAST=1`. The `ros2 topic list_agnocast` / `info_agnocast` / `hz_agnocast` commands depend on it.
- **message_filters**: `Subscriber::subscribe()` requires an `agnocast_wrapper::Node *`, so the wrapper is available to the Node Wrapper approach only.
- **tf2**: the buffer-only `TransformListener` constructor, and that the wrapper types are non-copyable / non-movable.

**docs/review_guide.md**

- **§3**: adds the service / client / timer macro families that were missing — `AUTOWARE_SERVER_*`, `AUTOWARE_CLIENT_*`, `AUTOWARE_SERVICE_PTR`, `AUTOWARE_TIMER_PTR`, the `*_ON_NODE` variants, and `AUTOWARE_CREATE_CLIENT*` / `AUTOWARE_CREATE_SERVICE*`.
- **§3.1 (new)**: polling subscribers via `polling::create_polling_subscriber`, including the `take_data()` return type, the policy tags, and that `polling_policy::All` is rejected at compile time.
- **§1**: adds two limits of the Bridge, without changing the existing "This means" list — an `AgnocastOnly` executor does not service plain rclcpp endpoints in its own process, and `AGNOCAST_BRIDGE_MODE` can disable or change bridging.
- **§5**: in agnocast-only mode the generated `main` calls `agnocast::init()` and skips `rclcpp::init()`, so ROS arguments do not reach `NodeOptions` and `rclcpp::shutdown()` is not called.
- **§7**: the discovery agent, and its relevance when verifying with the `*_agnocast` CLI commands.

**node.hpp**

- Doc comments on both `Node` classes explaining why they derive from `std::enable_shared_from_this`.

## Related links

**Parent Issue:**

- None.

## How was this PR tested?

## Notes for reviewers

## Interface changes

None.

## Effects on system behavior

None.
