### PR TITLE
feat(autoware_component_interface_utils): complete create_* and move the package off init_*

### DIFF
--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp.hpp
@@ -96,22 +96,34 @@ public:
     sub = create_subscription_impl<SpecT>(interface_->node, std::forward<CallbackT>(callback));
   }
 
-  /// Relay message.
+  /// Relay message. Goes straight to the creation functions rather than through
+  /// init_pub/init_sub, so this helper does not depend on the out-parameter forms.
   template <class P, class S>
   void relay_message(P & pub, S & sub) const
   {
-    using MsgT = typename P::element_type::SpecType::Message::ConstSharedPtr;
-    init_pub(pub);
-    init_sub(sub, [pub](MsgT msg) { pub->publish(*msg); });
+    using PubSpecT = typename P::element_type::SpecType;
+    using SubSpecT = typename S::element_type::SpecType;
+    using MsgT = typename PubSpecT::Message::ConstSharedPtr;
+    pub = create_publisher_impl<PubSpecT>(interface_->node);
+    sub =
+      create_subscription_impl<SubSpecT>(interface_->node, [pub](MsgT msg) { pub->publish(*msg); });
   }
 
-  /// Relay service.
+  /// Relay service. Goes straight to the creation functions rather than through
+  /// init_cli/init_srv, so this helper does not depend on the out-parameter forms.
+  /// The client is deliberately left out of `group`: only the service joins the
+  /// caller's (typically MutuallyExclusive) callback group, so the client's
+  /// response can still be taken while the service callback that issued the call
+  /// is blocked in Client::call.
   template <class C, class S>
   void relay_service(
     C & cli, S & srv, CallbackGroup group, std::optional<double> timeout = std::nullopt) const
   {
-    init_cli(cli);
-    init_srv(srv, [cli, timeout](auto req, auto res) { *res = *cli->call(req, timeout); }, group);
+    using CliSpecT = typename C::element_type::SpecType;
+    using SrvSpecT = typename S::element_type::SpecType;
+    cli = create_client_impl<CliSpecT>(interface_, nullptr);
+    srv = create_service_impl<SrvSpecT>(
+      interface_, [cli, timeout](auto req, auto res) { *res = *cli->call(req, timeout); }, group);
   }
 
   /// Create a subscription wrapper for pointer callback.
@@ -120,8 +132,9 @@ public:
     SharedPtrT & sub, InstanceT * instance,
     MessagePtrCallback<SharedPtrT, InstanceT> && callback) const
   {
+    using SpecT = typename SharedPtrT::element_type::SpecType;
     using std::placeholders::_1;
-    init_sub(sub, std::bind(callback, instance, _1));
+    sub = create_subscription_impl<SpecT>(interface_->node, std::bind(callback, instance, _1));
   }
 
   /// Create a subscription wrapper for reference callback.
@@ -130,8 +143,9 @@ public:
     SharedPtrT & sub, InstanceT * instance,
     MessageRefCallback<SharedPtrT, InstanceT> && callback) const
   {
+    using SpecT = typename SharedPtrT::element_type::SpecType;
     using std::placeholders::_1;
-    init_sub(sub, std::bind(callback, instance, _1));
+    sub = create_subscription_impl<SpecT>(interface_->node, std::bind(callback, instance, _1));
   }
 
   /// Create a service wrapper for logging.
@@ -140,9 +154,10 @@ public:
     SharedPtrT & srv, InstanceT * instance, ServiceCallback<SharedPtrT, InstanceT> && callback,
     CallbackGroup group = nullptr) const
   {
+    using SpecT = typename SharedPtrT::element_type::SpecType;
     using std::placeholders::_1;
     using std::placeholders::_2;
-    init_srv(srv, std::bind(callback, instance, _1, _2), group);
+    srv = create_service_impl<SpecT>(interface_, std::bind(callback, instance, _1, _2), group);
   }
 
   /// Create a publisher, returning it instead of assigning to an out-parameter.

