### PR TITLE
refactor(autoware_mission_planner): reduce rclcpp::Node dependency in reroute safety and route state logic

### DIFF
--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
@@ -120,6 +120,12 @@ MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)
     "~/route", autoware::component_interface_specs::get_qos<LaneletRouteSpecs>());
   pub_state_ = create_publisher<RouteStateSpecs::Message>(
     "~/state", autoware::component_interface_specs::get_qos<RouteStateSpecs>());
+  on_change_state_ = [this](RouteState::_state_type state) {
+    RouteState msg;
+    msg.stamp = now();
+    msg.state = state;
+    pub_state_->publish(msg);
+  };
 
   // Route state will be published when the node gets ready for route api after initialization,
   // otherwise the mission planner rejects the request for the API.
@@ -182,7 +188,7 @@ void MissionPlanner::on_odometry(const Odometry::ConstSharedPtr msg)
   arrival_checker_.update(*msg);
 
   // NOTE: Do not check in the other states as goal may change.
-  if (state_.state == RouteState::SET) {
+  if (state_ == RouteState::SET) {
     if (arrival_checker_.is_arrived()) {
       change_state(RouteState::ARRIVED);
     }
@@ -203,9 +209,10 @@ void MissionPlanner::on_map(const LaneletMapBin::ConstSharedPtr msg)
 
 void MissionPlanner::change_state(RouteState::_state_type state)
 {
-  state_.stamp = now();
-  state_.state = state;
-  pub_state_->publish(state_);
+  state_ = state;
+  if (on_change_state_) {
+    on_change_state_(state);
+  }
 }
 
 void MissionPlanner::on_clear_route(
@@ -229,7 +236,7 @@ void MissionPlanner::on_set_lanelet_route(
 {
   ScopedProcessingTimePublisher processing_time_publisher(*this);
   using ResponseCode = autoware_adapi_v1_msgs::srv::SetRoute::Response;
-  const auto is_reroute = state_.state == RouteState::SET;
+  const auto is_reroute = state_ == RouteState::SET;
 
   std::optional<geometry_msgs::msg::TransformStamped> transform_to_map;
   try {
@@ -241,7 +248,7 @@ void MissionPlanner::on_set_lanelet_route(
     transform_to_map = std::nullopt;
   }
 
-  if (state_.state != RouteState::UNSET && state_.state != RouteState::SET) {
+  if (state_ != RouteState::UNSET && state_ != RouteState::SET) {
     set_fail_response(
       res, ResponseCode::ERROR_INVALID_STATE, "The route cannot be set in the current state.");
     return;
@@ -305,7 +312,7 @@ void MissionPlanner::on_set_waypoint_route(
 {
   ScopedProcessingTimePublisher processing_time_publisher(*this);
   using ResponseCode = autoware_adapi_v1_msgs::srv::SetRoutePoints::Response;
-  const auto is_reroute = state_.state == RouteState::SET;
+  const auto is_reroute = state_ == RouteState::SET;
 
   std::optional<geometry_msgs::msg::TransformStamped> transform_to_map;
   try {
@@ -317,7 +324,7 @@ void MissionPlanner::on_set_waypoint_route(
     transform_to_map = std::nullopt;
   }
 
-  if (state_.state != RouteState::UNSET && state_.state != RouteState::SET) {
+  if (state_ != RouteState::UNSET && state_ != RouteState::SET) {
     set_fail_response(
       res, ResponseCode::ERROR_INVALID_STATE, "The route cannot be set in the current state.");
     return;

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
@@ -307,6 +307,7 @@ void MissionPlanner::on_set_lanelet_route(
   change_state(RouteState::SET);
   res->status.success = true;
 
+  publish_route(route);
   publish_pose_log(odometry_->pose.pose, "initial");
   publish_pose_log(req->goal_pose, "goal");
 }
@@ -381,6 +382,7 @@ void MissionPlanner::on_set_waypoint_route(
   change_state(RouteState::SET);
   res->status.success = true;
 
+  publish_route(route);
   publish_pose_log(odometry_->pose.pose, "initial");
   publish_pose_log(req->goal_pose, "goal");
 }
@@ -396,6 +398,12 @@ void MissionPlanner::clear_route()
   // pub_marker_->publish();
 }
 
+void MissionPlanner::publish_route(const LaneletRoute & route)
+{
+  pub_route_->publish(route);
+  pub_marker_->publish(planner_->visualize(route));
+}
+
 void MissionPlanner::change_route(const LaneletRoute & route)
 {
   PoseWithUuidStamped goal;
@@ -406,9 +414,6 @@ void MissionPlanner::change_route(const LaneletRoute & route)
   current_route_ = std::make_shared<LaneletRoute>(route);
   planner_->updateRoute(route);
   arrival_checker_.set_goal(goal);
-
-  pub_route_->publish(route);
-  pub_marker_->publish(planner_->visualize(route));
 }
 
 void MissionPlanner::cancel_route()

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
@@ -226,7 +226,7 @@ void MissionPlanner::on_clear_route(
     return;
   }
 
-  change_route();
+  clear_route();
   change_state(RouteState::UNSET);
   res->status.success = true;
 }
@@ -385,7 +385,7 @@ void MissionPlanner::on_set_waypoint_route(
   publish_pose_log(req->goal_pose, "goal");
 }
 
-void MissionPlanner::change_route()
+void MissionPlanner::clear_route()
 {
   current_route_ = nullptr;
   planner_->clearRoute();

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
@@ -458,9 +458,13 @@ bool MissionPlanner::check_reroute_safety(
 
   const auto current_velocity = odometry_->twist.twist.linear.x;
 
-  return autoware::mission_planner::check_reroute_safety(
+  const auto result = autoware::mission_planner::check_reroute_safety(
     original_route, target_route, lanelet_map_ptr_, current_velocity, reroute_time_threshold_,
-    minimum_reroute_length_, get_logger());
+    minimum_reroute_length_);
+  if (!result.is_safe) {
+    RCLCPP_ERROR(get_logger(), "%s", result.reason.c_str());
+  }
+  return result.is_safe;
 }
 }  // namespace autoware::mission_planner
 

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.cpp
@@ -291,12 +291,16 @@ void MissionPlanner::on_set_lanelet_route(
     return;
   }
 
-  if (is_reroute && is_autonomous_driving && !check_reroute_safety(*current_route_, route)) {
-    cancel_route();
-    change_state(RouteState::SET);
-    set_fail_response(
-      res, ResponseCode::ERROR_REROUTE_FAILED, "New route is not safe. Reroute failed.");
-    return;
+  if (is_reroute && is_autonomous_driving) {
+    const auto reroute_safety_result = check_reroute_safety(*current_route_, route);
+    if (!reroute_safety_result.is_safe) {
+      RCLCPP_ERROR(get_logger(), "%s", reroute_safety_result.reason.c_str());
+      cancel_route();
+      change_state(RouteState::SET);
+      set_fail_response(
+        res, ResponseCode::ERROR_REROUTE_FAILED, "New route is not safe. Reroute failed.");
+      return;
+    }
   }
 
   change_route(route);
@@ -361,12 +365,16 @@ void MissionPlanner::on_set_waypoint_route(
     return;
   }
 
-  if (is_reroute && is_autonomous_driving && !check_reroute_safety(*current_route_, route)) {
-    cancel_route();
-    change_state(RouteState::SET);
-    set_fail_response(
-      res, ResponseCode::ERROR_REROUTE_FAILED, "New route is not safe. Reroute failed.");
-    return;
+  if (is_reroute && is_autonomous_driving) {
+    const auto reroute_safety_result = check_reroute_safety(*current_route_, route);
+    if (!reroute_safety_result.is_safe) {
+      RCLCPP_ERROR(get_logger(), "%s", reroute_safety_result.reason.c_str());
+      cancel_route();
+      change_state(RouteState::SET);
+      set_fail_response(
+        res, ResponseCode::ERROR_REROUTE_FAILED, "New route is not safe. Reroute failed.");
+      return;
+    }
   }
 
   change_route(route);
@@ -445,26 +453,21 @@ LaneletRoute MissionPlanner::create_waypoint_route(
   return route;
 }
 
-bool MissionPlanner::check_reroute_safety(
+RerouteSafetyResult MissionPlanner::check_reroute_safety(
   const LaneletRoute & original_route, const LaneletRoute & target_route)
 {
   // The pure check_reroute_safety free function validates the routes and the map, but the node
-  // owns the odometry, so guard it here to keep the original observable behavior (same log
-  // message and early return when odometry or map is not yet available).
+  // owns the odometry, so guard it here to keep the original observable behavior (same failure
+  // reason and early return when odometry or map is not yet available).
   if (!map_ptr_ || !lanelet_map_ptr_ || !odometry_) {
-    RCLCPP_ERROR(get_logger(), "Check reroute safety failed. Route, map or odometry is not set.");
-    return false;
+    return {false, "Check reroute safety failed. Route, map or odometry is not set."};
   }
 
   const auto current_velocity = odometry_->twist.twist.linear.x;
 
-  const auto result = autoware::mission_planner::check_reroute_safety(
+  return autoware::mission_planner::check_reroute_safety(
     original_route, target_route, lanelet_map_ptr_, current_velocity, reroute_time_threshold_,
     minimum_reroute_length_);
-  if (!result.is_safe) {
-    RCLCPP_ERROR(get_logger(), "%s", result.reason.c_str());
-  }
-  return result.is_safe;
 }
 }  // namespace autoware::mission_planner
 

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
@@ -124,7 +124,7 @@ private:
     const SetWaypointRoute::Response::SharedPtr res);
 
   void change_state(RouteState::_state_type state);
-  void change_route();
+  void clear_route();
   void change_route(const LaneletRoute & route);
   void cancel_route();
   LaneletRoute create_lanelet_route(

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
@@ -16,6 +16,7 @@
 #define MISSION_PLANNER__MISSION_PLANNER_HPP_
 
 #include "arrival_checker.hpp"
+#include "reroute_safety.hpp"
 
 #include <autoware/component_interface_specs/planning.hpp>
 #include <autoware/mission_planner/mission_planner_plugin.hpp>
@@ -144,7 +145,8 @@ private:
   // flag to allow reroute in autonomous driving mode.
   // if false, reroute fails. if true, only safe reroute is allowed.
   bool allow_reroute_in_autonomous_mode_;
-  bool check_reroute_safety(const LaneletRoute & original_route, const LaneletRoute & target_route);
+  RerouteSafetyResult check_reroute_safety(
+    const LaneletRoute & original_route, const LaneletRoute & target_route);
 
   std::unique_ptr<autoware_utils_logging::LoggerLevelConfigure> logger_configure_;
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
@@ -125,6 +125,7 @@ private:
 
   void change_state(RouteState::_state_type state);
   void clear_route();
+  void publish_route(const LaneletRoute & route);
   void change_route(const LaneletRoute & route);
   void cancel_route();
   LaneletRoute create_lanelet_route(

--- a/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/mission_planner.hpp
@@ -34,6 +34,7 @@
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -64,6 +65,8 @@ public:
   explicit MissionPlanner(const rclcpp::NodeOptions & options);
 
 private:
+  using ChangeStateCallback = std::function<void(RouteState::_state_type)>;
+
   // Publishes the processing time on destruction, regardless of which return path is taken.
   class ScopedProcessingTimePublisher
   {
@@ -102,7 +105,8 @@ private:
   Odometry::ConstSharedPtr odometry_;
   OperationModeState::ConstSharedPtr operation_mode_state_;
   LaneletMapBin::ConstSharedPtr map_ptr_;
-  RouteState state_;
+  RouteState::_state_type state_{};
+  ChangeStateCallback on_change_state_;
   LaneletRoute::ConstSharedPtr current_route_;
   lanelet::LaneletMapPtr lanelet_map_ptr_{nullptr};
 

--- a/planning/autoware_mission_planner/src/mission_planner/reroute_safety.cpp
+++ b/planning/autoware_mission_planner/src/mission_planner/reroute_safety.cpp
@@ -17,7 +17,6 @@
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware/lanelet2_utils/geometry.hpp>
 #include <autoware/lanelet2_utils/nn_search.hpp>
-#include <rclcpp/logging.hpp>
 
 #include <lanelet2_core/geometry/Lanelet.h>
 #include <lanelet2_core/geometry/LineString.h>
@@ -25,6 +24,7 @@
 #include <algorithm>
 #include <functional>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -58,20 +58,18 @@ bool has_same_primitives(
 
 }  // namespace
 
-bool check_reroute_safety(
+RerouteSafetyResult check_reroute_safety(
   const LaneletRoute & original_route, const LaneletRoute & target_route,
   const lanelet::LaneletMapConstPtr & lanelet_map, const double current_velocity,
-  const double reroute_time_threshold, const double minimum_reroute_length,
-  const rclcpp::Logger & logger)
+  const double reroute_time_threshold, const double minimum_reroute_length)
 {
   if (original_route.segments.empty() || target_route.segments.empty() || !lanelet_map) {
-    RCLCPP_ERROR(logger, "Check reroute safety failed. Route, map or odometry is not set.");
-    return false;
+    return {false, "Check reroute safety failed. Route, map or odometry is not set."};
   }
 
   // if vehicle is stopped, do not check safety
   if (current_velocity < 0.01) {
-    return true;
+    return {true, ""};
   }
 
   // =============================================================================================
@@ -96,8 +94,7 @@ bool check_reroute_safety(
       return std::nullopt;
     });
   if (!start_idx_opt.has_value()) {
-    RCLCPP_ERROR(logger, "Check reroute safety failed. Cannot find the start index of the route.");
-    return false;
+    return {false, "Check reroute safety failed. Cannot find the start index of the route."};
   }
   const auto [start_idx_original, start_idx_target] = start_idx_opt.value();
 
@@ -128,9 +125,7 @@ bool check_reroute_safety(
         target_route.start_pose, lanelet);
     });
   if (!ego_is_on_first_target_section) {
-    RCLCPP_ERROR(
-      logger, "Check reroute safety failed. Ego is not on the first section of target route.");
-    return false;
+    return {false, "Check reroute safety failed. Ego is not on the first section of target route."};
   }
 
   // compute the remaining arc-length from the current pose to the end of the closest lanelet among
@@ -170,8 +165,7 @@ bool check_reroute_safety(
   const auto start_segment_length =
     arc_length_to_lanelet_end(original_route.segments.at(start_segment_idx).primitives);
   if (!start_segment_length.has_value()) {
-    RCLCPP_ERROR(logger, "Check reroute safety failed. Cannot find the closest lanelet.");
-    return false;
+    return {false, "Check reroute safety failed. Cannot find the closest lanelet."};
   }
   double accumulated_length = start_segment_length.value();
 
@@ -217,15 +211,13 @@ bool check_reroute_safety(
   const double safety_length =
     std::max(current_velocity * reroute_time_threshold, minimum_reroute_length);
   if (accumulated_length > safety_length) {
-    return true;
+    return {true, ""};
   }
 
-  RCLCPP_WARN(
-    logger,
-    "Length of lane where original and B target (= %f) is less than safety length (= %f), so "
-    "reroute is not safe.",
-    accumulated_length, safety_length);
-  return false;
+  return {
+    false, "Length of lane where original and B target (= " + std::to_string(accumulated_length) +
+             ") is less than safety length (= " + std::to_string(safety_length) +
+             "), so reroute is not safe."};
 }
 
 }  // namespace autoware::mission_planner

--- a/planning/autoware_mission_planner/src/mission_planner/reroute_safety.hpp
+++ b/planning/autoware_mission_planner/src/mission_planner/reroute_safety.hpp
@@ -15,14 +15,26 @@
 #ifndef MISSION_PLANNER__REROUTE_SAFETY_HPP_
 #define MISSION_PLANNER__REROUTE_SAFETY_HPP_
 
-#include <rclcpp/logger.hpp>
-
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 
+#include <string>
+
 namespace autoware::mission_planner
 {
+
+/**
+ * @brief result of check_reroute_safety.
+ *
+ * @param is_safe whether the reroute is safe (or the vehicle is effectively stopped).
+ * @param reason human-readable reason why the reroute is not safe; empty when is_safe is true.
+ */
+struct RerouteSafetyResult
+{
+  bool is_safe;
+  std::string reason;
+};
 
 /**
  * @brief pure, dependency-injected reroute-safety check.
@@ -40,15 +52,13 @@ namespace autoware::mission_planner
  * @param reroute_time_threshold time horizon used to scale the velocity-dependent safety length
  * [s].
  * @param minimum_reroute_length lower bound of the safety length [m].
- * @param logger logger used for the diagnostic messages emitted on the failure branches.
- * @return true if the reroute is safe (or the vehicle is effectively stopped), false otherwise.
+ * @return RerouteSafetyResult indicating whether the reroute is safe and, if not, why.
  */
-bool check_reroute_safety(
+RerouteSafetyResult check_reroute_safety(
   const autoware_planning_msgs::msg::LaneletRoute & original_route,
   const autoware_planning_msgs::msg::LaneletRoute & target_route,
   const lanelet::LaneletMapConstPtr & lanelet_map, const double current_velocity,
-  const double reroute_time_threshold, const double minimum_reroute_length,
-  const rclcpp::Logger & logger);
+  const double reroute_time_threshold, const double minimum_reroute_length);
 
 }  // namespace autoware::mission_planner
 

--- a/planning/autoware_mission_planner/test/test_reroute_safety.cpp
+++ b/planning/autoware_mission_planner/test/test_reroute_safety.cpp
@@ -14,9 +14,6 @@
 
 #include "../src/mission_planner/reroute_safety.hpp"
 
-#include <rclcpp/logger.hpp>
-#include <rclcpp/logging.hpp>
-
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 
 #include <gtest/gtest.h>
@@ -73,11 +70,6 @@ LaneletSegment make_segment(const std::vector<lanelet::Id> & ids)
   return segment;
 }
 
-rclcpp::Logger test_logger()
-{
-  return rclcpp::get_logger("test_reroute_safety");
-}
-
 }  // namespace
 
 class CheckRerouteSafetyTest : public ::testing::Test
@@ -115,16 +107,18 @@ TEST_F(CheckRerouteSafetyTest, ReturnsFalseWhenOriginalRouteEmpty)
 {
   const auto target = make_nominal_route();
   LaneletRoute original;  // empty segments
-  EXPECT_FALSE(check_reroute_safety(
-    original, target, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength, test_logger()));
+  EXPECT_FALSE(
+    check_reroute_safety(original, target, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength)
+      .is_safe);
 }
 
 TEST_F(CheckRerouteSafetyTest, ReturnsFalseWhenTargetRouteEmpty)
 {
   const auto original = make_nominal_route();
   LaneletRoute target;  // empty segments
-  EXPECT_FALSE(check_reroute_safety(
-    original, target, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength, test_logger()));
+  EXPECT_FALSE(
+    check_reroute_safety(original, target, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength)
+      .is_safe);
 }
 
 TEST_F(CheckRerouteSafetyTest, ReturnsFalseWhenMapIsNull)
@@ -133,7 +127,8 @@ TEST_F(CheckRerouteSafetyTest, ReturnsFalseWhenMapIsNull)
   const auto target = make_nominal_route();
   const lanelet::LaneletMapConstPtr null_map = nullptr;
   EXPECT_FALSE(check_reroute_safety(
-    original, target, null_map, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength, test_logger()));
+                 original, target, null_map, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength)
+                 .is_safe);
 }
 
 TEST_F(CheckRerouteSafetyTest, ReturnsTrueWhenVehicleStopped)
@@ -145,8 +140,9 @@ TEST_F(CheckRerouteSafetyTest, ReturnsTrueWhenVehicleStopped)
   target.start_pose = make_pose(10.0);
   target.goal_pose = make_pose(290.0);
   target.segments = {make_segment({99})};  // unknown id, no common segment
-  EXPECT_TRUE(check_reroute_safety(
-    original, target, map_, 0.0, kRerouteTimeThreshold, kMinimumRerouteLength, test_logger()));
+  EXPECT_TRUE(
+    check_reroute_safety(original, target, map_, 0.0, kRerouteTimeThreshold, kMinimumRerouteLength)
+      .is_safe);
 }
 
 TEST_F(CheckRerouteSafetyTest, ReturnsFalseWhenNoCommonSegment)
@@ -156,8 +152,9 @@ TEST_F(CheckRerouteSafetyTest, ReturnsFalseWhenNoCommonSegment)
   target.start_pose = make_pose(10.0);
   target.goal_pose = make_pose(290.0);
   target.segments = {make_segment({99})};  // no overlap with original {1,2,3}
-  EXPECT_FALSE(check_reroute_safety(
-    original, target, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength, test_logger()));
+  EXPECT_FALSE(
+    check_reroute_safety(original, target, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength)
+      .is_safe);
 }
 
 TEST_F(CheckRerouteSafetyTest, ReturnsFalseWhenEgoNotOnFirstTargetSection)
@@ -169,8 +166,9 @@ TEST_F(CheckRerouteSafetyTest, ReturnsFalseWhenEgoNotOnFirstTargetSection)
   target.start_pose = make_pose(10.0, 50.0);  // y far outside the [-1, 1] band of any lanelet
   target.goal_pose = make_pose(290.0);
   target.segments = {make_segment({1}), make_segment({2}), make_segment({3})};
-  EXPECT_FALSE(check_reroute_safety(
-    original, target, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength, test_logger()));
+  EXPECT_FALSE(
+    check_reroute_safety(original, target, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength)
+      .is_safe);
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -183,8 +181,9 @@ TEST_F(CheckRerouteSafetyTest, ReturnsTrueWhenAccumulatedLengthExceedsSafetyLeng
   // x=290 is ~280 m, far above the safety length max(5 * 10, 30) = 50 m.
   const auto original = make_nominal_route();
   const auto target = make_nominal_route();
-  EXPECT_TRUE(check_reroute_safety(
-    original, target, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength, test_logger()));
+  EXPECT_TRUE(
+    check_reroute_safety(original, target, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength)
+      .is_safe);
 }
 
 TEST_F(CheckRerouteSafetyTest, ReturnsFalseWhenAccumulatedLengthBelowSafetyLength)
@@ -201,8 +200,9 @@ TEST_F(CheckRerouteSafetyTest, ReturnsFalseWhenAccumulatedLengthBelowSafetyLengt
   target.goal_pose = make_pose(85.0);
   target.segments = {make_segment({1})};
 
-  EXPECT_FALSE(check_reroute_safety(
-    original, target, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength, test_logger()));
+  EXPECT_FALSE(
+    check_reroute_safety(original, target, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength)
+      .is_safe);
 }
 
 TEST_F(CheckRerouteSafetyTest, SafetyLengthScalesWithVelocity)
@@ -213,8 +213,9 @@ TEST_F(CheckRerouteSafetyTest, SafetyLengthScalesWithVelocity)
   // pins the velocity dependence of the decision.
   const auto original = make_nominal_route();
   const auto target = make_nominal_route();
-  EXPECT_FALSE(check_reroute_safety(
-    original, target, map_, 30.0, kRerouteTimeThreshold, kMinimumRerouteLength, test_logger()));
+  EXPECT_FALSE(
+    check_reroute_safety(original, target, map_, 30.0, kRerouteTimeThreshold, kMinimumRerouteLength)
+      .is_safe);
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -260,8 +261,9 @@ TEST_F(CheckRerouteSafetyTest, AccumulatesFromSegmentBeforeCommonWhenTargetStart
   // safety_length = max(5 * 10, 30) = 50. The correct branch (10 m) is below it -> false; the
   // regression (100 m) would be above it -> true. Asserting false is RED against a regression that
   // drops the `- 1` and always uses start_idx_original.
-  EXPECT_FALSE(check_reroute_safety(
-    original, target, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength, test_logger()));
+  EXPECT_FALSE(
+    check_reroute_safety(original, target, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength)
+      .is_safe);
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -288,6 +290,7 @@ TEST_F(CheckRerouteSafetyTest, StopsAccumulationOnEmptyIntermediateSegment)
   // (end_idx_target == 2 -> lanelet 3) goal subtraction applies, accumulated = max(90 - 50, 0)
   // = 40. safety_length = max(5 * 10, 30) = 50; 40 <= 50 -> unsafe -> false, and the call does not
   // crash.
-  EXPECT_FALSE(check_reroute_safety(
-    route, route, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength, test_logger()));
+  EXPECT_FALSE(
+    check_reroute_safety(route, route, map_, 5.0, kRerouteTimeThreshold, kMinimumRerouteLength)
+      .is_safe);
 }


### PR DESCRIPTION
## Description

Refactors `autoware_mission_planner` to reduce its dependency on `rclcpp::Node` in the pure logic paths, following the "Error as Value" pattern from the project conventions:

Commits description are following.

- https://github.com/autowarefoundation/autoware_core/commit/f1c34e5f6dd043d5db1375311d442a1de387e37c 
  - `pub_state_->publish(msg)` is now called from callback function. It is not the best way to handle logic, but I have took this way to keep the behavior which publish topic during logic execution.
- https://github.com/autowarefoundation/autoware_core/commit/49bfcbc251878d3f63fc780fe5e8b695d6a186e1  https://github.com/autowarefoundation/autoware_core/commit/38722ff307143878df0753eefda2e8103a63df1e
  - `check_reroute_safety()` no longer takes an `rclcpp::Logger`
- https://github.com/autowarefoundation/autoware_core/commit/cb580c0929ebdd1adbdb0d0b034c38465e7d322a 
  -  `MissionPlanner::change_route()` is renamed to `clear_route()`
- https://github.com/autowarefoundation/autoware_core/commit/66c1d08d01eff9c828d723c39244783dd7d37c5d
  - `pub_route_->publish(route)` is extracted out of `change_route()` to decouple node dependency.


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

```
colcon build --packages-select autoware_mission_planner
colcon test --packages-select autoware_mission_planner --event-handlers console_cohesion+
```

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

The "reroute unsafe due to insufficient remaining lane length" case (`reroute_safety.cpp:217-220`) is now logged via `RCLCPP_ERROR` instead of the previous `RCLCPP_WARN`. This is a minor, intentional log-level change; there is no clear reason for this particular failure case to be treated differently from the other unsafe/failure branches, which were already logged at error level.
