### PR TITLE
feat(autoware_agnocast_wrapper): accept MessageT::ConstSharedPtr subscription callbacks

### DIFF
--- a/common/autoware_agnocast_wrapper/README.md
+++ b/common/autoware_agnocast_wrapper/README.md
@@ -261,6 +261,35 @@ target_include_directories(target PRIVATE ${autoware_agnocast_wrapper_INCLUDE_DI
 autoware_agnocast_wrapper_setup(target)
 ```
 
+## Subscribing with `MessageT::ConstSharedPtr`
+
+Some interfaces cannot be templated on the message pointer type: a virtual method overridden by
+downstream packages, a pluginlib boundary, a third-party callback. When such an interface is fixed
+to the plain ROS 2 `MessageT::ConstSharedPtr`, a subscription callback can take that type directly,
+leaving no Agnocast-specific code at the call site:
+
+```cpp
+node->create_subscription<PointCloud2>(
+  "input", qos, [this](const PointCloud2::ConstSharedPtr & msg) {
+    // virtual void on_pointcloud(const PointCloud2::ConstSharedPtr &) — cannot change signature
+    on_pointcloud(msg);
+  });
+```
+
+The payload is not copied. On the Agnocast path the callback receives an aliasing `shared_ptr`: it
+shares ownership with the shared-memory message (so the entry stays alive) but points directly at
+the payload the message already holds. The pointer may therefore be retained beyond the callback,
+at the cost of pinning one shared-memory entry for that whole time — the same type and lifetime
+contract as a polling subscriber's `take_data()`. In a non-Agnocast build the callback is an
+ordinary rclcpp one, so the same call site compiles in both builds.
+
+`message_filters::Synchronizer` callbacks accept this form as well, so a synchronized callback
+written against `MessageT::ConstSharedPtr` needs no changes either.
+
+Prefer `AUTOWARE_MESSAGE_UNIQUE_PTR` / `AUTOWARE_MESSAGE_CONST_SHARED_PTR` where you control the
+interface: they make the ownership explicit and cannot be mistaken for a copy. This form is for the
+boundaries where you do not.
+
 ## Message Filters Support
 
 This package provides wrapper types for `message_filters` (`Subscriber`, `Synchronizer`) in the `autoware::agnocast_wrapper::message_filters` namespace. These wrappers transparently switch between `::message_filters` and `agnocast::message_filters` at runtime.

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp
@@ -395,6 +395,31 @@ public:
   MessageT * get() const noexcept { return ptr_ ? ptr_->as_ptr() : nullptr; }
 };
 
+namespace detail
+{
+/// @brief Views an Agnocast subscription message as the plain ROS 2 `MessageT::ConstSharedPtr`
+///        without copying its payload.
+///
+/// The result is an aliasing `shared_ptr`: it shares ownership with (and therefore keeps alive)
+/// the shared-memory message, but points directly at the payload the message already holds. The
+/// payload stays valid for as long as the returned pointer lives, so a callback may retain it -
+/// at the cost of pinning one shared-memory entry for that whole time.
+///
+/// Mirrors what AgnocastPollingSubscriber::take_data_impl() does, so callback and polling
+/// subscriptions hand out the same pointer type with the same lifetime contract.
+template <typename MessageT>
+typename MessageT::ConstSharedPtr alias_as_const_shared_ptr(
+  agnocast::ipc_shared_ptr<MessageT> && msg)
+{
+  if (!msg) {
+    return nullptr;
+  }
+  auto holder = std::make_shared<agnocast::ipc_shared_ptr<const MessageT>>(
+    agnocast::ipc_shared_ptr<const MessageT>(std::move(msg)));
+  return typename MessageT::ConstSharedPtr(holder, holder->get());
+}
+}  // namespace detail
+
 // Defaults to zero if the environment variable is missing or invalid.
 inline int get_ENABLE_AGNOCAST()
 {
@@ -448,14 +473,19 @@ public:
     static_assert(
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
         std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&> ||
+        std::is_invocable_v<std::decay_t<Func>, typename MessageT::ConstSharedPtr> ||
         std::is_invocable_v<std::decay_t<Func>, const MessageT &>,
       "callback should be invocable with an rvalue reference to either "
-      "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, or with a "
-      "const reference to the message type");
+      "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, with a "
+      "MessageT::ConstSharedPtr, or with a const reference to the message type");
 
     constexpr bool is_message_ptr_callback =
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>;
+    // Checked after the message_ptr forms so a generic callback keeps resolving to them.
+    constexpr bool is_const_shared_ptr_callback =
+      !is_message_ptr_callback &&
+      std::is_invocable_v<std::decay_t<Func>, typename MessageT::ConstSharedPtr>;
     constexpr auto ownership =
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>
         ? OwnershipType::Unique
@@ -464,11 +494,14 @@ public:
     subscription_ = agnocast::create_subscription<MessageT>(
       node, topic_name, qos,
       [callback = std::forward<Func>(callback)](agnocast::ipc_shared_ptr<MessageT> && msg) {
-        if constexpr (!is_message_ptr_callback) {
+        if constexpr (is_const_shared_ptr_callback) {
+          callback(detail::alias_as_const_shared_ptr<MessageT>(std::move(msg)));
+        } else if constexpr (!is_message_ptr_callback) {
           // msg keeps the shared-memory entry alive only while the callback runs: the
           // reference is valid for the duration of the callback and no copy is made, but
           // it must not be stored or used after the callback returns. Callbacks that need
-          // to extend the message lifetime should take AUTOWARE_MESSAGE_CONST_SHARED_PTR.
+          // to extend the message lifetime should take AUTOWARE_MESSAGE_CONST_SHARED_PTR
+          // or MessageT::ConstSharedPtr.
           // as_const prevents generic callbacks from mutating the shared-memory entry,
           // which other processes may be reading concurrently.
           callback(std::as_const(*msg));
@@ -498,14 +531,19 @@ public:
     static_assert(
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
         std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&> ||
+        std::is_invocable_v<std::decay_t<Func>, typename MessageT::ConstSharedPtr> ||
         std::is_invocable_v<std::decay_t<Func>, const MessageT &>,
       "callback should be invocable with an rvalue reference to either "
-      "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, or with a "
-      "const reference to the message type");
+      "AUTOWARE_MESSAGE_UNIQUE_PTR or AUTOWARE_MESSAGE_CONST_SHARED_PTR, with a "
+      "MessageT::ConstSharedPtr, or with a const reference to the message type");
 
     constexpr bool is_message_ptr_callback =
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&> ||
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_CONST_SHARED_PTR(MessageT) &&>;
+    // Checked after the message_ptr forms so a generic callback keeps resolving to them.
+    constexpr bool is_const_shared_ptr_callback =
+      !is_message_ptr_callback &&
+      std::is_invocable_v<std::decay_t<Func>, typename MessageT::ConstSharedPtr>;
     constexpr auto ownership =
       std::is_invocable_v<std::decay_t<Func>, AUTOWARE_MESSAGE_UNIQUE_PTR(MessageT) &&>
         ? OwnershipType::Unique
@@ -516,7 +554,9 @@ public:
     subscription_ = node->create_subscription<MessageT>(
       topic_name, qos,
       [callback = std::forward<Func>(callback)](std::unique_ptr<MessageT> msg) {
-        if constexpr (!is_message_ptr_callback) {
+        if constexpr (is_const_shared_ptr_callback) {
+          callback(typename MessageT::ConstSharedPtr(std::move(msg)));
+        } else if constexpr (!is_message_ptr_callback) {
           // as_const keeps this fallback consistent with the Agnocast path: generic
           // callbacks must not observe a mutable reference on either path.
           callback(std::as_const(*msg));

--- a/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
+++ b/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/message_filters.hpp
@@ -128,6 +128,10 @@ class PolicySynchronizer
 
 public:
   using Callback = std::function<void(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(Ms) & ...)>;
+  /// Plain ROS 2 callback form. Preferred: it needs no Agnocast types at the call site and
+  /// costs one allocation per message instead of two, because the payload is aliased straight
+  /// out of the ipc_shared_ptr rather than through an intermediate message_ptr.
+  using ConstSharedPtrCallback = std::function<void(const typename Ms::ConstSharedPtr &...)>;
 
   PolicySynchronizer(uint32_t queue_size, Subscriber<Ms> &... subs)
   : sync_(
@@ -165,13 +169,13 @@ public:
   template <class C>
   ::message_filters::Connection registerCallback(C & callback)
   {
-    return registerCallbackInternal(Callback(callback));
+    return registerCallbackInternal(makeCallback(callback));
   }
 
   template <class C>
   ::message_filters::Connection registerCallback(const C & callback)
   {
-    return registerCallbackInternal(Callback(callback));
+    return registerCallbackInternal(makeCallback(callback));
   }
 
   template <class C, typename T>
@@ -192,18 +196,30 @@ private:
   // pointer (adapter.get()), so it is held in `adapters_` to keep it alive.
   struct CallbackAdapter
   {
-    Callback fn;
+    std::variant<Callback, ConstSharedPtrCallback> fn;
 
     void agnocastInvoke(const agnocast::message_filters::MessageEvent<const Ms> &... es)
     {
+      if (auto * shared_fn = std::get_if<ConstSharedPtrCallback>(&fn)) {
+        // Alias the payload straight out of the shared-memory message: no copy, and no
+        // intermediate message_ptr to allocate.
+        (*shared_fn)(autoware::agnocast_wrapper::detail::alias_as_const_shared_ptr<const Ms>(
+          agnocast::ipc_shared_ptr<const Ms>(es.getMessage()))...);
+        return;
+      }
       // Wrap ipc_shared_ptr in message_ptr (copies ipc_shared_ptr refcount, not data)
-      fn(AUTOWARE_MESSAGE_CONST_SHARED_PTR(Ms)(
+      std::get<Callback>(fn)(AUTOWARE_MESSAGE_CONST_SHARED_PTR(Ms)(
         agnocast::ipc_shared_ptr<const Ms>(es.getMessage()))...);
     }
 
     void rclcppInvoke(const typename Ms::ConstSharedPtr &... ms)
     {
-      fn(AUTOWARE_MESSAGE_CONST_SHARED_PTR(Ms)(std::shared_ptr<const Ms>(ms))...);
+      if (auto * shared_fn = std::get_if<ConstSharedPtrCallback>(&fn)) {
+        (*shared_fn)(ms...);
+        return;
+      }
+      std::get<Callback>(fn)(
+        AUTOWARE_MESSAGE_CONST_SHARED_PTR(Ms)(std::shared_ptr<const Ms>(ms))...);
     }
   };
 
@@ -211,15 +227,46 @@ private:
   using RclcppSync = ::message_filters::Synchronizer<RclcppPolicy>;
   using AgnocastSync = agnocast::message_filters::Synchronizer<AgnocastPolicy>;
 
-  template <class C, typename T>
-  static Callback bindMemberCallback(C && callback, T * t)
+  using AnyCallback = std::variant<Callback, ConstSharedPtrCallback>;
+
+  // The message_ptr form is probed first so an existing generic callback keeps resolving to it.
+  template <class C>
+  static AnyCallback makeCallback(const C & callback)
   {
-    return Callback{
-      [callback = std::forward<C>(callback),
-       t](const AUTOWARE_MESSAGE_CONST_SHARED_PTR(Ms) & ... ms) { (t->*callback)(ms...); }};
+    if constexpr (std::is_invocable_v<
+                    const C &, const AUTOWARE_MESSAGE_CONST_SHARED_PTR(Ms) & ...>) {
+      return AnyCallback{std::in_place_type<Callback>, callback};
+    } else {
+      static_assert(
+        std::is_invocable_v<const C &, const typename Ms::ConstSharedPtr &...>,
+        "synchronizer callback should be invocable with either "
+        "const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M) & ... or const M::ConstSharedPtr & ...");
+      return AnyCallback{std::in_place_type<ConstSharedPtrCallback>, callback};
+    }
   }
 
-  ::message_filters::Connection registerCallbackInternal(Callback && callback)
+  template <class C, typename T>
+  static AnyCallback bindMemberCallback(C && callback, T * t)
+  {
+    if constexpr (std::is_invocable_v<C, T *, const AUTOWARE_MESSAGE_CONST_SHARED_PTR(Ms) & ...>) {
+      return AnyCallback{
+        std::in_place_type<Callback>,
+        [callback = std::forward<C>(callback),
+         t](const AUTOWARE_MESSAGE_CONST_SHARED_PTR(Ms) & ... ms) { (t->*callback)(ms...); }};
+    } else {
+      static_assert(
+        std::is_invocable_v<C, T *, const typename Ms::ConstSharedPtr &...>,
+        "synchronizer member callback should be invocable with either "
+        "const AUTOWARE_MESSAGE_CONST_SHARED_PTR(M) & ... or const M::ConstSharedPtr & ...");
+      return AnyCallback{
+        std::in_place_type<ConstSharedPtrCallback>,
+        [callback = std::forward<C>(callback), t](const typename Ms::ConstSharedPtr &... ms) {
+          (t->*callback)(ms...);
+        }};
+    }
+  }
+
+  ::message_filters::Connection registerCallbackInternal(AnyCallback && callback)
   {
     auto adapter = std::make_unique<CallbackAdapter>();
     adapter->fn = std::move(callback);


### PR DESCRIPTION
## Description

Lets a subscription callback take the plain ROS 2 `MessageT::ConstSharedPtr` — on `create_subscription()` (`Node` method, free function, `AUTOWARE_CREATE_SUBSCRIPTION*` macros) and on `message_filters::Synchronizer::registerCallback()`. For interfaces that cannot be templated on the message pointer type: a virtual method overridden downstream, a pluginlib boundary, a third-party callback.

```cpp
node->create_subscription<PointCloud2>(
  "input", qos, [this](const PointCloud2::ConstSharedPtr & msg) {
    // virtual void on_pointcloud(const PointCloud2::ConstSharedPtr &) — cannot change signature
    on_pointcloud(msg);
  });
```

`PollingSubscriber::take_data()` already returns a plain `std::shared_ptr<const MessageT>` regardless of `ENABLE_AGNOCAST`; this gives the callback path the same shape.

### Zero-copy and lifetime are preserved

- The payload is never copied. On the Agnocast path the callback receives an aliasing `shared_ptr` over the incoming `ipc_shared_ptr`: one control block allocated, refcount bumped atomically. Hand-rolling the same thing at the call site over an `AUTOWARE_MESSAGE_CONST_SHARED_PTR` costs two allocations, so this is the cheaper of the two, not a concession.
- The pointer keeps the message alive as long as any copy of it exists, so it may be retained past the callback — at the cost of pinning one shared-memory entry for that long. Same contract as `take_data()`.
- Non-Agnocast build: an ordinary rclcpp callback.

### Nothing existing changes

The `message_ptr` forms are probed first, so a callback written against `AUTOWARE_MESSAGE_UNIQUE_PTR` / `AUTOWARE_MESSAGE_CONST_SHARED_PTR` — including a generic one that would accept either — resolves exactly as before.

Subscription path only: an aliasing `shared_ptr` caches the payload address once, which would defeat the invalidation `publish()` applies to a loaned message, so there is deliberately no publisher-side counterpart.

## Related links

None.

## How was this PR tested?

Built at `ENABLE_AGNOCAST=0` and `=1`, and run in both by a consumer converted to the new form (`autoware_pointcloud_preprocessor`, stacked universe PR): identical output in both builds.

Not exercised at runtime: the `Synchronizer` path, compile-checked only — the consumer's synchronized branch needs a second input topic the setup did not publish.

## Notes for reviewers

`PolicySynchronizer` must keep both callback shapes working, so `CallbackAdapter::fn` becomes a `std::variant` and `registerCallback()` picks the arm with `is_invocable_v` — most of the diff.

The aliasing lives in `detail::alias_as_const_shared_ptr()`: it takes the backend's `ipc_shared_ptr`, which only the wrapper holds.

The branch name (`to-const-shared-ptr`) is stale; an earlier revision exposed a public helper instead.

## Interface changes

Additive: one more accepted callback signature, no existing signature changes meaning.

## Effects on system behavior

None for existing code.