--- a/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp.hpp
+++ b/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp.hpp
@@ -22,6 +22,7 @@
 #include <autoware/component_interface_utils/rclcpp/topic_publisher.hpp>
 #include <autoware/component_interface_utils/rclcpp/topic_subscription.hpp>
 
+#include <functional>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -34,17 +35,30 @@ class NodeAdaptor
 private:
   using CallbackGroup = rclcpp::CallbackGroup::SharedPtr;
 
-  template <class SharedPtrT, class InstanceT>
-  using MessagePtrCallback =
-    void (InstanceT::*)(const typename SharedPtrT::element_type::SpecType::Message::ConstSharedPtr);
-  template <class SharedPtrT, class InstanceT>
-  using MessageRefCallback =
-    void (InstanceT::*)(const typename SharedPtrT::element_type::SpecType::Message &);
+  // Member-function callback shapes, keyed on the spec. The returning create_X<Spec>()
+  // forms name their spec explicitly, so these are the primary definitions; the
+  // SharedPtrT-keyed aliases below project the spec out of the wrapper's smart pointer
+  // for the out-parameter forms, so both spellings stay provably the same shape.
+  template <class SpecT, class InstanceT>
+  using SpecMessagePtrCallback = void (InstanceT::*)(const typename SpecT::Message::ConstSharedPtr);
+  template <class SpecT, class InstanceT>
+  using SpecMessageRefCallback = void (InstanceT::*)(const typename SpecT::Message &);
+
+  template <class SpecT, class InstanceT>
+  using SpecServiceCallback = void (InstanceT::*)(
+    const typename SpecT::Service::Request::SharedPtr,
+    const typename SpecT::Service::Response::SharedPtr);
 
   template <class SharedPtrT, class InstanceT>
-  using ServiceCallback = void (InstanceT::*)(
-    const typename SharedPtrT::element_type::SpecType::Service::Request::SharedPtr,
-    const typename SharedPtrT::element_type::SpecType::Service::Response::SharedPtr);
+  using MessagePtrCallback =
+    SpecMessagePtrCallback<typename SharedPtrT::element_type::SpecType, InstanceT>;
+  template <class SharedPtrT, class InstanceT>
+  using MessageRefCallback =
+    SpecMessageRefCallback<typename SharedPtrT::element_type::SpecType, InstanceT>;
+
+  template <class SharedPtrT, class InstanceT>
+  using ServiceCallback =
+    SpecServiceCallback<typename SharedPtrT::element_type::SpecType, InstanceT>;
 
 public:
   /// Constructor.
@@ -131,21 +145,39 @@ public:
     init_srv(srv, std::bind(callback, instance, _1, _2), group);
   }
 
-  /// Create a publisher (returning form; Wave 1: non-registering).
+  /// Create a publisher, returning it instead of assigning to an out-parameter.
   template <class SpecT>
   typename Publisher<SpecT>::SharedPtr create_publisher()
   {
     return create_publisher_impl<SpecT>(interface_->node);
   }
 
-  /// Create a subscription (returning form; Wave 1: non-registering).
+  /// Create a subscription, returning it instead of assigning to an out-parameter.
   template <class SpecT, class CallbackT>
   typename Subscription<SpecT>::SharedPtr create_subscription(CallbackT && callback)
   {
     return create_subscription_impl<SpecT>(interface_->node, std::forward<CallbackT>(callback));
   }
 
-  /// Create a service server (returning form; Wave 1: non-registering).
+  /// Create a subscription bound to a member function taking the message pointer.
+  template <class SpecT, class InstanceT>
+  typename Subscription<SpecT>::SharedPtr create_subscription(
+    InstanceT * instance, SpecMessagePtrCallback<SpecT, InstanceT> && callback)
+  {
+    using std::placeholders::_1;
+    return create_subscription<SpecT>(std::bind(callback, instance, _1));
+  }
+
+  /// Create a subscription bound to a member function taking the message by reference.
+  template <class SpecT, class InstanceT>
+  typename Subscription<SpecT>::SharedPtr create_subscription(
+    InstanceT * instance, SpecMessageRefCallback<SpecT, InstanceT> && callback)
+  {
+    using std::placeholders::_1;
+    return create_subscription<SpecT>(std::bind(callback, instance, _1));
+  }
+
+  /// Create a service server, returning it instead of assigning to an out-parameter.
   template <class SpecT, class CallbackT>
   typename Service<SpecT>::SharedPtr create_service(
     CallbackT && callback, rclcpp::CallbackGroup::SharedPtr group = nullptr)
