### PR TITLE
refactor(`autoware_map_projection_loader`): keep core logic free of logging

### DIFF
--- a/map/autoware_map_projection_loader/CMakeLists.txt
+++ b/map/autoware_map_projection_loader/CMakeLists.txt
@@ -9,6 +9,7 @@ ament_auto_find_build_dependencies()
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/map_projection_loader.cpp
   src/load_info_from_lanelet2_map.cpp
+  src/map_projection_loader_node.cpp
 )
 
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}

--- a/map/autoware_map_projection_loader/README.md
+++ b/map/autoware_map_projection_loader/README.md
@@ -34,6 +34,8 @@ projector_type: Local
 
 Note that even if you input scale_factor, it will be overwritten to 1.0.
 
+The `projector_type` value is case-sensitive and must be exactly `Local`. The previously accepted lowercase `local` is no longer supported and will be rejected.
+
 #### Limitation
 
 The functionality that requires latitude and longitude will become unavailable.

--- a/map/autoware_map_projection_loader/src/map_projection_loader.cpp
+++ b/map/autoware_map_projection_loader/src/map_projection_loader.cpp
@@ -21,8 +21,6 @@
 #include <yaml-cpp/yaml.h>
 
 #include <filesystem>
-#include <fstream>
-#include <iostream>
 #include <string>
 #include <utility>
 
@@ -50,20 +48,11 @@ autoware_map_msgs::msg::MapProjectorInfo load_info_from_yaml(const std::string &
   } else if (msg.projector_type == autoware_map_msgs::msg::MapProjectorInfo::LOCAL) {
     ;  // do nothing
 
-  } else if (msg.projector_type == "local") {
-    RCLCPP_WARN_STREAM(
-      rclcpp::get_logger("MapProjectionLoader"),
-      "Load " << filename << "\n"
-              << "DEPRECATED WARNING: projector type \"local\" is deprecated."
-                 "Please use \"Local\" instead. For more info, visit "
-                 "https://github.com/autowarefoundation/autoware.universe/blob/main/map/"
-                 "map_projection_loader README.md");
-    msg.projector_type = autoware_map_msgs::msg::MapProjectorInfo::LOCAL;
   } else {
     throw std::runtime_error(
       "Invalid map projector type. Currently supported types: MGRS, LocalCartesian, "
       "LocalCartesianUTM, "
-      "TransverseMercator, and local");
+      "TransverseMercator, and Local");
   }
 
   // set scale factor
