### PR TITLE
ci: purge stale released Debian packages from the -above underlay

### DIFF
--- a/.github/workflows/build-and-test-diff-reusable.yaml
+++ b/.github/workflows/build-and-test-diff-reusable.yaml
@@ -105,11 +105,21 @@ jobs:
       - name: Remove self packages from underlay
         if: ${{ inputs.above }}
         run: |
+          ros_distro="${ROS_DISTRO:-${{ inputs.rosdistro }}}"
           for pkg_xml in $(find . -name package.xml); do
             pkg_name=$(xmllint --xpath 'string(//package/name)' "$pkg_xml")
             if [ -d "/opt/autoware/$pkg_name" ]; then
               echo "Removing /opt/autoware/$pkg_name"
               sudo rm -rf "/opt/autoware/$pkg_name"
+            fi
+            # The released Debian package installs the same headers under
+            # /opt/ros/$ROS_DISTRO/include, which is searched before the workspace include
+            # directory when packages above this repository are compiled. Leaving it in place
+            # lets a stale released header shadow the one just built from source.
+            deb_name="ros-${ros_distro}-${pkg_name//_/-}"
+            if dpkg-query -W -f='${Status}' "$deb_name" 2>/dev/null | grep -q '^install ok installed$'; then
+              echo "Removing $deb_name"
+              sudo dpkg --remove --force-depends "$deb_name"
             fi
           done
         shell: bash

--- a/.github/workflows/build-and-test-reusable.yaml
+++ b/.github/workflows/build-and-test-reusable.yaml
@@ -121,11 +121,21 @@ jobs:
       - name: Remove self packages from underlay
         if: ${{ inputs.above }}
         run: |
+          ros_distro="${ROS_DISTRO:-${{ inputs.rosdistro }}}"
           for pkg_xml in $(find . -name package.xml); do
             pkg_name=$(xmllint --xpath 'string(//package/name)' "$pkg_xml")
             if [ -d "/opt/autoware/$pkg_name" ]; then
               echo "Removing /opt/autoware/$pkg_name"
               sudo rm -rf "/opt/autoware/$pkg_name"
+            fi
+            # The released Debian package installs the same headers under
+            # /opt/ros/$ROS_DISTRO/include, which is searched before the workspace include
+            # directory when packages above this repository are compiled. Leaving it in place
+            # lets a stale released header shadow the one just built from source.
+            deb_name="ros-${ros_distro}-${pkg_name//_/-}"
+            if dpkg-query -W -f='${Status}' "$deb_name" 2>/dev/null | grep -q '^install ok installed$'; then
+              echo "Removing $deb_name"
+              sudo dpkg --remove --force-depends "$deb_name"
             fi
           done
         shell: bash


### PR DESCRIPTION
## Description

Every `build-and-test-diff-{humble,jazzy}-above / build-and-test-diff` job on `main` has been failing since `feat(point_types, object_recognition_utils): segmentation pointcloud (#1288)` landed, on PRs from several different authors and regardless of what those PRs change. The failure is always the same, in a header that the PR under test never touches:

```
install/autoware_object_recognition_utils/include/autoware_object_recognition_utils/autoware/object_recognition_utils/pointcloud_classification.hpp:29:30:
error: 'PointCloudClassification' has not been declared in 'autoware::point_types'
   29 | using autoware::point_types::PointCloudClassification;
```

### Root cause

The `-above` jobs build this repository from source on top of the prebuilt Autoware underlay, and the `Remove self packages from underlay` step already deletes the `/opt/autoware/<pkg>` copy of every package that is about to be rebuilt. The **released Debian package** of the same package is left installed, and it ships its headers into `/opt/ros/$ROS_DISTRO/include`:

```
$ dpkg -S /opt/ros/humble/include/autoware/point_types/types.hpp
ros-humble-autoware-point-types: /opt/ros/humble/include/autoware/point_types/types.hpp
$ dpkg -l | grep autoware-point-types
ii  ros-humble-autoware-point-types  1.8.0-3jammy.20260623.232751
```