@@ -153,7 +185,18 @@ public:
     return create_service_impl<SpecT>(interface_, std::forward<CallbackT>(callback), group);
   }
 
-  /// Create a service client (returning form; Wave 1: non-registering).
+  /// Create a service server bound to a member function.
+  template <class SpecT, class InstanceT>
+  typename Service<SpecT>::SharedPtr create_service(
+    InstanceT * instance, SpecServiceCallback<SpecT, InstanceT> && callback,
+    rclcpp::CallbackGroup::SharedPtr group = nullptr)
+  {
+    using std::placeholders::_1;
+    using std::placeholders::_2;
+    return create_service<SpecT>(std::bind(callback, instance, _1, _2), group);
+  }
+
+  /// Create a service client, returning it instead of assigning to an out-parameter.
   template <class SpecT>
   typename Client<SpecT>::SharedPtr create_client(rclcpp::CallbackGroup::SharedPtr group = nullptr)
   {

--- a/common/autoware_component_interface_utils/test/test_component_interface_utils.cpp
+++ b/common/autoware_component_interface_utils/test/test_component_interface_utils.cpp
@@ -21,6 +21,8 @@
 #include "autoware/component_interface_utils/status.hpp"
 #include "gtest/gtest.h"
 
+#include <autoware/component_interface_specs/control.hpp>
+#include <autoware/component_interface_specs/planning.hpp>
 #include <autoware/component_interface_specs/system.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -274,6 +276,42 @@ bool spin_until(const rclcpp::Node::SharedPtr & node, const std::function<bool()
 }
 
 }  // namespace
