### PR TITLE
refactor(autoware_component_interface_utils): template the adaptor and wrappers on the node type

### DIFF
--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp.hpp
@@ -29,6 +29,7 @@
 namespace autoware::component_interface_utils
 {
 
+template <class NodeT = rclcpp::Node>
 class NodeAdaptor
 {
 private:
@@ -47,8 +48,13 @@ private:
     const typename SharedPtrT::element_type::SpecType::Service::Response::SharedPtr);
 
 public:
-  /// Constructor.
-  explicit NodeAdaptor(rclcpp::Node * node) { interface_ = std::make_shared<NodeInterface>(node); }
+  /// Constructor. D is deduced separately from NodeT so that `NodeAdaptor(this)` on a derived
+  /// node keeps NodeT at its default instead of deducing the derived type.
+  template <class D>
+  explicit NodeAdaptor(D * node)
+  {
+    interface_ = std::make_shared<NodeInterface<NodeT>>(node);
+  }
 
   /// Create a client wrapper for logging.
   template <class SharedPtrT>
@@ -133,21 +139,21 @@ public:
 
   /// Create a publisher (returning form; Wave 1: non-registering).
   template <class SpecT>
-  typename Publisher<SpecT>::SharedPtr create_publisher()
+  typename Publisher<SpecT, NodeT>::SharedPtr create_publisher()
   {
     return create_publisher_impl<SpecT>(interface_->node);
   }
 
   /// Create a subscription (returning form; Wave 1: non-registering).
   template <class SpecT, class CallbackT>
-  typename Subscription<SpecT>::SharedPtr create_subscription(CallbackT && callback)
+  typename Subscription<SpecT, NodeT>::SharedPtr create_subscription(CallbackT && callback)
   {
     return create_subscription_impl<SpecT>(interface_->node, std::forward<CallbackT>(callback));
   }
 
   /// Create a service server (returning form; Wave 1: non-registering).
   template <class SpecT, class CallbackT>
-  typename Service<SpecT>::SharedPtr create_service(
+  typename Service<SpecT, NodeT>::SharedPtr create_service(
     CallbackT && callback, rclcpp::CallbackGroup::SharedPtr group = nullptr)
   {
     return create_service_impl<SpecT>(interface_, std::forward<CallbackT>(callback), group);
@@ -155,14 +161,15 @@ public:
 
   /// Create a service client (returning form; Wave 1: non-registering).
   template <class SpecT>
-  typename Client<SpecT>::SharedPtr create_client(rclcpp::CallbackGroup::SharedPtr group = nullptr)
+  typename Client<SpecT, NodeT>::SharedPtr create_client(
+    rclcpp::CallbackGroup::SharedPtr group = nullptr)
   {
     return create_client_impl<SpecT>(interface_, group);
   }
 
 private:
   // Use a node pointer because shared_from_this cannot be used in constructor.
-  NodeInterface::SharedPtr interface_;
+  typename NodeInterface<NodeT>::SharedPtr interface_;
 };
 
 }  // namespace autoware::component_interface_utils

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp.hpp
@@ -182,7 +182,7 @@ public:
 
   /// Create a subscription bound to a member function taking the message pointer.
   template <class SpecT, class InstanceT>
-  typename Subscription<SpecT>::SharedPtr create_subscription(
+  typename Subscription<SpecT, NodeT>::SharedPtr create_subscription(
     InstanceT * instance, SpecMessagePtrCallback<SpecT, InstanceT> && callback)
   {
     using std::placeholders::_1;
@@ -191,7 +191,7 @@ public:
 
   /// Create a subscription bound to a member function taking the message by reference.
   template <class SpecT, class InstanceT>
-  typename Subscription<SpecT>::SharedPtr create_subscription(
+  typename Subscription<SpecT, NodeT>::SharedPtr create_subscription(
     InstanceT * instance, SpecMessageRefCallback<SpecT, InstanceT> && callback)
   {
     using std::placeholders::_1;
@@ -208,7 +208,7 @@ public:
 
   /// Create a service server bound to a member function.
   template <class SpecT, class InstanceT>
-  typename Service<SpecT>::SharedPtr create_service(
+  typename Service<SpecT, NodeT>::SharedPtr create_service(
     InstanceT * instance, SpecServiceCallback<SpecT, InstanceT> && callback,
     rclcpp::CallbackGroup::SharedPtr group = nullptr)
   {

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/create_interface.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/create_interface.hpp
@@ -23,46 +23,47 @@
 #include <autoware/component_interface_utils/specs.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <memory>
 #include <utility>
 
 namespace autoware::component_interface_utils
 {
 
 /// Create a client wrapper for logging. This is a private implementation.
-template <class SpecT>
-typename Client<SpecT>::SharedPtr create_client_impl(
-  NodeInterface::SharedPtr interface, rclcpp::CallbackGroup::SharedPtr group = nullptr)
+template <class SpecT, class NodeT>
+typename Client<SpecT, NodeT>::SharedPtr create_client_impl(
+  std::shared_ptr<NodeInterface<NodeT>> interface, rclcpp::CallbackGroup::SharedPtr group = nullptr)
 {
   // This function is a wrapper for the following.
   // https://github.com/ros2/rclcpp/blob/48068130edbb43cdd61076dc1851672ff1a80408/rclcpp/include/rclcpp/node.hpp#L253-L265
-  return Client<SpecT>::make_shared(interface, group);
+  return Client<SpecT, NodeT>::make_shared(interface, group);
 }
 
 /// Create a service wrapper for logging. This is a private implementation.
-template <class SpecT, class CallbackT>
-typename Service<SpecT>::SharedPtr create_service_impl(
-  NodeInterface::SharedPtr interface, CallbackT && callback,
+template <class SpecT, class NodeT, class CallbackT>
+typename Service<SpecT, NodeT>::SharedPtr create_service_impl(
+  std::shared_ptr<NodeInterface<NodeT>> interface, CallbackT && callback,
   rclcpp::CallbackGroup::SharedPtr group = nullptr)
 {
   // This function is a wrapper for the following.
   // https://github.com/ros2/rclcpp/blob/48068130edbb43cdd61076dc1851672ff1a80408/rclcpp/include/rclcpp/node.hpp#L267-L281
-  return Service<SpecT>::make_shared(interface, std::forward<CallbackT>(callback), group);
+  return Service<SpecT, NodeT>::make_shared(interface, std::forward<CallbackT>(callback), group);
 }
 
 /// Create a publisher using traits like services. This is a private implementation.
 template <class SpecT, class NodeT>
-typename Publisher<SpecT>::SharedPtr create_publisher_impl(NodeT * node)
+typename Publisher<SpecT, NodeT>::SharedPtr create_publisher_impl(NodeT * node)
 {
   // This function is a wrapper for the following.
   // https://github.com/ros2/rclcpp/blob/48068130edbb43cdd61076dc1851672ff1a80408/rclcpp/include/rclcpp/node.hpp#L167-L205
   auto publisher =
     node->template create_publisher<typename SpecT::Message>(SpecT::name, get_qos<SpecT>());
-  return Publisher<SpecT>::make_shared(publisher);
+  return Publisher<SpecT, NodeT>::make_shared(publisher);
 }
 
 /// Create a subscription using traits like services. This is a private implementation.
 template <class SpecT, class NodeT, class CallbackT>
-typename Subscription<SpecT>::SharedPtr create_subscription_impl(
+typename Subscription<SpecT, NodeT>::SharedPtr create_subscription_impl(
   NodeT * node, CallbackT && callback)
 {
   if constexpr (!std::is_null_pointer_v<CallbackT>) {
@@ -70,7 +71,7 @@ typename Subscription<SpecT>::SharedPtr create_subscription_impl(
     // https://github.com/ros2/rclcpp/blob/48068130edbb43cdd61076dc1851672ff1a80408/rclcpp/include/rclcpp/node.hpp#L207-L238
     auto subscription = node->template create_subscription<typename SpecT::Message>(
       SpecT::name, get_qos<SpecT>(), std::forward<CallbackT>(callback));
-    return Subscription<SpecT>::make_shared(subscription);
+    return Subscription<SpecT, NodeT>::make_shared(subscription);
   } else {
     // If the callback is nullptr, create a subscription for polling.
     // https://github.com/autowarefoundation/autoware.universe/tree/main/common/autoware_universe_utils/include/autoware/universe_utils/ros/polling_subscriber.hpp
@@ -80,7 +81,7 @@ typename Subscription<SpecT>::SharedPtr create_subscription_impl(
 
     auto subscription = node->template create_subscription<typename SpecT::Message>(
       SpecT::name, get_qos<SpecT>(), [](const typename SpecT::Message) {}, options);
-    return Subscription<SpecT>::make_shared(subscription);
+    return Subscription<SpecT, NodeT>::make_shared(subscription);
   }
 }
 

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/interface.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/interface.hpp
@@ -44,17 +44,19 @@ namespace autoware::component_interface_utils
 /// ("off" | "metadata" | "contents", default "off"). Service-call tracing is
 /// provided by ROS 2 service introspection (see the service wrappers), not a
 /// custom log topic.
+template <class NodeT = rclcpp::Node>
 struct NodeInterface
 {
   using SharedPtr = std::shared_ptr<NodeInterface>;
+  using NodeType = NodeT;
 
-  explicit NodeInterface(rclcpp::Node * node) : node(node)
+  explicit NodeInterface(NodeT * node) : node(node)
   {
 #if AUTOWARE_COMPONENT_INTERFACE_UTILS_RCLCPP_GE_IRON
     const std::string param = "component_interface.service_introspection";
     const std::string mode = node->has_parameter(param)
                                ? node->get_parameter(param).as_string()
-                               : node->declare_parameter<std::string>(param, "off");
+                               : node->template declare_parameter<std::string>(param, "off");
     if (mode == "contents") {
       introspection_state = RCL_SERVICE_INTROSPECTION_CONTENTS;
     } else if (mode == "metadata") {
@@ -65,7 +67,7 @@ struct NodeInterface
 #endif
   }
 
-  rclcpp::Node * node;
+  NodeT * node;
 #if AUTOWARE_COMPONENT_INTERFACE_UTILS_RCLCPP_GE_IRON
   rcl_service_introspection_state_t introspection_state = RCL_SERVICE_INTROSPECTION_OFF;
 #endif

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/interface.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/interface.hpp
@@ -50,7 +50,9 @@ struct NodeInterface
   using SharedPtr = std::shared_ptr<NodeInterface>;
   using NodeType = NodeT;
 
-  explicit NodeInterface(NodeT * node) : node(node)
+  /// D is deduced separately from NodeT so a derived node does not hijack it, as in NodeAdaptor.
+  template <class D>
+  explicit NodeInterface(D * node) : node(node)
   {
 #if AUTOWARE_COMPONENT_INTERFACE_UTILS_RCLCPP_GE_IRON
     const std::string param = "component_interface.service_introspection";

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/service_client.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/service_client.hpp
@@ -21,43 +21,61 @@
 
 #include <chrono>
 #include <future>
+#include <memory>
 #include <optional>
+#include <utility>
 
 namespace autoware::component_interface_utils
 {
 
-/// The wrapper class of rclcpp::Client. Service-call tracing is provided by ROS 2
+/// Create the underlying client handle. Gated in one place because the handle type is deduced
+/// from this call, and Humble (rclcpp 16) has no rclcpp::QoS overload of create_client().
+template <class SpecT, class NodeT>
+auto create_client_handle(NodeT * node, rclcpp::CallbackGroup::SharedPtr group)
+{
+#if AUTOWARE_COMPONENT_INTERFACE_UTILS_RCLCPP_GE_IRON
+  return node->template create_client<typename SpecT::Service>(
+    SpecT::name, rclcpp::ServicesQoS(), group);
+#else
+  return node->template create_client<typename SpecT::Service>(
+    SpecT::name, rmw_qos_profile_services_default, group);
+#endif
+}
+
+/// The wrapper class of a service client. Service-call tracing is provided by ROS 2
 /// service introspection (enabled via NodeInterface::introspection_state), not a
-/// custom log topic.
-template <class SpecT>
+/// custom log topic. The request/response/future aliases are spelled from the spec rather than
+/// taken off the handle, so they do not depend on the node type.
+template <class SpecT, class NodeT = rclcpp::Node>
 class Client
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(Client)
   using SpecType = SpecT;
-  using WrapType = rclcpp::Client<typename SpecT::Service>;
+  using NodeType = NodeT;
+  using WrapSharedPtr = decltype(create_client_handle<SpecT>(
+    std::declval<NodeT *>(), std::declval<rclcpp::CallbackGroup::SharedPtr>()));
+  using WrapType = typename WrapSharedPtr::element_type;
+
+  using SharedRequest = std::shared_ptr<typename SpecT::Service::Request>;
+  using SharedResponse = std::shared_ptr<typename SpecT::Service::Response>;
+  using SharedFuture = std::shared_future<SharedResponse>;
 
   /// Constructor.
-  Client(NodeInterface::SharedPtr interface, rclcpp::CallbackGroup::SharedPtr group)
+  Client(typename NodeInterface<NodeT>::SharedPtr interface, rclcpp::CallbackGroup::SharedPtr group)
   : interface_(interface)
   {
+    client_ = create_client_handle<SpecT>(interface_->node, group);
 #if AUTOWARE_COMPONENT_INTERFACE_UTILS_RCLCPP_GE_IRON
-    client_ = interface_->node->create_client<typename SpecT::Service>(
-      SpecT::name, rclcpp::ServicesQoS(), group);
     if (interface_->introspection_state != RCL_SERVICE_INTROSPECTION_OFF) {
       client_->configure_introspection(
         interface_->node->get_clock(), rclcpp::QoS(1), interface_->introspection_state);
     }
-#else
-    // ROS 2 Humble exposes only the (non-deprecated) rmw_qos_profile_t overload.
-    client_ = interface_->node->create_client<typename SpecT::Service>(
-      SpecT::name, rmw_qos_profile_services_default, group);
 #endif
   }
 
   /// Send request.
-  typename WrapType::SharedResponse call(
-    const typename WrapType::SharedRequest request, std::optional<double> timeout = std::nullopt)
+  SharedResponse call(const SharedRequest request, std::optional<double> timeout = std::nullopt)
   {
     if (!client_->service_is_ready()) {
       throw ServiceUnready(SpecT::name);
@@ -74,7 +92,7 @@ public:
   }
 
   /// Send request.
-  typename WrapType::SharedFuture async_send_request(typename WrapType::SharedRequest request)
+  SharedFuture async_send_request(SharedRequest request)
   {
     return client_->async_send_request(request).future;
   }
@@ -83,12 +101,10 @@ public:
   /// concrete-signature lambda so callers may pass a generic (auto-parameter)
   /// callback, which rclcpp::Client::async_send_request would otherwise reject.
   template <class CallbackT>
-  typename WrapType::SharedFuture async_send_request(
-    typename WrapType::SharedRequest request, CallbackT && callback)
+  SharedFuture async_send_request(SharedRequest request, CallbackT && callback)
   {
     return client_
-      ->async_send_request(
-        request, [callback](typename WrapType::SharedFuture future) { callback(future); })
+      ->async_send_request(request, [callback](SharedFuture future) { callback(future); })
       .future;
   }
 
@@ -97,8 +113,8 @@ public:
 
 private:
   RCLCPP_DISABLE_COPY(Client)
-  typename WrapType::SharedPtr client_;
-  NodeInterface::SharedPtr interface_;
+  WrapSharedPtr client_;
+  typename NodeInterface<NodeT>::SharedPtr interface_;
 };
 
 }  // namespace autoware::component_interface_utils

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/service_server.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/service_server.hpp
@@ -19,16 +19,39 @@
 #include <autoware/component_interface_utils/rclcpp/interface.hpp>
 #include <rclcpp/node.hpp>
 
+#include <functional>
+#include <memory>
 #include <type_traits>
 #include <utility>
 
 namespace autoware::component_interface_utils
 {
 
-/// The wrapper class of rclcpp::Service. Service-call tracing is provided by ROS 2
+/// The callback handed to create_service(). Spelled from the spec rather than taken off the
+/// handle, which would make the handle type depend on itself.
+template <class SpecT>
+using ServiceCallbackFn = std::function<void(
+  typename SpecT::Service::Request::SharedPtr, typename SpecT::Service::Response::SharedPtr)>;
+
+/// Create the underlying service handle. Gated in one place because the handle type is deduced
+/// from this call, and Humble (rclcpp 16) has no rclcpp::QoS overload of create_service().
+template <class SpecT, class NodeT>
+auto create_service_handle(
+  NodeT * node, ServiceCallbackFn<SpecT> callback, rclcpp::CallbackGroup::SharedPtr group)
+{
+#if AUTOWARE_COMPONENT_INTERFACE_UTILS_RCLCPP_GE_IRON
+  return node->template create_service<typename SpecT::Service>(
+    SpecT::name, callback, rclcpp::ServicesQoS(), group);
+#else
+  return node->template create_service<typename SpecT::Service>(
+    SpecT::name, callback, rmw_qos_profile_services_default, group);
+#endif
+}
+
+/// The wrapper class of a service server. Service-call tracing is provided by ROS 2
 /// service introspection (enabled via NodeInterface::introspection_state), not a
 /// custom log topic.
-template <class SpecT>
+template <class SpecT, class NodeT = rclcpp::Node>
 class Service
 {
 private:
@@ -49,32 +72,32 @@ private:
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(Service)
   using SpecType = SpecT;
-  using WrapType = rclcpp::Service<typename SpecT::Service>;
+  using NodeType = NodeT;
+  using CallbackType = ServiceCallbackFn<SpecT>;
+  using WrapSharedPtr = decltype(create_service_handle<SpecT>(
+    std::declval<NodeT *>(), std::declval<CallbackType>(),
+    std::declval<rclcpp::CallbackGroup::SharedPtr>()));
+  using WrapType = typename WrapSharedPtr::element_type;
 
   /// Constructor.
   template <class CallbackT>
   Service(
-    NodeInterface::SharedPtr interface, CallbackT && callback,
+    typename NodeInterface<NodeT>::SharedPtr interface, CallbackT && callback,
     rclcpp::CallbackGroup::SharedPtr group)
   : interface_(interface)
   {
+    service_ = create_service_handle<SpecT>(interface_->node, wrap(callback), group);
 #if AUTOWARE_COMPONENT_INTERFACE_UTILS_RCLCPP_GE_IRON
-    service_ = interface_->node->create_service<typename SpecT::Service>(
-      SpecT::name, wrap(callback), rclcpp::ServicesQoS(), group);
     if (interface_->introspection_state != RCL_SERVICE_INTROSPECTION_OFF) {
       service_->configure_introspection(
         interface_->node->get_clock(), rclcpp::QoS(1), interface_->introspection_state);
     }
-#else
-    // ROS 2 Humble exposes only the (non-deprecated) rmw_qos_profile_t overload.
-    service_ = interface_->node->create_service<typename SpecT::Service>(
-      SpecT::name, wrap(callback), rmw_qos_profile_services_default, group);
 #endif
   }
 
   /// Create a service callback that converts exceptions into the response status.
   template <class CallbackT>
-  typename WrapType::CallbackType wrap(CallbackT && callback)
+  CallbackType wrap(CallbackT && callback)
   {
     return [callback](
              typename SpecT::Service::Request::SharedPtr request,
@@ -94,8 +117,8 @@ public:
 
 private:
   RCLCPP_DISABLE_COPY(Service)
-  typename WrapType::SharedPtr service_;
-  NodeInterface::SharedPtr interface_;
+  WrapSharedPtr service_;
+  typename NodeInterface<NodeT>::SharedPtr interface_;
 };
 
 }  // namespace autoware::component_interface_utils

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/topic_publisher.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/topic_publisher.hpp
@@ -15,22 +15,31 @@
 #ifndef AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__TOPIC_PUBLISHER_HPP_
 #define AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__TOPIC_PUBLISHER_HPP_
 
+#include <rclcpp/node.hpp>
 #include <rclcpp/publisher.hpp>
+#include <rclcpp/qos.hpp>
+
+#include <string>
+#include <utility>
 
 namespace autoware::component_interface_utils
 {
 
-/// The wrapper class of rclcpp::Publisher. This is for future use and no functionality now.
-template <class SpecT>
+/// The wrapper class of a publisher. The handle type comes from the node's create_publisher().
+template <class SpecT, class NodeT = rclcpp::Node>
 class Publisher
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(Publisher)
   using SpecType = SpecT;
-  using WrapType = rclcpp::Publisher<typename SpecT::Message>;
+  using NodeType = NodeT;
+  using WrapSharedPtr =
+    decltype(std::declval<NodeT &>().template create_publisher<typename SpecT::Message>(
+      std::declval<const std::string &>(), std::declval<const rclcpp::QoS &>()));
+  using WrapType = typename WrapSharedPtr::element_type;
 
   /// Constructor.
-  explicit Publisher(typename WrapType::SharedPtr publisher)
+  explicit Publisher(WrapSharedPtr publisher)
   {
     publisher_ = publisher;  // to keep the reference count
   }
@@ -40,7 +49,7 @@ public:
 
 private:
   RCLCPP_DISABLE_COPY(Publisher)
-  typename WrapType::SharedPtr publisher_;
+  WrapSharedPtr publisher_;
 };
 
 }  // namespace autoware::component_interface_utils

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/topic_subscription.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/topic_subscription.hpp
@@ -15,24 +15,36 @@
 #ifndef AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__TOPIC_SUBSCRIPTION_HPP_
 #define AUTOWARE__COMPONENT_INTERFACE_UTILS__RCLCPP__TOPIC_SUBSCRIPTION_HPP_
 
+#include <rclcpp/node.hpp>
+#include <rclcpp/qos.hpp>
 #include <rclcpp/subscription.hpp>
 
+#include <functional>
 #include <memory>
+#include <string>
+#include <utility>
 
 namespace autoware::component_interface_utils
 {
 
-/// The wrapper class of rclcpp::Subscription. This is for future use and no functionality now.
-template <class SpecT>
+/// The wrapper class of a subscription. The handle type comes from the node's
+/// create_subscription(). take() and take_and_update() additionally need the handle to provide
+/// rclcpp's take(), and being ordinary members they are only instantiated when called.
+template <class SpecT, class NodeT = rclcpp::Node>
 class Subscription
 {
 public:
   RCLCPP_SMART_PTR_DEFINITIONS(Subscription)
   using SpecType = SpecT;
-  using WrapType = rclcpp::Subscription<typename SpecT::Message>;
+  using NodeType = NodeT;
+  using WrapSharedPtr =
+    decltype(std::declval<NodeT &>().template create_subscription<typename SpecT::Message>(
+      std::declval<const std::string &>(), std::declval<const rclcpp::QoS &>(),
+      std::declval<std::function<void(const typename SpecT::Message &)>>()));
+  using WrapType = typename WrapSharedPtr::element_type;
 
   /// Constructor.
-  explicit Subscription(typename WrapType::SharedPtr subscription)
+  explicit Subscription(WrapSharedPtr subscription)
   {
     subscription_ = subscription;  // to keep the reference count
   }

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/topic_subscription.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/topic_subscription.hpp
@@ -85,7 +85,7 @@ public:
 
 private:
   RCLCPP_DISABLE_COPY(Subscription)
-  typename WrapType::SharedPtr subscription_;
+  WrapSharedPtr subscription_;
 };
 
 }  // namespace autoware::component_interface_utils

--- a/common/autoware_component_interface_utils/test/test_component_interface_utils.cpp
+++ b/common/autoware_component_interface_utils/test/test_component_interface_utils.cpp
@@ -29,9 +29,46 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <type_traits>
+#include <utility>
 
 namespace
 {
+
+/// Minimal stand-in for a node type other than rclcpp::Node, with its own endpoint types.
+template <class MessageT>
+struct FakePublisher
+{
+  using SharedPtr = std::shared_ptr<FakePublisher>;
+  void publish(const MessageT &) {}
+};
+
+template <class MessageT>
+struct FakeSubscription
+{
+  using SharedPtr = std::shared_ptr<FakeSubscription>;
+};
+
+struct FakeNode
+{
+  template <class MessageT>
+  typename FakePublisher<MessageT>::SharedPtr create_publisher(
+    const std::string &, const rclcpp::QoS &)
+  {
+    return std::make_shared<FakePublisher<MessageT>>();
+  }
+
+  template <class MessageT, class CallbackT>
+  typename FakeSubscription<MessageT>::SharedPtr create_subscription(
+    const std::string &, const rclcpp::QoS &, CallbackT &&)
+  {
+    return std::make_shared<FakeSubscription<MessageT>>();
+  }
+};
+
+struct DerivedNode : public rclcpp::Node
+{
+};
 
 /// Graph discovery of even local endpoints is asynchronous, so poll until the
 /// topic has at least one publisher (or the timeout elapses) rather than assume
@@ -161,7 +198,8 @@ TEST(interface, service_wrappers_without_service_log)
   using ChangeOperationMode = autoware::component_interface_specs::system::ChangeOperationMode;
   rclcpp::init(0, nullptr);
   auto node = std::make_shared<rclcpp::Node>("test_service");
-  auto interface = std::make_shared<autoware::component_interface_utils::NodeInterface>(node.get());
+  auto interface =
+    std::make_shared<autoware::component_interface_utils::NodeInterface<>>(node.get());
 
   auto srv = autoware::component_interface_utils::Service<ChangeOperationMode>::make_shared(
     interface, [](auto, auto res) { res->status.success = true; }, nullptr);
@@ -198,6 +236,44 @@ TEST(interface, client_async_send_request_callback_overload)
   auto future = cli->async_send_request(req, [](auto) {});
   EXPECT_TRUE(future.valid());
   rclcpp::shutdown();
+}
+
+TEST(interface, wrappers_deduce_endpoint_types_from_node)
+{
+  using OperationModeState = autoware::component_interface_specs::system::OperationModeState;
+  using ChangeOperationMode = autoware::component_interface_specs::system::ChangeOperationMode;
+  using Message = OperationModeState::Message;
+  using Srv = ChangeOperationMode::Service;
+  namespace utils = autoware::component_interface_utils;
+
+  // The default node type keeps the endpoint types the wrappers used before they were templated.
+  static_assert(
+    std::is_same_v<
+      typename utils::Publisher<OperationModeState>::WrapType, rclcpp::Publisher<Message>>);
+  static_assert(
+    std::is_same_v<
+      typename utils::Subscription<OperationModeState>::WrapType, rclcpp::Subscription<Message>>);
+  static_assert(
+    std::is_same_v<typename utils::Client<ChangeOperationMode>::WrapType, rclcpp::Client<Srv>>);
+  static_assert(
+    std::is_same_v<typename utils::Service<ChangeOperationMode>::WrapType, rclcpp::Service<Srv>>);
+
+  // Another node type contributes its own endpoint types instead.
+  static_assert(
+    std::is_same_v<
+      typename utils::Publisher<OperationModeState, FakeNode>::WrapType, FakePublisher<Message>>);
+  static_assert(std::is_same_v<
+                typename utils::Subscription<OperationModeState, FakeNode>::WrapType,
+                FakeSubscription<Message>>);
+
+  // A derived node must not be deduced as the adaptor's node type, or the wrappers it creates
+  // would stop matching the consumers' member declarations.
+  static_assert(std::is_same_v<
+                decltype(utils::NodeAdaptor(std::declval<DerivedNode *>())),
+                utils::NodeAdaptor<rclcpp::Node>>);
+  static_assert(std::is_same_v<
+                decltype(utils::NodeAdaptor(std::declval<rclcpp::Node *>())),
+                utils::NodeAdaptor<rclcpp::Node>>);
 }
 
 TEST(interface, node_adaptor_create_publisher_qos)

--- a/common/autoware_component_interface_utils/test/test_component_interface_utils.cpp
+++ b/common/autoware_component_interface_utils/test/test_component_interface_utils.cpp
@@ -43,27 +43,25 @@ namespace
 template <class MessageT>
 struct FakePublisher
 {
-  using SharedPtr = std::shared_ptr<FakePublisher>;
   void publish(const MessageT &) {}
 };
 
 template <class MessageT>
 struct FakeSubscription
 {
-  using SharedPtr = std::shared_ptr<FakeSubscription>;
 };
 
 struct FakeNode
 {
   template <class MessageT>
-  typename FakePublisher<MessageT>::SharedPtr create_publisher(
+  std::shared_ptr<FakePublisher<MessageT>> create_publisher(
     const std::string &, const rclcpp::QoS &)
   {
     return std::make_shared<FakePublisher<MessageT>>();
   }
 
   template <class MessageT, class CallbackT>
-  typename FakeSubscription<MessageT>::SharedPtr create_subscription(
+  std::shared_ptr<FakeSubscription<MessageT>> create_subscription(
     const std::string &, const rclcpp::QoS &, CallbackT &&)
   {
     return std::make_shared<FakeSubscription<MessageT>>();
@@ -278,6 +276,9 @@ TEST(interface, wrappers_deduce_endpoint_types_from_node)
   static_assert(std::is_same_v<
                 decltype(utils::NodeAdaptor(std::declval<rclcpp::Node *>())),
                 utils::NodeAdaptor<rclcpp::Node>>);
+  static_assert(std::is_same_v<
+                decltype(utils::NodeInterface(std::declval<DerivedNode *>())),
+                utils::NodeInterface<rclcpp::Node>>);
 }
 
 TEST(interface, node_adaptor_create_publisher_qos)


### PR DESCRIPTION
## Description

`NodeAdaptor`, `NodeInterface`, `Publisher`, `Subscription`, `Service` and `Client` hard-coded `rclcpp::Node` and rclcpp's endpoint types. Adapting any other node type therefore could not be done in this package alone: it would take rewriting the member declarations of every consumer.

This adds a `NodeT` template parameter defaulting to `rclcpp::Node`, and deduces each endpoint type from the node's own `create_*` method instead of naming rclcpp's. Pure refactor, no behavior change.

Consumers are untouched, by design:

- `NodeAdaptor(this)` still resolves to `NodeAdaptor<rclcpp::Node>` even when `this` is a derived node. The passed node type is a separate constructor template parameter, so it does not deduce `NodeT`.
- `Publisher<Spec>` still means `Publisher<Spec, rclcpp::Node>`, and its `WrapType` is still `rclcpp::Publisher<Message>`. Same for the other three wrappers.
- `Client`'s request / response / future aliases and `Service`'s callback alias are now spelled from the spec instead of taken off the handle. The types are unchanged; they just no longer depend on the node type.

The version gate for the Iron+ `rclcpp::QoS` `create_client` / `create_service` overloads moves into one helper per endpoint (`create_client_handle` / `create_service_handle`), because the handle type is now deduced from that call and the gate would otherwise have to be repeated in the `decltype`.

The only source-level change this implies is that `NodeInterface` spelled bare now needs `NodeInterface<>` where CTAD cannot apply (`std::make_shared<NodeInterface<>>`). No consumer uses `NodeInterface` directly; the one occurrence is in this package's own test.

## Related links

**Parent Issue:**

- None.

## How was this PR tested?

Built and tested on ROS 2 Humble (`rclcpp` 16, so the `RCLCPP_VERSION_GTE(21, 0, 0)` branch is not exercised locally; CI covers Jazzy):

- `colcon test` for this package: 6/6 gtest cases pass. The added `wrappers_deduce_endpoint_types_from_node` case is `static_assert`-only and pins that (1) the default node type keeps the previous rclcpp endpoint types, (2) another node type contributes its own, and (3) passing a derived node still yields `NodeAdaptor<rclcpp::Node>`.
- Every consumer of this package builds with **no source change**: `autoware_default_adapi_universe`, `autoware_vehicle_cmd_gate`, `autoware_control_command_gate`, `autoware_operation_mode_transition_manager`, `autoware_predicted_path_checker`, `autoware_geo_pose_projector`, `autoware_automatic_pose_initializer`, `tier4_adapi_rviz_plugin`.

## Notes for reviewers

This is groundwork so that the planned rollout of the adaptor to the remaining interface consumers does not have to be redone later. If consumers are written against an API fixed to `rclcpp::Node`, adapting another node type afterwards means touching all of them again; with this in, it is a template argument at each declaration.

Everything a specific other node type needs is deliberately left out, so that this PR carries only what the templatization itself requires.

## Interface changes

None.

## Effects on system behavior

None.
