### PR TITLE
fix(autoware_test_utils): guard the yaml-cpp target for humble

### DIFF
--- a/testing/autoware_test_utils/CMakeLists.txt
+++ b/testing/autoware_test_utils/CMakeLists.txt
@@ -6,6 +6,16 @@ autoware_package()
 
 find_package(yaml-cpp REQUIRED)
 
+# Ubuntu 22.04 ships yaml-cpp 0.7, which exports the target without a namespace.
+# Ubuntu 24.04 ships 0.8, which exports yaml-cpp::yaml-cpp.
+if(NOT TARGET yaml-cpp::yaml-cpp)
+  add_library(yaml-cpp::yaml-cpp INTERFACE IMPORTED)
+  set_property(
+    TARGET yaml-cpp::yaml-cpp
+    PROPERTY INTERFACE_LINK_LIBRARIES yaml-cpp
+  )
+endif()
+
 ament_auto_add_library(autoware_test_utils SHARED
   src/autoware_test_utils.cpp
   src/mock_data_parser.cpp
@@ -23,7 +33,7 @@ endif()
 
 ament_auto_add_executable(topic_snapshot_saver src/topic_snapshot_saver.cpp)
 
-target_link_libraries(topic_snapshot_saver autoware_test_utils yaml-cpp)
+target_link_libraries(topic_snapshot_saver autoware_test_utils yaml-cpp::yaml-cpp)
 
 if(BUILD_TESTING)
   ament_auto_add_gtest(test_autoware_test_utils


### PR DESCRIPTION
## Description

Every humble build of `autoware_test_utils` stops at the CMake generate step:

```text
Target "autoware_test_utils" links to target "yaml-cpp::yaml-cpp" but the
target was not found.
```

Ubuntu 24.04 ships yaml-cpp 0.8, which exports `yaml-cpp::yaml-cpp`. Ubuntu 22.04 ships 0.7, which exports the target without a namespace. Jazzy therefore passes, and only humble fails.

This change keeps the namespaced target. When a yaml-cpp config does not give that target, the change defines it. `topic_snapshot_saver` moves to the same target, so both link lines agree.

## Related links

- Caused by: #1272

That PR merged on 2026-08-07. CI skipped all of its build jobs, because the `run:build-and-test-differential` label was absent. The daily build on `main` was green on 2026-08-07 and red on 2026-08-08. `autoware_universe` shows the same error, because its CI builds core from source.

## How was this PR tested?

In the `core-dependencies-humble` image, before and after. The image reproduces the error without this change, and builds the package with it. The package also still builds on jazzy.

## Effects on system behavior

None. The guard does nothing on a distro whose yaml-cpp config already gives the namespaced target.

## AI usage

**AI usage:** Written with Claude Code, from a search through the autoware_universe and autoware_core daily builds.

**Self-review:** Done ✅

<details>
<summary><strong>Verification:</strong> The humble image reproduces the error without this change and builds the package with it, and the result links `libyaml-cpp.so.0.7`. Jazzy still builds.</summary>

### The humble image, before and after

Image `ghcr.io/autowarefoundation/autoware:core-dependencies-humble`, which carries `libyaml-cpp-dev 0.7.0+dfsg-8build1`. The workspace held `autoware_test_utils` plus `autoware_cmake`, which the image does not provide.

- Without this change: `CMake Generate step failed`, and `autoware_test_utils`, `topic_snapshot_saver` and `test_autoware_test_utils` all report `links to target "yaml-cpp::yaml-cpp" but the target was not found`
- With this change: `Finished <<< autoware_test_utils [1min 6s]`, 3 packages finished
- `ldd libautoware_test_utils.so` shows `libyaml-cpp.so.0.7`
- Not run here: the test suite, and a full core build. Both runs stopped at `colcon build` for this package and its build dependencies.

### The package on jazzy

- `colcon build --packages-select autoware_test_utils --cmake-args -DCMAKE_BUILD_TYPE=Release` gives `Finished <<< autoware_test_utils`
- `ldd libautoware_test_utils.so` shows `libyaml-cpp.so.0.8`
- A probe reports that `find_package(yaml-cpp)` gives no `yaml-cpp` target, only `yaml-cpp::yaml-cpp`, at version 0.8.0
- Not run here: the in-repo CI jobs. `build-and-test-diff-humble` was still pending when I wrote this.

</details>
