### PR TITLE
refactor(autoware_default_adapi): create endpoints through NodeAdaptor

### DIFF
--- a/api/autoware_default_adapi/package.xml
+++ b/api/autoware_default_adapi/package.xml
@@ -17,11 +17,11 @@
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_adapi_version_msgs</depend>
   <depend>autoware_component_interface_specs</depend>
+  <depend>autoware_component_interface_utils</depend>
   <depend>autoware_geography_utils</depend>
   <depend>autoware_localization_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
-  <depend>autoware_qos_utils</depend>
   <depend>autoware_system_msgs</depend>
   <depend>autoware_utils_rclcpp</depend>
   <depend>autoware_vehicle_info_utils</depend>

--- a/api/autoware_default_adapi/src/interface.cpp
+++ b/api/autoware_default_adapi/src/interface.cpp
@@ -19,15 +19,13 @@ namespace autoware::default_adapi
 
 InterfaceNode::InterfaceNode(const rclcpp::NodeOptions & options)
 : Node("interface", options),
-  srv_(
-    create_service<Version::Service>(
-      Version::name, [](
-                       const Version::Service::Request::SharedPtr,
-                       const Version::Service::Response::SharedPtr res) {
-        res->major = 1;
-        res->minor = 9;
-        res->patch = 1;
-      }))
+  srv_(adaptor_.create_service<Version>(
+    [](
+      const Version::Service::Request::SharedPtr, const Version::Service::Response::SharedPtr res) {
+      res->major = 1;
+      res->minor = 9;
+      res->patch = 1;
+    }))
 {
 }
 

--- a/api/autoware_default_adapi/src/interface.hpp
+++ b/api/autoware_default_adapi/src/interface.hpp
@@ -16,6 +16,7 @@
 #define INTERFACE_HPP_
 
 #include <autoware/adapi_specs/interface.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 namespace autoware::default_adapi
@@ -28,7 +29,8 @@ public:
 
 private:
   using Version = autoware::adapi_specs::interface::Version;
-  rclcpp::Service<Version::Service>::SharedPtr srv_;
+  autoware::component_interface_utils::NodeAdaptor adaptor_{this};
+  autoware::component_interface_utils::Service<Version>::SharedPtr srv_;
 };
 
 }  // namespace autoware::default_adapi

--- a/api/autoware_default_adapi/src/localization.cpp
+++ b/api/autoware_default_adapi/src/localization.cpp
@@ -16,9 +16,6 @@
 
 #include "utils/localization_conversion.hpp"
 
-#include <autoware/component_interface_specs/utils.hpp>
-#include <autoware/qos_utils/qos_compatibility.hpp>
-
 namespace autoware::default_adapi
 {
 
@@ -31,25 +28,18 @@ LocalizationNode::LocalizationNode(const rclcpp::NodeOptions & options)
   group_cli_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
   // AD API
-  pub_state_ = create_publisher<autoware::adapi_specs::localization::InitializationState::Message>(
-    autoware::adapi_specs::localization::InitializationState::name,
-    autoware::component_interface_specs::get_qos<
-      autoware::adapi_specs::localization::InitializationState>());
-  srv_initialize_ = create_service<autoware::adapi_specs::localization::Initialize::Service>(
-    autoware::adapi_specs::localization::Initialize::name,
-    std::bind(&LocalizationNode::on_initialize, this, std::placeholders::_1, std::placeholders::_2),
-    AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE(), group_cli_);
+  pub_state_ =
+    adaptor_.create_publisher<autoware::adapi_specs::localization::InitializationState>();
+  srv_initialize_ = adaptor_.create_service<autoware::adapi_specs::localization::Initialize>(
+    this, &LocalizationNode::on_initialize, group_cli_);
 
   // Component Interface
-  sub_state_ = create_subscription<
-    autoware::component_interface_specs::localization::InitializationState::Message>(
-    autoware::component_interface_specs::localization::InitializationState::name,
-    autoware::component_interface_specs::get_qos<
-      autoware::component_interface_specs::localization::InitializationState>(),
-    std::bind(&LocalizationNode::on_state, this, std::placeholders::_1));
+  sub_state_ =
+    adaptor_
+      .create_subscription<autoware::component_interface_specs::localization::InitializationState>(
+        this, &LocalizationNode::on_state);
   cli_initialize_ =
-    create_client<autoware::component_interface_specs::localization::Initialize::Service>(
-      autoware::component_interface_specs::localization::Initialize::name);
+    adaptor_.create_client<autoware::component_interface_specs::localization::Initialize>();
 
   state_.state = ImplState::Message::UNKNOWN;
 }

