### PR TITLE
fix(autoware_adapi_specs): declare the dependencies it includes

### DIFF
--- a/api/autoware_adapi_specs/package.xml
+++ b/api/autoware_adapi_specs/package.xml
@@ -11,6 +11,10 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_adapi_v1_msgs</depend>
+  <depend>autoware_adapi_version_msgs</depend>
+  <depend>rclcpp</depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 


### PR DESCRIPTION
## Description

`autoware_adapi_specs` includes headers from packages that it never declares. This adds the 3 missing entries.

The package builds today only because another declared dependency re-exports the owner. When an unrelated repository stops re-exporting, this package no longer compiles, and nothing here has changed.

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `autoware_adapi_v1_msgs` | `<depend>` | 30 | [`include/autoware/adapi_specs/control.hpp#L20`](https://github.com/autowarefoundation/autoware_core/blob/1a48ae12454d92b7b34291f46d90ad50697ba373/api/autoware_adapi_specs/include/autoware/adapi_specs/control.hpp#L20) |
| `autoware_adapi_version_msgs` | `<depend>` | 1 | [`include/autoware/adapi_specs/interface.hpp#L18`](https://github.com/autowarefoundation/autoware_core/blob/1a48ae12454d92b7b34291f46d90ad50697ba373/api/autoware_adapi_specs/include/autoware/adapi_specs/interface.hpp#L18) |
| `rclcpp` | `<depend>` | 10 | [`include/autoware/adapi_specs/control.hpp#L18`](https://github.com/autowarefoundation/autoware_core/blob/1a48ae12454d92b7b34291f46d90ad50697ba373/api/autoware_adapi_specs/include/autoware/adapi_specs/control.hpp#L18) |

The tag follows where the dependency is used. A type named in an installed header is part of the public API of the package and takes `<depend>`. A dependency that only `test/` reaches takes `<test_depend>`.

- Part of autowarefoundation/autoware_core#1355
- Parent issue: autowarefoundation/autoware#7263

## AI usage

**AI usage:** entry generated with Claude Code by a checker that resolves every `#include` to the package that ships the header, then normalized with the `sort-package-xml` and `prettier-package-xml` hooks of this repository.

**Self-review:** One round ran, by an agent that did not write the change. I read the diff, the full `package.xml`, `CMakeLists.txt`, and all 11 headers, and resolved every `#include` to the package that ships the header. `rclcpp/qos.hpp` appears in 10 headers, `autoware_adapi_v1_msgs` in 30 includes, and `autoware_adapi_version_msgs` once in `interface.hpp`. Each header is real: `/opt/ros/jazzy/include/rclcpp/rclcpp/qos.hpp`, and the 2 message packages in their own install trees. The package ships headers only, with no `src/` and no `test/`, so `<depend>` is the correct tag for all 3 entries. No entry repeats another tag, the file parses as XML, and the `<depend>` group is in sort order. The diff touches this one file, the base is `main`, and the pull request is still a draft. I found nothing to fix. Two notes that need no change here: the headers use the `RMW_QOS_POLICY_*` macros of `rmw` through `rclcpp/qos.hpp`, without a direct `rmw` include; and this package compiles no source of its own, so a lost re-export breaks a consumer of these headers before it breaks this package.

<details>
<summary><strong>Verification:</strong> The exact diff of this pull request built clean inside a 399 package closure build, and independent per-package reviews confirmed all 3 entries as directly used.</summary>

### Build

ROS 2 jazzy. The combined branch `cc70587f` carries all 44 packages and 211 entries for this repository, including the exact diff of this pull request. It was checked out in the workspace and built with its full reverse-dependency closure and dependencies.

- `colcon build` over that closure: **399 packages, 399 at `rc: 0`, 0 failed**, in 41 min.
- All 44 changed packages built, each `rc: 0`.
- An earlier 139-entry version of the branch also built clean over the full 491-package workspace.

### Checks

- `rosdep check --from-paths . --ignore-src --rosdistro jazzy` over the repository: no unresolvable key.
- `pre-commit run sort-package-xml` and `prettier-package-xml`: `Passed`, no file rewritten.
- No entry creates a dependency cycle. The generator refuses those.

### Independent review

- Several review rounds ran, one agent per package, each proving or rejecting every entry against the sources with no knowledge of how it was produced.
- The final rounds confirmed every entry of this pull request as directly used, with file and line evidence.
- The rounds also corrected the checker five times. Entries that turned out to be comment-only, redundant, or wrongly tagged were removed before this pull request took its current form.

### What did not run

- No build of this single-package branch on its own. The evidence above comes from the combined branch.
- No humble build. Only jazzy was used.
- No runtime or simulation test. The change touches a manifest only.

</details>

