### PR TITLE
fix(autoware_map_loader): always publish the pointcloud map metadata

### DIFF
--- a/map/autoware_map_loader/CMakeLists.txt
+++ b/map/autoware_map_loader/CMakeLists.txt
@@ -50,6 +50,10 @@ if(BUILD_TESTING)
       test/lanelet2_map_loader_launch.test.py
       TIMEOUT "30"
     )
+    add_launch_test(
+      test/pointcloud_map_loader_metadata_launch.test.py
+      TIMEOUT "30"
+    )
   endif()
   install(DIRECTORY
     test/data/

--- a/map/autoware_map_loader/README.md
+++ b/map/autoware_map_loader/README.md
@@ -115,8 +115,8 @@ Please see [the description of `GetSelectedPointCloudMap.srv`](https://github.co
 
 ### Interfaces
 
-- `output/pointcloud_map` (sensor_msgs/msg/PointCloud2) : Raw pointcloud map
-- `output/pointcloud_map_metadata` (autoware_map_msgs/msg/PointCloudMapMetaData) : Metadata of pointcloud map
+- `output/pointcloud_map` (sensor_msgs/msg/PointCloud2) : Raw pointcloud map. Published only when `enable_whole_load` is true.
+- `output/pointcloud_map_metadata` (autoware_map_msgs/msg/PointCloudMapMetaData) : Metadata of pointcloud map. Always published once, latched (`transient_local`), as soon as the PCD metadata is loaded. Because it does not depend on `enable_whole_load`, it is the delivery-independent signal that the map is loaded and servable, and it is what a deployment using only the differential/partial services can monitor for map-module health.
 - `output/debug/downsampled_pointcloud_map` (sensor_msgs/msg/PointCloud2) : Downsampled pointcloud map
 - `service/get_partial_pcd_map` (autoware_map_msgs/srv/GetPartialPointCloudMap) : Partial pointcloud map
 - `service/get_differential_pcd_map` (autoware_map_msgs/srv/GetDifferentialPointCloudMap) : Differential pointcloud map

--- a/map/autoware_map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
+++ b/map/autoware_map_loader/src/pointcloud_map_loader/pointcloud_map_loader_node.cpp
@@ -87,6 +87,19 @@ PointCloudMapLoaderNode::PointCloudMapLoaderNode(const rclcpp::NodeOptions & opt
     RCLCPP_WARN_STREAM(get_logger(), msg);
   };
 
+  // The map metadata is the delivery-independent evidence that the PCD map was loaded and is
+  // servable. It is published whenever the metadata dict exists — that is, always, since the
+  // differential loader below is unconditional — so a deployment that turns `enable_whole_load`
+  // off and consumes the map through the differential/partial services still has a liveness
+  // signal for the map module to monitor.
+  {
+    rclcpp::QoS durable_qos{1};
+    durable_qos.transient_local();
+    pub_metadata_ = create_publisher<autoware_map_msgs::msg::PointCloudMapMetaData>(
+      "output/pointcloud_map_metadata", durable_qos);
+    pub_metadata_->publish(create_metadata(pcd_metadata_dict));
+  }
+
   if (enable_partial_load) {
     partial_map_loader_ =
       std::make_unique<PartialMapLoaderModule>(pcd_metadata_dict, on_cell_load_error);
@@ -116,12 +129,6 @@ PointCloudMapLoaderNode::PointCloudMapLoaderNode(const rclcpp::NodeOptions & opt
                                         GetSelectedPointCloudMap::Response::SharedPtr res) {
         return selected_map_loader_->create_response(req, res);
       });
-
-    rclcpp::QoS durable_qos{1};
-    durable_qos.transient_local();
-    pub_metadata_ = create_publisher<autoware_map_msgs::msg::PointCloudMapMetaData>(
-      "output/pointcloud_map_metadata", durable_qos);
-    pub_metadata_->publish(create_metadata(pcd_metadata_dict));
   }
 }
 }  // namespace autoware::map_loader