--- a/api/autoware_default_adapi/src/localization.hpp
+++ b/api/autoware_default_adapi/src/localization.hpp
@@ -17,6 +17,7 @@
 
 #include <autoware/adapi_specs/localization.hpp>
 #include <autoware/component_interface_specs/localization.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -31,16 +32,16 @@ public:
 private:
   using ImplState = autoware::component_interface_specs::localization::InitializationState;
 
+  autoware::component_interface_utils::NodeAdaptor adaptor_{this};
   rclcpp::CallbackGroup::SharedPtr group_cli_;
-  rclcpp::Service<autoware::adapi_specs::localization::Initialize::Service>::SharedPtr
-    srv_initialize_;
-  rclcpp::Publisher<autoware::adapi_specs::localization::InitializationState::Message>::SharedPtr
-    pub_state_;
-  rclcpp::Client<autoware::component_interface_specs::localization::Initialize::Service>::SharedPtr
-    cli_initialize_;
-  rclcpp::Subscription<
-    autoware::component_interface_specs::localization::InitializationState::Message>::SharedPtr
-    sub_state_;
+  autoware::component_interface_utils::Service<
+    autoware::adapi_specs::localization::Initialize>::SharedPtr srv_initialize_;
+  autoware::component_interface_utils::Publisher<
+    autoware::adapi_specs::localization::InitializationState>::SharedPtr pub_state_;
+  autoware::component_interface_utils::Client<
+    autoware::component_interface_specs::localization::Initialize>::SharedPtr cli_initialize_;
+  autoware::component_interface_utils::Subscription<
+    autoware::component_interface_specs::localization::InitializationState>::SharedPtr sub_state_;
 
   void diagnose_state(diagnostic_updater::DiagnosticStatusWrapper & stat);
   void on_state(const ImplState::Message::ConstSharedPtr msg);

--- a/api/autoware_default_adapi/src/routing.cpp
+++ b/api/autoware_default_adapi/src/routing.cpp
@@ -16,8 +16,6 @@
 
 #include "utils/route_conversion.hpp"
 
-#include <autoware/qos_utils/qos_compatibility.hpp>
-
 #include <memory>
 
 namespace
@@ -61,67 +59,42 @@ RoutingNode::RoutingNode(const rclcpp::NodeOptions & options)
   group_cli_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 
   // AD API Interface
-  pub_state_ = create_publisher<autoware::adapi_specs::routing::RouteState::Message>(
-    autoware::adapi_specs::routing::RouteState::name,
-    autoware::component_interface_specs::get_qos<autoware::adapi_specs::routing::RouteState>());
-  pub_route_ = create_publisher<autoware::adapi_specs::routing::Route::Message>(
-    autoware::adapi_specs::routing::Route::name,
-    autoware::component_interface_specs::get_qos<autoware::adapi_specs::routing::Route>());
-  srv_clear_route_ = create_service<autoware::adapi_specs::routing::ClearRoute::Service>(
-    autoware::adapi_specs::routing::ClearRoute::name,
-    std::bind(&RoutingNode::on_clear_route, this, std::placeholders::_1, std::placeholders::_2));
-  srv_set_route_ = create_service<autoware::adapi_specs::routing::SetRoute::Service>(
-    autoware::adapi_specs::routing::SetRoute::name,
-    std::bind(&RoutingNode::on_set_route, this, std::placeholders::_1, std::placeholders::_2));
-  srv_set_route_points_ = create_service<autoware::adapi_specs::routing::SetRoutePoints::Service>(
-    autoware::adapi_specs::routing::SetRoutePoints::name,
-    std::bind(
-      &RoutingNode::on_set_route_points, this, std::placeholders::_1, std::placeholders::_2));
-  srv_change_route_ = create_service<autoware::adapi_specs::routing::ChangeRoute::Service>(
-    autoware::adapi_specs::routing::ChangeRoute::name,
-    std::bind(&RoutingNode::on_change_route, this, std::placeholders::_1, std::placeholders::_2));
+  pub_state_ = adaptor_.create_publisher<autoware::adapi_specs::routing::RouteState>();
+  pub_route_ = adaptor_.create_publisher<autoware::adapi_specs::routing::Route>();
+  srv_clear_route_ = adaptor_.create_service<autoware::adapi_specs::routing::ClearRoute>(
+    this, &RoutingNode::on_clear_route);
+  srv_set_route_ = adaptor_.create_service<autoware::adapi_specs::routing::SetRoute>(
+    this, &RoutingNode::on_set_route);
+  srv_set_route_points_ = adaptor_.create_service<autoware::adapi_specs::routing::SetRoutePoints>(
+    this, &RoutingNode::on_set_route_points);
+  srv_change_route_ = adaptor_.create_service<autoware::adapi_specs::routing::ChangeRoute>(
+    this, &RoutingNode::on_change_route);
   srv_change_route_points_ =
