### PR TITLE
fix(localization): declare the dependencies these packages use

### DIFF
--- a/localization/autoware_ekf_localizer/package.xml
+++ b/localization/autoware_ekf_localizer/package.xml
@@ -40,6 +40,7 @@
   <test_depend>autoware_lint_common</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>ros_testing</test_depend>
+  <test_depend>rosgraph_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/localization/autoware_gyro_odometer/package.xml
+++ b/localization/autoware_gyro_odometer/package.xml
@@ -32,6 +32,7 @@
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
+  <test_depend>builtin_interfaces</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/localization/autoware_localization_util/package.xml
+++ b/localization/autoware_localization_util/package.xml
@@ -18,6 +18,7 @@
   <depend>autoware_utils_geometry</depend>
   <depend>autoware_utils_math</depend>
   <depend>diagnostic_msgs</depend>
+  <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
@@ -29,6 +30,7 @@
   <test_depend>ament_cmake_cppcheck</test_depend>
   <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
+  <test_depend>builtin_interfaces</test_depend>
   <test_depend>rcl_yaml_param_parser</test_depend>
 
   <export>

--- a/localization/autoware_ndt_scan_matcher/package.xml
+++ b/localization/autoware_ndt_scan_matcher/package.xml
@@ -21,18 +21,23 @@
   <depend>autoware_map_msgs</depend>
   <depend>autoware_qos_utils</depend>
   <depend>autoware_utils_diagnostics</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>autoware_utils_logging</depend>
   <depend>autoware_utils_pcl</depend>
   <depend>autoware_utils_visualization</depend>
+  <depend>builtin_interfaces</depend>
   <depend>diagnostic_msgs</depend>
+  <depend>eigen</depend>
   <depend>fmt</depend>
   <depend>geometry_msgs</depend>
+  <depend>libboost-dev</depend>
   <depend>libpcl-all</depend>
   <depend>nav_msgs</depend>
   <depend>pcl_conversions</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
   <depend>std_srvs</depend>
   <depend>tf2</depend>
   <depend>tf2_eigen</depend>
@@ -46,6 +51,7 @@
   <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>rcl_yaml_param_parser</test_depend>
   <test_depend>ros_testing</test_depend>
 
   <export>

--- a/localization/autoware_pose_initializer/package.xml
+++ b/localization/autoware_pose_initializer/package.xml
@@ -16,13 +16,17 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
+  <depend>autoware_common_msgs</depend>
   <depend>autoware_component_interface_specs</depend>
   <depend>autoware_component_interface_utils</depend>
+  <depend>autoware_internal_localization_msgs</depend>
   <depend>autoware_map_height_fitter</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_utils_diagnostics</depend>
   <depend>autoware_utils_geometry</depend>
   <depend>autoware_utils_logging</depend>
+  <depend>diagnostic_msgs</depend>
+  <depend>fmt</depend>
   <depend>geometry_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>


### PR DESCRIPTION
## Description

The 5 packages under `localization/` use packages or system libraries that they never declare. This adds the 14 missing entries, one collapsible block per package. Each `Use` cell links one line that needs the entry and quotes it.

These packages build today only because another declared dependency re-exports the owner, or some other package installs the system library. When an unrelated repository stops re-exporting, a package here no longer compiles, and the CI of this repository never sees the change.

<details>
<summary><code>autoware_ekf_localizer</code>: 1 missing entry</summary>

