### PR TITLE
refactor(autoware_pose_initializer): create endpoints through NodeAdaptor

### DIFF
--- a/localization/autoware_pose_initializer/package.xml
+++ b/localization/autoware_pose_initializer/package.xml
@@ -17,9 +17,9 @@
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_component_interface_specs</depend>
+  <depend>autoware_component_interface_utils</depend>
   <depend>autoware_map_height_fitter</depend>
   <depend>autoware_motion_utils</depend>
-  <depend>autoware_qos_utils</depend>
   <depend>autoware_utils_diagnostics</depend>
   <depend>autoware_utils_geometry</depend>
   <depend>autoware_utils_logging</depend>

--- a/localization/autoware_pose_initializer/src/pose_initializer_core.cpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core.cpp
@@ -21,8 +21,6 @@
 #include "pose_error_check_module.hpp"
 #include "stop_check_module.hpp"
 
-#include <autoware/qos_utils/qos_compatibility.hpp>
-
 #include <autoware_adapi_v1_msgs/msg/response_status.hpp>
 
 #include <memory>
@@ -33,18 +31,12 @@ namespace autoware::pose_initializer
 {
 PoseInitializer::PoseInitializer(const rclcpp::NodeOptions & options)
 : rclcpp::Node("pose_initializer", options),
-  group_srv_(create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive))
+  group_srv_(create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive)),
+  pub_reset_(create_publisher<PoseWithCovarianceStamped>("pose_reset", 1))
 {
-  rclcpp::QoS qos_state(1);
-  qos_state.reliability(RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-  qos_state.durability(RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
-  pub_state_ = create_publisher<State::Message>(
-    State::name, autoware::component_interface_specs::get_qos<State>());
-  srv_initialize_ = create_service<Initialize::Service>(
-    Initialize::name,
-    std::bind(&PoseInitializer::on_initialize, this, std::placeholders::_1, std::placeholders::_2),
-    AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE(), group_srv_);
-  pub_reset_ = create_publisher<PoseWithCovarianceStamped>("pose_reset", 1);
+  pub_state_ = adaptor_.create_publisher<State>();
+  srv_initialize_ =
+    adaptor_.create_service<Initialize>(this, &PoseInitializer::on_initialize, group_srv_);
 
   output_pose_covariance_ = get_covariance_parameter(this, "output_pose_covariance");
   gnss_particle_covariance_ = get_covariance_parameter(this, "gnss_particle_covariance");

--- a/localization/autoware_pose_initializer/src/pose_initializer_core.hpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core.hpp
@@ -16,6 +16,7 @@
 #define POSE_INITIALIZER_CORE_HPP_
 
 #include <autoware/component_interface_specs/localization.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <autoware_utils_diagnostics/diagnostics_interface.hpp>
 #include <autoware_utils_logging/logger_level_configure.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -45,10 +46,11 @@ private:
   using State = autoware::component_interface_specs::localization::InitializationState;
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
 
+  autoware::component_interface_utils::NodeAdaptor adaptor_{this};
   rclcpp::CallbackGroup::SharedPtr group_srv_;
   rclcpp::Publisher<PoseWithCovarianceStamped>::SharedPtr pub_reset_;
-  rclcpp::Publisher<State::Message>::SharedPtr pub_state_;
-  rclcpp::Service<Initialize::Service>::SharedPtr srv_initialize_;
+  autoware::component_interface_utils::Publisher<State>::SharedPtr pub_state_;
+  autoware::component_interface_utils::Service<Initialize>::SharedPtr srv_initialize_;
   State::Message state_;
   std::array<double, 36> output_pose_covariance_{};
   std::array<double, 36> gnss_particle_covariance_{};


### PR DESCRIPTION
## Description

`PoseInitializer`'s two spec-derived endpoints — the initialization-state publisher and the initialize service — restated their spec's name and QoS at the call site. This PR creates them through `NodeAdaptor` so each names its spec once:

```diff
-  pub_state_ = create_publisher<State::Message>(
-    State::name, autoware::component_interface_specs::get_qos<State>());
-  srv_initialize_ = create_service<Initialize::Service>(
-    Initialize::name,
-    std::bind(&PoseInitializer::on_initialize, this, std::placeholders::_1, std::placeholders::_2),
-    AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE(), group_srv_);
+  pub_state_ = adaptor_.create_publisher<State>();
+  srv_initialize_ =
+    adaptor_.create_service<Initialize>(this, &PoseInitializer::on_initialize, group_srv_);
```

It also removes a dead local. `qos_state` was built with depth 1, reliable and transient-local — and then never passed to anything, because the publisher on the very next line already called `get_qos<State>()`. It has been dead since it was written, and the three lines that construct it go away here.

`pub_reset_` is not spec-derived — it publishes `PoseWithCovarianceStamped` on the node-local name `"pose_reset"` — and keeps that name and QoS. It does move into the member-initializer list, though. Deleting the three `qos_state` lines made its assignment the first statement in the constructor body, which is exactly the shape cppcheck's `useInitializationList` looks for; the dead code had been masking it. `adaptor_` is declared before `group_srv_` and `pub_reset_`, so the initializer list stays in declaration order.

With `AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE()` gone, `<autoware/qos_utils/qos_compatibility.hpp>` is removed, and with it the package's last reference to `autoware_qos_utils` — so that `<depend>` is dropped and `autoware_component_interface_utils` is declared in its place.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

## How was this PR tested?

Built and tested in the `autoware:universe-devel-jazzy` image with `colcon build --symlink-install --packages-select autoware_pose_initializer`, then `colcon test --packages-select autoware_pose_initializer` and `colcon test-result --verbose --test-result-base build/autoware_pose_initializer`: **51 tests, 0 errors, 0 failures, 16 skipped**, no new compiler warnings. `pre-commit` runs clean on every changed file.

Both endpoints' name and QoS were compared against the deleted hand-written forms:

- `pub_state_` already passed `State::name` and `get_qos<State>()`, which is exactly what `NodeAdaptor::create_publisher<State>()` derives.
- `srv_initialize_` already passed `Initialize::name`, and `AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE()` is what `NodeAdaptor`'s service wrapper uses — `rclcpp::ServicesQoS()` on Jazzy, its `rmw` profile on Humble, the same value either way. `group_srv_` is still passed through.

`qos_state` was confirmed dead by grep before deletion: the only occurrences in the file are its own three construction lines.

`ament_auto_add_library` derives include paths from `package.xml`, so removing a `<depend>` can break a build even with no textual reference to it. The package was rebuilt after the manifest edit specifically to prove that did not happen here.

## Notes for reviewers

**`adaptor_` is declared before `group_srv_`** in the header. Members initialise in declaration order, so anything constructed from `adaptor_` has to come after it.

**A dead `#include` at `pose_initializer_core.hpp:25` is left in place.** It predates this change; removing it is unrelated cleanup.

## Interface changes

No topic or service changes. One node parameter is added by `NodeAdaptor`'s constructor.

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name                              | Type     | Default Value | Description                                                                                                |
| :---------- | :------------------------------------------ | :------- | :------------ | :--------------------------------------------------------------------------------------------------------- |
| Added       | `component_interface.service_introspection` | `string` | `"off"`       | ROS 2 service introspection mode (`"off"` \| `"metadata"` \| `"contents"`), declared once per node by `NodeAdaptor` |

The parameter is gated on rclcpp ≥ 21, so it appears on Jazzy and not on Humble. Its default leaves service introspection off, which is the state before this PR. Declaration is idempotent — a node that already has the parameter keeps its value.

## Effects on system behavior

None. Both endpoints keep their name and their QoS, the callback group on the service is preserved, and the only deleted local was never used.