-    create_service<autoware::adapi_specs::routing::ChangeRoutePoints::Service>(
-      autoware::adapi_specs::routing::ChangeRoutePoints::name,
-      std::bind(
-        &RoutingNode::on_change_route_points, this, std::placeholders::_1, std::placeholders::_2));
+    adaptor_.create_service<autoware::adapi_specs::routing::ChangeRoutePoints>(
+      this, &RoutingNode::on_change_route_points);
 
   // Component Interface
   sub_state_ =
-    create_subscription<autoware::component_interface_specs::planning::RouteState::Message>(
-      autoware::component_interface_specs::planning::RouteState::name,
-      autoware::component_interface_specs::get_qos<
-        autoware::component_interface_specs::planning::RouteState>(),
-      std::bind(&RoutingNode::on_state, this, std::placeholders::_1));
+    adaptor_.create_subscription<autoware::component_interface_specs::planning::RouteState>(
+      this, &RoutingNode::on_state);
   sub_route_ =
-    create_subscription<autoware::component_interface_specs::planning::LaneletRoute::Message>(
-      autoware::component_interface_specs::planning::LaneletRoute::name,
-      autoware::component_interface_specs::get_qos<
-        autoware::component_interface_specs::planning::LaneletRoute>(),
-      std::bind(&RoutingNode::on_route, this, std::placeholders::_1));
+    adaptor_.create_subscription<autoware::component_interface_specs::planning::LaneletRoute>(
+      this, &RoutingNode::on_route);
   cli_clear_route_ =
-    create_client<autoware::component_interface_specs::planning::ClearRoute::Service>(
-      autoware::component_interface_specs::planning::ClearRoute::name,
-      AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE(), group_cli_);
+    adaptor_.create_client<autoware::component_interface_specs::planning::ClearRoute>(group_cli_);
   cli_set_waypoint_route_ =
-    create_client<autoware::component_interface_specs::planning::SetWaypointRoute::Service>(
-      autoware::component_interface_specs::planning::SetWaypointRoute::name,
-      AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE(), group_cli_);
+    adaptor_.create_client<autoware::component_interface_specs::planning::SetWaypointRoute>(
+      group_cli_);
   cli_set_lanelet_route_ =
-    create_client<autoware::component_interface_specs::planning::SetLaneletRoute::Service>(
-      autoware::component_interface_specs::planning::SetLaneletRoute::name,
-      AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE(), group_cli_);
+    adaptor_.create_client<autoware::component_interface_specs::planning::SetLaneletRoute>(
+      group_cli_);
   sub_operation_mode_ =
-    create_subscription<autoware::component_interface_specs::system::OperationModeState::Message>(
-      autoware::component_interface_specs::system::OperationModeState::name,
-      autoware::component_interface_specs::get_qos<
-        autoware::component_interface_specs::system::OperationModeState>(),
-      std::bind(&RoutingNode::on_operation_mode, this, std::placeholders::_1));
+    adaptor_.create_subscription<autoware::component_interface_specs::system::OperationModeState>(
+      this, &RoutingNode::on_operation_mode);
 
   cli_operation_mode_ =
-    create_client<autoware::component_interface_specs::system::ChangeOperationMode::Service>(
-      autoware::component_interface_specs::system::ChangeOperationMode::name,
-      AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE(), group_cli_);
+    adaptor_.create_client<autoware::component_interface_specs::system::ChangeOperationMode>(
+      group_cli_);
 
   is_autoware_control_ = false;
   is_auto_mode_ = false;

--- a/api/autoware_default_adapi/src/routing.hpp
+++ b/api/autoware_default_adapi/src/routing.hpp
@@ -18,6 +18,7 @@
 #include <autoware/adapi_specs/routing.hpp>
 #include <autoware/component_interface_specs/planning.hpp>
 #include <autoware/component_interface_specs/system.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <autoware/motion_utils/vehicle/vehicle_state_checker.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -35,36 +36,43 @@ private:
   using State = autoware::component_interface_specs::planning::RouteState;
   using Route = autoware::component_interface_specs::planning::LaneletRoute;
 
