### PR TITLE
fix(component_interface_utils): fix build errors related to NodeAdaptor

### DIFF
--- a/api/autoware_adapi_adaptors/src/initial_pose_adaptor.hpp
+++ b/api/autoware_adapi_adaptors/src/initial_pose_adaptor.hpp
@@ -33,7 +33,7 @@ public:
 private:
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
   using Initialize = autoware::adapi_specs::localization::Initialize;
-  autoware::component_interface_utils::NodeAdaptor adaptor_{this};
+  autoware::component_interface_utils::NodeAdaptor<rclcpp::Node> adaptor_{this};
   rclcpp::Subscription<PoseWithCovarianceStamped>::SharedPtr sub_initial_pose_;
   autoware::component_interface_utils::Client<Initialize>::SharedPtr cli_initialize_;
   std::array<double, 36> rviz_particle_covariance_;

--- a/api/autoware_adapi_adaptors/src/routing_adaptor.hpp
+++ b/api/autoware_adapi_adaptors/src/routing_adaptor.hpp
@@ -37,7 +37,7 @@ private:
   using ChangeRoutePoints = autoware::adapi_specs::routing::ChangeRoutePoints;
   using ClearRoute = autoware::adapi_specs::routing::ClearRoute;
   using RouteState = autoware::adapi_specs::routing::RouteState;
-  autoware::component_interface_utils::NodeAdaptor adaptor_{this};
+  autoware::component_interface_utils::NodeAdaptor<rclcpp::Node> adaptor_{this};
   autoware::component_interface_utils::Client<ChangeRoutePoints>::SharedPtr cli_reroute_;
   autoware::component_interface_utils::Client<SetRoutePoints>::SharedPtr cli_route_;
   autoware::component_interface_utils::Client<ClearRoute>::SharedPtr cli_clear_;

--- a/api/autoware_default_adapi/src/interface.hpp
+++ b/api/autoware_default_adapi/src/interface.hpp
@@ -29,7 +29,7 @@ public:
 
 private:
   using Version = autoware::adapi_specs::interface::Version;
-  autoware::component_interface_utils::NodeAdaptor adaptor_{this};
+  autoware::component_interface_utils::NodeAdaptor<rclcpp::Node> adaptor_{this};
   autoware::component_interface_utils::Service<Version>::SharedPtr srv_;
 };
 

--- a/api/autoware_default_adapi/src/localization.hpp
+++ b/api/autoware_default_adapi/src/localization.hpp
@@ -32,7 +32,7 @@ public:
 private:
   using ImplState = autoware::component_interface_specs::localization::InitializationState;
 
-  autoware::component_interface_utils::NodeAdaptor adaptor_{this};
+  autoware::component_interface_utils::NodeAdaptor<rclcpp::Node> adaptor_{this};
   rclcpp::CallbackGroup::SharedPtr group_cli_;
   autoware::component_interface_utils::Service<
     autoware::adapi_specs::localization::Initialize>::SharedPtr srv_initialize_;

--- a/api/autoware_default_adapi/src/routing.hpp
+++ b/api/autoware_default_adapi/src/routing.hpp
@@ -36,7 +36,7 @@ private:
   using State = autoware::component_interface_specs::planning::RouteState;
   using Route = autoware::component_interface_specs::planning::LaneletRoute;
 
-  autoware::component_interface_utils::NodeAdaptor adaptor_{this};
+  autoware::component_interface_utils::NodeAdaptor<rclcpp::Node> adaptor_{this};
   rclcpp::CallbackGroup::SharedPtr group_cli_;
 
   // AD API Interface

--- a/localization/autoware_pose_initializer/src/pose_initializer_core.hpp
+++ b/localization/autoware_pose_initializer/src/pose_initializer_core.hpp
@@ -46,7 +46,7 @@ private:
   using State = autoware::component_interface_specs::localization::InitializationState;
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
 
-  autoware::component_interface_utils::NodeAdaptor adaptor_{this};
+  autoware::component_interface_utils::NodeAdaptor<rclcpp::Node> adaptor_{this};
   rclcpp::CallbackGroup::SharedPtr group_srv_;
   rclcpp::Publisher<PoseWithCovarianceStamped>::SharedPtr pub_reset_;
   autoware::component_interface_utils::Publisher<State>::SharedPtr pub_state_;


### PR DESCRIPTION
## Description

Fix a build error that occurred when NodeAdaptor was simultaneously templated and applied.

## Related links

https://github.com/autowarefoundation/autoware_core/pull/1319
https://github.com/autowarefoundation/autoware_core/pull/1326
https://github.com/autowarefoundation/autoware_core/pull/1329
https://github.com/autowarefoundation/autoware_core/pull/1330

## How was this PR tested?

Check build.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
