### PR TITLE
refactor(autoware_adapi_adaptors): create endpoints through NodeAdaptor

### DIFF
--- a/api/autoware_adapi_adaptors/package.xml
+++ b/api/autoware_adapi_adaptors/package.xml
@@ -16,8 +16,8 @@
   <depend>autoware_adapi_specs</depend>
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_component_interface_specs</depend>
+  <depend>autoware_component_interface_utils</depend>
   <depend>autoware_map_height_fitter</depend>
-  <depend>autoware_qos_utils</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 

--- a/api/autoware_adapi_adaptors/src/initial_pose_adaptor.cpp
+++ b/api/autoware_adapi_adaptors/src/initial_pose_adaptor.cpp
@@ -16,8 +16,6 @@
 
 #include "parameter_helper.hpp"
 
-#include <autoware/qos_utils/qos_compatibility.hpp>
-
 #include <memory>
 #include <string>
 #include <vector>
@@ -40,8 +38,7 @@ InitialPoseAdaptor::InitialPoseAdaptor(const rclcpp::NodeOptions & options)
     "~/initialpose", rclcpp::QoS(1),
     std::bind(&InitialPoseAdaptor::on_initial_pose, this, std::placeholders::_1));
 
-  cli_initialize_ =
-    create_client<Initialize::Service>(Initialize::name, AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE());
+  cli_initialize_ = adaptor_.create_client<Initialize>();
 }
 
 void InitialPoseAdaptor::on_initial_pose(const PoseWithCovarianceStamped::ConstSharedPtr msg)

--- a/api/autoware_adapi_adaptors/src/initial_pose_adaptor.hpp
+++ b/api/autoware_adapi_adaptors/src/initial_pose_adaptor.hpp
@@ -16,6 +16,7 @@
 #define INITIAL_POSE_ADAPTOR_HPP_
 
 #include <autoware/adapi_specs/localization.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <autoware/map_height_fitter/map_height_fitter.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -32,8 +33,9 @@ public:
 private:
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
   using Initialize = autoware::adapi_specs::localization::Initialize;
+  autoware::component_interface_utils::NodeAdaptor adaptor_{this};
   rclcpp::Subscription<PoseWithCovarianceStamped>::SharedPtr sub_initial_pose_;
-  rclcpp::Client<Initialize::Service>::SharedPtr cli_initialize_;
+  autoware::component_interface_utils::Client<Initialize>::SharedPtr cli_initialize_;
   std::array<double, 36> rviz_particle_covariance_;
   autoware::map_height_fitter::MapHeightFitter fitter_;
 

--- a/api/autoware_adapi_adaptors/src/routing_adaptor.cpp
+++ b/api/autoware_adapi_adaptors/src/routing_adaptor.cpp
@@ -17,8 +17,6 @@
 #include "request_state_machine.hpp"
 #include "route_builder.hpp"
 
-#include <autoware/qos_utils/qos_compatibility.hpp>
-
 #include <memory>
 
 namespace autoware::adapi_adaptors
@@ -38,18 +36,11 @@ RoutingAdaptor::RoutingAdaptor(const rclcpp::NodeOptions & options)
   sub_waypoint_ = create_subscription<PoseStamped>(
     "~/input/waypoint", 10, std::bind(&RoutingAdaptor::on_waypoint, this, _1));
 
-  cli_reroute_ = create_client<ChangeRoutePoints::Service>(
-    ChangeRoutePoints::name, AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE());
-  cli_route_ = create_client<SetRoutePoints::Service>(
-    SetRoutePoints::name, AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE());
-  cli_clear_ =
-    create_client<ClearRoute::Service>(ClearRoute::name, AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE());
+  cli_reroute_ = adaptor_.create_client<ChangeRoutePoints>();
+  cli_route_ = adaptor_.create_client<SetRoutePoints>();
+  cli_clear_ = adaptor_.create_client<ClearRoute>();
 
