### PR TITLE
refactor(autoware_command_gate): create endpoints through NodeAdaptor

### DIFF
--- a/control/autoware_command_gate/package.xml
+++ b/control/autoware_command_gate/package.xml
@@ -15,6 +15,7 @@
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_common_msgs</depend>
   <depend>autoware_component_interface_specs</depend>
+  <depend>autoware_component_interface_utils</depend>
   <depend>autoware_system_msgs</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>builtin_interfaces</depend>

--- a/control/autoware_command_gate/src/autoware_command_gate.cpp
+++ b/control/autoware_command_gate/src/autoware_command_gate.cpp
@@ -78,7 +78,7 @@ private:
     system_state_pub_->publish(outputs.state);
   }
 
-  autoware::component_interface_utils::NodeAdaptor adaptor_{this};
+  autoware::component_interface_utils::NodeAdaptor<rclcpp::Node> adaptor_{this};
   autoware::component_interface_utils::Publisher<spec::OperationModeState>::SharedPtr state_pub_;
   autoware::component_interface_utils::Publisher<system::OperationModeState>::SharedPtr
     system_state_pub_;

--- a/control/autoware_command_gate/src/autoware_command_gate.cpp
+++ b/control/autoware_command_gate/src/autoware_command_gate.cpp
@@ -15,12 +15,11 @@
 #include "command_gate_mode_builder.hpp"
 
 #include <autoware/adapi_specs/operation_mode.hpp>
+#include <autoware/component_interface_specs/control.hpp>
 #include <autoware/component_interface_specs/system.hpp>
-#include <autoware/component_interface_specs/utils.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
-
-#include <autoware_vehicle_msgs/msg/gear_command.hpp>
 
 #include <rmw/types.h>
 
@@ -34,12 +33,7 @@ namespace spec
 using ChangeToStop = autoware::adapi_specs::operation_mode::ChangeToStop;
 using ChangeToAutonomous = autoware::adapi_specs::operation_mode::ChangeToAutonomous;
 using OperationModeState = autoware::adapi_specs::operation_mode::OperationModeState;
-
-struct GearCommand
-{
-  using Message = autoware_vehicle_msgs::msg::GearCommand;
-  static constexpr char name[] = "/control/command/gear_cmd";
-};
+using GearCommand = autoware::component_interface_specs::control::GearCommand;
 }  // namespace spec
 
 namespace system
@@ -55,22 +49,15 @@ class AutowareCommandGateNode : public rclcpp::Node
 public:
   explicit AutowareCommandGateNode(const rclcpp::NodeOptions & options)
   : rclcpp::Node("autoware_command_gate", options),