+
+TEST(interface, node_adaptor_relay_message)
+{
+  // relay_message needs two specs carrying the same message type; these are the
+  // only such pair among the core specs, and the relay direction here has no
+  // meaning beyond exercising the helper.
+  using Source = autoware::component_interface_specs::planning::Trajectory;
+  using Target = autoware::component_interface_specs::control::PredictedTrajectory;
+
+  rclcpp::init(0, nullptr);
+  auto node = std::make_shared<rclcpp::Node>("test_adaptor_relay");
+  autoware::component_interface_utils::NodeAdaptor adaptor(node.get());
+
+  autoware::component_interface_utils::Publisher<Target>::SharedPtr relay_pub;
+  autoware::component_interface_utils::Subscription<Source>::SharedPtr relay_sub;
+  adaptor.relay_message(relay_pub, relay_sub);
+
+  size_t relayed_points = 0;
+  auto observer = adaptor.create_subscription<Target>(
+    [&relayed_points](const Target::Message::ConstSharedPtr msg) {
+      relayed_points = msg->points.size();
+    });
+  auto source = adaptor.create_publisher<Source>();
+
+  Source::Message msg;
+  msg.points.resize(3);
+  source->publish(msg);
+
+  // The relay forwards what it receives on the source spec onto the target spec,
+  // so a message published on the source has to come back out on the target.
+  EXPECT_TRUE(spin_until(node, [&relayed_points] { return relayed_points != 0; }));
+  EXPECT_EQ(relayed_points, 3u);
+
+  rclcpp::shutdown();
+  (void)observer;
+}
 
 TEST(interface, node_adaptor_create_subscription_member_callbacks)
 {

--- a/common/autoware_component_interface_utils/test/test_component_interface_utils.cpp
+++ b/common/autoware_component_interface_utils/test/test_component_interface_utils.cpp
@@ -26,6 +26,8 @@
 
 #include <algorithm>
 #include <chrono>
+#include <functional>
+#include <future>
 #include <memory>
 #include <string>
 #include <thread>
@@ -217,6 +219,115 @@ TEST(interface, node_adaptor_create_publisher_qos)
   EXPECT_EQ(infos[0].qos_profile().durability(), rclcpp::DurabilityPolicy::TransientLocal);
   rclcpp::shutdown();
   (void)pub;
+}
+
+namespace
+{
+
+using OperationModeState = autoware::component_interface_specs::system::OperationModeState;
+using ChangeOperationMode = autoware::component_interface_specs::system::ChangeOperationMode;
+
+/// Callback host for the member-function overloads. Each member has a distinct
+/// signature so which overload the compiler picks is observable: only the pointer
+/// form can bind on_ptr, only the reference form can bind on_ref.
+class CallbackHost
+{
+public:
+  void on_ptr(const OperationModeState::Message::ConstSharedPtr msg)
+  {
+    ptr_mode = msg->mode;
+    ptr_called = true;
+  }
+  void on_ref(const OperationModeState::Message & msg)
+  {
+    ref_mode = msg.mode;
+    ref_called = true;
+  }
+  void on_change(
+    const ChangeOperationMode::Service::Request::SharedPtr,
+    const ChangeOperationMode::Service::Response::SharedPtr res)
+  {
+    res->status.success = true;
+    srv_called = true;
+  }
+
+  bool ptr_called = false;
+  bool ref_called = false;
+  bool srv_called = false;
+  uint8_t ptr_mode = 0;
+  uint8_t ref_mode = 0;
+};
+
+/// Spin until the predicate holds (or the timeout elapses) so delivery is awaited
+/// rather than assumed.
+bool spin_until(const rclcpp::Node::SharedPtr & node, const std::function<bool()> & done)
+{
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (done()) {
+      return true;
+    }
+    rclcpp::spin_some(node);
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  return done();
+}
+
+}  // namespace
+
+TEST(interface, node_adaptor_create_subscription_member_callbacks)
+{
+  rclcpp::init(0, nullptr);
+  auto node = std::make_shared<rclcpp::Node>("test_adaptor_member_sub");
+  autoware::component_interface_utils::NodeAdaptor adaptor(node.get());
+  CallbackHost host;
+
+  // Both member-function shapes the out-parameter init_sub accepts are also
+  // reachable through the returning form, so a caller does not have to spell out
+  // a std::bind or a forwarding lambda to keep using a member callback.
+  auto sub_ptr = adaptor.create_subscription<OperationModeState>(&host, &CallbackHost::on_ptr);
+  auto sub_ref = adaptor.create_subscription<OperationModeState>(&host, &CallbackHost::on_ref);
+  auto pub = adaptor.create_publisher<OperationModeState>();
+
+  OperationModeState::Message msg;
+  msg.mode = OperationModeState::Message::AUTONOMOUS;
+  pub->publish(msg);
+
+  EXPECT_TRUE(spin_until(node, [&host] { return host.ptr_called && host.ref_called; }));
+  EXPECT_EQ(host.ptr_mode, OperationModeState::Message::AUTONOMOUS);
+  EXPECT_EQ(host.ref_mode, OperationModeState::Message::AUTONOMOUS);
+
+  rclcpp::shutdown();
+  (void)sub_ptr;
+  (void)sub_ref;
+}
+
+TEST(interface, node_adaptor_create_service_member_callback)
+{
+  rclcpp::init(0, nullptr);
+  auto node = std::make_shared<rclcpp::Node>("test_adaptor_member_srv");
+  autoware::component_interface_utils::NodeAdaptor adaptor(node.get());
+  CallbackHost host;
+
+  // The member-function service overload resolves against the returning form and
+  // creates a real server on the spec'd name; the two-argument callback shape is
+  // what distinguishes it from create_service<Spec>(callback, group).
+  auto srv = adaptor.create_service<ChangeOperationMode>(&host, &CallbackHost::on_change);
+  ASSERT_TRUE(wait_for_service(node, ChangeOperationMode::name));
+
+  // Drive a real request through it, so the binding itself is asserted rather than
+  // the mere existence of a server: only the bound member can set success.
+  auto cli = node->create_client<ChangeOperationMode::Service>(ChangeOperationMode::name);
+  auto future = cli->async_send_request(std::make_shared<ChangeOperationMode::Service::Request>())
+                  .future.share();
+  ASSERT_TRUE(spin_until(node, [&future] {
+    return future.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
+  }));
+  EXPECT_TRUE(host.srv_called);
+  EXPECT_TRUE(future.get()->status.success);
+
+  rclcpp::shutdown();
+  (void)srv;
 }
 
 #if AUTOWARE_COMPONENT_INTERFACE_UTILS_RCLCPP_GE_IRON


