### PR TITLE
fix(testing): declare the dependencies these packages use

### DIFF
--- a/testing/autoware_planning_test_manager/package.xml
+++ b/testing/autoware_planning_test_manager/package.xml
@@ -16,11 +16,14 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_component_interface_specs</depend>
+  <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_route_handler</depend>
   <depend>autoware_test_utils</depend>
   <depend>autoware_utils_geometry</depend>
+  <depend>geometry_msgs</depend>
+  <depend>lanelet2_core</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
   <depend>tf2_msgs</depend>
@@ -32,6 +35,7 @@
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
+  <test_depend>rosidl_runtime_cpp</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/testing/autoware_test_utils/package.xml
+++ b/testing/autoware_test_utils/package.xml
@@ -26,10 +26,18 @@
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_utils_geometry</depend>
+  <depend>builtin_interfaces</depend>
+  <depend>geometry_msgs</depend>
+  <depend>lanelet2_core</depend>
   <depend>lanelet2_io</depend>
+  <depend>libboost-dev</depend>
+  <depend>libboost-serialization-dev</depend>
   <depend>nav_msgs</depend>
   <depend>rclcpp</depend>
+  <depend>rosgraph_msgs</depend>
+  <depend>std_msgs</depend>
   <depend>std_srvs</depend>
+  <depend>tf2</depend>
   <depend>tf2_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>unique_identifier_msgs</depend>


### PR DESCRIPTION
## Description

The 2 packages under `testing/` use packages or system libraries that they never declare. This adds the 12 missing entries, one collapsible block per package. Each `Use` cell links one line that needs the entry and quotes it.

These packages build today only because another declared dependency re-exports the owner, or some other package installs the system library. When an unrelated repository stops re-exporting, a package here no longer compiles, and the CI of this repository never sees the change.

<details>
<summary><code>autoware_planning_test_manager</code>: 4 missing entries</summary>

