### PR TITLE
fix(autoware_component_interface_specs): declare the dependencies it includes

### DIFF
--- a/common/autoware_component_interface_specs/package.xml
+++ b/common/autoware_component_interface_specs/package.xml
@@ -23,6 +23,7 @@
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>rmw</depend>
   <depend>rosidl_runtime_cpp</depend>
   <depend>sensor_msgs</depend>
 


### PR DESCRIPTION
## Description

`autoware_component_interface_specs` includes a header from a package that it never declares. This adds the 1 missing entry.

The package builds today only because another declared dependency re-exports the owner. When an unrelated repository stops re-exporting, this package no longer compiles, and nothing here has changed.

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `rmw` | `<depend>` | 11 | [`include/autoware/component_interface_specs/concepts.hpp#L44`](https://github.com/autowarefoundation/autoware_core/blob/1a48ae12454d92b7b34291f46d90ad50697ba373/common/autoware_component_interface_specs/include/autoware/component_interface_specs/concepts.hpp#L44) |

The tag follows where the dependency is used. A type named in an installed header is part of the public API of the package and takes `<depend>`. A dependency that only `test/` reaches takes `<test_depend>`.

- Part of autowarefoundation/autoware_core#1355
- Parent issue: autowarefoundation/autoware#7263

## AI usage

**AI usage:** entry generated with Claude Code by a checker that resolves every `#include` to the package that ships the header, then normalized with the `sort-package-xml` and `prettier-package-xml` hooks of this repository.

**Self-review:** One review round ran, by an agent that did not write the change. That agent read the diff, `package.xml`, `CMakeLists.txt`, and every `#include` under `include/`, `src/`, and `test/`. `dpkg -S /opt/ros/jazzy/include/rmw/rmw/qos_profiles.h` gives `ros-jazzy-rmw`, so the `rmw` package owns the header that this package includes at 11 sites. 9 of those sites are installed headers under `include/`, so `<depend>` is the correct tag, and the other 13 entries cover every remaining include. `rmw` is not declared twice, the file stays valid XML, and the new line keeps the alphabetical order. The pull request targets `main` as a draft, and the two red checks are cancelled runs from `cancel-previous-workflows`. This round found no problem, so there is nothing to fix.

<details>
<summary><strong>Verification:</strong> The exact diff of this pull request built clean inside a 399 package closure build, and independent per-package reviews confirmed the entry as directly used.</summary>

### Build

ROS 2 jazzy. The combined branch `cc70587f` carries all 44 packages and 211 entries for this repository, including the exact diff of this pull request. It was checked out in the workspace and built with its full reverse-dependency closure and dependencies.

- `colcon build` over that closure: **399 packages, 399 at `rc: 0`, 0 failed**, in 41 min.
- All 44 changed packages built, each `rc: 0`.
- An earlier 139-entry version of the branch also built clean over the full 491-package workspace.

### Checks

- `rosdep check --from-paths . --ignore-src --rosdistro jazzy` over the repository: no unresolvable key.
- `pre-commit run sort-package-xml` and `prettier-package-xml`: `Passed`, no file rewritten.
- No entry creates a dependency cycle. The generator refuses those.

### Independent review

- Several review rounds ran, one agent per package, each proving or rejecting every entry against the sources with no knowledge of how it was produced.
- The final rounds confirmed every entry of this pull request as directly used, with file and line evidence.
- The rounds also corrected the checker five times. Entries that turned out to be comment-only, redundant, or wrongly tagged were removed before this pull request took its current form.

### What did not run

- No build of this single-package branch on its own. The evidence above comes from the combined branch.
- No humble build. Only jazzy was used.
- No runtime or simulation test. The change touches a manifest only.

</details>