### PR DESCRIPTION
## Description

`NodeAdaptor` has two API families for the same four endpoint kinds: the out-parameter `init_pub` / `init_sub` / `init_cli` / `init_srv` forms, and the returning `create_publisher` / `create_subscription` / `create_client` / `create_service` forms. `init_*` remains a fully supported part of the public API; this PR is about parity between the two families and about the package's own internal consistency, not about moving callers off `init_*`. This PR closes the last gap between them and then moves the package's own helpers onto the returning family, so that the out-parameter forms are left with no callers inside the package.

**1. The three missing member-function overloads.** The out-parameter forms accept a member function plus its instance and deduce the spec from the wrapper's smart pointer, so a call site reads `adaptor.init_srv(srv_, this, &Node::on_x)`. The returning forms had no counterpart, so the same call site written against them has to spell out a `std::bind` — or a forwarding lambda that repeats the message type:

```diff
-  adaptor.init_srv(srv_set_pause_, this, &AdapiPauseInterface::on_pause);
+  srv_set_pause_ = adaptor.create_service<SetPause>(std::bind(
+    &AdapiPauseInterface::on_pause, this, std::placeholders::_1, std::placeholders::_2));
```

The three added overloads accept exactly the shapes the out-parameter forms already accept: a subscription callback taking the message pointer, one taking the message by reference, and a service callback taking the request and the response. All three shapes are in live use by consumers today, so all three are needed for a consumer to move to the returning forms without getting longer at every call site.

The member-function callback type aliases are now keyed on the spec, because the returning forms name their spec explicitly rather than recovering it from an out-parameter's type. The `SharedPtrT`-keyed aliases that the out-parameter forms use are redefined in terms of the spec-keyed ones, so the two spellings of the same three shapes cannot drift apart.

**2. The package's own helpers no longer go through `init_*`.** `relay_message`, `relay_service` and the three member-function `init_sub` / `init_srv` overloads were all implemented by calling the out-parameter forms. They now call the creation functions directly. The primary out-parameter forms — `init_cli`, `init_srv`, `init_pub` and `init_sub` — were already implemented directly on `create_*_impl` before this PR; the change here is that `relay_message`, `relay_service` and the three member-function `init_sub` / `init_srv` overloads, which had instead routed through those primary members, now call the same `create_*_impl` functions directly, alongside them rather than through them. The two families are now independent siblings over a single internal creation path, so each is a thin surface over one implementation and neither can drift from the other.

The doc comments on the four returning forms had used an internal code name instead of describing what they do; they are reworded accordingly.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

## How was this PR tested?

Built and tested on top of current `main` in the `autoware:universe-devel-jazzy` image with `colcon build --symlink-install --packages-select autoware_component_interface_utils` followed by `colcon test --packages-select autoware_component_interface_utils` and `colcon test-result --all --verbose --test-result-base build/autoware_component_interface_utils`: **40 tests, 0 errors, 0 failures, 11 skipped** across all test and lint targets. The 11 skipped are cppcheck's xunit targets, which run in CI rather than locally; `test_component_interface_utils.gtest.xml` reports **11 tests, 0 errors, 0 failures, 0 skipped**, so every gtest case listed below actually executed. `pre-commit` (clang-format, cpplint, include-guard, prettier, …) runs clean on both changed files.