Package: [`localization/autoware_ekf_localizer`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_ekf_localizer) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_ekf_localizer/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `rosgraph_msgs` | `<test_depend>` | 2 | [`test/test_ekf_localizer_integration.cpp#L23`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_ekf_localizer/test/test_ekf_localizer_integration.cpp#L23): `#include <rosgraph_msgs/msg/clock.hpp>` |

</details>
<details>
<summary><code>autoware_gyro_odometer</code>: 1 missing entry</summary>

Package: [`localization/autoware_gyro_odometer`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_gyro_odometer) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_gyro_odometer/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `builtin_interfaces` | `<test_depend>` | 2 | [`test/test_gyro_odometer.cpp#L18`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_gyro_odometer/test/test_gyro_odometer.cpp#L18): `#include <builtin_interfaces/msg/time.hpp>` |

</details>
<details>
<summary><code>autoware_localization_util</code>: 2 missing entries</summary>

Package: [`localization/autoware_localization_util`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_localization_util) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_localization_util/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `eigen` | `<depend>` | 7 | [`include/autoware/localization_util/util_func.hpp#L61`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_localization_util/include/autoware/localization_util/util_func.hpp#L61): `Eigen::Affine3d pose_to_affine3d(const geometry_msgs::msg::Pose & ros_pose);` |
| `builtin_interfaces` | `<test_depend>` | 1 | [`test/test_smart_pose_buffer.cpp#L75`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_localization_util/test/test_smart_pose_buffer.cpp#L75): `builtin_interfaces::msg::Time target_ros_time_msg;` |

</details>
<details>
<summary><code>autoware_ndt_scan_matcher</code>: 6 missing entries</summary>

Package: [`localization/autoware_ndt_scan_matcher`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_ndt_scan_matcher) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_ndt_scan_matcher/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `autoware_utils_geometry` | `<depend>` | 2 | [`src/ndt_scan_matcher_core.cpp#L24`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp#L24): `#include <autoware_utils_geometry/geometry.hpp>` |
| `builtin_interfaces` | `<depend>` | 3 | [`include/autoware/ndt_scan_matcher/particle.hpp#L41`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/particle.hpp#L41): `visualization_msgs::msg::MarkerArray & marker_array, const builtin_interfaces::msg::Time & stamp,` |
| `eigen` | `<depend>` | 23 | [`include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp#L143`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_scan_matcher_core.hpp#L143): `Eigen::Matrix2d estimate_covariance(` |
| `libboost-dev` | `<depend>` | 4 | [`include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h#L113`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_ndt_scan_matcher/include/autoware/ndt_scan_matcher/ndt_omp/multigrid_ndt_omp.h#L113): `typedef boost::shared_ptr<MultiGridNormalDistributionsTransform<PointSource, PointTarget>> Ptr;` |
| `std_msgs` | `<depend>` | 1 | [`src/ndt_scan_matcher_core.cpp#L896`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_ndt_scan_matcher/src/ndt_scan_matcher_core.cpp#L896): `std_msgs::msg::ColorRGBA color =` |
| `rcl_yaml_param_parser` | `<test_depend>` | 3 | [`test/test_fixture.hpp#L29`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_ndt_scan_matcher/test/test_fixture.hpp#L29): `#include <rcl_yaml_param_parser/parser.h>` |

</details>
<details>
<summary><code>autoware_pose_initializer</code>: 4 missing entries</summary>

Package: [`localization/autoware_pose_initializer`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_pose_initializer) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_pose_initializer/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `autoware_common_msgs` | `<depend>` | 1 | [`src/pose_initializer_core.cpp#L223`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_pose_initializer/src/pose_initializer_core.cpp#L223): `respose_status.code = autoware_common_msgs::msg::ResponseStatus::PARAMETER_ERROR;` |
| `autoware_internal_localization_msgs` | `<depend>` | 3 | [`src/localization_module.hpp#L20`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_pose_initializer/src/localization_module.hpp#L20): `#include <autoware_internal_localization_msgs/srv/pose_with_covariance_stamped.hpp>` |
| `diagnostic_msgs` | `<depend>` | 1 | [`src/pose_initializer_core.cpp#L195`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_pose_initializer/src/pose_initializer_core.cpp#L195): `diagnostic_msgs::msg::DiagnosticStatus::WARN, message.str());` |
| `fmt` | `<depend>` | 1 | [`src/copy_vector_to_array.hpp#L18`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/localization/autoware_pose_initializer/src/copy_vector_to_array.hpp#L18): `#include <fmt/core.h>` |

</details>

The tag comes from where the dependency is used. A use in an installed header or in code compiled into the library takes `<depend>`. A dependency that only `test/` reaches takes `<test_depend>`. System libraries are named by the rosdep key that this workspace already prefers.

- Part of autowarefoundation/autoware_core#1355
- Parent issue: autowarefoundation/autoware#7263

## AI usage

**AI usage:** entries generated with Claude Code by a checker that resolves every `#include` to the package that ships the header, resolves qualified names to the package that owns them, and resolves system headers through the compiler search paths and the rosdep cache. The result was normalized with the `sort-package-xml` and `prettier-package-xml` hooks of this repository.

**Self-review:** Every item is really used, checked one by one manually ✅

<details>
<summary><strong>Verification:</strong> The exact diff of this pull request built clean inside a 399 package closure build, and independent per-package reviews confirmed every entry as used.</summary>

### Build

ROS 2 jazzy. The combined branch `cc70587f` carries all 44 packages and 211 entries for this repository, and it includes the exact diff of this pull request. It was checked out in the workspace and built with its full reverse-dependency closure and dependencies.

- `colcon build` over that closure: **399 packages, 399 at `rc: 0`, 0 failed**, in 41 min.
- All 44 changed packages built, each `rc: 0`.
- An earlier 139-entry version of the branch also built clean over the full 491-package workspace.

### Checks

- `rosdep check --from-paths . --ignore-src --rosdistro jazzy` over the repository: no unresolvable key.
- `pre-commit run sort-package-xml` and `prettier-package-xml` over the changed files of this branch: `Passed`, no file rewritten.
- No entry creates a dependency cycle. The generator refuses those.

### Independent review

- Several review rounds ran, one agent per package, each proving or rejecting every entry against the sources with no knowledge of how it was produced.
- The final rounds confirmed every entry of this pull request as directly used, with file and line evidence.
- The rounds also corrected the checker five times. Entries that turned out to be comment-only, redundant, or wrongly tagged were removed before this pull request took its current form.

### What did not run

- No build of this branch on its own. The evidence above comes from the combined branch, which was based on `15a891d6`. This branch carries the same diff on the current `main`, and `main` changed no file of these packages after `15a891d6`.
- No humble build. Only jazzy was used.
- No runtime or simulation test. The change touches manifests only.

</details>
