### PR TITLE
feat(autoware_component_interface_specs): pivot QoS compatibility semantics

### DIFF
--- a/common/autoware_component_interface_specs/CMakeLists.txt
+++ b/common/autoware_component_interface_specs/CMakeLists.txt
@@ -48,6 +48,7 @@ if(BUILD_TESTING)
       test/test_concepts.cpp
       test/test_manifest.cpp
       test/test_service_qos.cpp
+      test/test_qos_compatibility.cpp
     )
     # test_concepts.cpp exercises the C++20 concepts header.
     target_compile_features(gtest_${PROJECT_NAME} PRIVATE cxx_std_20)

--- a/common/autoware_component_interface_specs/README.md
+++ b/common/autoware_component_interface_specs/README.md
@@ -112,3 +112,29 @@ colcon build --symlink-install --packages-select autoware_component_interface_sp
 ```
 
 The generator emits the same layout Prettier produces, so the committed file is stable across regenerations. Adjust the output path to match where the package lives in your workspace. `test_manifest.cpp` diffs the generator's output against the committed file, so a stale manifest fails the build rather than reaching consumers.
+
+## QoS semantics: the declared QoS is a pivot
+
+The QoS a spec declares (`depth`, `reliability`, `durability`) is a
+**compatibility pivot**, not an exact-match requirement:
+
+- A **provider** must offer QoS at least as strong as the pivot.
+- A **consumer** must request QoS at most as strong as the pivot.
+
+Strength follows the DDS request-vs-offered partial order per policy
+(`RELIABLE` > `BEST_EFFORT`, `TRANSIENT_LOCAL` > `VOLATILE`); a connection
+forms iff the offered QoS is at least the requested QoS on every axis, so the
+pivot rule plus transitivity guarantees that every conforming
+provider/consumer pair connects. A provider may therefore offer
+`TRANSIENT_LOCAL` where the pivot says `VOLATILE`, and a consumer may request
+`BEST_EFFORT` where the pivot says `RELIABLE` — but never the reverse.
+
+`depth` is **not** a compatibility axis (DDS history is endpoint-local); the
+declared value is an advisory per-endpoint default. Deadline, liveliness and
+lifespan are not declared by specs.
+
+`qos_compatibility.hpp` provides the constexpr helpers
+(`is_qos_compatible`, `provider_satisfies_pivot`, `consumer_satisfies_pivot`,
+`pivot_of<Spec>()`); the deploy-time admission gate applies the same rule to
+recorded endpoint QoS. The manifest's top-level `"qos_semantics": "pivot"`
+marker identifies this semantics revision to external tools.

--- a/common/autoware_component_interface_specs/include/autoware/component_interface_specs/qos_compatibility.hpp
+++ b/common/autoware_component_interface_specs/include/autoware/component_interface_specs/qos_compatibility.hpp
@@ -1,0 +1,111 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__COMPONENT_INTERFACE_SPECS__QOS_COMPATIBILITY_HPP_
+#define AUTOWARE__COMPONENT_INTERFACE_SPECS__QOS_COMPATIBILITY_HPP_
+
+#include <rmw/types.h>
+
+namespace autoware::component_interface_specs
+{
+
+/// Reliability/durability pair: the two QoS axes DDS checks for endpoint
+/// compatibility, and the two every spec declares. Depth/history are
+/// endpoint-local and deliberately absent.
+struct QosPair
+{
+  rmw_qos_reliability_policy_t reliability;
+  rmw_qos_durability_policy_t durability;
+};
+
+/// Strength rank of a reliability policy. RELIABLE delivers everything
+/// BEST_EFFORT does and more, so it ranks higher. The RMW enum integer values
+/// do NOT follow this order (BEST_EFFORT = 2 > RELIABLE = 1) -- never compare
+/// raw enums. Policies outside the two the specs can declare (SYSTEM_DEFAULT,
+/// UNKNOWN, ...) rank -1: incomparable, so every check involving them fails
+/// (fail closed).
+///
+/// The admission package restates these ranks on the JSON string encoding
+/// (it is a no-dependency leaf that cannot include this header). Change one
+/// and the other must follow: autoware_component_interface_admission,
+/// admission_rule.hpp.
+constexpr int reliability_rank(rmw_qos_reliability_policy_t policy)
+{
+  switch (policy) {
+    case RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT:
+      return 0;
+    case RMW_QOS_POLICY_RELIABILITY_RELIABLE:
+      return 1;
+    default:
+      return -1;
+  }
+}
+
+constexpr int durability_rank(rmw_qos_durability_policy_t policy)
+{
+  switch (policy) {
+    case RMW_QOS_POLICY_DURABILITY_VOLATILE:
+      return 0;
+    case RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL:
+      return 1;
+    default:
+      return -1;
+  }
+}
+
+constexpr bool reliability_at_least(rmw_qos_reliability_policy_t a, rmw_qos_reliability_policy_t b)
+{
+  return reliability_rank(a) >= 0 && reliability_rank(b) >= 0 &&
+         reliability_rank(a) >= reliability_rank(b);
+}
+
+constexpr bool durability_at_least(rmw_qos_durability_policy_t a, rmw_qos_durability_policy_t b)
+{
+  return durability_rank(a) >= 0 && durability_rank(b) >= 0 &&
+         durability_rank(a) >= durability_rank(b);
+}
+
+/// DDS request-vs-offered compatibility: a connection forms iff the offered
+/// QoS is at least as strong as the requested QoS on every axis.
+constexpr bool is_qos_compatible(const QosPair & offered, const QosPair & requested)
+{
+  return reliability_at_least(offered.reliability, requested.reliability) &&
+         durability_at_least(offered.durability, requested.durability);
+}
+
+/// The pivot rule. A spec's declared QoS is a pivot, not an exact-match
+/// requirement: a provider must offer at least the pivot and a consumer must
+/// request at most the pivot. Transitivity of the DDS partial order then
+/// guarantees every conforming provider/consumer pair connects
+/// (offered >= pivot >= requested).
+constexpr bool provider_satisfies_pivot(const QosPair & offered, const QosPair & pivot)
+{
+  return is_qos_compatible(offered, pivot);
+}
+
+constexpr bool consumer_satisfies_pivot(const QosPair & requested, const QosPair & pivot)
+{
+  return is_qos_compatible(pivot, requested);
+}
+
+/// The pivot a topic spec declares.
+template <class SpecT>
+constexpr QosPair pivot_of()
+{
+  return QosPair{SpecT::reliability, SpecT::durability};
+}
+
+}  // namespace autoware::component_interface_specs
+
+#endif  // AUTOWARE__COMPONENT_INTERFACE_SPECS__QOS_COMPATIBILITY_HPP_

--- a/common/autoware_component_interface_specs/interface_manifest.json
+++ b/common/autoware_component_interface_specs/interface_manifest.json
@@ -1,5 +1,6 @@
 {
   "owner": "autowarefoundation",
+  "qos_semantics": "pivot",
   "interfaces": [
     {
       "domain": "control",

--- a/common/autoware_component_interface_specs/src/generate_interface_manifest.cpp
+++ b/common/autoware_component_interface_specs/src/generate_interface_manifest.cpp
@@ -165,6 +165,7 @@ int main(int argc, char ** argv)
   try {
     os << "{\n";
     os << "  \"owner\": \"" << cis::owner << "\",\n";
+    os << "  \"qos_semantics\": \"pivot\",\n";
     os << "  \"interfaces\": [\n";
     for (std::size_t i = 0; i < entries.size(); ++i) {
       const auto & e = entries[i];

--- a/common/autoware_component_interface_specs/test/test_cxx17_compat.cpp
+++ b/common/autoware_component_interface_specs/test/test_cxx17_compat.cpp
@@ -24,6 +24,7 @@
 #include "autoware/component_interface_specs/map.hpp"
 #include "autoware/component_interface_specs/perception.hpp"
 #include "autoware/component_interface_specs/planning.hpp"
+#include "autoware/component_interface_specs/qos_compatibility.hpp"
 #include "autoware/component_interface_specs/sensing.hpp"
 #include "autoware/component_interface_specs/system.hpp"
 #include "autoware/component_interface_specs/utils.hpp"

--- a/common/autoware_component_interface_specs/test/test_manifest.cpp
+++ b/common/autoware_component_interface_specs/test/test_manifest.cpp
@@ -52,6 +52,9 @@ TEST(manifest, generates_known_boundaries)
   EXPECT_NE(json.find("nav_msgs/msg/Odometry"), std::string::npos);
   EXPECT_NE(json.find("/planning/set_lanelet_route"), std::string::npos);
   EXPECT_NE(json.find("\"version\": \"0.1.0\""), std::string::npos);
+  // The declared QoS is a compatibility pivot, not an exact-match requirement;
+  // external tools distinguish the semantics revision by this marker.
+  EXPECT_NE(json.find("\"qos_semantics\": \"pivot\""), std::string::npos);
 }
 
 // QoS is half of a topic's contract: a RELIABLE subscription never hears a BEST_EFFORT

--- a/common/autoware_component_interface_specs/test/test_qos_compatibility.cpp
+++ b/common/autoware_component_interface_specs/test/test_qos_compatibility.cpp
@@ -1,0 +1,87 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/component_interface_specs/qos_compatibility.hpp"
+#include "autoware/component_interface_specs/system.hpp"
+#include "gtest/gtest.h"
+
+namespace cis = autoware::component_interface_specs;
+
+namespace
+{
+constexpr auto kReliable = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+constexpr auto kBestEffort = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+constexpr auto kVolatile = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+constexpr auto kTransientLocal = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+}  // namespace
+
+// The RMW enum integers do NOT follow semantic strength order
+// (BEST_EFFORT = 2 > RELIABLE = 1); the ranks must invert that.
+TEST(qos_compatibility, ranks_follow_strength_not_enum_integers)
+{
+  static_assert(kBestEffort > kReliable, "enum-integer trap the ranks must not fall into");
+  EXPECT_GT(cis::reliability_rank(kReliable), cis::reliability_rank(kBestEffort));
+  EXPECT_GT(cis::durability_rank(kTransientLocal), cis::durability_rank(kVolatile));
+}
+
+TEST(qos_compatibility, at_least_is_the_dds_partial_order)
+{
+  EXPECT_TRUE(cis::reliability_at_least(kReliable, kBestEffort));
+  EXPECT_TRUE(cis::reliability_at_least(kReliable, kReliable));
+  EXPECT_FALSE(cis::reliability_at_least(kBestEffort, kReliable));
+  EXPECT_TRUE(cis::durability_at_least(kTransientLocal, kVolatile));
+  EXPECT_FALSE(cis::durability_at_least(kVolatile, kTransientLocal));
+}
+
+// A connection forms iff offered >= requested on every axis.
+TEST(qos_compatibility, compatibility_needs_every_axis)
+{
+  EXPECT_TRUE(cis::is_qos_compatible({kReliable, kTransientLocal}, {kBestEffort, kVolatile}));
+  EXPECT_TRUE(cis::is_qos_compatible({kReliable, kVolatile}, {kReliable, kVolatile}));
+  // The user-facing canonical case: a BEST_EFFORT offer cannot serve a RELIABLE request.
+  EXPECT_FALSE(cis::is_qos_compatible({kBestEffort, kVolatile}, {kReliable, kVolatile}));
+  EXPECT_FALSE(cis::is_qos_compatible({kReliable, kVolatile}, {kReliable, kTransientLocal}));
+}
+
+// SYSTEM_DEFAULT / UNKNOWN are incomparable: every check fails (fail closed).
+TEST(qos_compatibility, unknown_policies_fail_closed)
+{
+  constexpr auto kSysRel = RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT;
+  constexpr auto kSysDur = RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT;
+  EXPECT_FALSE(cis::reliability_at_least(kSysRel, kBestEffort));
+  EXPECT_FALSE(cis::reliability_at_least(kReliable, kSysRel));
+  EXPECT_FALSE(cis::is_qos_compatible({kSysRel, kVolatile}, {kBestEffort, kVolatile}));
+  EXPECT_FALSE(cis::is_qos_compatible({kReliable, kSysDur}, {kReliable, kVolatile}));
+}
+
+// Pivot rule: provider offers >= pivot, consumer requests <= pivot.
+TEST(qos_compatibility, pivot_rule)
+{
+  constexpr cis::QosPair pivot{kReliable, kVolatile};
+  EXPECT_TRUE(cis::provider_satisfies_pivot({kReliable, kTransientLocal}, pivot));
+  EXPECT_TRUE(cis::provider_satisfies_pivot({kReliable, kVolatile}, pivot));
+  EXPECT_FALSE(cis::provider_satisfies_pivot({kBestEffort, kVolatile}, pivot));
+  EXPECT_TRUE(cis::consumer_satisfies_pivot({kBestEffort, kVolatile}, pivot));
+  EXPECT_FALSE(cis::consumer_satisfies_pivot({kReliable, kTransientLocal}, pivot));
+}
+
+// pivot_of<Spec>() reads the spec's declared members; everything is constexpr.
+TEST(qos_compatibility, pivot_of_spec_is_constexpr)
+{
+  using Spec = cis::system::OperationModeState;
+  constexpr auto pivot = cis::pivot_of<Spec>();
+  static_assert(pivot.durability == RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
+  static_assert(cis::provider_satisfies_pivot(pivot, pivot));
+  EXPECT_EQ(pivot.reliability, Spec::reliability);
+}

--- a/common/autoware_interface_spec_lint/autoware_interface_spec_lint/checks.py
+++ b/common/autoware_interface_spec_lint/autoware_interface_spec_lint/checks.py
@@ -40,7 +40,7 @@ SUPPRESS_MARKER = "// interface-spec-lint: not-versioned"
 GENERATOR_ENV = "INTERFACE_MANIFEST_GENERATOR"
 
 # Headers that are not per-domain spec files and carry no domain version / Specs.
-_SKIP_HEADERS = {"utils.hpp", "version.hpp", "concepts.hpp"}
+_SKIP_HEADERS = {"utils.hpp", "version.hpp", "concepts.hpp", "qos_compatibility.hpp"}
 
 # The header declaring the one QoS profile every service spec runs on.
 _UTILS_HEADER = "utils.hpp"


### PR DESCRIPTION
## Description

This PR establishes that a spec's declared QoS is a **compatibility pivot** rather than an exact-match requirement, and gives that rule an executable encoding.

The pivot rule: a **provider** must offer QoS at least as strong as the pivot, and a **consumer** must request QoS at most as strong as the pivot. Strength follows the DDS request-vs-offered partial order per policy (`RELIABLE` > `BEST_EFFORT`, `TRANSIENT_LOCAL` > `VOLATILE`), so the pivot rule plus transitivity guarantees that every conforming provider/consumer pair connects. A provider may therefore offer `TRANSIENT_LOCAL` where the pivot says `VOLATILE`, and a consumer may request `BEST_EFFORT` where the pivot says `RELIABLE` — but never the reverse. `depth` is deliberately **not** a compatibility axis (DDS history is endpoint-local); the declared value is an advisory per-endpoint default.

Three pieces:

- **`qos_compatibility.hpp`** (new header) provides the constexpr helpers that encode the rule: `QosPair`, `reliability_rank`, `durability_rank`, `reliability_at_least`, `durability_at_least`, `is_qos_compatible`, `provider_satisfies_pivot`, `consumer_satisfies_pivot`, and `pivot_of<Spec>()`. The ranks exist because the RMW enum integers do **not** follow semantic strength order (`BEST_EFFORT` = 2 > `RELIABLE` = 1), so comparing raw enum values would silently invert the rule. Policies outside the two a spec can declare (`SYSTEM_DEFAULT`, `UNKNOWN`, …) rank `-1`, making every comparison involving them fail closed. The header is C++17-clean and is pinned as such by the existing `test_cxx17_compat` target.
- **`interface_manifest.json`** gains a top-level `"qos_semantics": "pivot"` marker so external tooling can identify this semantics revision. The manifest is regenerated by its in-package generator, not hand-edited; the diff against the current base is exactly that one added line.
- **`README.md`** documents the rule alongside the code that implements it.

The fourth commit is a one-line fix to `autoware_interface_spec_lint`: its static checks walk every header in the specs include directory and require each to declare exactly one domain `Version` and `Specs` tuple. `qos_compatibility.hpp` is a QoS-ranking helper with no per-domain specs of its own — the same role `utils.hpp`, `version.hpp` and `concepts.hpp` already play, and those three are already exempted via `_SKIP_HEADERS`. Adding this header to that same set is the correct fix; declaring a spurious `Version` on a header that documents no domain would not be.

**No declared spec QoS value changes in this PR.**

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

## How was this PR tested?

Built and tested in the project's `autoware:universe-devel-jazzy` container against this PR's current base, with `colcon build --symlink-install --packages-up-to autoware_component_interface_specs` followed by `colcon test` and `colcon test-result --verbose`:

- `autoware_component_interface_specs`: all gtest targets pass, including the new `test/test_qos_compatibility.cpp` (rank ordering vs the enum-integer trap, the `at_least` partial order, per-axis compatibility, fail-closed behavior for `SYSTEM_DEFAULT`, the pivot rule for both roles, and a `constexpr` `pivot_of<Spec>()` check via `static_assert`), the `qos_semantics` marker expectation in `test/test_manifest.cpp`, and `manifest.committed_file_is_up_to_date` — the byte-equality gate that diffs the generator's output against the committed manifest, which is what proves the committed file has no hand-edits.
- `autoware_interface_spec_lint`: all 41 pytest cases pass, including `test_committed_specs.py`, which fails without the fourth commit.

## Notes for reviewers

The `qos_compatibility.hpp` ranks are restated in one other place — a deploy-time admission tool that consumes the JSON string encoding rather than the RMW enums, proposed separately in autowarefoundation/autoware_core#1317. The header carries a comment naming that duplication so the two cannot drift silently; the ranks, the fail-closed behavior, the provider/consumer asymmetry, and the exclusion of `depth` are identical on both sides.

autowarefoundation/autoware_core#1315 also modifies `autoware_interface_spec_lint`, but it does not touch `_SKIP_HEADERS`; the line this PR patches is byte-identical on that branch, so the two apply cleanly in either merge order.

## Interface changes

None. No declared spec QoS value changes. The additions are a new header of `constexpr` helpers and an informational top-level marker in the generated manifest.

## Effects on system behavior

None. Runtime QoS behavior is unchanged — this PR documents and encodes the semantics that the declared values already carry, and adds no runtime code path.