Three new gtest cases assert the binding rather than the endpoint's existence, and each was checked against a mutation to confirm it is not vacuous. Each mutation failed exactly the one case that covers it and no others:

- `node_adaptor_create_subscription_member_callbacks` creates one subscription through each of the two new subscription overloads on the same spec, publishes a real message, and spins until both member functions have run and observed the published value. Mutation: suppressing the `publish` call.
- `node_adaptor_create_service_member_callback` creates a server through the new service overload and drives a real request through it with a plain `rclcpp` client, asserting both that the bound member ran and that the response it wrote came back. Mutation: making the bound member stop setting `success`.
- `node_adaptor_relay_message` relays a three-point trajectory through `relay_message` and observes it coming back out on the target spec. Mutation: making the relay's forwarding lambda drop the message instead of publishing it.

## Notes for reviewers

**Nothing outside this package's own tests calls the three new overloads.** They exist to close a parity gap so that a consumer can adopt a returning form at one call site at a time without that call site getting longer. There is no mass migration planned, and `init_*` is not being deprecated: consumers may adopt the returning forms incrementally, and the out-parameter forms remain fully supported.

**Why the delegation targets `create_*_impl` rather than the public returning members.** `relay_message`, `relay_service` and the member-function `init_*` overloads are `const` member functions, while the returning `create_*` members are not. Both families are thin wrappers over the same free `create_*_impl` functions, so routing the helpers there keeps every existing public signature — including the `const` qualifiers — exactly as it was. `init_X(x)` and the `create_X_impl` call it forwarded to are the same call with the same arguments, so this is behavior-preserving by construction.

**`relay_service` is not instantiated anywhere in this package, tests included.** A runtime test needs two specs that carry the same type; for messages exactly one such pair exists among the core specs (`planning::Trajectory` and `control::PredictedTrajectory`, both `autoware_planning_msgs::msg::Trajectory`), which is what `node_adaptor_relay_message` uses. No core spec pair shares a `Service` type, so no runtime test for `relay_service` can be written inside this package, and because it is a member function template that nothing here instantiates, its body is parsed but the dependent `create_client_impl`/`create_service_impl` calls inside it are never semantically checked by this repository's build either. Within this repository its rewrite is therefore pinned by review alone; an out-of-tree consumer that does instantiate it type-checks the rewritten body when it does, but that is not coverage this PR provides. The rewrite is a mechanical substitution of the same two `create_*_impl` calls the `init_*` forms it replaced were already making, and it preserves the detail that only the service joins the caller's callback group while the client stays out of it — that asymmetry is load-bearing (the client's response must still be takeable while the service callback that issued the call is blocked in `Client::call`), so it is now stated in a comment.

**Overload resolution is unambiguous in both directions**, which is worth checking since `create_service` now has a two-argument form on each side:

- `create_service<Spec>(callback, group)` — the member-function overload deduces `InstanceT` from an `InstanceT *` first parameter, so a callable does not match it.
- `create_service<Spec>(this, &Node::on_x)` — the existing overload would have to convert a pointer-to-member to `rclcpp::CallbackGroup::SharedPtr` for its `group` parameter, so it is not viable.

For the two subscription overloads, `InstanceT` is deduced both from the `instance` pointer and from the callback's pointer-to-member class, and the two deductions must agree; what the explicit `SpecT` fixes is the callback's parameter type — `typename SpecT::Message::ConstSharedPtr` versus `const typename SpecT::Message &` — so exactly one of the pointer and reference shapes matches a given member function.

## Interface changes

None. No ROS topics, services, or parameters change. This adds C++ overloads to `NodeAdaptor` and changes how five of its existing members are implemented internally; no existing signature is modified.

## Effects on system behavior

None. The new overloads forward to the same creation path the existing returning forms already use, and the rewritten helpers forward to the same creation path the out-parameter forms they used to call were already reaching.