Package: [`testing/autoware_planning_test_manager`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/testing/autoware_planning_test_manager) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/testing/autoware_planning_test_manager/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `autoware_internal_planning_msgs` | `<depend>` | 3 | [`src/autoware_planning_test_manager.cpp#L19`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/testing/autoware_planning_test_manager/src/autoware_planning_test_manager.cpp#L19): `#include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>` |
| `geometry_msgs` | `<depend>` | 2 | [`include/autoware/planning_test_manager/autoware_planning_test_manager_utils.hpp#L22`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/testing/autoware_planning_test_manager/include/autoware/planning_test_manager/autoware_planning_test_manager_utils.hpp#L22): `#include <geometry_msgs/msg/pose.hpp>` |
| `lanelet2_core` | `<depend>` | 3 | [`test/test_planning_test_manager_utils.cpp#L21`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/testing/autoware_planning_test_manager/test/test_planning_test_manager_utils.cpp#L21): `#include <lanelet2_core/LaneletMap.h>` |
| `rosidl_runtime_cpp` | `<test_depend>` | 1 | [`test/test_planning_test_manager.cpp#L142`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/testing/autoware_planning_test_manager/test/test_planning_test_manager.cpp#L142): `Odometry msg{rosidl_runtime_cpp::MessageInitialization::ZERO};` |

</details>
<details>
<summary><code>autoware_test_utils</code>: 8 missing entries</summary>

Package: [`testing/autoware_test_utils`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/testing/autoware_test_utils) &nbsp;&middot;&nbsp; [`package.xml`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/testing/autoware_test_utils/package.xml)

| Entry | Tag | Sites | Use |
|---|---|---|---|
| `builtin_interfaces` | `<depend>` | 3 | [`include/autoware_test_utils/mock_data_parser.hpp#L18`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/testing/autoware_test_utils/include/autoware_test_utils/mock_data_parser.hpp#L18): `#include <builtin_interfaces/msg/duration.hpp>` |
| `geometry_msgs` | `<depend>` | 10 | [`include/autoware_test_utils/mock_data_parser.hpp#L29`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/testing/autoware_test_utils/include/autoware_test_utils/mock_data_parser.hpp#L29): `#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>` |
| `lanelet2_core` | `<depend>` | 5 | [`include/autoware_test_utils/visualization.hpp#L26`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/testing/autoware_test_utils/include/autoware_test_utils/visualization.hpp#L26): `#include <lanelet2_core/primitives/Lanelet.h>` |
| `libboost-dev` | `<depend>` | 3 | [`src/autoware_test_utils.cpp#L25`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/testing/autoware_test_utils/src/autoware_test_utils.cpp#L25): `#include <boost/archive/binary_iarchive.hpp>` |
| `libboost-serialization-dev` | `<depend>` | 1 | [`src/autoware_test_utils.cpp#L25`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/testing/autoware_test_utils/src/autoware_test_utils.cpp#L25): `#include <boost/archive/binary_iarchive.hpp>` |
| `rosgraph_msgs` | `<depend>` | 2 | [`include/autoware_test_utils/autoware_test_utils.hpp#L34`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/testing/autoware_test_utils/include/autoware_test_utils/autoware_test_utils.hpp#L34): `#include <rosgraph_msgs/msg/clock.hpp>` |
| `std_msgs` | `<depend>` | 3 | [`include/autoware_test_utils/mock_data_parser.hpp#L76`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/testing/autoware_test_utils/include/autoware_test_utils/mock_data_parser.hpp#L76): `using std_msgs::msg::Header;` |
| `tf2` | `<depend>` | 1 | [`src/autoware_test_utils.cpp#L23`](https://github.com/autowarefoundation/autoware_core/blob/15a891d6b6f0939456b1b1b8c1b1159d708d5804/testing/autoware_test_utils/src/autoware_test_utils.cpp#L23): `#include <tf2/utils.hpp>` |

</details>

The tag comes from where the dependency is used. A use in an installed header or in code compiled into the library takes `<depend>`. A dependency that only `test/` reaches takes `<test_depend>`. System libraries are named by the rosdep key that this workspace already prefers. `Boost.Serialization` is declared separately from `libboost-dev` because it needs its own library at link time.

- Part of autowarefoundation/autoware_core#1355
- Parent issue: autowarefoundation/autoware#7263

## AI usage

**AI usage:** entries generated with Claude Code by a checker that resolves every `#include` to the package that ships the header, resolves qualified names to the package that owns them, and resolves system headers through the compiler search paths and the rosdep cache. The result was normalized with the `sort-package-xml` and `prettier-package-xml` hooks of this repository.

**Self-review:** Checked all usages and verified manually. https://github.com/boostorg/serialization/blob/b8fa83c2bc1c0291b5f1059cbeae8e768be9e71d/include/boost/archive/binary_iarchive.hpp also made sure boost serialization thing actually exists too.

<details>
<summary><strong>Verification:</strong> The exact diff of this pull request built clean inside a 399 package closure build, and independent per-package reviews confirmed every entry as used.</summary>

### Build

ROS 2 jazzy. The combined branch `cc70587f` carries all 44 packages and 211 entries for this repository, and it includes the exact diff of this pull request. It was checked out in the workspace and built with its full reverse-dependency closure and dependencies.

- `colcon build` over that closure: **399 packages, 399 at `rc: 0`, 0 failed**, in 41 min.
- All 44 changed packages built, each `rc: 0`.
- An earlier 139-entry version of the branch also built clean over the full 491-package workspace.

### Checks

- `rosdep check --from-paths . --ignore-src --rosdistro jazzy` over the repository: no unresolvable key.
- `pre-commit run sort-package-xml` and `prettier-package-xml` over the changed files of this branch: `Passed`, no file rewritten.
- No entry creates a dependency cycle. The generator refuses those.

### Independent review

- Several review rounds ran, one agent per package, each proving or rejecting every entry against the sources with no knowledge of how it was produced.
- The final rounds confirmed every entry of this pull request as directly used, with file and line evidence.
- The rounds also corrected the checker five times. Entries that turned out to be comment-only, redundant, or wrongly tagged were removed before this pull request took its current form.

### What did not run

- No build of this branch on its own. The evidence above comes from the combined branch, which was based on `15a891d6`. This branch carries the same diff on the current `main`, and `main` changed no file of these packages after `15a891d6`.
- No humble build. Only jazzy was used.
- No runtime or simulation test. The change touches manifests only.

</details>