`/opt/ros/$ROS_DISTRO/include` is searched **before** the workspace include directory when a package above this repository is compiled. In `autoware_cluster_merger` the include flags come out as `-isystem /opt/ros/humble/include` at position 42 and `-isystem <ws>/install/autoware_point_types/include` at position 49, so `#include <autoware/point_types/types.hpp>` resolves to the released 1.8.0 header, which predates `PointCloudClassification`.

#1288 added `PointCloudClassification` to `autoware_point_types` and wired the new `pointcloud_classification.hpp` into the aggregate `object_recognition_utils.hpp`, so every downstream consumer of that aggregate header now compiles `autoware/point_types/types.hpp` and hits the stale copy. The package's own tests build fine, because inside this repository the workspace include directory wins. #1288 itself merged with all `-above` checks `SKIPPED`, so the gate never ran on it.

### Fix

Remove the matching Debian package alongside the `/opt/autoware` copy, so the source build is the only version visible to the packages built above it. `dpkg --remove --force-depends` is used deliberately: `apt-get remove` would cascade into the Universe dependency packages that the job still needs.

## Tests performed

Reproduced and verified locally in the exact CI container (`ghcr.io/autowarefoundation/autoware:universe-dependencies-humble`), with a workspace holding `autoware_point_types` + `autoware_object_recognition_utils` at `main` and the real `autoware_cluster_merger` from `autoware_universe`, after running the `Remove self packages from underlay` step:

- **Before this change** — `Failed <<< autoware_cluster_merger [12.2s, exited with code 2]`, with the identical `'PointCloudClassification' has not been declared` error.
- **After this change** (running the step's shell body verbatim) — `Removing ros-humble-autoware-point-types` then `Finished <<< autoware_cluster_merger [25.0s]`, `Summary: 4 packages finished`.

`pre-commit run` passes on both changed files.

## Notes for reviewers

The same step exists in `build-and-test-reusable.yaml` and has the same defect, so both copies are updated.

This is a CI-environment fix, not a revert: the code from #1288 is correct, and the `-above` job was simply testing a released header instead of the one it had just built. The stale-shadowing hazard applies to every core package with a released Debian package (`autoware_interpolation`, `autoware_motion_utils`, `autoware_trajectory`, `autoware_utils_*`, `autoware_vehicle_info_utils`, ...), so this also prevents the next occurrence rather than only unblocking the current one.

## CI evidence

Fork CI on `youtalk/autoware_core`, run [30430831448](https://github.com/youtalk/autoware_core/actions/runs/30430831448), commit `aab5bb35`:

| Job | Result |
| --- | --- |
| [build-and-test-diff-humble-above / build-and-test-diff](https://github.com/youtalk/autoware_core/actions/runs/30430831448/job/90507614825) | success |
| [build-and-test-diff-jazzy-above / build-and-test-diff](https://github.com/youtalk/autoware_core/actions/runs/30430831448/job/90507614809) | success |
| [build-and-test-diff-humble / build-and-test-diff](https://github.com/youtalk/autoware_core/actions/runs/30430831448/job/90507614752) | success |
| [build-and-test-diff-jazzy / build-and-test-diff](https://github.com/youtalk/autoware_core/actions/runs/30430831448/job/90507614762) | success |
| [build-and-test-diff-jazzy-agnocast / build-and-test-diff](https://github.com/youtalk/autoware_core/actions/runs/30430831448/job/90507614795) | success |

Both `-above` jobs completed a full 361-package build with no failures. The new step reports what it removed, on each distro:

```
Removing ros-humble-autoware-interpolation
Removing ros-humble-autoware-lanelet2-utils
Removing ros-humble-autoware-motion-utils
Removing ros-humble-autoware-point-types
Removing ros-humble-autoware-trajectory
Removing ros-humble-autoware-vehicle-info-utils
```

So six released packages were shadowing the source build, not just `autoware_point_types`; the others simply had not yet gained a symbol that a workspace header needed.