--- a/map/autoware_map_loader/test/pointcloud_map_loader_metadata_launch.test.py
+++ b/map/autoware_map_loader/test/pointcloud_map_loader_metadata_launch.test.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The map metadata must be published even when the whole-load topic is disabled.
+
+A deployment that delivers the PCD map through the differential/partial services sets
+``enable_whole_load: false``. Before this test, ``output/pointcloud_map_metadata`` was only
+advertised when ``enable_selected_load`` was also true, leaving such a deployment with no
+latched topic to prove the map is loaded.
+"""
+
+import os
+import tempfile
+import unittest
+
+from autoware_map_msgs.msg import PointCloudMapMetaData
+import launch
+from launch import LaunchDescription
+from launch_ros.actions import Node
+import launch_testing
+import pytest
+import rclpy
+from rclpy.qos import DurabilityPolicy
+from rclpy.qos import QoSProfile
+from rclpy.qos import ReliabilityPolicy
+
+_PCD = """\
+# .PCD v0.7 - Point Cloud Data file format
+VERSION 0.7
+FIELDS x y z
+SIZE 4 4 4
+TYPE F F F
+COUNT 1 1 1
+WIDTH 3
+HEIGHT 1
+VIEWPOINT 0 0 0 1 0 0 0
+POINTS 3
+DATA ascii
+0.0 0.0 0.0
+1.0 0.0 0.0
+0.0 1.0 0.0
+"""
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    tmp_dir = tempfile.mkdtemp(prefix="pcd_map_loader_test_")
+    pcd_path = os.path.join(tmp_dir, "single.pcd")
+    with open(pcd_path, "w") as f:
+        f.write(_PCD)
+
+    pointcloud_map_loader = Node(
+        package="autoware_map_loader",
+        executable="autoware_pointcloud_map_loader",
+        parameters=[
+            {
+                "pcd_paths_or_directory": [pcd_path],
+                # Absent on purpose: a single-PCD map synthesizes its metadata.
+                "pcd_metadata_path": os.path.join(tmp_dir, "absent_metadata.yaml"),
+                # The deployment under test: no whole-load topic, no selected-load service.
+                "enable_whole_load": False,
+                "enable_downsampled_whole_load": False,
+                "enable_partial_load": True,
+                "enable_selected_load": False,
+            }
+        ],
+    )
+
+    return (
+        LaunchDescription(
+            [
+                pointcloud_map_loader,
+                launch.actions.TimerAction(
+                    period=1.0, actions=[launch_testing.actions.ReadyToTest()]
+                ),
+            ]
+        ),
+        {},
+    )
+
+
+class TestMetadataIsPublished(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node("pointcloud_map_loader_metadata_test")
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def test_metadata_is_latched_without_whole_load(self):
+        received = []
+        # transient_local: the loader publishes once, on construction, before we subscribe.
+        qos = QoSProfile(
+            depth=1,
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
+            reliability=ReliabilityPolicy.RELIABLE,
+        )
+        self.node.create_subscription(
+            PointCloudMapMetaData,
+            "/output/pointcloud_map_metadata",
+            lambda msg: received.append(msg),
+            qos,
+        )
+
+        end = self.node.get_clock().now().nanoseconds + 10 * 1_000_000_000
+        while not received and self.node.get_clock().now().nanoseconds < end:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+
+        self.assertEqual(len(received), 1, "metadata was never published")
+        self.assertEqual(received[0].header.frame_id, "map")
+        self.assertEqual(len(received[0].metadata_list), 1, "one PCD cell expected")
+
+    def test_whole_load_topic_stays_unadvertised(self):
+        # The metadata is the liveness signal precisely because the raw map topic is gone.
+        end = self.node.get_clock().now().nanoseconds + 3 * 1_000_000_000
+        while self.node.get_clock().now().nanoseconds < end:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+        names = [n for n, _ in self.node.get_topic_names_and_types()]
+        self.assertNotIn("/output/pointcloud_map", names)
+
+
+@launch_testing.post_shutdown_test()
+class TestProcessOutput(unittest.TestCase):
+    def test_exit_code(self, proc_info):
+        launch_testing.asserts.assertExitCodes(proc_info)


### PR DESCRIPTION
## Description

`output/pointcloud_map_metadata` was only advertised when `enable_selected_load` was true, even though the metadata dict it is built from is always available and the differential map loader that serves the map is constructed unconditionally. This PR publishes the latched metadata as soon as the PCD metadata is parsed, so `enable_selected_load` governs only the selected-load service, as its name implies.

The motivation is a deployment that delivers the PCD map over the differential/partial services and therefore sets `enable_whole_load: false`. That retires `/map/pointcloud_map`, and with it the only topic the map module's health check could watch. `autoware_topic_state_monitor` evaluates `isNotReceived()` before any rate or timeout threshold, so a never-published topic is a hard error regardless of the configured thresholds, and the map module then never leaves that error state. The metadata topic is the delivery-independent evidence that the map is loaded and servable, so it is what such a deployment can monitor instead.

- `pointcloud_map_loader_node.cpp`: hoist the transient-local `output/pointcloud_map_metadata` publisher out of the `enable_selected_load` branch to just after `build_pcd_metadata_dict()`. Same topic, same type, same depth-1 `transient_local` QoS, same payload (`create_metadata(pcd_metadata_dict)`); it is now published on every configuration rather than one.
- `test/pointcloud_map_loader_metadata_launch.test.py` (new): a launch test that runs the loader with `enable_whole_load: false` and `enable_selected_load: false`, asserts the metadata arrives on a `transient_local` subscription with one PCD cell and `frame_id == "map"`, and asserts `output/pointcloud_map` stays unadvertised.
- `README.md`: state that the metadata is always published and latched, and that `output/pointcloud_map` is conditional on `enable_whole_load`.

A single-file PCD map synthesizes its metadata (`build_pcd_metadata_dict` handles the no-metadata-yaml case), so the dict is always populated or the node throws; there is no configuration in which the publisher would have nothing to send.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

## How was this PR tested?

Built and tested in an Autoware Jazzy devel container (`ghcr.io/autowarefoundation/autoware:universe-devel-jazzy`), mounting `map/autoware_map_loader` (and its `autoware_agnocast_wrapper` build dependency, needed as source because the image's installed version predates the `AUTOWARE_SERVICE_PTR` macro this package now uses) over a fresh `colcon` workspace: `colcon build --packages-up-to autoware_map_loader --cmake-args -DBUILD_TESTING=ON`, then `colcon test --packages-select autoware_map_loader && colcon test-result --verbose`. Build succeeded with no errors. The whole `autoware_map_loader` suite is green: **153 tests, 0 errors, 0 failures, 35 skipped** (the higher count than in earlier runs of this branch reflects test files that landed upstream in `autoware_map_loader` after this branch was first cut; all of them pass unmodified against the rebased branch).

The new launch test was verified to be a genuine regression pin, not a tautology: with the publisher restored to its original `enable_selected_load`-gated position the test fails with `AssertionError: 0 != 1 : metadata was never published`, and it passes once the publisher is hoisted.

The end-to-end consequence was reproduced on the Open AD Kit `logging-simulation` deployment (real sample map and rosbag, `SYSTEM_RUN_MODE=logging_simulation`), by bind-mounting configs over the released images:

| Configuration | `/map/pointcloud_map` publishers | `/autoware/map` |
|:--|:--|:--|
| stock (`enable_whole_load: true`) | 1 | `OK` |
| `enable_whole_load: false` only | 0 | **`ERROR`** |
| `enable_whole_load: false` + monitor watching the metadata topic | topic absent | `OK` |

`pre-commit run --files ...` is clean on every changed file.

## Notes for reviewers

A companion change that repoints `component_state_monitor` and the diagnostics graph at `/map/pointcloud_map_metadata` belongs in `autoware_launch` and is separate follow-up work, not part of this PR. It has to follow this one, because the metadata topic is not published in the default configuration until this change lands. This PR is self-contained and useful on its own: it makes the metadata topic available unconditionally, which is the prerequisite that change needs.

## Interface changes

### Topic changes

#### Modifications

| Version | Topic Type | Topic Name | Message Type | Description |
|:--|:--|:--|:--|:--|
| Old | Pub | `output/pointcloud_map_metadata` | `autoware_map_msgs/msg/PointCloudMapMetaData` | Published only when `enable_selected_load` is true |
| New | Pub | `output/pointcloud_map_metadata` | `autoware_map_msgs/msg/PointCloudMapMetaData` | Always published once, latched (`transient_local`, depth 1) |

## Effects on system behavior

`output/pointcloud_map_metadata` is now advertised and published in configurations where it previously was not (`enable_selected_load: false`). It is a latched, publish-once topic carrying the PCD cell metadata, so the added cost is one message per run. No existing publisher, service, or message payload changes, and no topic is removed. Nodes that already subscribed to it under `enable_selected_load: true` see identical behavior.