-    state_pub_(
-      create_publisher<spec::OperationModeState::Message>(
-        spec::OperationModeState::name,
-        autoware::component_interface_specs::get_qos<spec::OperationModeState>())),
-    system_state_pub_(
-      create_publisher<system::OperationModeState::Message>(
-        system::OperationModeState::name,
-        autoware::component_interface_specs::get_qos<system::OperationModeState>())),
-    gear_pub_(create_publisher<spec::GearCommand::Message>(spec::GearCommand::name, rclcpp::QoS{1}))
+    state_pub_(adaptor_.create_publisher<spec::OperationModeState>()),
+    system_state_pub_(adaptor_.create_publisher<system::OperationModeState>()),
+    gear_pub_(adaptor_.create_publisher<spec::GearCommand>())
   {
     /*
       System layer where the final decision to trigger the mode change is made.
       The state is published to the same topic for simplicity, but it can be separated if needed.
     */
-    srv_system_mode_ = create_service<SystemChangeOperationMode::Service>(
-      SystemChangeOperationMode::name,
+    srv_system_mode_ = adaptor_.create_service<SystemChangeOperationMode>(
       [this](
         const SystemChangeOperationMode::Service::Request::SharedPtr req,
         const SystemChangeOperationMode::Service::Response::SharedPtr res) {
@@ -84,9 +71,6 @@ public:
   }
 
 private:
-  using OperationModeStateMsg = spec::OperationModeState::Message;
-  using OperationModeSystemStateMsg = system::OperationModeState::Message;
-  using GearCommand = autoware_vehicle_msgs::msg::GearCommand;
   void publish(const ModeOutputs & outputs)
   {
     state_pub_->publish(outputs.state);
@@ -94,10 +78,13 @@ private:
     system_state_pub_->publish(outputs.state);
   }
 
-  rclcpp::Publisher<OperationModeStateMsg>::SharedPtr state_pub_;
-  rclcpp::Publisher<OperationModeSystemStateMsg>::SharedPtr system_state_pub_;
-  rclcpp::Publisher<GearCommand>::SharedPtr gear_pub_;
-  rclcpp::Service<SystemChangeOperationMode::Service>::SharedPtr srv_system_mode_;
+  autoware::component_interface_utils::NodeAdaptor adaptor_{this};
+  autoware::component_interface_utils::Publisher<spec::OperationModeState>::SharedPtr state_pub_;
+  autoware::component_interface_utils::Publisher<system::OperationModeState>::SharedPtr
+    system_state_pub_;
+  autoware::component_interface_utils::Publisher<spec::GearCommand>::SharedPtr gear_pub_;
+  autoware::component_interface_utils::Service<SystemChangeOperationMode>::SharedPtr
+    srv_system_mode_;
 };
 
 }  // namespace autoware::control::command_gate


### PR DESCRIPTION
## Description

`autoware_command_gate.cpp` defined its own `GearCommand` spec:

```cpp
struct GearCommand
{
  using Message = autoware_vehicle_msgs::msg::GearCommand;
  static constexpr char name[] = "/control/command/gear_cmd";
};
```

`autoware::component_interface_specs::control::GearCommand` already exists, with the same message type and the same name, plus the QoS the local copy lacked. The three aliases sitting directly beside this struct in the same `namespace spec` block are all plain aliases to central specs; this one was the odd one out, and a divergence between the two definitions would be invisible until something on the wire disagreed.

This PR replaces the local definition with an alias to the real spec, matching its neighbours, and creates all four of the node's endpoints through `NodeAdaptor`:

```diff
-struct GearCommand
-{
-  using Message = autoware_vehicle_msgs::msg::GearCommand;
-  static constexpr char name[] = "/control/command/gear_cmd";
-};
+using GearCommand = autoware::component_interface_specs::control::GearCommand;
```

```diff
-    gear_pub_(create_publisher<spec::GearCommand::Message>(spec::GearCommand::name, rclcpp::QoS{1}))
+    gear_pub_(adaptor_.create_publisher<spec::GearCommand>())
```

The other two publishers already called `get_qos<Spec>()`, which is exactly what `NodeAdaptor` derives, and the service already passed `Spec::name`. The `<autoware/component_interface_specs/utils.hpp>` and `<autoware_vehicle_msgs/msg/gear_command.hpp>` includes go with the call sites that needed them, and the three now-unused member type aliases (`OperationModeStateMsg`, `OperationModeSystemStateMsg`, `GearCommand`) are removed with the raw `rclcpp::Publisher` / `rclcpp::Service` declarations that used them.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

## How was this PR tested?

Built and tested in the `autoware:universe-devel-jazzy` image with `colcon build --symlink-install --packages-select autoware_command_gate`, then `colcon test --packages-select autoware_command_gate` and `colcon test-result --verbose --test-result-base build/autoware_command_gate`: **20 tests, 0 errors, 0 failures, 0 skipped**. `pre-commit` runs clean on the changed files.

Swapping a QoS-less local struct for a central spec that carries QoS is the one substitution in this change that could actually move something on the wire, so it was checked directly at runtime rather than argued on paper. With the node running, `ros2 topic info --verbose /control/command/gear_cmd` reports **RELIABLE / VOLATILE / KEEP_LAST(1)** — which is what the deleted `rclcpp::QoS{1}` resolved to, and what the central spec's `depth = 1`, `RELIABILITY_RELIABLE`, `DURABILITY_VOLATILE` produce.

## Notes for reviewers

**The service still takes a lambda.** It took one before; `NodeAdaptor::create_service` accepts a callable as well as a member function, and nothing about the callback's shape changes. Only the redundant `Spec::name` argument goes away.

**`<rmw/types.h>` and `<cstdint>` are left in place.** Both look unused, but they predate this change and removing them is unrelated cleanup.

## Interface changes

No topic or service changes. One node parameter is added by `NodeAdaptor`'s constructor.

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name                              | Type     | Default Value | Description                                                                                                |
| :---------- | :------------------------------------------ | :------- | :------------ | :--------------------------------------------------------------------------------------------------------- |
| Added       | `component_interface.service_introspection` | `string` | `"off"`       | ROS 2 service introspection mode (`"off"` \| `"metadata"` \| `"contents"`), declared once per node by `NodeAdaptor` |

The parameter is gated on rclcpp ≥ 21, so it appears on Jazzy and not on Humble. Its default leaves service introspection off, which is the state before this PR. Declaration is idempotent — a node that already has the parameter keeps its value.

## Effects on system behavior

None. All four endpoints keep their names and their QoS: the central `GearCommand` spec resolves to the same reliable / volatile / depth-1 profile the hand-written `rclcpp::QoS{1}` produced, confirmed at runtime above; the two `OperationModeState` publishers were already on `get_qos<Spec>()`; and the service moves from rclcpp's default services QoS to `rclcpp::ServicesQoS()`, the same value. The message type behind `spec::GearCommand` is `autoware_vehicle_msgs::msg::GearCommand` in both the deleted local struct and the central spec.

