### PR TITLE
fix(autoware_agnocast_wrapper): declare the dependencies it includes

### DIFF
--- a/common/autoware_agnocast_wrapper/package.xml
+++ b/common/autoware_agnocast_wrapper/package.xml
@@ -22,6 +22,8 @@
   <depend>geometry_msgs</depend>
   <depend>libgoogle-glog-dev</depend>
   <depend>message_filters</depend>
+  <depend>rcl</depend>
+  <depend>rcl_interfaces</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tf2</depend>


### PR DESCRIPTION
## Description

`autoware_agnocast_wrapper` uses 2 packages that it never declares. This adds the 2 missing entries.

The package builds today only because `rclcpp` re-exports them. When an unrelated repository stops re-exporting, this package no longer compiles, and nothing here has changed.

| Entry | Tag | Evidence |
|---|---|---|
| `rcl` | `<depend>` | includes `<rcl/timer.h>`, [`include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp#L20`](https://github.com/autowarefoundation/autoware_core/blob/1a48ae12454d92b7b34291f46d90ad50697ba373/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp#L20) |
| `rcl_interfaces` | `<depend>` | names `rcl_interfaces::msg::ParameterDescriptor` in an installed header, [`include/autoware/agnocast_wrapper/node.hpp#L113`](https://github.com/autowarefoundation/autoware_core/blob/1a48ae12454d92b7b34291f46d90ad50697ba373/common/autoware_agnocast_wrapper/include/autoware/agnocast_wrapper/node.hpp#L113) |

`rcl_interfaces` is named without a direct `#include`, because the header arrives through `rclcpp`. An include scan alone does not see it. Both are named in installed headers, so both take `<depend>`.

- Part of autowarefoundation/autoware_core#1355
- Parent issue: autowarefoundation/autoware#7263

## AI usage

**AI usage:** entries generated with Claude Code by a checker that resolves every `#include` to the package that ships the header, and resolves a qualified name whose first component is itself a package, then normalized with the `sort-package-xml` and `prettier-package-xml` hooks of this repository.

**Self-review:** One independent round reviewed the current two-entry diff, in a clean context and with no part in writing the change. It confirmed `rcl` from the direct include at `autoware_agnocast_wrapper.hpp:20`, and `rcl_interfaces` from `rcl_interfaces::msg::ParameterDescriptor` named in the installed `node.hpp` with no direct include. It found nothing to fix. Two earlier entries, `diagnostic_msgs` and `sensor_msgs`, were proposed and then removed after review showed every mention sits inside Doxygen comment blocks.

<details>
<summary><strong>Verification:</strong> The exact diff of this pull request built clean inside a 399 package closure build, and an independent review confirmed both entries. Two earlier entries were removed as comment-only.</summary>

### Build

ROS 2 jazzy. The combined branch `cc70587f` carries all 44 packages and 211 entries for this repository, including the exact diff of this pull request. It was checked out in the workspace and built with its full reverse-dependency closure and dependencies.

- `colcon build` over that closure: **399 packages, 399 at `rc: 0`, 0 failed**, in 41 min.
- All 44 changed packages built, each `rc: 0`.
- An earlier 139-entry version of the branch also built clean over the full 491-package workspace.

### Checks

- `rosdep check --from-paths . --ignore-src --rosdistro jazzy` over the repository: no unresolvable key.
- `pre-commit run sort-package-xml` and `prettier-package-xml`: `Passed`, no file rewritten.
- No entry creates a dependency cycle. The generator refuses those.

### Independent review

- Several review rounds ran, one agent per package, each proving or rejecting every entry against the sources with no knowledge of how it was produced.
- The final rounds confirmed every entry of this pull request as directly used, with file and line evidence.
- The rounds also corrected the checker five times. Entries that turned out to be comment-only, redundant, or wrongly tagged were removed before this pull request took its current form.

### What did not run

- No build of this single-package branch on its own. The evidence above comes from the combined branch.
- No humble build. Only jazzy was used.
- No runtime or simulation test. The change touches a manifest only.

</details>