-  const auto state_qos = rclcpp::QoS{RouteState::depth}
-                           .reliability(RouteState::reliability)
-                           .durability(RouteState::durability);
-  sub_state_ = create_subscription<RouteState::Message>(
-    RouteState::name, state_qos,
+  sub_state_ = adaptor_.create_subscription<RouteState>(
     [this](const RouteState::Message::ConstSharedPtr msg) { state_ = msg->state; });
 
   const auto rate = rclcpp::Rate(5.0);

--- a/api/autoware_adapi_adaptors/src/routing_adaptor.hpp
+++ b/api/autoware_adapi_adaptors/src/routing_adaptor.hpp
@@ -16,6 +16,7 @@
 #define ROUTING_ADAPTOR_HPP_
 
 #include <autoware/adapi_specs/routing.hpp>
+#include <autoware/component_interface_utils/rclcpp.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <geometry_msgs/msg/pose_stamped.hpp>
@@ -36,10 +37,11 @@ private:
   using ChangeRoutePoints = autoware::adapi_specs::routing::ChangeRoutePoints;
   using ClearRoute = autoware::adapi_specs::routing::ClearRoute;
   using RouteState = autoware::adapi_specs::routing::RouteState;
-  rclcpp::Client<ChangeRoutePoints::Service>::SharedPtr cli_reroute_;
-  rclcpp::Client<SetRoutePoints::Service>::SharedPtr cli_route_;
-  rclcpp::Client<ClearRoute::Service>::SharedPtr cli_clear_;
-  rclcpp::Subscription<RouteState::Message>::SharedPtr sub_state_;
+  autoware::component_interface_utils::NodeAdaptor adaptor_{this};
+  autoware::component_interface_utils::Client<ChangeRoutePoints>::SharedPtr cli_reroute_;
+  autoware::component_interface_utils::Client<SetRoutePoints>::SharedPtr cli_route_;
+  autoware::component_interface_utils::Client<ClearRoute>::SharedPtr cli_clear_;
+  autoware::component_interface_utils::Subscription<RouteState>::SharedPtr sub_state_;
   rclcpp::Subscription<PoseStamped>::SharedPtr sub_fixed_goal_;
   rclcpp::Subscription<PoseStamped>::SharedPtr sub_rough_goal_;
   rclcpp::Subscription<PoseStamped>::SharedPtr sub_waypoint_;


### PR DESCRIPTION
## Description

Five spec-derived endpoints across the two adaptor nodes re-derived their name and QoS from specs that already carry both. This PR creates them through `NodeAdaptor`, so each names its spec once: four clients (`cli_initialize_` in `InitialPoseAdaptor`; `cli_reroute_`, `cli_route_` and `cli_clear_` in `RoutingAdaptor`) and one subscription (`sub_state_` in `RoutingAdaptor`).

The route-state subscription is the interesting one. It built its QoS by writing out the body of `get_qos<RouteState>()` into a local — depth, reliability and durability all read off the same spec the call site was already naming:

```diff
-  const auto state_qos = rclcpp::QoS{RouteState::depth}
-                           .reliability(RouteState::reliability)
-                           .durability(RouteState::durability);
-  sub_state_ = create_subscription<RouteState::Message>(
-    RouteState::name, state_qos,
+  sub_state_ = adaptor_.create_subscription<RouteState>(
     [this](const RouteState::Message::ConstSharedPtr msg) { state_ = msg->state; });
```

That local is redundant once the subscription derives its QoS from the spec, and is removed with the call site it served.

The four clients each dropped `Spec::name` and `AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE()`, so `<autoware/qos_utils/qos_compatibility.hpp>` goes from both `.cpp` files. With that the package no longer references `autoware_qos_utils` anywhere, so its `<depend>` is removed and `autoware_component_interface_utils` is declared in its place.

The three non-spec subscriptions in `RoutingAdaptor` (`~/input/fixed_goal`, `~/input/rough_goal`, `~/input/waypoint`) and the one in `InitialPoseAdaptor` (`~/initialpose`) are not spec-derived and are untouched.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware/issues/7210

## How was this PR tested?

Built and tested in the `autoware:universe-devel-jazzy` image with `colcon build --symlink-install --packages-select autoware_adapi_adaptors`, then `colcon test --packages-select autoware_adapi_adaptors` and `colcon test-result --verbose --test-result-base build/autoware_adapi_adaptors`: **37 tests, 0 errors, 0 failures, 8 skipped**, no new compiler warnings. `pre-commit` runs clean on every changed file.

Wire neutrality was checked per endpoint against the deleted expressions rather than by a runtime capture, since these two nodes are less convenient to stand up standalone than the API and planning ones:

- The four clients all passed `Spec::name` already, and `AUTOWARE_DEFAULT_SERVICES_QOS_PROFILE()` is what `NodeAdaptor`'s client wrapper uses — it expands to `rclcpp::ServicesQoS()` on Jazzy and to its `rmw` profile on Humble, the same value either way.
- The subscription's deleted `state_qos` is `get_qos<RouteState>()` written out longhand, term for term: `RouteState::depth`, `RouteState::reliability`, `RouteState::durability`. `RouteState` resolves to depth 1, RELIABLE, TRANSIENT_LOCAL both before and after.

`ament_auto_add_library` derives include paths from `package.xml`, so removing a `<depend>` can break a build even with no textual reference to it. Both packages were rebuilt after the manifest edit specifically to prove that did not happen here.

## Notes for reviewers

**The route-state subscription still takes a lambda.** It took one before, and `NodeAdaptor::create_subscription` accepts a callable as well as a member function. Only the name and QoS arguments go away.

**`<string>` in `routing_adaptor.hpp` and the `Future` alias in `initial_pose_adaptor.cpp` are left in place.** Both look unused, but both predate this change; removing them is unrelated cleanup.

## Interface changes

No topic or service changes. One node parameter is added by `NodeAdaptor`'s constructor.

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name                              | Type     | Default Value | Description                                                                                                |
| :---------- | :------------------------------------------ | :------- | :------------ | :--------------------------------------------------------------------------------------------------------- |
| Added       | `component_interface.service_introspection` | `string` | `"off"`       | ROS 2 service introspection mode (`"off"` \| `"metadata"` \| `"contents"`), declared once per node by `NodeAdaptor` |

The parameter is gated on rclcpp ≥ 21, so it appears on Jazzy and not on Humble. Its default leaves service introspection off, which is the state before this PR. Declaration is idempotent — a node that already has the parameter keeps its value.

## Effects on system behavior

None. All five endpoints keep their names — every one already passed `Spec::name` — and every QoS is the value the deleted expression already resolved to.