+  autoware::component_interface_utils::NodeAdaptor adaptor_{this};
   rclcpp::CallbackGroup::SharedPtr group_cli_;
 
   // AD API Interface
-  rclcpp::Publisher<autoware::adapi_specs::routing::RouteState::Message>::SharedPtr pub_state_;
-  rclcpp::Publisher<autoware::adapi_specs::routing::Route::Message>::SharedPtr pub_route_;
-  rclcpp::Service<autoware::adapi_specs::routing::SetRoutePoints::Service>::SharedPtr
-    srv_set_route_points_;
-  rclcpp::Service<autoware::adapi_specs::routing::SetRoute::Service>::SharedPtr srv_set_route_;
-  rclcpp::Service<autoware::adapi_specs::routing::ChangeRoutePoints::Service>::SharedPtr
-    srv_change_route_points_;
-  rclcpp::Service<autoware::adapi_specs::routing::ChangeRoute::Service>::SharedPtr
-    srv_change_route_;
-  rclcpp::Service<autoware::adapi_specs::routing::ClearRoute::Service>::SharedPtr srv_clear_route_;
+  autoware::component_interface_utils::Publisher<
+    autoware::adapi_specs::routing::RouteState>::SharedPtr pub_state_;
+  autoware::component_interface_utils::Publisher<autoware::adapi_specs::routing::Route>::SharedPtr
+    pub_route_;
+  autoware::component_interface_utils::Service<
+    autoware::adapi_specs::routing::SetRoutePoints>::SharedPtr srv_set_route_points_;
+  autoware::component_interface_utils::Service<autoware::adapi_specs::routing::SetRoute>::SharedPtr
+    srv_set_route_;
+  autoware::component_interface_utils::Service<
+    autoware::adapi_specs::routing::ChangeRoutePoints>::SharedPtr srv_change_route_points_;
+  autoware::component_interface_utils::Service<
+    autoware::adapi_specs::routing::ChangeRoute>::SharedPtr srv_change_route_;
+  autoware::component_interface_utils::Service<
+    autoware::adapi_specs::routing::ClearRoute>::SharedPtr srv_clear_route_;
 
   // Component Interface
-  rclcpp::Subscription<
-    autoware::component_interface_specs::planning::RouteState::Message>::SharedPtr sub_state_;
-  rclcpp::Subscription<
-    autoware::component_interface_specs::planning::LaneletRoute::Message>::SharedPtr sub_route_;
-  rclcpp::Client<autoware::component_interface_specs::planning::SetWaypointRoute::Service>::
-    SharedPtr cli_set_waypoint_route_;
-  rclcpp::Client<autoware::component_interface_specs::planning::SetLaneletRoute::Service>::SharedPtr
+  autoware::component_interface_utils::Subscription<
+    autoware::component_interface_specs::planning::RouteState>::SharedPtr sub_state_;
+  autoware::component_interface_utils::Subscription<
+    autoware::component_interface_specs::planning::LaneletRoute>::SharedPtr sub_route_;
+  autoware::component_interface_utils::Client<
+    autoware::component_interface_specs::planning::SetWaypointRoute>::SharedPtr
+    cli_set_waypoint_route_;
+  autoware::component_interface_utils::Client<
+    autoware::component_interface_specs::planning::SetLaneletRoute>::SharedPtr
     cli_set_lanelet_route_;
-  rclcpp::Client<autoware::component_interface_specs::planning::ClearRoute::Service>::SharedPtr
-    cli_clear_route_;
-  rclcpp::Subscription<autoware::component_interface_specs::system::OperationModeState::Message>::
-    SharedPtr sub_operation_mode_;
-
-  rclcpp::Client<autoware::component_interface_specs::system::ChangeOperationMode::Service>::
-    SharedPtr cli_operation_mode_;
+  autoware::component_interface_utils::Client<
+    autoware::component_interface_specs::planning::ClearRoute>::SharedPtr cli_clear_route_;
+  autoware::component_interface_utils::Subscription<
+    autoware::component_interface_specs::system::OperationModeState>::SharedPtr sub_operation_mode_;
+  autoware::component_interface_utils::Client<
+    autoware::component_interface_specs::system::ChangeOperationMode>::SharedPtr
+    cli_operation_mode_;
 
   void diagnose_state(diagnostic_updater::DiagnosticStatusWrapper & stat);
   void change_stop_mode();


### PR DESCRIPTION
## Description