@@ -98,17 +87,11 @@ autoware_map_msgs::msg::MapProjectorInfo load_map_projector_info(
   autoware_map_msgs::msg::MapProjectorInfo msg;
 
   if (std::filesystem::exists(yaml_filename)) {
-    std::cout << "Load " << yaml_filename << std::endl;
     msg = load_info_from_yaml(yaml_filename);
   } else if (std::filesystem::exists(lanelet2_map_filename)) {
-    std::cout << "Load " << lanelet2_map_filename << std::endl;
-    std::cout
-      << "DEPRECATED WARNING: Loading map projection info from lanelet2 map may soon be deleted. "
-         "Please use map_projector_info.yaml instead. For more info, visit "
-         "https://github.com/autowarefoundation/autoware.universe/blob/main/map/"
-         "map_projection_loader/"
-         "README.md"
-      << std::endl;
+    // TODO(sasakisasaki, added on 29th July 2026):
+    //   Remove this deprecated way, which is used for backward compatibility.
+    //   Ref. https://github.com/autowarefoundation/autoware_universe/pull/3986
     msg = load_info_from_lanelet2_map(lanelet2_map_filename);
   } else {
     throw std::runtime_error(
@@ -125,8 +108,13 @@ MapProjectionLoader::MapProjectionLoader(const rclcpp::NodeOptions & options)
   const std::string lanelet2_map_filename =
     this->declare_parameter<std::string>("lanelet2_map_path");
 
+  RCLCPP_INFO_STREAM(get_logger(), "map_projector_info_path: " << yaml_filename);
+  RCLCPP_INFO_STREAM(get_logger(), "lanelet2_map_path: " << lanelet2_map_filename);
+
   const autoware_map_msgs::msg::MapProjectorInfo msg =
     load_map_projector_info(yaml_filename, lanelet2_map_filename);
+
+  RCLCPP_INFO_STREAM(get_logger(), "Loaded map projector info");
 
   // Publish the message
   publisher_ = this->create_publisher<MapProjectorInfo::Message>(

--- a/map/autoware_map_projection_loader/src/map_projection_loader.cpp
+++ b/map/autoware_map_projection_loader/src/map_projection_loader.cpp
@@ -22,7 +22,6 @@
 
 #include <filesystem>
 #include <string>
-#include <utility>
 
 namespace autoware::map_projection_loader
 {
@@ -100,30 +99,4 @@ autoware_map_msgs::msg::MapProjectorInfo load_map_projector_info(
   }
   return msg;
 }
-
-MapProjectionLoader::MapProjectionLoader(const rclcpp::NodeOptions & options)
-: Node("map_projection_loader", options)
-{
-  const std::string yaml_filename = this->declare_parameter<std::string>("map_projector_info_path");
-  const std::string lanelet2_map_filename =
-    this->declare_parameter<std::string>("lanelet2_map_path");
-
-  RCLCPP_INFO_STREAM(get_logger(), "map_projector_info_path: " << yaml_filename);
-  RCLCPP_INFO_STREAM(get_logger(), "lanelet2_map_path: " << lanelet2_map_filename);
-
-  const autoware_map_msgs::msg::MapProjectorInfo msg =
-    load_map_projector_info(yaml_filename, lanelet2_map_filename);
-
-  RCLCPP_INFO_STREAM(get_logger(), "Loaded map projector info");
-
-  // Publish the message
-  publisher_ = this->create_publisher<MapProjectorInfo::Message>(
-    MapProjectorInfo::name, autoware::component_interface_specs::get_qos<MapProjectorInfo>());
-  auto output = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(publisher_);
-  *output = msg;
-  publisher_->publish(std::move(output));
-}
 }  // namespace autoware::map_projection_loader
-
-#include <rclcpp_components/register_node_macro.hpp>
-RCLCPP_COMPONENTS_REGISTER_NODE(autoware::map_projection_loader::MapProjectionLoader)

--- a/map/autoware_map_projection_loader/src/map_projection_loader_node.cpp
+++ b/map/autoware_map_projection_loader/src/map_projection_loader_node.cpp
@@ -1,0 +1,51 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "map_projection_loader_node.hpp"
+
+#include "autoware/map_projection_loader/map_projection_loader.hpp"
+
+#include <autoware_map_msgs/msg/map_projector_info.hpp>
+
+#include <string>
+#include <utility>
+
+namespace autoware::map_projection_loader
+{
+MapProjectionLoader::MapProjectionLoader(const rclcpp::NodeOptions & options)
+: Node("map_projection_loader", options)
+{
+  const std::string yaml_filename = this->declare_parameter<std::string>("map_projector_info_path");
+  const std::string lanelet2_map_filename =
+    this->declare_parameter<std::string>("lanelet2_map_path");
+
+  RCLCPP_INFO_STREAM(get_logger(), "map_projector_info_path: " << yaml_filename);
+  RCLCPP_INFO_STREAM(get_logger(), "lanelet2_map_path: " << lanelet2_map_filename);
+
+  const autoware_map_msgs::msg::MapProjectorInfo msg =
+    load_map_projector_info(yaml_filename, lanelet2_map_filename);
+
+  RCLCPP_INFO_STREAM(get_logger(), "Loaded map projector info");
+
+  // Publish the message
+  publisher_ = this->create_publisher<MapProjectorInfo::Message>(
+    MapProjectorInfo::name, autoware::component_interface_specs::get_qos<MapProjectorInfo>());
+  auto output = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(publisher_);
+  *output = msg;
+  publisher_->publish(std::move(output));
+}
+}  // namespace autoware::map_projection_loader
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::map_projection_loader::MapProjectionLoader)

--- a/map/autoware_map_projection_loader/src/map_projection_loader_node.hpp
+++ b/map/autoware_map_projection_loader/src/map_projection_loader_node.hpp
@@ -12,18 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__MAP_PROJECTION_LOADER__MAP_PROJECTION_LOADER_HPP_
-#define AUTOWARE__MAP_PROJECTION_LOADER__MAP_PROJECTION_LOADER_HPP_
+#ifndef MAP_PROJECTION_LOADER_NODE_HPP_
+#define MAP_PROJECTION_LOADER_NODE_HPP_
 
-#include <autoware_map_msgs/msg/map_projector_info.hpp>
-
-#include <string>
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/component_interface_specs/map.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 namespace autoware::map_projection_loader
 {
-autoware_map_msgs::msg::MapProjectorInfo load_info_from_yaml(const std::string & filename);
-autoware_map_msgs::msg::MapProjectorInfo load_map_projector_info(
-  const std::string & yaml_filename, const std::string & lanelet2_map_filename);
+class MapProjectionLoader : public autoware::agnocast_wrapper::Node
+{
+public:
+  explicit MapProjectionLoader(const rclcpp::NodeOptions & options);
+
+private:
+  using MapProjectorInfo = autoware::component_interface_specs::map::MapProjectorInfo;
+  AUTOWARE_PUBLISHER_PTR(MapProjectorInfo::Message) publisher_;
+};
 }  // namespace autoware::map_projection_loader
 
-#endif  // AUTOWARE__MAP_PROJECTION_LOADER__MAP_PROJECTION_LOADER_HPP_
+#endif  // MAP_PROJECTION_LOADER_NODE_HPP_

--- a/map/autoware_map_projection_loader/test/test_load_info_from_yaml.cpp
+++ b/map/autoware_map_projection_loader/test/test_load_info_from_yaml.cpp
@@ -152,16 +152,14 @@ TEST(TestLoadInfoFromYaml, LoadTransverseMercatorExplicitScaleFactor)
   EXPECT_FLOAT_EQ(msg.scale_factor, 0.5F);
 }
 
-TEST(TestLoadInfoFromYaml, LoadDeprecatedLowercaseLocal)
+TEST(TestLoadInfoFromYaml, LoadDeprecatedLowercaseLocalThrows)
 {
   const std::string output_path = "/tmp/test_load_info_from_yaml_deprecated_local.yaml";
   write_yaml("projector_type: local\n", output_path);
 
-  const auto msg = autoware::map_projection_loader::load_info_from_yaml(output_path);
-
-  // Deprecated lowercase "local" is remapped to the canonical "Local".
-  EXPECT_EQ(msg.projector_type, autoware_map_msgs::msg::MapProjectorInfo::LOCAL);
-  EXPECT_FLOAT_EQ(msg.scale_factor, 1.0F);
+  // The deprecated lowercase "local" projector type is no longer supported and is rejected.
+  EXPECT_THROW(
+    autoware::map_projection_loader::load_info_from_yaml(output_path), std::runtime_error);
 }
 
 TEST(TestLoadInfoFromYaml, InvalidProjectorTypeThrows)


### PR DESCRIPTION
## Description

**Note: Some of files changed are generated by using Claude Code. I have done self-review and verified there is no any non-intended changes. Thus, I declare this PR is ready for review.**

- Keep the core logic of `autoware_map_projection_loader` free of ROS/logging:
- Remove support for the deprecated lowercase `local` projector type (`Local` is still supported).

## Related links
- N/A

## How was this PR tested?
```bash
$ colcon build --symlink-install --packages-up-to autoware_map_projection_loader
$ colcon test --packages-select autoware_map_projection_loader --event-handlers console_direct+
$ colcon test-result --verbose
```
Then I could see:
```bash
100% tests passed, 0 tests failed out of 10
```

(ADDED) Also, as `autoware_static_centerline_generator` in `autoware_tools` is using the public header, I also tested by:
```bash
$ colcon build --symlink-install --packages-up-to autoware_static_centerline_generator
```

The build succeeded without any error.

## Notes for reviewers
Unit tests have changes as follows:
- The lowercase `local` projector type is now rejected; its unit test was updated to expect a thrown error.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior
- A map with `projector_type: local` (lowercase) is now rejected instead of being remapped to `Local`. Use the canonical `Local`.