### PR TITLE
fix(autoware_component_interface_utils): declare the dependencies it includes

### DIFF
--- a/common/autoware_component_interface_utils/package.xml
+++ b/common/autoware_component_interface_utils/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
+  <depend>rcl</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 


### PR DESCRIPTION
## Description

`autoware_component_interface_utils` includes a header from a package that it never declares. This adds the 1 missing entry.

The package builds today only because another declared dependency re-exports the owner. When an unrelated repository stops re-exporting, this package no longer compiles, and nothing here has changed.

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `rcl` | `<depend>` | 1 | [`include/autoware/component_interface_utils/rclcpp/interface.hpp#L29`](https://github.com/autowarefoundation/autoware_core/blob/1a48ae12454d92b7b34291f46d90ad50697ba373/common/autoware_component_interface_utils/include/autoware/component_interface_utils/rclcpp/interface.hpp#L29) |

The tag follows where the dependency is used. A type named in an installed header is part of the public API of the package and takes `<depend>`. A dependency that only `test/` reaches takes `<test_depend>`.

- Part of autowarefoundation/autoware_core#1355
- Parent issue: autowarefoundation/autoware#7263

## AI usage

**AI usage:** entry generated with Claude Code by a checker that resolves every `#include` to the package that ships the header, then normalized with the `sort-package-xml` and `prettier-package-xml` hooks of this repository.

**Self-review:** One round, by an agent with a clean context that did not write the change. It read the diff, `package.xml`, `CMakeLists.txt`, and every header and test file of the package, then checked the `rcl` entry against the sources. `include/autoware/component_interface_utils/rclcpp/interface.hpp` includes `<rcl/service_introspection.h>`, a header that the `rcl` package ships, and it names `rcl_service_introspection_state_t` in the public member `NodeInterface::introspection_state`, so `<depend>` is the right tag for an installed header. The entry is not a duplicate, the file stays valid XML and sorted, and the pull request targets `main` as a draft. Nothing was found that needs a fix. One note only: `CMakeLists.txt` reaches the `rcl` include path through `rclcpp`, so this entry helps downstream users through `ament_export_dependencies` and `rosdep` rather than the compile of this package itself. The `build-and-test` jobs were still pending when the review ran.

<details>
<summary><strong>Verification:</strong> The exact diff of this pull request built clean inside a 399 package closure build, and independent per-package reviews confirmed the entry as directly used.</summary>

### Build

ROS 2 jazzy. The combined branch `cc70587f` carries all 44 packages and 211 entries for this repository, including the exact diff of this pull request. It was checked out in the workspace and built with its full reverse-dependency closure and dependencies.

- `colcon build` over that closure: **399 packages, 399 at `rc: 0`, 0 failed**, in 41 min.
- All 44 changed packages built, each `rc: 0`.
- An earlier 139-entry version of the branch also built clean over the full 491-package workspace.

### Checks

- `rosdep check --from-paths . --ignore-src --rosdistro jazzy` over the repository: no unresolvable key.
- `pre-commit run sort-package-xml` and `prettier-package-xml`: `Passed`, no file rewritten.
- No entry creates a dependency cycle. The generator refuses those.

### Independent review

- Several review rounds ran, one agent per package, each proving or rejecting every entry against the sources with no knowledge of how it was produced.
- The final rounds confirmed every entry of this pull request as directly used, with file and line evidence.
- The rounds also corrected the checker five times. Entries that turned out to be comment-only, redundant, or wrongly tagged were removed before this pull request took its current form.

### What did not run

- No build of this single-package branch on its own. The evidence above comes from the combined branch.
- No humble build. Only jazzy was used.
- No runtime or simulation test. The change touches a manifest only.

</details>