The nineteen spec-derived endpoints in this package each re-derived their type, name and QoS by hand from a spec that already carries all three. A publisher spelled out `create_publisher<Spec::Message>(Spec::name, get_qos<Spec>())`; a service spelled out `create_service<Spec::Service>(Spec::name, std::bind(&Node::on_x, this, _1, _2), AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE(), group)`. Every one of those three arguments is recoverable from the spec, so restating them is duplication that can silently drift from the spec it copies.

This PR creates all nineteen through `NodeAdaptor`, so each call site names its spec once:

```diff
-  pub_state_ = create_publisher<autoware::adapi_specs::routing::RouteState::Message>(
-    autoware::adapi_specs::routing::RouteState::name,
-    autoware::component_interface_specs::get_qos<autoware::adapi_specs::routing::RouteState>());
+  pub_state_ = adaptor_.create_publisher<autoware::adapi_specs::routing::RouteState>();
```

The nineteen are 1 service in `InterfaceNode`; 1 publisher, 1 subscription, 1 service and 1 client in `LocalizationNode`; and 2 publishers, 3 subscriptions, 5 services and 4 clients in `RoutingNode`. Member declarations move from `rclcpp::Publisher<Spec::Message>` and friends to the `component_interface_utils` wrappers parameterised on the spec itself, and `adaptor_` is declared ahead of every member initialised from it so the member-initialiser order stays valid.

Two `#include`s go with the call sites they served: `<autoware/qos_utils/qos_compatibility.hpp>` in `localization.cpp` and `routing.cpp` (it supplied only `AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE()`), and `<autoware/component_interface_specs/utils.hpp>` in `localization.cpp` (it supplied only `get_qos<Spec>()`). With those gone the package no longer references `autoware_qos_utils` anywhere, so its `<depend>` is removed and `autoware_component_interface_utils` is declared in its place.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

## How was this PR tested?

Built and tested in the `autoware:universe-devel-jazzy` image with `colcon build --symlink-install --packages-select autoware_default_adapi`, then `colcon test --packages-select autoware_default_adapi` and `colcon test-result --verbose --test-result-base build/autoware_default_adapi`: **50 tests, 0 errors, 0 failures, 11 skipped**, all 15 gtest cases passing, no new compiler warnings. `pre-commit` runs clean on every changed file.

The acceptance evidence for wire neutrality is a runtime endpoint capture. The three nodes were loaded before and after the change and `ros2 topic list` / `ros2 service list` captured each time: **11 topics and 34 services, byte-identical between the two captures**. (Loading `RoutingNode` standalone additionally needs `-p stop_check_duration:=1.0`; that is a launch detail of the capture, not part of this change.)

`topic list` and `service list` prove name neutrality but do not surface QoS, so QoS was closed by reading the derivation rather than observing it: `NodeAdaptor::create_publisher` / `create_subscription` call the same `get_qos<SpecT>()` these call sites called by hand, and the service and client wrappers use `rclcpp::ServicesQoS()`, which is what `AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE()` expands to on both Humble and Jazzy. Every deleted QoS expression is one of those two forms, so the substitution is value-for-value.

## Notes for reviewers

**`std::bind` becomes a member-function overload only where the base code used `std::bind`.** The one call site that passed a lambda — the version service in `interface.cpp` — still passes a lambda. Nothing changes shape beyond what the spec-derived arguments removed.

**Callback groups are preserved exactly.** `group_cli_` is still passed to the four clients and the one service that had it, and still withheld from the ones that did not.

**Known-stale documentation left alone.** `document/routing.md:5` describes the old arrangement; it was already out of date before this PR and correcting it is a separate concern.

## Interface changes

No topic or service changes. One node parameter is added by `NodeAdaptor`'s constructor.

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name                              | Type     | Default Value | Description                                                                                                |
| :---------- | :------------------------------------------ | :------- | :------------ | :--------------------------------------------------------------------------------------------------------- |
| Added       | `component_interface.service_introspection` | `string` | `"off"`       | ROS 2 service introspection mode (`"off"` \| `"metadata"` \| `"contents"`), declared once per node by `NodeAdaptor` |

The parameter is gated on rclcpp ≥ 21, so it appears on Jazzy and not on Humble. Its default leaves service introspection off, which is the state before this PR. Declaration is idempotent — a node that already has the parameter keeps its value.

## Effects on system behavior

None. The topic and service lists are identical before and after, every QoS is the value the deleted expression already resolved to, and no callback, callback group or message type changes.

